### PR TITLE
Error throw

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -160,7 +160,7 @@ abstract class Admin extends ContainerAware
                     $this->urlize($matches[5])
                 );
             } else {
-                throw new \RuntimeException(sprintf('Please define a default `baseRoutePattern` value for the admin class `%s`', get_class($this)));
+                throw new \RuntimeException(sprintf('Please define a default `baseRouteName` value for the admin class `%s`', get_class($this)));
             }
         }
 


### PR DESCRIPTION
I corrected the error thrown when a default baseRouteName is not set. It was reporting that baseRoutePattern was missing.
