### PR TITLE
unset empty $groups[$name] for the dashboard

### DIFF
--- a/Admin/Pool.php
+++ b/Admin/Pool.php
@@ -57,6 +57,10 @@ class Pool
 
                 $groups[$name][$id] = $this->container->get($id);
             }
+
+            if (empty($groups[$name])) {
+                unset($groups[$name]);
+            }
         }
 
         return $groups;


### PR DESCRIPTION
this will prevent displaying empty groups on the dashboard
