### PR TITLE
Incorrect function name Definition::setArgument()

### DIFF
--- a/DependencyInjection/AddDependencyCallsPass.php
+++ b/DependencyInjection/AddDependencyCallsPass.php
@@ -43,11 +43,11 @@ class AddDependencyCallsPass implements CompilerPassInterface
             $arguments = $definition->getArguments();
 
             if (strlen($arguments[0]) == 0) {
-                $definition->setArgument(0, $id);
+                $definition->replaceArgument(0, $id);
             }
 
             if (strlen($arguments[2]) == 0) {
-                $definition->setArgument(2, 'SonataAdminBundle:CRUD');
+                $definition->replaceArgument(2, 'SonataAdminBundle:CRUD');
             }
 
             $this->applyDefaults($definition, $attributes);


### PR DESCRIPTION
Changed Definition::setArgument() by Definition::replaceArgument()

Related commit : https://github.com/symfony/symfony/commit/cdf706d357b8f74acae5e7a29b4982010a854bf9
