### PR TITLE
adds role for DASHBOARD to hide certain groups from dashboard and top navigation

### DIFF
--- a/Admin/Pool.php
+++ b/Admin/Pool.php
@@ -68,8 +68,16 @@ class Pool
                     $groups[$name]['items'][$key] = $this->getInstance($id);
                 }
             }
+            
+            // If access is denied for this function, unset the item from the group
+            foreach ($groups[$name]['items'] as $key => $admin) {
+                if (!$admin->isGranted('DASHBOARD')) {
+                    unset($groups[$name]['items'][$key]);
+                }
+            }
 
-            if (empty($groups[$name])) {
+            // if the group or the group's items are empty, unset the group
+            if (empty($groups[$name]) || empty($groups[$name]['items'])) {
                 unset($groups[$name]);
             }
         }


### PR DESCRIPTION
I've added a check for the role `DASHBOARD`, which will determine whether or not a user sees a certain admin or admin group on their dashboard.

Restricting read/write/edit permissions to other users do not remove that admin from the top nav or from the dashboard.  It simply removes the available actions.  These changes will hide admins without this permission, and also hide admin GROUPS when no admin is available within it.

I could not find any way to restrict this currently.  

_Use Cases_
1. The admin group `User Management` contains the admins `Users` and `Contacts`.  Only super admins can manage Users, but normal admins can manage Contacts.  We want the User Management group to show in the dashboard/top nav, but not the Users row.
2. The admin group `Administration` contains the admins `Company` and `User`, and is for super admins only.  We do not want this to show up on any other user's dashboard
