### PR TITLE
Added prefix s in the uniqid

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -482,7 +482,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
      */
     public function initialize()
     {
-        $this->uniqid = uniqid();
+        $this->uniqid = "s".uniqid();
 
         if (!$this->classnameLabel) {
             $this->classnameLabel = substr($this->getClass(), strrpos($this->getClass(), '\\') + 1);


### PR DESCRIPTION
Right now sonataAdminBundle sometimes generate html code like
&lt;div id="4f2c0s7878752_videoCategory"&gt;

Thats actually wrong behavior, because identificator name in css cant start from digit - it generate problems with
css in our application.

I have created small patch - so all names are prefixed with s (Sonata)
