### PR TITLE
ACL: refactored + updated roles + updated default permission map to use the meanings of the Built-in Permission Map of Symfony

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -497,6 +497,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         $this->prePersist($object);
         $this->getModelManager()->create($object);
         $this->postPersist($object);
+        $this->createObjectOwner($object);
     }
 
     public function delete($object)
@@ -2063,21 +2064,29 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Return the list of security name available for the current admin
+     * Return the roles and permissions per role for the admin ACL
      * This should be used by experimented users
      *
-     * @return array
+     * @return array [role] => array([permission], [permission])
      */
     public function getSecurityInformation()
     {
         return array(
-            'EDIT'      => array('EDIT'),
-            'LIST'      => array('LIST'),
-            'CREATE'    => array('CREATE'),
-            'VIEW'      => array('VIEW'),
-            'DELETE'    => array('DELETE'),
-            'OPERATOR'  => array('OPERATOR')
+            'GUEST'    => array('VIEW', 'LIST'),
+            'STAFF'    => array('EDIT', 'LIST', 'CREATE'),
+            'EDITOR'   => array('OPERATOR'),
+            'ADMIN'    => array('MASTER'),
         );
+    }
+
+    /**
+     * Create security object owner
+     *
+     * @param $object
+     */
+    public function createObjectOwner($object)
+    {
+        $this->getSecurityHandler()->createObjectOwner($this, $object);
     }
 
     /**

--- a/Command/SetupAclCommand.php
+++ b/Command/SetupAclCommand.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Command;
 
+
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -65,7 +66,8 @@ class SetupAclCommand extends ContainerAwareCommand
                 $acl = $aclProvider->createAcl($objectIdentity);
             }
 
-
+            // create admin ACL, fe.
+            // Comment admin ACL
             $this->configureACL($output, $acl, $builder, $securityHandler->buildSecurityInformation($admin));
 
             $aclProvider->updateAcl($acl);
@@ -74,14 +76,14 @@ class SetupAclCommand extends ContainerAwareCommand
 
     public function configureACL(OutputInterface $output, AclInterface $acl, MaskBuilder $builder, array $aclInformations = array())
     {
-        foreach ($aclInformations as $name => $masks) {
-            foreach ($masks as $mask) {
-                $builder->add($mask);
+        foreach ($aclInformations as $role => $permissions) {
+            foreach ($permissions as $permission) {
+                $builder->add($permission);
             }
 
-            $acl->insertClassAce(new RoleSecurityIdentity($name), $builder->get());
+            $acl->insertClassAce(new RoleSecurityIdentity($role), $builder->get());
 
-            $output->writeln(sprintf('   - add role: %s, ACL: %s', $name, json_encode($masks)));
+            $output->writeln(sprintf('   - add role: %s, permissions: %s', $role, json_encode($permissions)));
 
             $builder->reset();
         }

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -429,7 +429,7 @@ class CRUDController extends Controller
      */
     public function showAction($id = null)
     {
-        if (false === $this->admin->isGranted('SHOW')) {
+        if (false === $this->admin->isGranted('VIEW')) {
             throw new AccessDeniedException();
         }
 

--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -35,6 +35,7 @@
 
         <service id="sonata.admin.security.handler.acl" class="Sonata\AdminBundle\Security\Handler\AclSecurityHandler">
             <argument type="service" id="security.context" on-invalid="null" />
+            <argument type="service" id="security.acl.provider" on-invalid="null" />
             <argument type="collection">
                 <argument>ROLE_SUPER_ADMIN</argument>
             </argument>

--- a/Resources/views/CRUD/base_edit.html.twig
+++ b/Resources/views/CRUD/base_edit.html.twig
@@ -88,7 +88,7 @@ file that was distributed with this source code.
                         <input type="submit" class="btn primary" name="btn_update_and_edit" value="{% trans from 'SonataAdminBundle' %}btn_update_and_edit_again{% endtrans %}"/>
                         <input type="submit" class="btn" name="btn_update_and_list" value="{% trans from 'SonataAdminBundle' %}btn_update_and_return_to_list{% endtrans %}"/>
 
-                        {% if admin.hasroute('delete') and admin.isGranted('DELETE') %}
+                        {% if admin.hasroute('delete') and admin.isGranted('DELETE', object) %}
                             {% trans from 'SonataAdminBundle' %}delete_or{% endtrans %}
                             <a class="btn danger" href="{{ admin.generateObjectUrl('delete', object) }}">{% trans from 'SonataAdminBundle' %}link_delete{% endtrans %}</a>
                         {% endif %}

--- a/Resources/views/CRUD/base_list_field.html.twig
+++ b/Resources/views/CRUD/base_list_field.html.twig
@@ -10,11 +10,11 @@ file that was distributed with this source code.
 #}
 
 <td class="sonata-ba-list-field sonata-ba-list-field-{{ field_description.type }}" objectId="{{ admin.id(object) }}">
-    {% if field_description.options.identifier is defined and admin.isGranted(['EDIT', 'SHOW']) %}
+    {% if field_description.options.identifier is defined and admin.isGranted('VIEW') %}
 
         {% if admin.hasroute('edit') and admin.isGranted('EDIT') %}
             <a href="{{ admin.generateObjectUrl('edit', object) }}">
-        {% elseif admin.hasroute('show') %}
+        {% elseif admin.hasroute('show') and admin.show|length > 0 %}
             <a href="{{ admin.generateObjectUrl('show', object) }}">
         {% endif %}
 

--- a/Security/Acl/Permission/AdminPermissionMap.php
+++ b/Security/Acl/Permission/AdminPermissionMap.php
@@ -22,48 +22,77 @@ use Symfony\Component\Security\Acl\Permission\PermissionMapInterface;
  */
 class AdminPermissionMap implements PermissionMapInterface
 {
-    const PERMISSION_SHOW        = 'SHOW';
+    const PERMISSION_VIEW        = 'VIEW';
     const PERMISSION_EDIT        = 'EDIT';
     const PERMISSION_CREATE      = 'CREATE';
     const PERMISSION_DELETE      = 'DELETE';
     const PERMISSION_UNDELETE    = 'UNDELETE';
+    const PERMISSION_LIST        = 'LIST';
     const PERMISSION_OPERATOR    = 'OPERATOR';
     const PERMISSION_MASTER      = 'MASTER';
     const PERMISSION_OWNER       = 'OWNER';
 
-    const PERMISSION_LIST        = 'LIST';
-
+    /**
+     * Map each permission to the permissions it should grant access for
+     * fe. grant access for the view permission if the user has the edit permission
+     *
+     * @var array
+     */
     private $map = array(
-        self::PERMISSION_LIST => array(
-            MaskBuilder::MASK_LIST
-        ),
 
-        self::PERMISSION_SHOW => array(
+        self::PERMISSION_VIEW => array(
             MaskBuilder::MASK_VIEW,
+            MaskBuilder::MASK_LIST,
+            MaskBuilder::MASK_EDIT,
+            MaskBuilder::MASK_OPERATOR,
+            MaskBuilder::MASK_MASTER,
+            MaskBuilder::MASK_OWNER
         ),
 
         self::PERMISSION_EDIT => array(
             MaskBuilder::MASK_EDIT,
+            MaskBuilder::MASK_OPERATOR,
+            MaskBuilder::MASK_MASTER,
+            MaskBuilder::MASK_OWNER
         ),
 
         self::PERMISSION_CREATE => array(
             MaskBuilder::MASK_CREATE,
+            MaskBuilder::MASK_OPERATOR,
+            MaskBuilder::MASK_MASTER,
+            MaskBuilder::MASK_OWNER
         ),
 
         self::PERMISSION_DELETE => array(
             MaskBuilder::MASK_DELETE,
+            MaskBuilder::MASK_OPERATOR,
+            MaskBuilder::MASK_MASTER,
+            MaskBuilder::MASK_OWNER
         ),
 
         self::PERMISSION_UNDELETE => array(
             MaskBuilder::MASK_UNDELETE,
+            MaskBuilder::MASK_OPERATOR,
+            MaskBuilder::MASK_MASTER,
+            MaskBuilder::MASK_OWNER
         ),
 
-        self::PERMISSION_OPERATOR => array(
+        self::PERMISSION_LIST => array(
+            MaskBuilder::MASK_LIST,
             MaskBuilder::MASK_OPERATOR,
+            MaskBuilder::MASK_MASTER,
+            MaskBuilder::MASK_OWNER
+        ),
+
+       self::PERMISSION_OPERATOR => array(
+            MaskBuilder::MASK_OPERATOR,
+            MaskBuilder::MASK_MASTER,
+            MaskBuilder::MASK_OWNER
         ),
 
         self::PERMISSION_MASTER => array(
             MaskBuilder::MASK_MASTER,
+            MaskBuilder::MASK_OWNER,
         ),
 
         self::PERMISSION_OWNER => array(

--- a/Security/Acl/Permission/MaskBuilder.php
+++ b/Security/Acl/Permission/MaskBuilder.php
@@ -13,6 +13,10 @@ namespace Sonata\AdminBundle\Security\Acl\Permission;
 
 use Symfony\Component\Security\Acl\Permission\MaskBuilder as BaseMaskBuilder;
 
+/**
+ * {@inheritDoc}
+ * - LIST: the SID is allowed to view a list of the domain objects / fields
+ */
 class MaskBuilder extends BaseMaskBuilder
 {
     const MASK_LIST         = 4096;       // 1 << 12

--- a/Security/Handler/AclSecurityHandler.php
+++ b/Security/Handler/AclSecurityHandler.php
@@ -13,21 +13,27 @@ namespace Sonata\AdminBundle\Security\Handler;
 
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
+use Symfony\Component\Security\Acl\Model\AclProviderInterface;
+use Symfony\Component\Security\Acl\Model\AclInterface;
+use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
+use Symfony\Component\Security\Acl\Permission\MaskBuilder;
 use Sonata\AdminBundle\Admin\AdminInterface;
 
 class AclSecurityHandler implements SecurityHandlerInterface
 {
     protected $securityContext;
-
+    protected $aclProvider;
     protected $superAdminRoles;
 
     /**
      * @param \Symfony\Component\Security\Core\SecurityContextInterface $securityContext
      * @param array $superAdminRoles
      */
-    public function __construct(SecurityContextInterface $securityContext, array $superAdminRoles)
+    public function __construct(SecurityContextInterface $securityContext, AclProviderInterface $aclProvider, array $superAdminRoles)
     {
         $this->securityContext = $securityContext;
+        $this->aclProvider = $aclProvider;
         $this->superAdminRoles = $superAdminRoles;
     }
 
@@ -40,19 +46,8 @@ class AclSecurityHandler implements SecurityHandlerInterface
             $attributes = array($attributes);
         }
 
-        if ($object instanceof AdminInterface) {
-            foreach ($attributes as $pos => $attribute) {
-                $attributes[$pos] = sprintf('ROLE_%s_%s',
-                    str_replace('.', '_', strtoupper($admin->getCode())),
-                    $attribute
-                );
-            }
-        }
-
-        $attributes = array_merge($attributes, $this->superAdminRoles);
-
         try {
-            return $this->securityContext->isGranted($attributes, $object);
+            return $this->securityContext->isGranted($this->superAdminRoles) || $this->securityContext->isGranted($attributes, $object);
         } catch (AuthenticationCredentialsNotFoundException $e) {
             return false;
         } catch (\Exception $e) {
@@ -60,18 +55,71 @@ class AclSecurityHandler implements SecurityHandlerInterface
         }
     }
 
+    public function getBaseRole(AdminInterface $admin)
+    {
+        return 'ROLE_'.str_replace('.', '_', strtoupper($admin->getCode())).'_%s';
+    }
+
     /**
      * {@inheritDoc}
      */
     public function buildSecurityInformation(AdminInterface $admin)
     {
-        $baseRole = 'ROLE_'.str_replace('.', '_', strtoupper($admin->getCode())).'_%s';
+        $baseRole = $this->getBaseRole($admin);
 
         $results = array();
-        foreach ($admin->getSecurityInformation() as $name => $permissions) {
-            $results[sprintf($baseRole, $name)] = $permissions;
+        foreach ($admin->getSecurityInformation() as $role => $permissions) {
+            $results[sprintf($baseRole, $role)] = $permissions;
         }
 
         return $results;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createObjectOwner(AdminInterface $admin, $object)
+    {
+        $acl = $this->getNewObjectOwnerAcl($admin, $object);
+        $this->updateAcl($acl);
+    }
+
+    /**
+     * Get a new ACL with an object ACE where the currently logged in user is set as owner
+     *
+     * @param AdminInterface $admin
+     * @param object $object
+     * @return Symfony\Component\Security\Acl\Model\AclInterface
+     */
+    public function getNewObjectOwnerAcl(AdminInterface $admin, $object)
+    {
+        // creating the ACL, fe.
+        // Comment 1 ACL
+        $objectIdentity = ObjectIdentity::fromDomainObject($object);
+        $acl = $this->aclProvider->createAcl($objectIdentity);
+
+        // inherit class ACE's from the admin ACL, fe.
+        // Comment admin ACL
+        //  - Comment 1 ACL
+        $parentOid = ObjectIdentity::fromDomainObject($admin);
+        $parentAcl = $this->aclProvider->findAcl($parentOid);
+        $acl->setParentAcl($parentAcl);
+
+        // retrieving the security identity of the currently logged-in user
+        $user = $this->securityContext->getToken()->getUser();
+        $securityIdentity = UserSecurityIdentity::fromAccount($user);
+
+        // grant owner access
+        $acl->insertObjectAce($securityIdentity, MaskBuilder::MASK_OWNER);
+
+        return $acl;
+    }
+
+    /**
+     * Update the ACL
+     */
+    public function updateAcl(AclInterface $acl)
+    {
+        $this->aclProvider->updateAcl($acl);
     }
 }

--- a/Security/Handler/NoopSecurityHandler.php
+++ b/Security/Handler/NoopSecurityHandler.php
@@ -30,4 +30,11 @@ class NoopSecurityHandler implements SecurityHandlerInterface
     {
         return array();
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createObjectOwner(AdminInterface $admin, $object)
+    {
+    }
 }

--- a/Security/Handler/SecurityHandlerInterface.php
+++ b/Security/Handler/SecurityHandlerInterface.php
@@ -29,4 +29,14 @@ interface SecurityHandlerInterface
      * @return void
      */
     function buildSecurityInformation(AdminInterface $admin);
+
+    /**
+     * Make the current user owner of the object
+     *
+     * @abstract
+     * @param \Sonata\AdminBundle\Admin\AdminInterface $admin
+     * @param object $object
+     * @return void
+     */
+    function createObjectOwner(AdminInterface $admin, $object);
 }


### PR DESCRIPTION
Hi,

I did some test and played with the ACL implementation, I found out some issues that this PR tries to solve:
- the meanings of permissions documented in the Symfony cookbook, do not work
  - there is no permission inheritance used in the permission map
  - the permission map always returns NULL to the AclVoter because the role is checked instead of a permission by the "isGranted" method
- I updated the roles and permissions:
  - to give a better understanding and show the difference between roles and permissions
  - to be more logical to the end-user, do you agree? Could be that it is only for me this way, easy thing to turn back.
- using the "unanimous" access decission strategy does not work and therefore you cannot implement your own voter, this is because the "admin.isGranted" checks if you are super admin and checks the ROLE specified, if you are no super admin always 1 vote is denied, what does not work for the "unanimous" strategy
- be able to use object-scope permissions and inherit from the class-scope permissions
  - this allows to grant a user EDIT and CREATE permission, however if this user created an object, and is therefore the owner, the user is also allowed to delete it.

Furthermore I documented the knowledge I gained about ACL in the security.rst file. I read a lot of blog and community posts to learn the best practices, hope I got them right.

I have looked at the caching posibilities and as far as I see the caching is done by default. Perhaps a good idea to still document some best practices, but I guess that is more something for the Symfony docs or can be added later.

I am interested in your feedback.

I also looked at improving the user management, I will create a PR for the UserBundle soon.

Cheers,

Roel
