### PR TITLE
Removed extra markup

### DIFF
--- a/Resources/views/CRUD/base_show_field.html.twig
+++ b/Resources/views/CRUD/base_show_field.html.twig
@@ -9,8 +9,5 @@ file that was distributed with this source code.
 
 #}
 
-
-<tr>
-    <th>{% block name %}{{ field_description.name }}{% endblock %}</th>
-    <td>{% block value %}{{ value }}{% endblock %}</td>
-</tr>
+<th>{% block name %}{{ field_description.name }}{% endblock %}</th>
+<td>{% block value %}{{ value }}{% endblock %}</td>


### PR DESCRIPTION
The `<tr>` tag is already written in the template in which the view is rendered.
