### PR TITLE
Fixed pluralization for PL language for list_results_count

### DIFF
--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -242,7 +242,7 @@
 
             <trans-unit id="list_results_count">
                 <source>list_results_count</source>
-                <target>list_results_count|list_results_count</target>
+                <target>%count% wynik|%count% wyniki|%count% wyników</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
PL locale needs 3 parts for plurals, not 2 as is now.
