### PR TITLE
Fix list currency template if value is null

### DIFF
--- a/Resources/views/CRUD/list_currency.html.twig
+++ b/Resources/views/CRUD/list_currency.html.twig
@@ -12,5 +12,7 @@ file that was distributed with this source code.
 {% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
 
 {% block field %}
-    {{ field_description.options.currency }} {{ value }}
+    {% if value is not null %}
+        {{ field_description.options.currency }} {{ value }}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
Avoid displaying 0.00 € if value is null
