### PR TITLE
Template fix

### DIFF
--- a/Resources/views/Core/dashboard.html.twig
+++ b/Resources/views/Core/dashboard.html.twig
@@ -12,6 +12,7 @@ file that was distributed with this source code.
 {% extends base_template %}
 
 {% block title %}{% trans 'title_dashboard' from 'BaseApplicationBundle' %}{% endblock%}
+{% block breadcrumb %}{% trans 'title_dashboard' from 'BaseApplicationBundle' %}{% endblock %}
 {% block content %}
 
     {% for code, group in groups %}


### PR DESCRIPTION
Add the Dasboard title back to the dasboard template (breadcrumb section).
