### PR TITLE
Fix for filter field label using name instead of label in Twig template

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -49,9 +49,7 @@ file that was distributed with this source code.
                                     <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}">
                                         {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters) }}">{% endif %}
 
-                                        {% if field_description.options.label is defined %}
-                                            {{ field_description.options.label|trans({}, admin.translationdomain) }}
-                                        {% elseif field_description.options.name is defined %}
+                                        {% if field_description.options.name is defined %}
                                             {{ field_description.options.name|trans({}, admin.translationdomain) }}
                                         {% else %}
                                             {{ field_description.name|trans({}, admin.translationdomain) }}


### PR DESCRIPTION
The base_filter_field.html.twig file was using the filter field name instead of the label.  Label is a valid option in the filter field description and was being ignored.  The label defaults to the name making a viable file to use.
