### PR TITLE
added asset() call to fix incorrect paths for images representing boolean

### DIFF
--- a/Resources/views/CRUD/list_boolean.html.twig
+++ b/Resources/views/CRUD/list_boolean.html.twig
@@ -11,5 +11,5 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
 
-{% block field%}<img src="/bundles/sonataadmin/famfamfam/{% if value %}accept{% else %}exclamation{% endif %}.png" />{% endblock %}
+{% block field%}<img src="{{ asset('bundles/sonataadmin/famfamfam/') }}{% if value %}accept{% else %}exclamation{% endif %}.png" />{% endblock %}
 


### PR DESCRIPTION
The boolean images were 404ing before due to a static path in the template.
