### PR TITLE
highlighting of activate filters + filter drawer stays open upon activated filters

### DIFF
--- a/Datagrid/Datagrid.php
+++ b/Datagrid/Datagrid.php
@@ -178,6 +178,30 @@ class Datagrid implements DatagridInterface
     }
 
     /**
+     * @return boolean
+     */
+    public function hasActiveFilters()
+    {
+        foreach ($this->filters as $name => $filter) {
+            if ($this->hasActiveFilter($name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param $name
+     * @return bool
+     */
+    public function hasActiveFilter($name)
+    {
+        return isset($this->values[$name])
+            && ! empty($this->values[$name]['value']);
+    }
+
+    /**
      * @return \Sonata\AdminBundle\Admin\FieldDescriptionCollection
      */
     public function getColumns()

--- a/Datagrid/DatagridInterface.php
+++ b/Datagrid/DatagridInterface.php
@@ -96,4 +96,17 @@ interface DatagridInterface
      * @param $name
      */
     function removeFilter($name);
+
+    /**
+     * @abstract
+     * @return boolean
+     */
+    public function hasActiveFilters();
+
+    /**
+     * @abstract
+     * @param $name
+     * @return bool
+     */
+    public function hasActiveFilter($name);
 }

--- a/Resources/public/base.js
+++ b/Resources/public/base.js
@@ -111,7 +111,7 @@ var Admin = {
     },
 
     add_filters: function(subject) {
-        jQuery('div.filter_container', subject).hide();
+        jQuery('div.filter_container.inactive', subject).hide();
         jQuery('fieldset.filter_legend', subject).click(function(event) {
            jQuery('div.filter_container', jQuery(event.target).parent()).toggle();
         });

--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -85,6 +85,13 @@ body.sonata-bc {
     padding-left: 0;
 }
 
+
+.sonata-bc legend.filter_legend.active,
+.sonata-bc tr.filter.active * {
+    font-weight: bold;
+    color: #000;
+}
+
 .sonata-bc table.sonata-ba-list td {
     width: 75px;
 }

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -152,12 +152,12 @@ file that was distributed with this source code.
     {% if admin.datagrid.filters %}
         <form class="sonata-filter-form form-stacked {{ admin.isChild and 1 == admin.datagrid.filters|length ? 'hide' : '' }}" action="{{ admin.generateUrl('list') }}" method="GET">
             <fieldset class="filter_legend">
-                <legend class="filter_legend">{% trans from 'SonataAdminBundle' %}label_filters{% endtrans %}</legend>
+                <legend class="filter_legend {{ admin.datagrid.hasActiveFilters ? 'active' : 'inactive' }}">{% trans from 'SonataAdminBundle' %}label_filters{% endtrans %}</legend>
 
-                <div class="filter_container">
+                <div class="filter_container {{ admin.datagrid.hasActiveFilters ? 'active' : 'inactive' }}">
                     <table class="bordered-table">
                         {% for filter in admin.datagrid.filters %}
-                            <tr id="filter_{{ filter.name }}_row">
+                        <tr id="filter_{{ filter.name }}_row" class="filter {{ admin.datagrid.hasActiveFilter(filter.name) ? 'active' : 'inactive' }}">
                                 <td class="filter-title">{{ admin.trans(filter.label) }}</td>
                                 <td class="filter-type">{{ form_widget(form.getChild(filter.name).getChild('type')) }}</td>
                                 <td class="filter-value">{{ form_widget(form.getChild(filter.name).getChild('value')) }}</td>


### PR DESCRIPTION
Basically:

When a filter is set: the filter drawer stays open, the filter row is made bold as does the "Filters" title.

To make clearly visible to the user that some filter is set on a list view.

Following a discussion at https://github.com/sonata-project/SonataAdminBundle/pull/554#issuecomment-4108332 .
