### PR TITLE
fix name collision

### DIFF
--- a/Route/AdminPoolLoader.php
+++ b/Route/AdminPoolLoader.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\AdminBundle\Route;
 
-use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouteCollection as SymfonyRouteCollection;
 use Symfony\Component\Routing\Route;
 
 use Symfony\Component\Config\Loader\FileLoader;
@@ -65,7 +65,7 @@ class AdminPoolLoader extends FileLoader
      */
     public function load($resource, $type = null)
     {
-        $collection = new RouteCollection;
+        $collection = new SymfonyRouteCollection;
         foreach ($this->adminServiceIds as $id) {
 
             $admin = $this->pool->getInstance($id);


### PR DESCRIPTION
_Sonata\AdminBundle\Route\AdminPoolLoader_ uses _Symfony\Component\Routing\RouteCollection_ which refers to _Sonata\AdminBundle\Route\RouteCollection_ in case of non-FQCN invocation. Fatal error is triggered.
