### PR TITLE
Fixed Two Minor Bugs in ShowMapper

### DIFF
--- a/Admin/FieldDescriptionInterface.php
+++ b/Admin/FieldDescriptionInterface.php
@@ -239,4 +239,11 @@ interface FieldDescriptionInterface
      * @return int|string
      */
     function getMappingType();
+
+    /**
+     * return the label to use for the current field
+     *
+     * @return string
+     */
+    function getLabel();
 }

--- a/Show/ShowMapper.php
+++ b/Show/ShowMapper.php
@@ -75,7 +75,7 @@ class ShowMapper
             throw new \RuntimeException('invalid state');
         }
 
-        if (!$fieldDescription->getOption('label')) {
+        if (!$fieldDescription->getLabel()) {
             $fieldDescription->setOption('label', $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'show', 'label'));
         }
 


### PR DESCRIPTION
First, if $name is a FieldDescription, ShowMapper now gets the string representation ($name->getName()) and uses that as the array key, rather than the object (which was illegal).

Second, I replaced a call to getLabel(), which doesn't exist, with a call to getOption('label').
