### PR TITLE
acl: fix passing object to isGranted in templates

### DIFF
--- a/Resources/views/CRUD/base_edit.html.twig
+++ b/Resources/views/CRUD/base_edit.html.twig
@@ -25,7 +25,7 @@ file that was distributed with this source code.
             {% if admin.hasroute('show') and admin.id(object) and admin.isGranted('VIEW', object) and admin.show|length > 0 %}
                 <li class="btn sonata-action-element"><a href="{{ admin.generateObjectUrl('show', object) }}">{% trans from 'SonataAdminBundle' %}link_action_show{% endtrans %}</a></li>
             {% endif %}
-            {% if admin.hasroute('history') and admin.id(object) and admin.isGranted('EDIT') %}
+            {% if admin.hasroute('history') and admin.id(object) and admin.isGranted('EDIT', object) %}
                 <li class="btn sonata-action-element"><a href="{{ admin.generateObjectUrl('history', object) }}">{% trans from 'SonataAdminBundle' %}link_action_history{% endtrans %}</a></li>
             {% endif %}
             {% if admin.hasroute('create') and admin.isGranted('CREATE')%}

--- a/Resources/views/CRUD/base_history.html.twig
+++ b/Resources/views/CRUD/base_history.html.twig
@@ -14,10 +14,10 @@ file that was distributed with this source code.
 {% block actions %}
     <div class="sonata-actions">
         <ul>
-            {% if admin.hasroute('edit') and admin.id(object) and admin.isGranted('EDIT') and admin.show|length > 0 %}
+            {% if admin.hasroute('edit') and admin.id(object) and admin.isGranted('EDIT', object) and admin.show|length > 0 %}
                 <li class="btn sonata-action-element"><a href="{{ admin.generateObjectUrl('edit', object) }}">{% trans from 'SonataAdminBundle' %}link_action_edit{% endtrans %}</a></li>
             {% endif %}
-            {% if admin.hasroute('show') and admin.isGranted('SHOW')%}
+            {% if admin.hasroute('show') and admin.isGranted('VIEW', object)%}
                 <li class="btn sonata-action-element"><a href="{{ admin.generateObjectUrl('show', object) }}">{% trans from 'SonataAdminBundle' %}link_action_show{% endtrans %}</a></li>
             {% endif %}
             {% if admin.hasroute('list') and admin.isGranted('LIST')%}

--- a/Resources/views/CRUD/base_list_field.html.twig
+++ b/Resources/views/CRUD/base_list_field.html.twig
@@ -10,7 +10,7 @@ file that was distributed with this source code.
 #}
 
 <td class="sonata-ba-list-field sonata-ba-list-field-{{ field_description.type }}" objectId="{{ admin.id(object) }}">
-    {% if field_description.options.identifier is defined and admin.isGranted(field_description.options.route.name|upper) and admin.hasRoute(field_description.options.route.name) %}
+    {% if field_description.options.identifier is defined and admin.isGranted(field_description.options.route.name == 'show' ? 'VIEW' : field_description.options.route.name|upper, object) and admin.hasRoute(field_description.options.route.name) %}
         <a href="{{ admin.generateObjectUrl(field_description.options.route.name, object, field_description.options.route.parameters) }}">
             {%- block field %}{{ value }}{% endblock -%}
         </a>

--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -17,7 +17,7 @@ file that was distributed with this source code.
             {% if admin.hasRoute('edit') and admin.isGranted('EDIT', object)%}
                 <li class="btn sonata-action-element"><a href="{{ admin.generateObjectUrl('edit', object) }}">{% trans from 'SonataAdminBundle' %}link_action_edit{% endtrans %}</a></li>
             {% endif %}
-            {% if admin.hasroute('history') and admin.id(object) and admin.isGranted('EDIT') %}
+            {% if admin.hasroute('history') and admin.id(object) and admin.isGranted('EDIT', object) %}
                 <li class="btn sonata-action-element"><a href="{{ admin.generateObjectUrl('history', object) }}">{% trans from 'SonataAdminBundle' %}link_action_history{% endtrans %}</a></li>
             {% endif %}
             {% if admin.hasRoute('create') and admin.isGranted('CREATE')%}

--- a/Resources/views/CRUD/delete.html.twig
+++ b/Resources/views/CRUD/delete.html.twig
@@ -40,7 +40,7 @@ file that was distributed with this source code.
 
                 <input type="submit" class="btn danger" value="{% trans from 'SonataAdminBundle' %}btn_delete{% endtrans %}" />
 
-                {% if admin.hasRoute('edit') and admin.isGranted('EDIT') %}
+                {% if admin.hasRoute('edit') and admin.isGranted('EDIT', object) %}
                     {% trans from 'SonataAdminBundle' %}delete_or{% endtrans %}
 
                     <a class="btn success" href="{{ admin.generateObjectUrl('edit', object) }}">{% trans from 'SonataAdminBundle' %}link_action_edit{% endtrans %}</a>


### PR DESCRIPTION
Updated some templates that did not pass the object when checking an "object permission".

The `base_list_field.html.twig` template uses the route name as permission name, the route "show" needs to be transformed to the permission "view".
