### PR TITLE
Added a way to override a single template for an admin from services

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1006,6 +1006,16 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
+     * @param $name
+     * @param $template
+     * @return void
+     */
+    public function setTemplate($name, $template)
+    {
+        $this->templates[$name] = $template;
+    }
+
+    /**
      * @return array
      */
     public function getTemplates()


### PR DESCRIPTION
There is no simple way to override a single template for an admin. With this method you can call:

```
        - [setTemplates,[%sonata.admin.configuration.templates%] ]
        - [setTemplate,['list', "template_for_list"]]
```

and override only the template for the list.
