### PR TITLE
Di config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -43,7 +43,7 @@ class Configuration
                 ->requiresAtLeastOneElement()
                 ->prototype('array')
                     ->scalarNode('label')->cannotBeEmpty()->defaultValue('default')->end()
-                    ->scalarNode('group')->isRequired()->cannotBeEmpty()->end()
+                    ->scalarNode('group')->cannotBeEmpty()->defaultValue('default')->end()
                     ->scalarNode('class')->isRequired()->cannotBeEmpty()->end()
                     ->scalarNode('entity')->isRequired()->cannotBeEmpty()->end()
                     ->scalarNode('controller')->isRequired()->end()


### PR DESCRIPTION
I believe that if you can omit the label setting in an entity, you should also be able to omit the group one. Therefor changing the definition of the group setting to "cannot be empty" and "defaults to 'default'".
