### PR TITLE
NULL date and datetimes no longer render as current date/datetime in CRUD show templates

### DIFF
--- a/Resources/views/CRUD/show_date.html.twig
+++ b/Resources/views/CRUD/show_date.html.twig
@@ -11,4 +11,10 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
 
-{% block field %}{{ value|date('F j, Y') }}{% endblock %}
+{% block field%}
+    {%- if value is empty -%}
+        &nbsp;
+    {%- else -%}
+        {{ value|date('F j, Y') }}
+    {%- endif -%}
+{% endblock %}

--- a/Resources/views/CRUD/show_datetime.html.twig
+++ b/Resources/views/CRUD/show_datetime.html.twig
@@ -11,5 +11,11 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
 
-{% block field %}{{ value|date }}{% endblock %}
+{% block field %}
+    {%- if value is empty -%}
+        &nbsp;
+    {%- else -%}
+        {{ value|date }}
+    {%- endif -%}
+{% endblock %}
 


### PR DESCRIPTION
For NULL date and date times in the show templates, the current date or datetime is being rendered instead of an empty string.

This issue was filed here for the LIST view: https://github.com/sonata-project/SonataAdminBundle/issues/371

And then was fixed in this PR: https://github.com/sonata-project/SonataAdminBundle/pull/197

...but the same thing is happening for null dates in show templates.  This PR fixes the issue.
