### PR TITLE
When retrieving the identifier values, retrieve the updated values

### DIFF
--- a/Model/ORM/ModelManager.php
+++ b/Model/ORM/ModelManager.php
@@ -193,7 +193,19 @@ class ModelManager implements ModelManagerInterface
             throw new \RuntimeException('Entities passed to the choice field must be managed');
         }
 
-        return $this->getEntityManager()->getUnitOfWork()->getEntityIdentifier($entity);
+        // Retrieve the updated data
+        $updatedData = $this->getEntityManager()->getUnitOfWork()->getOriginalEntityData($entity);
+
+        // Replace the original identifier values with the updated data,
+        // so we can later on redirect using the correct IDs.
+        $identifierValues = $this->getEntityManager()->getUnitOfWork()->getEntityIdentifier($entity);
+        foreach ($identifierValues as $identifier => $oldvalue) {
+            if (isset($updatedData[$identifier]) && !is_object($updatedData[$identifier])) {
+                $identifierValues[$identifier] = $updatedData[$identifier];
+            }
+        }
+
+        return $identifierValues;
     }
 
     /**


### PR DESCRIPTION
When retrieving the identifier values, replace the original identifier values with the updated data, so we can later on redirect using the correct IDs.

This fixes the problem that when changing the value of an identifier, the user gets a 404 error as the AdminBundle can no longer find the _old_ id.
