### PR TITLE
Alternative approach for the dashboard and pulldown menu filter

### DIFF
--- a/Admin/Pool.php
+++ b/Admin/Pool.php
@@ -67,7 +67,7 @@ class Pool
                 foreach ($adminGroup['items'] as $key => $id) {
                     $admin = $this->getInstance($id);
 
-                    if ($admin->showIn(Admin::CONTEXT_DASHBOARD)) {
+                    if ($admin->showIn(Admin::CONTEXT_DASHBOARD) && ($admin->hasroute('create') && $admin->isGranted('CREATE') || $admin->hasroute('list') && $admin->isGranted('LIST'))) {
                         $groups[$name]['items'][$key] = $admin;
                     } else {
                         unset($groups[$name]['items'][$key]);

--- a/Resources/views/Core/dashboard.html.twig
+++ b/Resources/views/Core/dashboard.html.twig
@@ -26,27 +26,25 @@ file that was distributed with this source code.
 
                 <tbody>
                     {% for admin in group.items %}
-                        {% if admin.hasroute('create') and admin.isGranted('CREATE') or admin.hasroute('list') and admin.isGranted('LIST') %}
-                            <tr>
-                                <td class="sonata-ba-list-label">{{ admin.label|trans({}, admin.translationdomain) }}</td>
-                                <td>
-                                    {% if admin.hasroute('create') and admin.isGranted('CREATE') %}
-                                        <a href="{{ admin.generateUrl('create')}}">
-                                            <img src="{{ asset('bundles/sonataadmin/famfamfam/add.png') }}"  alt="{%- trans from 'SonataAdminBundle' %}link_add{% endtrans -%}" />
-                                            {%- trans from 'SonataAdminBundle' %}link_add{% endtrans -%}
-                                        </a>
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if admin.hasroute('list') and admin.isGranted('LIST') %}
-                                        <a href="{{ admin.generateUrl('list')}}">
-                                            <img src="{{ asset('bundles/sonataadmin/famfamfam/application_view_list.png') }}" alt="{%- trans from 'SonataAdminBundle' %}link_list{% endtrans -%}" />
-                                            {%- trans from 'SonataAdminBundle' %}link_list{% endtrans -%}
-                                        </a>
-                                    {% endif %}
-                                </td>
-                            </tr>
-                        {% endif %}
+                        <tr>
+                            <td class="sonata-ba-list-label">{{ admin.label|trans({}, admin.translationdomain) }}</td>
+                            <td>
+                                {% if admin.hasroute('create') and admin.isGranted('CREATE') %}
+                                    <a href="{{ admin.generateUrl('create')}}">
+                                        <img src="{{ asset('bundles/sonataadmin/famfamfam/add.png') }}"  alt="{%- trans from 'SonataAdminBundle' %}link_add{% endtrans -%}" />
+                                        {%- trans from 'SonataAdminBundle' %}link_add{% endtrans -%}
+                                    </a>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if admin.hasroute('list') and admin.isGranted('LIST') %}
+                                    <a href="{{ admin.generateUrl('list')}}">
+                                        <img src="{{ asset('bundles/sonataadmin/famfamfam/application_view_list.png') }}" alt="{%- trans from 'SonataAdminBundle' %}link_list{% endtrans -%}" />
+                                        {%- trans from 'SonataAdminBundle' %}link_list{% endtrans -%}
+                                    </a>
+                                {% endif %}
+                            </td>
+                        </tr>
                     {% endfor %}
                 </tbody>
             </table>

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -90,9 +90,7 @@ file that was distributed with this source code.
                                             <a href="#" class="dropdown-toggle">{{ group.label|trans({}, 'SonataAdminBundle') }}</a>
                                             <ul class="dropdown-menu">
                                                 {% for admin in group.items %}
-                                                    {% if admin.hasroute('create') and admin.isGranted('CREATE') or admin.hasroute('list') and admin.isGranted('LIST') %}
-                                                        <li><a href="{{ admin.generateUrl('list')}}">{{ admin.label|trans({}, admin.translationdomain) }}</a></li>
-                                                    {% endif %}
+                                                    <li><a href="{{ admin.generateUrl('list')}}">{{ admin.label|trans({}, admin.translationdomain) }}</a></li>
                                                 {% endfor %}
                                             </ul>
                                         </li>


### PR DESCRIPTION
Alternative approach for the filter implemented in #584 and #587. Admin items are only displayed on the dashboard and in the pulldown menu if the user has access to them. With this approach the check is done in the business logic and not in the view. Empty admin groups are hidden from both the dashboard and the menu.
