### PR TITLE
Methods getBaseRole createObjectSecurity deleteObjectSecurity in AdminExtractor

### DIFF
--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -194,4 +194,26 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
 
         return $label;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getBaseRole(AdminInterface $admin)
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createObjectSecurity(AdminInterface $admin, $object)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deleteObjectSecurity(AdminInterface $admin, $object)
+    {
+    }
 }


### PR DESCRIPTION
were missing.
This resulted in error (i have JMS translation bundle installed_
 I've added them, like they are implemented in NoopSecurityHandler. 
AdminExtractor  works for me. Tested only via 
php app/console translation:extract pl --enable-extractor=jms_i18n_routing,sonata_admin --output-dir=./app/Resources/translations --output-format=yml

Tell me if further test are required. 
