### PR TITLE
acl: fix generate object acl command - get partial result findObjectAcls did not work

### DIFF
--- a/Security/Handler/AclSecurityHandler.php
+++ b/Security/Handler/AclSecurityHandler.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
+use Symfony\Component\Security\Acl\Exception\NotAllAclsFoundException;
 use Sonata\AdminBundle\Admin\AdminInterface;
 
 class AclSecurityHandler implements AclSecurityHandlerInterface


### PR DESCRIPTION
fixed `app/console sonata:admin:generate-object-acl`, it did not work or produced errors for:
- objects with existing object ACLs
- or when more then 20 (batch size) ACLs for the same class where created
