### PR TITLE
Clone $object to use it in postRemove

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -452,10 +452,11 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     public function delete($object)
-    {
+    {    
+        $media = clone $object;
         $this->preRemove($object);
         $this->modelManager->delete($object);
-        $this->postRemove($object);
+        $this->postRemove($media);
     }
 
     public function preUpdate($object)


### PR DESCRIPTION
When $object is removed in the modelManager, if you try to get the id in postRemove method, id is null.
