### PR TITLE
fixed an issue that caused exceptions to be thrown on the list page

### DIFF
--- a/Datagrid/ORM/Pager.php
+++ b/Datagrid/ORM/Pager.php
@@ -39,7 +39,7 @@ class Pager extends BasePager
 
         $countQuery->select(sprintf('DISTINCT count(%s.%s) as cnt', $countQuery->getRootAlias(), $this->getCountColumn()));
 
-        return $countQuery->getSingleScalarResult();
+        return $countQuery->getQuery()->getSingleScalarResult();
     }
 
 
@@ -51,7 +51,7 @@ class Pager extends BasePager
      */
     public function getResults($hydrationMode = Query::HYDRATE_OBJECT)
     {
-        return $this->getQuery()->execute(array(), $hydrationMode);
+        return $this->getQuery()->getQuery()->execute(array(), $hydrationMode);
     }
 
     /**


### PR DESCRIPTION
Results were being fetched from a QueryBuilder object in the ORM pager, which
doesn't seem to be valid in the latest Doctrine revision. I added an additional
getQuery() call to each occurence and it works now.
