### PR TITLE
Remove QueryBuilder type to be compatible with FilterInterface::filter()

### DIFF
--- a/Filter/ORM/IntegerFilter.php
+++ b/Filter/ORM/IntegerFilter.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\QueryBuilder;
 class IntegerFilter extends Filter
 {
 
-   public function filter(QueryBuilder $queryBuilder, $alias, $field, $value)
+   public function filter($queryBuilder, $alias, $field, $value)
     {
 
         if ($value == null) {


### PR DESCRIPTION
To avoid this error :
Fatal error: Declaration of Sonata\AdminBundle\Filter\ORM\IntegerFilter::filter() must be compatible with that of Sonata\AdminBundle\Filter\FilterInterface::filter()
