### PR TITLE
Fixed copy/paste error

### DIFF
--- a/Resources/views/CRUD/show_boolean.html.twig
+++ b/Resources/views/CRUD/show_boolean.html.twig
@@ -18,6 +18,5 @@ file that was distributed with this source code.
     {% else %}
         <img src="{{ asset('bundles/sonataadmin/famfamfam/exclamation.png') }}" alt="{%- trans from 'SonataAdminBundle' %}label_type_no{% endtrans -%}" />
     {% endif %}
-{% endif %}
 {% endspaceless %}
 {% endblock %}


### PR DESCRIPTION
There was an additional `{% endif %}` tag in the template which resulted in `Unknown tag name "endif" in SonataAdminBundle:CRUD:show_boolean.html.twig at line 21`
