### PR TITLE
More descriptive exception when adding duplicate or incorrect fields in ListMapper

### DIFF
--- a/Datagrid/ListMapper.php
+++ b/Datagrid/ListMapper.php
@@ -70,7 +70,7 @@ class ListMapper
                 $fieldDescriptionOptions
             );
         } else {
-            throw new \RuntimeException('invalid state');
+            throw new \RuntimeException('Unknown or duplicate field name in list mapper. Field name should be either of FieldDescriptionInterface interface or string. Names should be unique.');
         }
 
         if (!$fieldDescription->getLabel()) {


### PR DESCRIPTION
Was a bit stumbled with 'invalid state' exception just because of occasionally duplicated field names in configureListFields...
