### PR TITLE
Fix for some fields to show without the proper styling.

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -109,6 +109,10 @@ file that was distributed with this source code.
     {% endif %}
 {% endblock field_row %}
 
+{% block form_row %}
+    {{ block('field_row') }}
+{% endblock form_row %}
+
 {% block collection_widget_row %}
 {% spaceless %}
     <div class="sonata-collection-row">


### PR DESCRIPTION
This change https://github.com/symfony/symfony/commit/0a4519d1030e9b3937edd299c84c6cb0ec2bfdad added form_row to the default theme. Sonata is not overriding it.
