### PR TITLE
Let user override form field template for doctrine association fields

### DIFF
--- a/Builder/ORM/FormContractor.php
+++ b/Builder/ORM/FormContractor.php
@@ -318,10 +318,6 @@ class FormContractor implements FormContractorInterface
             
             if ($fieldDescription->getType() == ClassMetadataInfo::ONE_TO_MANY) {
                 $fieldDescription->setTemplate('SonataAdminBundle:CRUD:edit_orm_one_to_many.html.twig');
-            
-                if ($fieldDescription->getOption('edit') == 'inline' && !$fieldDescription->getOption('widget_form_field')) {
-                    $fieldDescription->setOption('widget_form_field', 'Bundle\\Sonata\\AdminBundle\\Form\\EditableFieldGroup');
-                }
             }
         }
         


### PR DESCRIPTION
With the current code, if two entities `Post` and `Category` are two entities with a many to one relation, this in `PostAdmin.php:configureFormFields` has no effet :

``` PHP
$formMapper->add('category', array(), array(
    'template' => 'AcmeBlogBundle:Admin:my_custom_template.html.twig'
));
```

This patch makes it possible to override such templates.
