### PR TITLE
Fix assignment of correct Admin class

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1085,6 +1085,11 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         $pool = $this->getConfigurationPool();
 
         $admin = $pool->getAdminByClass($fieldDescription->getTargetEntity());
+        
+        if ($this->hasSubject() && $this->has($admin->getCode())) {
+            $admin = $this->getChild($admin->getCode());
+        }
+        
         if (!$admin) {
             return;
         }


### PR DESCRIPTION
I have been having problems with the creation of certain associations when configured as a non null relationship (For example, a comment that MUST have a post before being saved to the database).

The URL generated when clicking the little add icon does not take you to the child admin instance, rather the admin instance that is not associated with a parent (which, ultimately I'd like to be able to not use - I have no need of a non associated child admin class - it NEEDS a parent). 

I've traced the problem to the function in this pull - in every case, the related FieldDescription is assigned the unassociated child admin class, when IMO it should be assigned the child admin class.

I am unsure if this is an appropriate fix, but since it fixes the problem I've encountered - I hope it can at least start a discussion about the issue.
