### PR TITLE
Wrong colspan in ajax popup

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -73,7 +73,7 @@ file that was distributed with this source code.
 
                 {% block table_footer %}
                     <tr>
-                        <th colspan="{{ admin.list.elements|length - 1 }}">
+                        <th colspan="{{ admin.list.elements|length - (app.request.isXmlHttpRequest ? 2 : 1) }}">
                             {{ admin.datagrid.pager.page }} / {{ admin.datagrid.pager.lastpage }} -
                             {{ "label_export_download"|trans({}, "SonataAdminBundle") }}
                             {% for format in admin.getExportFormats() %}


### PR DESCRIPTION
in ajax popup the colspan is wrong (because there isn't the batch column) so the layout is messy.
Added the ability to check for the "context" of the request, and change the colspan based on the isXmlHttpRequest parameter.

You could safely merge this also on master
