### PR TITLE
Fix configuration show method spelling accordingly to source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ class PostAdmin extends Admin
         ;
     }
 
-    public function configureFormFields(FormMapper $formMapper)
+    public function configureFormField(FormMapper $formMapper)
     {
         $formMapper
             ->with('General')


### PR DESCRIPTION
this fix remove misunderstanding with readme, docs and source code
