### PR TITLE
[BUGFIX] Export to different file formats can't be turned off or limited

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -542,6 +542,12 @@ class CRUDController extends Controller
     {
         $format = $request->get('format');
 
+        $allowedExportFormats = (array) $this->admin->getExportFormats();
+
+        if(!in_array($format, $allowedExportFormats) ) {
+            throw new \RuntimeException(sprintf('Export in format `%s` is not allowed for class: `%s`. Allowed formats are: `%s`', $format, $this->admin->getClass(), implode(', ', $allowedExportFormats)));
+        }
+
         $filename = sprintf('export_%s_%s.%s',
             strtolower(substr($this->admin->getClass(), strripos($this->admin->getClass(), '\\') + 1)),
             date('Y_m_d_H_i_s', strtotime('now')),

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -74,11 +74,15 @@ file that was distributed with this source code.
                 {% block table_footer %}
                     <tr>
                         <th colspan="{{ admin.list.elements|length - (app.request.isXmlHttpRequest ? 2 : 1) }}">
-                            {{ admin.datagrid.pager.page }} / {{ admin.datagrid.pager.lastpage }} -
-                            {{ "label_export_download"|trans({}, "SonataAdminBundle") }}
-                            {% for format in admin.getExportFormats() %}
-                                <a href="{{ admin.generateUrl('export', admin.modelmanager.paginationparameters(admin.datagrid, 0) + {'format' : format}) }}">{{ format }}</a>{% if not loop.last%},{% endif %}
-                            {% endfor %}
+                            {{ admin.datagrid.pager.page }} / {{ admin.datagrid.pager.lastpage }}
+
+                            {% if admin.getExportFormats()|length > 0 %}
+                                -
+                                {{ "label_export_download"|trans({}, "SonataAdminBundle") }}
+                                {% for format in admin.getExportFormats() %}
+                                    <a href="{{ admin.generateUrl('export', admin.modelmanager.paginationparameters(admin.datagrid, 0) + {'format' : format}) }}">{{ format }}</a>{% if not loop.last%},{% endif %}
+                                {% endfor %}
+                            {% endif %}
                         </th>
 
                         <th>


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Fixes the following tickets: -
Todo: -

This PR fixes these problems:
- Export data to different file formats can be limited/changed with method `getExportFormats()` but even if it is used, the export is still possible, when user change the url parameter `...&format=FILE_FORMAT` to some other value. This is also security issue.
- Export data can't be turned off setting empty array or false in method `getExportFormats()`. The export is still available with the URL parameter `...&format=`. This is also security issue.
- Label `Export` is still displayed, even if no file export is enabled.
