### PR TITLE
Fix typo in base_show.html.twig template

### DIFF
--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -41,8 +41,8 @@ file that was distributed with this source code.
 
                 {% for field_name in view_group.fields %}
                     <tr class="sonata-ba-view-container">
-                        {% if admin.show[field_name] is defined %}
-                            {{ admin.show[field_name]|render_view_element(object) }}
+                        {% if admin.showFieldDescriptions[field_name] is defined %}
+                            {{ admin.showFieldDescriptions[field_name]|render_view_element(object) }}
                         {% endif %}
                     </tr>
                 {% endfor %}


### PR DESCRIPTION
admin.show is not used  but showFieldDescriptions is.
