### PR TITLE
[Translation] Fixed key

### DIFF
--- a/Resources/translations/SonataAdminBundle.pt_PT.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_PT.xliff
@@ -110,8 +110,8 @@
                 <source>action_edit</source>
                 <target>Editar</target>
             </trans-unit>
-            <trans-unit id="action_view">
-                <source>action_view</source>
+            <trans-unit id="action_show">
+                <source>action_show</source>
                 <target>Ver</target>
             </trans-unit>
             <trans-unit id="all_elements">

--- a/Resources/views/CRUD/list__action_view.html.twig
+++ b/Resources/views/CRUD/list__action_view.html.twig
@@ -1,5 +1,5 @@
 {% if admin.hasRoute('show') %}
-    <a href="{{ admin.generateObjectUrl('show', object) }}" class="view_link" title="{% trans from 'SonataAdminBundle' %}action_view{% endtrans %}">
-        <img src="{{ asset('bundles/sonataadmin/famfamfam/magnifier.png') }}" alt="{% trans from 'SonataAdminBundle' %}action_view{% endtrans %}" />
+    <a href="{{ admin.generateObjectUrl('show', object) }}" class="view_link" title="{% trans from 'SonataAdminBundle' %}action_show{% endtrans %}">
+        <img src="{{ asset('bundles/sonataadmin/famfamfam/magnifier.png') }}" alt="{% trans from 'SonataAdminBundle' %}action_show{% endtrans %}" />
     </a>
 {% endif %}


### PR DESCRIPTION
All but `pt_PT` translation file and template used `action_show` key, figured it makes more sense and is easier to change (explanation why I did not change other way around)
