### PR TITLE
Adjust to latest symfony 2.1-DEV

### DIFF
--- a/Form/ChoiceList/ModelChoiceList.php
+++ b/Form/ChoiceList/ModelChoiceList.php
@@ -14,10 +14,10 @@ namespace Sonata\AdminBundle\Form\ChoiceList;
 use Symfony\Component\Form\Util\PropertyPath;
 use Symfony\Component\Form\Exception\FormException;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
-use Symfony\Component\Form\Extension\Core\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 
-class ModelChoiceList extends ArrayChoiceList
+class ModelChoiceList extends SimpleChoiceList
 {
     /**
      * @var \Sonata\AdminBundle\Model\ModelManagerInterface
@@ -86,6 +86,8 @@ class ModelChoiceList extends ArrayChoiceList
         }
 
         $this->choices = $choices;
+        $this->load();
+        parent::__construct($this->choices);
     }
 
     /**
@@ -109,8 +111,6 @@ class ModelChoiceList extends ArrayChoiceList
      */
     protected function load()
     {
-        parent::load();
-
         if (is_array($this->choices)) {
             $entities = $this->choices;
         } else if ($this->query) {

--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -69,7 +69,7 @@ class ModelType extends AbstractType
 
     public function getParent(array $options)
     {
-        return $options['parent'];
+        return isset($options['parent']) ? $options['parent'] : 'choice';
     }
 
     public function getName()


### PR DESCRIPTION
BC break with symfony 2.0!

The ArrayChoiceList is no longer part of symfony, it has been replaced by the SimpleChoiceList. Also options no longer contain the defaults in the getParent method of a type. 

See also https://github.com/symfony/symfony/blob/master/UPGRADE-2.1.md to explain the changes.
