### PR TITLE
Init query with setMaxResults = null instead of 0

### DIFF
--- a/Datagrid/ORM/Pager.php
+++ b/Datagrid/ORM/Pager.php
@@ -69,8 +69,8 @@ class Pager extends BasePager
 
         $this->setNbResults($this->computeNbResult());
 
-        $this->getQuery()->setFirstResult(0);
-        $this->getQuery()->setMaxResults(0);
+        $this->getQuery()->setFirstResult(null);
+        $this->getQuery()->setMaxResults(null);
 
         if (count($this->getParameters()) > 0) {
             $this->getQuery()->setParameters($this->getParameters());


### PR DESCRIPTION
If we set maxResults to 0 we have 0 results but if set it to null, doctrine remove the limit

I use this code to add a "See all" link inside my listAction

``` php
<?php
if ($this->getRequest()->query->get('all', 0)) {
    $this->admin->setMaxPerPage(null);
}
```
