### PR TITLE
Add dependenices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*",
-        "symfony/security-bundle": "2.*"
+        "symfony/security-bundle": "2.*",
+        "knplabs/knp-menu-bundle": "master-dev",
+        "sonata/jquery-bundle": "master-dev"
     },
     "suggest": {
         "sonata/doctrine-orm-admin-bundle": "*"


### PR DESCRIPTION
I updated the dependencies listed in `composer.json`. A few things of note:
- `knplabs/knp-menu` is not added because it is a dependency of `knplabs/knp-menu-bundle`.
- You need to add a `composer.json` file to your jQuery bundle, and then register it on packagist.org
