### PR TITLE
use bootstrap.php.cache rather than autoload.php as the later expects bo...

### DIFF
--- a/Tests/tests/autoload.php.dist
+++ b/Tests/tests/autoload.php.dist
@@ -1,7 +1,7 @@
 <?php
 
 // try to reuse lib defined in a current symfony2 project
-$autoload = __DIR__.'/../../../../../../app/autoload.php';
+$autoload = __DIR__.'/../../../../../../app/bootstrap.php.cache';
 if (is_file($autoload)) {
     include $autoload;
 } else {


### PR DESCRIPTION
...otstrap to have been run for having Symfony\Component\ClassLoader\UniversalClassLoader loaded

stumbled over this while trying to run the tests. 
