### PR TITLE
corrected the documentation on form field options

### DIFF
--- a/Resources/doc/reference/form_field_definition.rst
+++ b/Resources/doc/reference/form_field_definition.rst
@@ -18,7 +18,7 @@ Example
             'author' => array('edit' => 'list'),
             'enabled',
             'title',
-            'abstract',
+            'abstract' => array('form_field_options' => array('required' => false)),
             'content',
         );
 


### PR DESCRIPTION
The documentation made no mention of the 'form_field_options' array key being required to set options for the form widget.
