### PR TITLE
Update Admin/AdminHelper.php

### DIFF
--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -130,12 +130,12 @@ class AdminHelper
         $this->addNewInstance($form->getData(), $fieldDescription);
         $data[$childFormBuilder->getName()][] = $value;
 
-        $form = $admin->getFormBuilder()->getForm();
+        $finalForm = $admin->getFormBuilder()->getForm();
 
         // bind the data
-        $form->bind($data);
+        $finalForm->setData($form->getData());
 
-        return array($fieldDescription, $form);
+        return array($fieldDescription, $finalForm);
     }
 
     /**


### PR DESCRIPTION
When adding a row with sonata_type_collection, helper return a binded form that trigger error messages as value are empty (so errors are shown in template). Prefered trigger setData that just init value without doing validation
