### PR TITLE
Added a missing trans domain

### DIFF
--- a/Resources/views/CRUD/base_edit.html.twig
+++ b/Resources/views/CRUD/base_edit.html.twig
@@ -42,7 +42,7 @@ file that was distributed with this source code.
             {% if name %}
                 <fieldset>
                     <legend>
-                        {{ name|trans }}
+                        {{ name|trans({}, admin.translationdomain) }}
                         {% if form_group.collapsed %}
                             <a href="" class="sonata-ba-collapsed">{% trans from 'AdminBundle' %}link_expand{% endtrans %}</a>
                         {% endif %}


### PR DESCRIPTION
This is the only place where the trans tag uses the `messages` domain instead of the one defined in the admin class.
