### PR TITLE
Help message alternative syntax

### DIFF
--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -124,7 +124,17 @@ class FormMapper
                 $options['label'] = $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'form', 'label');
             }
 
+            $help = null;
+            if (isset($options['help'])) {
+                $help = $options['help'];
+                unset($options['help']);
+            }
+
             $this->formBuilder->add($name, $type, $options);
+
+            if (null !== $help) {
+                $this->admin->getFormFieldDescription($name)->setHelp($help);
+            }
         }
 
         return $this;


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Fixes the following tickets: -
Todo: -

Current way of defining help messages is this:

``` php
protected function configureFormFields(FormMapper $formMapper)
{
    $formMapper
        ->with('General')
            ->add('title')
            ->add('keywords')
            ->setHelps(array(
                'title' => 'Some help message1',
                'keywords' => 'Some help message2',
            ))
        ->end();
}

```

With this PR, the help messages can be set to form element as parameter `help`, too. I think, it is more intuitive way, than the current one with `setHelps()` method.

``` php
protected function configureFormFields(FormMapper $formMapper)
{
    $formMapper
        ->with('General')
            ->add('title', null, array('help'=>'Some help message1'))
            ->add('keywords', null, array('help'=>'Some help message2'))
        ->end();
}
```

I will update the documentation of SonataAdminBundle after this PR will be merged.
