### PR TITLE
Possibility to choose list identifier route

### DIFF
--- a/Datagrid/ListMapper.php
+++ b/Datagrid/ListMapper.php
@@ -43,6 +43,10 @@ class ListMapper
             $fieldDescriptionOptions['route']['name'] = 'edit';
         }
 
+        if (!isset($fieldDescriptionOptions['route']['parameters'])) {
+            $fieldDescriptionOptions['route']['parameters'] = array();
+        }
+
         return $this->add($name, $type, $fieldDescriptionOptions);
     }
 

--- a/Resources/views/CRUD/base_list_field.html.twig
+++ b/Resources/views/CRUD/base_list_field.html.twig
@@ -10,17 +10,10 @@ file that was distributed with this source code.
 #}
 
 <td class="sonata-ba-list-field sonata-ba-list-field-{{ field_description.type }}" objectId="{{ admin.id(object) }}">
-    {% if field_description.options.identifier is defined and admin.isGranted(['EDIT', 'SHOW']) %}
-
-        {% if field_description.options.route.name == 'edit' and admin.hasroute('edit') and admin.isGranted('EDIT') %}
-            <a href="{{ admin.generateObjectUrl('edit', object) }}">
-        {% elseif admin.hasroute('show') %}
-            <a href="{{ admin.generateObjectUrl('show', object) }}">
-        {% endif %}
-
-            {% block field %}{{ value }}{% endblock %}
+    {% if field_description.options.identifier is defined and admin.isGranted(field_description.options.route.name|upper) and admin.hasRoute(field_description.options.route.name) %}
+        <a href="{{ admin.generateObjectUrl(field_description.options.route.name, object, field_description.options.route.parameters) }}">
+            {%- block field %}{{ value }}{% endblock -%}
         </a>
-
     {% else %}
         {{ block('field') }}
     {% endif %}


### PR DESCRIPTION
This allows to choose which route to use to create identifiers links :

`$listMapper->addIdentifier('title', null, array('route' => 'show'))`

Edit is still the default route.
