### PR TITLE
Fix strict standards errors on filter class

### DIFF
--- a/Filter/BooleanFilter.php
+++ b/Filter/BooleanFilter.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\QueryBuilder;
 class BooleanFilter extends Filter
 {
 
-    public function filter(QueryBuilder $queryBuilder, $alias, $field, $value)
+    public function doFilter(QueryBuilder $queryBuilder, $alias, $field, $value)
     {
 
         if ($this->getField()->isMultipleChoice()) {

--- a/Filter/CallbackFilter.php
+++ b/Filter/CallbackFilter.php
@@ -22,7 +22,7 @@ class CallbackFilter extends Filter
         return array($queryBuilder->getRootAlias(), false);
     }
 
-    public function filter(QueryBuilder $queryBuilder, $alias, $field, $value)
+    public function doFilter(QueryBuilder $queryBuilder, $alias, $field, $value)
     {
 
         call_user_func($this->getOption('filter'), $queryBuilder, $alias, $field, $value);

--- a/Filter/ChoiceFilter.php
+++ b/Filter/ChoiceFilter.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\QueryBuilder;
 class ChoiceFilter extends Filter
 {
 
-    public function filter(QueryBuilder $queryBuilder, $alias, $field, $value)
+    public function doFilter(QueryBuilder $queryBuilder, $alias, $field, $value)
     {
 
 

--- a/Filter/Filter.php
+++ b/Filter/Filter.php
@@ -35,7 +35,7 @@ abstract class Filter extends Configurable
      * @param  $alias the root alias
      * @return void
      */
-    abstract public function filter(QueryBuilder $queryBuilder, $alias, $field, $value);
+    abstract public function doFilter(QueryBuilder $queryBuilder, $alias, $field, $value);
 
     /**
      * get the related form field filter
@@ -83,7 +83,7 @@ abstract class Filter extends Configurable
 
         list($alias, $field) = $this->association($queryBuilder, $this->field->getData());
 
-        $this->filter($queryBuilder, $alias, $field, $this->field->getData());
+        $this->doFilter($queryBuilder, $alias, $field, $this->field->getData());
     }
 
     protected function association(QueryBuilder $queryBuilder, $value)

--- a/Filter/IntegerFilter.php
+++ b/Filter/IntegerFilter.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\QueryBuilder;
 class IntegerFilter extends Filter
 {
 
-   public function filter(QueryBuilder $queryBuilder, $alias, $field, $value)
+   public function doFilter(QueryBuilder $queryBuilder, $alias, $field, $value)
     {
 
         if ($value == null) {

--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\QueryBuilder;
 class StringFilter extends Filter
 {
 
-    public function filter(QueryBuilder $queryBuilder, $alias, $field, $value)
+    public function doFilter(QueryBuilder $queryBuilder, $alias, $field, $value)
     {
 
         if ($value == null) {


### PR DESCRIPTION
Strict standards: Redefining already defined constructor for class Sonata\AdminBundle\Filter\Filter in /home/www/xxx/src/Sonata/AdminBundle/Filter/Filter.php on line 48
