### PR TITLE
New command sonata:admin:generate-class to create admin class stubs

### DIFF
--- a/Command/GenerateAdminClassCommand.php
+++ b/Command/GenerateAdminClassCommand.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is based on GenerateDoctrineFormCommand part of the Symfony package.
+ *
+ * Phil Rennie phil@philrennie.co.uk
+ * Origianlly (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Bundle\DoctrineBundle\Mapping\MetadataFactory;
+use Sonata\AdminBundle\Generator\AdminClassGenerator;
+
+/**
+ * Generates a sonata admin class for a given Doctrine entity.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Hugo Hamon <hugo.hamon@sensio.com>
+ */
+class GenerateAdminClassCommand extends ContainerAwareCommand
+{
+    /**
+     * @see Command
+     */
+    public function configure()
+    {
+        $this
+            ->setName('sonata:admin:generate-class')
+            ->setDefinition(array(
+                new InputArgument('entity', InputArgument::REQUIRED, 'The entity class name to initialize (shortcut notation)'),
+            ))
+            ->setDescription('Generates a sonata admin class based on a Doctrine entity')
+            ->setHelp(<<<EOT
+The <info>sonata:admin:generate-class</info> command generates a sonata admin class based on a Doctrine entity.
+
+<info>php app/console sonata:admin:generate-class AcmeBlogBundle:Post</info>
+EOT
+            )
+        ;
+    }
+
+    /**
+     * @see Command
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        //$entity = Validators::validateEntityName($input->getArgument('entity'));
+        //list($bundle, $entity) = $this->parseShortcutNotation($entity);
+        
+        list($bundle, $entity) = Validators::validateEntityName($input->getArgument('entity'));
+
+        $entityClass = $this->getContainer()->get('doctrine')->getEntityNamespace($bundle).'\\'.$entity;
+        $metadata = $this->getEntityMetadata($entityClass);
+        $bundle   = $this->getApplication()->getKernel()->getBundle($bundle);
+
+        $generator = new AdminClassGenerator($this->getContainer()->get('filesystem'),  __DIR__.'/../Resources/skeleton/admin');
+        $generator->generate($bundle, $entity, $metadata[0]);
+
+        $output->writeln(sprintf(
+            'The new %s.php class file has been created under %s.',
+            $generator->getClassName(),
+            $generator->getClassPath()
+        ));
+    }
+    
+    protected function parseShortcutNotation($shortcut)
+    {
+        $entity = str_replace('/', '\\', $shortcut);
+    
+        if (false === $pos = strpos($entity, ':')) {
+            throw new \InvalidArgumentException(sprintf('The entity name must contain a : ("%s" given, expecting something like AcmeBlogBundle:Blog/Post)', $entity));
+        }
+    
+        return array(substr($entity, 0, $pos), substr($entity, $pos + 1));
+    }
+    
+    protected function getEntityMetadata($entity)
+    {
+        $factory = new MetadataFactory($this->getContainer()->get('doctrine'));
+    
+        return $factory->getClassMetadata($entity)->getMetadata();
+    }
+}

--- a/Generator/AdminClassGenerator.php
+++ b/Generator/AdminClassGenerator.php
@@ -87,8 +87,6 @@ class AdminClassGenerator extends Generator
      */
     private function getFieldsFromMetadata(ClassMetadataInfo $metadata)
     {
-        print_r($metadata);
-        die();
         $fields = (array) $metadata->fieldNames;
 
         // Remove the primary key field if it's not managed manually

--- a/Generator/AdminClassGenerator.php
+++ b/Generator/AdminClassGenerator.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is based on GenerateDoctrineFormCommand part of the Symfony package.
+ *
+ * Phil Rennie phil@philrennie.co.uk
+ * Origianlly (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Generator;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+
+/**
+ * Generates a form class based on a Doctrine entity.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Hugo Hamon <hugo.hamon@sensio.com>
+ */
+class AdminClassGenerator extends Generator
+{
+    private $filesystem;
+    private $skeletonDir;
+    private $className;
+    private $classPath;
+
+    public function __construct(Filesystem $filesystem, $skeletonDir)
+    {
+        $this->filesystem = $filesystem;
+        $this->skeletonDir = $skeletonDir;
+    }
+
+    public function getClassName()
+    {
+        return $this->className;
+    }
+
+    public function getClassPath()
+    {
+        return $this->classPath;
+    }
+
+    /**
+     * Generates the entity form class if it does not exist.
+     *
+     * @param BundleInterface $bundle The bundle in which to create the class
+     * @param string $entity The entity relative class name
+     * @param ClassMetadataInfo $metadata The entity metadata class
+     */
+    public function generate(BundleInterface $bundle, $entity, ClassMetadataInfo $metadata)
+    {
+        $parts       = explode('\\', $entity);
+        $entityClass = array_pop($parts);
+
+        $this->className = $entityClass.'Admin';
+        $dirPath         = $bundle->getPath().'/Admin';
+        $this->classPath = $dirPath.'/'.str_replace('\\', '/', $entity).'Admin.php';
+
+        if (file_exists($this->classPath)) {
+            throw new \RuntimeException(sprintf('Unable to generate the %s form class as it already exists under the %s file', $this->className, $this->classPath));
+        }
+
+        $parts = explode('\\', $entity);
+        array_pop($parts);
+
+        $this->renderFile($this->skeletonDir, 'AdminClass.php', $this->classPath, array(
+            'dir'              => $this->skeletonDir,
+            'fields'           => $this->getFieldsFromMetadata($metadata),
+            'namespace'        => $bundle->getNamespace(),
+            'entity_namespace' => implode('\\', $parts),
+            'form_class'       => $this->className,
+            'form_type_name'   => strtolower(str_replace('\\', '_', $bundle->getNamespace()).($parts ? '_' : '').implode('_', $parts).'_'.$this->className),
+        ));
+    }
+
+    /**
+     * Returns an array of fields. Fields can be both column fields and
+     * association fields.
+     *
+     * @param ClassMetadataInfo $metadata
+     * @return array $fields
+     */
+    private function getFieldsFromMetadata(ClassMetadataInfo $metadata)
+    {
+        print_r($metadata);
+        die();
+        $fields = (array) $metadata->fieldNames;
+
+        // Remove the primary key field if it's not managed manually
+        if (!$metadata->isIdentifierNatural()) {
+            $fields = array_diff($fields, $metadata->identifier);
+        }
+
+        foreach ($metadata->associationMappings as $fieldName => $relation) {
+            if ($relation['type'] !== ClassMetadataInfo::ONE_TO_MANY) {
+                $fields[] = $fieldName;
+            }
+        }
+
+        return $fields;
+    }
+}

--- a/Generator/Generator.php
+++ b/Generator/Generator.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Generator;
+
+/**
+ * Generator is the base class for all generators.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class Generator
+{
+    protected function renderFile($skeletonDir, $template, $target, $parameters)
+    {
+        if (!is_dir(dirname($target))) {
+            mkdir(dirname($target), 0777, true);
+        }
+
+        $twig = new \Twig_Environment(new \Twig_Loader_Filesystem($skeletonDir), array(
+            'debug'            => true,
+            'cache'            => false,
+            'strict_variables' => true,
+            'autoescape'       => false,
+        ));
+
+        file_put_contents($target, $twig->render($template, $parameters));
+    }
+}

--- a/Resources/skeleton/admin/AdminClass.php
+++ b/Resources/skeleton/admin/AdminClass.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace {{ namespace }}\Admin{{ entity_namespace ? '\\' ~ entity_namespace : '' }};
+
+use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder;
+
+class {{ form_class }} extends Admin
+{
+    //protected $translationDomain = '';
+
+/*    protected $formOptions = array(
+            'validation_groups' => 'Profile'
+    ); */
+    
+    public function configureShowFields(ShowMapper $showMapper)
+    {
+        $showMapper
+        {% for field in fields %}
+        ->add('{{ field }}')
+        {% endfor %}
+        ;
+    }
+    
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+        {% for field in fields %}
+        {% if loop.first == true %}
+        ->addIdentifier('{{ field }}')
+        {% else %}
+        ->add('{{ field }}')
+        {% endif %}
+        {% endfor %}
+        ;
+    }
+
+    protected function configureDatagridFilters(DatagridMapper $filterMapper)
+    {
+        $filterMapper
+        {% for field in fields %}
+        ->add('{{ field }}')
+        {% endfor %}
+        ;
+    }
+
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+        ->with('General')
+        {% for field in fields %}
+        ->add('{{ field }}')
+        {% endfor %}
+        ->end()
+        ;
+    }
+}


### PR DESCRIPTION
Added a new command sonata:admin:generate-class to create admin class stubs.

sonata:admin:generate-class AcmeDemoBundle:Post 

will create src/Acme/DemoBundle/Admin/PostAdmin.php with stubs for showFields,
listFields, datagridFilter and formFields listing mapped fields from
the entity.

Copied from the Sensio generator bundle command to generate formType
class stubs.
