### PR TITLE
Fixed incorrect image url in boolean when symfony configured to use asset

### DIFF
--- a/Resources/views/CRUD/list_boolean.html.twig
+++ b/Resources/views/CRUD/list_boolean.html.twig
@@ -11,5 +11,12 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
 
-{% block field%}<img src="{{ asset('bundles/sonataadmin/famfamfam/') }}{% if value %}accept{% else %}exclamation{% endif %}.png" />{% endblock %}
-
+{% block field %}
+{% spaceless %}
+    {% if value %}
+        <img src="{{ asset('bundles/sonataadmin/famfamfam/accept.png') }}" />
+    {% else %}
+        <img src="{{ asset('bundles/sonataadmin/famfamfam/exclamation.png') }}" />
+    {% endif %}
+{% endspaceless %}
+{% endblock %}


### PR DESCRIPTION
When asset version is used in framework config such as this:

framework:
    ...
    templating:
        assets_version: VERSION

the generated url comes out as:

```
/bundles/sonataadmin/famfamfam/?VERSION/exclamation.png
```

Had a brief look for other occurances of the same asset() strategy but couldn't see any
