### PR TITLE
The docs should default to the easiest configuration to get started with...

### DIFF
--- a/Resources/doc/reference/architecture.rst
+++ b/Resources/doc/reference/architecture.rst
@@ -135,7 +135,7 @@ Examples:
 </service>
 
 If you want to define your own controller for handling CRUD operations, change the last argument
-in the servicedefinition to::
+ in the service definition to::
 
   <argument>SonataNewsBundle:PostAdmin</argument>
 


### PR DESCRIPTION
I spent some time looking into the Sonata News Bundle before I understood what I had to do. Here's a suggested change to the docs to make this easier. 
