### PR TITLE
Fix adding new related entities from forms

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -64,7 +64,7 @@ class HelperController extends Controller
         $admin      = $helper->getAdmin($code);
 
         $subject = $admin->getModelManager()->findOne($admin->getClass(), $objectId);
-        if (!$subject) {
+        if (!$subject && $objectId) {
             throw new NotFoundHttpException(sprintf('Unable to find the object id: %s, class: %s', $objectId, $admin->getClass()));
         }
 


### PR DESCRIPTION
When you are creating a new object, it has no objectId so it can't find an object by that id (null) and 404's before it returns the updated select box.
