### PR TITLE
Beautified main container CSS

### DIFF
--- a/Resources/public/css/colors.css
+++ b/Resources/public/css/colors.css
@@ -8,7 +8,15 @@ a {
 }
 
 div.container {
+    -moz-box-shadow: 0px 0px 2px #AAA;
+    -webkit-box-shadow: 0px 0px 2px #AAA;
+    -o-box-shadow: 0px 0px 2px #AAA;
+    box-shadow: 0px 0px 2px #AAA;
 
+    border: 1px solid #CCCCCC;
+    border-top: 0;
+
+    width: 960px;
 }
 
 div.container div.header {
@@ -97,16 +105,16 @@ input.title {
 }
 
 div.sonata-ba-form-error {
-		width: 495px;
-		border: 3px solid #CE6F6F;
-		background-color: #F79992;
-		color: #9C2F2F;
-		padding: 5px;
-		margin-bottom: 10px;
+    width: 495px;
+    border: 3px solid #CE6F6F;
+    background-color: #F79992;
+    color: #9C2F2F;
+    padding: 5px;
+    margin-bottom: 10px;
 }
 
 div.sonata-ba-form-error ul {
-		margin: 0;
+    margin: 0;
 }
 
 div.sonata-ba-field-error input{


### PR DESCRIPTION
Added border and slight shadow to main container, made container width match content width. It looks a bit better now, hope it is OK as default :]

Ignore `@@ -97,16 +105,16 @@`, tabs->spaces.
