### PR TITLE
Change to Configuration Documentation

### DIFF
--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -3,9 +3,10 @@ Configuration
 
 Configuration options
 
-* ``security_handler``
-    * ``sonata.admin.security.handler.noop`` : The default value
-    * ``sonata.admin.security.handler.acl`` : Use this service if you want ACL
+* ``security``
+    * ``handler``
+        * ``sonata.admin.security.handler.role`` : The default value
+        * ``sonata.admin.security.handler.acl`` : Use this service if you want ACL
 
 * ``title`` : The admin's title, can be the client name for instance (default: Sonata Admin)
 * ``title_logo`` : logo to use, must be an image with a height of 28px (default : /bundles/sonataadmin/logo_title.png)
@@ -19,7 +20,8 @@ Full Configuration Options
 .. code-block:: yaml
 
     sonata_admin:
-        security_handler: sonata.admin.security.handler.noop
+        security:
+            handler: sonata.admin.security.handler.role
 
         title:      Sonata Project
         title_logo: /bundles/sonataadmin/logo_title.png


### PR DESCRIPTION
Hello, I've changed security section in Configuration page of Documentation to be alligned to AdminBundle security implementation update (http://sonata-project.org/blog/2012/01/23/admin-bundle-security-implementation-update)

Bye.
