### PR TITLE
add some ajax default datatype to prevent errors

### DIFF
--- a/Resources/public/base.js
+++ b/Resources/public/base.js
@@ -1,7 +1,7 @@
 //add some ajax default datatype
-$.ajaxSetup({
+jQuery.ajaxSetup({
     dataType: 'html'
-	});
+});
 
 jQuery(document).ready(function() {
     jQuery('html').removeClass('no-js');


### PR DESCRIPTION
add some ajax default datatype to prevent errors if datatype not given (i.e. listpicker)
