### PR TITLE
Added page number/results counts in list footer

### DIFF
--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -301,6 +301,11 @@
                 <target>View Revision</target>
             </trans-unit>
 
+            <trans-unit id="list_results_count">
+                <source>list_results_count</source>
+                <target>{1}1 result|]1,Inf] %count% results</target>
+            </trans-unit>
+
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -259,6 +259,10 @@
                 <target>Afficher la révision</target>
             </trans-unit>
 
+            <trans-unit id="list_results_count">
+                <source>list_results_count</source>
+                <target>{1}1 résultat|]1,Inf] %count% résultats</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -72,6 +72,15 @@ file that was distributed with this source code.
                 {% endblock %}
 
                 {% block table_footer %}
+                    <tr>
+                        <th colspan="{{ admin.list.elements|length - 1 }}">
+                            {{ admin.datagrid.pager.page }} / {{ admin.datagrid.pager.lastpage }}
+                        </th>
+                        <th>
+                            {% transchoice admin.datagrid.pager.nbresults with {'%count%': admin.datagrid.pager.nbresults} from 'SonataAdminBundle' %}list_results_count{% endtranschoice %}
+                        </th>
+                    </tr>
+
                     {% if admin.datagrid.pager.haveToPaginate() %}
                         <tr>
                             <td colspan="{{ admin.list.elements|length }}" class="pager">


### PR DESCRIPTION
This commit adds in the list footer :
- the current page / the last page (ex: 2/5)
- the number of results (ex: 142 results)
