### PR TITLE
[Form][Filter] Adding missing options, which are introduced by the Number

### DIFF
--- a/Form/Type/Filter/NumberType.php
+++ b/Form/Type/Filter/NumberType.php
@@ -62,4 +62,16 @@ class NumberType extends AbstractType
             ->add('value', 'number', array('required' => false))
         ;
     }
+
+    public function getDefaultOptions(array $options)
+    {
+        $defaultOptions = array(
+            'field_type'       => 'text',
+            'field_options'    => array()
+        );
+
+        $options = array_replace($options, $defaultOptions);
+
+        return $options;
+    }
 }


### PR DESCRIPTION
Hey guys!

I don't really understand the architecture yet, but these two options seem to be missing - they are introduced by the NumberFilter::getRenderSettings() method.

Thanks!
