### PR TITLE
Form global errors

### DIFF
--- a/Resources/public/css/colors.css
+++ b/Resources/public/css/colors.css
@@ -96,6 +96,19 @@ input.title {
     width: 500px;
 }
 
+div.sonata-ba-form-error {
+		width: 495px;
+		border: 3px solid #CE6F6F;
+		background-color: #F79992;
+		color: #9C2F2F;
+		padding: 5px;
+		margin-bottom: 10px;
+}
+
+div.sonata-ba-form-error ul {
+		margin: 0px;
+}
+
 div.sonata-ba-field-error input{
     border: 1px solid #f79992;
 }

--- a/Resources/views/CRUD/base_edit.twig.html
+++ b/Resources/views/CRUD/base_edit.twig.html
@@ -37,6 +37,12 @@ file that was distributed with this source code.
 
         {{ form_hidden(form) }}
         
+        {% if form.errors %}
+            <div class="sonata-ba-form-error">
+                {{ form_errors(form) }}
+            </div>
+        {% endif %}
+        
         {% for name, form_group in form_groups %}
             {% if name %}
                 <fieldset>


### PR DESCRIPTION
Adding the global form errors to the edit template so that errors that are not tied to a particular field also get displayed.
