### PR TITLE
Adding 'help' as reserved key for FieldDescription

### DIFF
--- a/Admin/BaseFieldDescription.php
+++ b/Admin/BaseFieldDescription.php
@@ -190,6 +190,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
      * Define the options value, if the options array contains the reserved keywords
      *   - type
      *   - template
+     *   - help
      *
      * Then the value are copied across to the related property value
      *
@@ -208,6 +209,12 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         if (isset($options['template'])) {
             $this->setTemplate($options['template']);
             unset($options['template']);
+        }
+
+        // set help if provided
+        if (isset($options['help'])) {
+            $this->setHelp($options['help']);
+            unset($options['help']);
         }
 
         $this->options = $options;

--- a/Tests/Admin/BaseFieldDescriptionTest.php
+++ b/Tests/Admin/BaseFieldDescriptionTest.php
@@ -49,10 +49,11 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('trucmuche', $description->getLabel());
 
         $this->assertNull($description->getTemplate());
-        $description->setOptions(array('type' => 'integer', 'template' => 'foo.twig.html'));
+        $description->setOptions(array('type' => 'integer', 'template' => 'foo.twig.html', 'help' => 'fooHelp'));
 
         $this->assertEquals('integer', $description->getType());
         $this->assertEquals('foo.twig.html', $description->getTemplate());
+        $this->assertEquals('fooHelp', $description->getHelp());
 
         $this->assertCount(0, $description->getOptions());
 


### PR DESCRIPTION
I added help to 'setOptions' to make it work with Admin as this example:
```class FooAdmin extends Admin
{
    public function configureFormFields(FormMapper $formMapper)
    {
        $formMapper->add('foo', null, array(), array('help' => 'fooHelp'))
        ;
    }
}

``````
and the template that is already created:
```{% if sonata_admin.field_description.help %}
    <span class="help-block sonata-ba-field-help">{{ sonata_admin.field_description.help }}</span>
{% endif %}
``````
