### PR TITLE
Change button styling to apply the btn class to the a instead of the li

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -34,6 +34,10 @@ body.sonata-bc {
     margin-bottom: 0px;
 }
 
+li.sonata-action-element {
+    list-style: none;
+    display: inline-block;
+}
 
 .sonata-bc div.connection .form-stacked .actions {
     margin-left: -20px;

--- a/Resources/views/CRUD/base_edit.html.twig
+++ b/Resources/views/CRUD/base_edit.html.twig
@@ -23,16 +23,16 @@ file that was distributed with this source code.
     <div class="sonata-actions">
         <ul>
             {% if admin.hasroute('show') and admin.id(object) and admin.isGranted('VIEW', object) and admin.show|length > 0 %}
-                <li class="btn sonata-action-element"><a href="{{ admin.generateObjectUrl('show', object) }}">{% trans from 'SonataAdminBundle' %}link_action_show{% endtrans %}</a></li>
+                <li class="sonata-action-element"><a class="btn" href="{{ admin.generateObjectUrl('show', object) }}">{% trans from 'SonataAdminBundle' %}link_action_show{% endtrans %}</a></li>
             {% endif %}
             {% if admin.hasroute('history') and admin.id(object) and admin.isGranted('EDIT', object) %}
-                <li class="btn sonata-action-element"><a href="{{ admin.generateObjectUrl('history', object) }}">{% trans from 'SonataAdminBundle' %}link_action_history{% endtrans %}</a></li>
+                <li class="sonata-action-element"><a class="btn" href="{{ admin.generateObjectUrl('history', object) }}">{% trans from 'SonataAdminBundle' %}link_action_history{% endtrans %}</a></li>
             {% endif %}
             {% if admin.hasroute('create') and admin.isGranted('CREATE')%}
-                <li class="btn sonata-action-element"><a href="{{ admin.generateUrl('create') }}">{% trans from 'SonataAdminBundle' %}link_action_create{% endtrans %}</a></li>
+                <li class="sonata-action-element"><a class="btn" href="{{ admin.generateUrl('create') }}">{% trans from 'SonataAdminBundle' %}link_action_create{% endtrans %}</a></li>
             {% endif %}
             {% if admin.hasroute('list') and admin.isGranted('LIST')%}
-                <li class="btn sonata-action-element"><a href="{{ admin.generateUrl('list') }}">{% trans from 'SonataAdminBundle' %}link_action_list{% endtrans %}</a></li>
+                <li class="sonata-action-element"><a class="btn" href="{{ admin.generateUrl('list') }}">{% trans from 'SonataAdminBundle' %}link_action_list{% endtrans %}</a></li>
             {% endif %}
         </ul>
     </div>


### PR DESCRIPTION
This allows the whole button to be clickable, as well as makes it easier for people that want to use one of the other bootstrap button styles, as the link's blue text color doesn't interfere

This does change the link color from blue to gray (as is default in bootstrap).
