### PR TITLE
Fix setting of form data when building a partial form

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -98,7 +98,7 @@ class HelperController extends Controller
         $formBuilder = $admin->getFormBuilder($subject);
 
         $form = $formBuilder->getForm();
-        $form->bindRequest($this->get('request'));
+        $form->setData($subject);
 
         $view = $helper->getChildFormView($form->createView(), $elementId);
 


### PR DESCRIPTION
When using an embedded collection to create a item, the javascript will call the HelperController to render the part of the form that needs to be updated.
When the form is rebuilded, the data that shoud be used is not the posted data but the data extracted from the ModelManager.
