### PR TITLE
added format date in view template

### DIFF
--- a/Resources/views/CRUD/base_view_field.html.twig
+++ b/Resources/views/CRUD/base_view_field.html.twig
@@ -12,5 +12,13 @@ file that was distributed with this source code.
 
 <tr>
     <th>{% block name %}{{ field_description.name }}{% endblock %}</th>
-    <td>{% block value %}{{ value }}{% endblock %}</td>
+    <td>
+        {% block value %}
+            {% if field_description.type == 'date' or field_description.type == 'datetime' %}
+                {{ value|date }}
+            {% else %}
+                {{ value }}
+            {% endif %}
+        {% endblock %}
+    </td>
 </tr>


### PR DESCRIPTION
Hello,

If the type of field description is date or datetime, an error is displayed because DateTime object cannot convert to string.

So I added the twig condition and display in date format.

Regards,
