### PR TITLE
Custom actions

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -53,11 +53,9 @@ class CRUDController extends Controller
 
     public function configure()
     {
-        $actionName = $this->container->get('request')->get('_bab_action');
-        
         $this->admin = $this->container
             ->get('sonata_base_application.admin.pool')
-            ->getAdminByActionName($actionName);
+            ->getAdminByControllerName(get_class($this));
 
         if(!$this->admin) {
             throw new \RuntimeException(sprintf('Unable to find the admin class related to the current controller (%s)', get_class($this)));


### PR DESCRIPTION
The new way of getting admin by action name made it impossible to have custom actions in the admin controllers. I believe it should be possible to add actions there to do some custom things BAB is not made for (ordering menu elements for example). Therefore I changed the way the admin is retrieved and am using getAdminByControllerName which works just a well if not better.
