### PR TITLE
fix css for filter no double line

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -72,7 +72,7 @@ body.sonata-bc {
 }
 
 .sonata-bc fieldset.filter_legend table {
-    margin: 0;
+    margin: 10px 0;
 }
 
 .sonata-bc legend.filter_legend {

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -155,28 +155,14 @@ file that was distributed with this source code.
                 <legend class="filter_legend">{% trans from 'SonataAdminBundle' %}label_filters{% endtrans %}</legend>
 
                 <div class="filter_container">
-                    <table>
-                        <tr>
-                            <td>
-                                <table class="bordered-table">
-                                    {% for filter in admin.datagrid.filters %}
-                                        <tr id="filter_{{ filter.name }}_row">
-                                            <td class="filter-title">{{ admin.trans(filter.label) }}</td>
-                                            <td class="filter-type">{{ form_widget(form.getChild(filter.name).getChild('type')) }}</td>
-                                            <td class="filter-value">{{ form_widget(form.getChild(filter.name).getChild('value')) }}</td>
-                                        </tr>
-                                    {% endfor %}
-                                </table>
-                            </td>
-                            {#<td>#}
-                                {#<label for="add_filter_select">{% trans from 'SonataAdminBundle' %}add_filter{% endtrans %}</label>#}
-                                {#<select id="add_filter_select">#}
-                                    {#{% for filter in admin.datagrid.filters %}#}
-                                        {#<option value="{{ filter.name }}">{{ admin.trans(filter.name) }}</option>#}
-                                    {#{% endfor %}#}
-                                {#</select>#}
-                            {#</td>#}
-                        </tr>
+                    <table class="bordered-table">
+                        {% for filter in admin.datagrid.filters %}
+                            <tr id="filter_{{ filter.name }}_row">
+                                <td class="filter-title">{{ admin.trans(filter.label) }}</td>
+                                <td class="filter-type">{{ form_widget(form.getChild(filter.name).getChild('type')) }}</td>
+                                <td class="filter-value">{{ form_widget(form.getChild(filter.name).getChild('value')) }}</td>
+                            </tr>
+                        {% endfor %}
                     </table>
 
                     <input type="hidden" name="filter[_page]" id="filter__page" value="1" />


### PR DESCRIPTION
the filter has a double line when expanded so i think the table around was added for the extra space top and bottom i have use css for that.

So no double line and smaller html code
