### PR TITLE
Inject SecurityContext into Admin classes

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -18,6 +18,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -282,6 +283,13 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
      * @var \Symfony\Component\HttpFoundation\Request
      */
     protected $request;
+
+    /**
+     * The current security context object
+     *
+     * @var \Symfony\Component\Security\Core\SecurityContextInterface
+     */
+    protected $securityContext;
 
     /**
      * The translator component
@@ -1914,6 +1922,27 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     public function hasRequest()
     {
         return $this->request !== null;
+    }
+
+    /**
+     * @param \Symfony\Component\Security\Core\SecurityContextInterface $securityContext
+     * @return void
+     */
+    public function setSecurityContext(SecurityContextInterface $securityContext)
+    {
+        $this->securityContext = $securityContext;
+
+        foreach ($this->getChildren() as $children) {
+            $children->setSecurityContext($securityContext);
+        }
+    }
+
+    /**
+     * @return \Symfony\Component\Security\Core\SecurityContextInterface
+     */
+    public function getSecurityContext()
+    {
+        return $this->securityContext;
     }
 
     /**

--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -176,7 +176,8 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             'security_handler'          => 'sonata.admin.security.handler',
             'menu_factory'              => 'knp_menu.factory',
             'route_builder'             => 'sonata.admin.route.path_info',
-            'label_translator_strategy' => 'sonata.admin.label.strategy.native'
+            'label_translator_strategy' => 'sonata.admin.label.strategy.native',
+            'securityContext'           => 'security.context',
         );
 
         $definition->addMethodCall('setManagerType', array($manager_type));


### PR DESCRIPTION
I needed the SecurityContext to be available in the Admin class in order to be more flexible when overriding admin->isGranted(...). Hence this pull request. In your admin classes you will now be able to do things such as:

```
public function isGranted($name, $object = null)
{
    return $this->getSecurityContext()->isGranted('ROLE_ADMIN');
}
```
