### PR TITLE
Used an alias for the default security handler instead of using a hack

### DIFF
--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -60,7 +60,7 @@ class SonataAdminExtension extends Extension
         // setups parameters with values in config.yml, default values from external files used if not
         $this->configSetupTemplates($config, $container);
 
-        $container->getDefinition('sonata.admin.pool')->addMethodCall('__hack__', $config);
+        $container->setAlias('sonata.admin.security.handler', $config['security_handler']);
     }
 
     protected function configSetupTemplates($config, $container)


### PR DESCRIPTION
This removes the hack you use to pass the security handler to use by default, using a clean way to do the same result.
