### PR TITLE
Fixes in the translations of some languages

### DIFF
--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="title_edit">
                 <source>title_edit</source>
-                <target>Bearbeiten</target>
+                <target>Bearbeiten "%name%"</target>
             </trans-unit>
             <trans-unit id="title_list">
                 <source>title_list</source>

--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="title_edit">
                 <source>title_edit</source>
-                <target>Uređivanje</target>
+                <target>Uređivanje "%name%"</target>
             </trans-unit>
             <trans-unit id="title_list">
                 <source>title_list</source>

--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="title_edit">
                 <source>title_edit</source>
-                <target>Modifica</target>
+                <target>Modifica "%name%"</target>
             </trans-unit>
             <trans-unit id="title_list">
                 <source>title_list</source>

--- a/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/Resources/translations/SonataAdminBundle.ja.xliff
@@ -72,7 +72,7 @@
             </trans-unit>
             <trans-unit id="title_edit">
                 <source>title_edit</source>
-                <target>編集</target>
+                <target>編集 "%name%"</target>
             </trans-unit>
             <trans-unit id="title_list">
                 <source>title_list</source>

--- a/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/Resources/translations/SonataAdminBundle.lb.xliff
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="title_edit">
                 <source>title_edit</source>
-                <target>Beaarbechten</target>
+                <target>Beaarbechten "%name%"</target>
             </trans-unit>
             <trans-unit id="title_list">
                 <source>title_list</source>

--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -64,7 +64,7 @@
             </trans-unit>
             <trans-unit id="title_edit">
                 <source>title_edit</source>
-                <target>Wijzig</target>
+                <target>Wijzig "%name%"</target>
             </trans-unit>
             <trans-unit id="title_list">
                 <source>title_list</source>

--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="title_edit">
                 <source>title_edit</source>
-                <target>Edytuj</target>
+                <target>Edytuj "%name%"</target>
             </trans-unit>
             <trans-unit id="title_list">
                 <source>title_list</source>

--- a/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="title_edit">
                 <source>title_edit</source>
-                <target>Editar</target>
+                <target>Editar "%name%"</target>
             </trans-unit>
             <trans-unit id="title_list">
                 <source>title_list</source>

--- a/Resources/translations/SonataAdminBundle.pt_PT.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_PT.xliff
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="title_edit">
                 <source>title_edit</source>
-                <target>Editar</target>
+                <target>Editar "%name%"</target>
             </trans-unit>
             <trans-unit id="title_list">
                 <source>title_list</source>

--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -52,7 +52,7 @@
             </trans-unit>
             <trans-unit id="link_action_edit">
                 <source>link_action_edit</source>
-                <target>Редактировать</target>
+                <target>Редактировать "%name%"</target>
             </trans-unit>
             <trans-unit id="link_add">
                 <source>link_add</source>

--- a/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/Resources/translations/SonataAdminBundle.uk.xliff
@@ -64,7 +64,7 @@
             </trans-unit>
             <trans-unit id="title_edit">
                 <source>title_edit</source>
-                <target>Редагувати</target>
+                <target>Редагувати "%name%"</target>
             </trans-unit>
             <trans-unit id="title_list">
                 <source>title_list</source>


### PR DESCRIPTION
The page title doesn't show the name of the editable page for some languages
