### PR TITLE
Admin::getSubject is not valid for MongoDB (the breadcrumb in childAdmin on MongoDB)

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1342,7 +1342,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     {
         if ($this->subject === null && $this->request) {
             $id = $this->request->get($this->getIdParameter());
-            if (!is_numeric($id)) {
+            if (!preg_match('#^[0-9A-Fa-f]+$#', $id)) {
                 $this->subject = false;
             } else {
                 $this->subject = $this->getModelManager()->find($this->getClass(), $id);


### PR DESCRIPTION
Hello,

A MongoId is not a numeric (in php viewpoint), it's a hexadecimal (96 bits) in a string

the test is_numeric() fails in method Admin::getSubject(), luckily, most of calls to subject are made by $this->subject in the class.

Anyway, it creates some bugs in the breadcrumb, child Admin, etc... on MongoDb

I've replaced is_numeric by a preg_match. Could use ctype_xdigit too (matter of taste)

Perhaps, a better approch could be used here : the validator of an Identifier should be specific for each ODM, ORM, PhpCR, I don't know ? Added in the ModelManagerInterface, maybe ?

By the way, your work on Sonata is excellent ! Thx
