### PR TITLE
Display a nicer error message to the user

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -166,8 +166,12 @@ class CRUDController extends Controller
         }
 
         $modelManager = $this->admin->getModelManager();
-        $modelManager->batchDelete($this->admin->getClass(), $query);
-        $this->get('session')->setFlash('sonata_flash_success', 'flash_batch_delete_success');
+        try {
+            $modelManager->batchDelete($this->admin->getClass(), $query);
+            $this->get('session')->setFlash('sonata_flash_success', 'flash_batch_delete_success');
+        } catch ( \PDOException $e ) {
+            $this->get('session')->setFlash('sonata_flash_error', 'flash_batch_delete_error');
+        }
 
         return new RedirectResponse($this->admin->generateUrl('list', $this->admin->getFilterParameters()));
     }
@@ -191,8 +195,12 @@ class CRUDController extends Controller
         }
 
         if ($this->getRequest()->getMethod() == 'DELETE') {
-            $this->admin->delete($object);
-            $this->get('session')->setFlash('sonata_flash_success', 'flash_delete_success');
+            try {
+                $this->admin->delete($object);
+                $this->get('session')->setFlash('sonata_flash_success', 'flash_delete_success');
+            } catch ( \PDOException $e ) {
+                $this->get('session')->setFlash('sonata_flash_error', 'flash_delete_error');
+            }
 
             return new RedirectResponse($this->admin->generateUrl('list'));
         }


### PR DESCRIPTION
Catch database exceptions (e.g. due to foreign key constraint) and display a nicer error message to the user. The translation strings (flash_batch_delete_error and flash_delete_error) were already there but were not used.
