### PR TITLE
Fix #195 - renamed RouteCollection to avoid name collision

### DIFF
--- a/Route/AdminPoolLoader.php
+++ b/Route/AdminPoolLoader.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\AdminBundle\Route;
 
-use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouteCollection as sfRouteCollection;
 use Symfony\Component\Routing\Route;
 
 use Symfony\Component\Config\Loader\FileLoader;
@@ -65,7 +65,7 @@ class AdminPoolLoader extends FileLoader
      */
     public function load($resource, $type = null)
     {
-        $collection = new RouteCollection;
+        $collection = new sfRouteCollection;
         foreach ($this->adminServiceIds as $id) {
 
             $admin = $this->pool->getInstance($id);


### PR DESCRIPTION
Fix for issue #195.

I am not sure this is the right way to do it, please criticize me if it is not. I have not found a better to fix it.
