### PR TITLE
ACL: show admin in dashboard and menu depending on roles, by default the LIST role

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -44,6 +44,9 @@ use Knp\Menu\MenuItem;
 
 abstract class Admin implements AdminInterface, DomainObjectInterface
 {
+    const CONTEXT_MENU       = 'menu';
+    const CONTEXT_DASHBOARD  = 'dashboard';
+
     /**
      * The class name managed by the admin class
      *
@@ -2078,6 +2081,38 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
             'DELETE'    => array('DELETE'),
             'OPERATOR'  => array('OPERATOR')
         );
+    }
+
+    /**
+     * Return the list of permissions the user should have in order to display the admin
+     *
+     * @param string $context
+     * @return array
+     */
+    public function getPermissionsShow($context)
+    {
+        switch ($context) {
+            case self::CONTEXT_DASHBOARD:
+            case self::CONTEXT_MENU:
+            default:
+                return array('LIST');
+        }
+    }
+
+    /**
+     * Return if this admin is displayed depending on the context
+     *
+     * @param string $context
+     * @return boolean
+     */
+    public function showIn($context)
+    {
+        switch ($context) {
+            case self::CONTEXT_DASHBOARD:
+            case self::CONTEXT_MENU:
+            default:
+                return $this->isGranted($this->getPermissionsShow($context));
+        }
     }
 
     /**

--- a/Admin/Pool.php
+++ b/Admin/Pool.php
@@ -65,11 +65,16 @@ class Pool
         foreach ($this->adminGroups as $name => $adminGroup) {
             if (isset($adminGroup['items'])) {
                 foreach ($adminGroup['items'] as $key => $id) {
-                    $groups[$name]['items'][$key] = $this->getInstance($id);
+                    $admin = $this->getInstance($id);
+                    if ($admin->showIn(Admin::CONTEXT_DASHBOARD)) {
+                        $groups[$name]['items'][$key] = $admin;
+                    } else {
+                        unset($groups[$name]['items'][$key]);
+                    }
                 }
             }
 
-            if (empty($groups[$name])) {
+            if (empty($groups[$name]['items'])) {
                 unset($groups[$name]);
             }
         }

--- a/Resources/doc/reference/security.rst
+++ b/Resources/doc/reference/security.rst
@@ -134,6 +134,9 @@ If you have Admin classes, you can install the related CRUD ACL rules :
 
 If you try to access to the admin class you should see the login form, just logon with the ``root`` user.
 
+An Admin is displayed in the dashboard (and menu) when the user has the role ``LIST``. To change this override the ``showIn`` 
+method in the Admin class.
+
 Usage
 ~~~~~
 


### PR DESCRIPTION
Hi,

While implementing, I found out it was easier to change the getDashboardGroups method of the admin pool instead of changing the templates. To be able to configure when the admin is displayed in the dashboard (and menu) I added 2 more methods.

Cheers,

Roel
