### PR TITLE
fix ajax list table footer colspan

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -73,7 +73,7 @@ file that was distributed with this source code.
 
                 {% block table_footer %}
                     <tr>
-                    	<th colspan="{% if 'SonataAdminBundle::ajax_layout.html.twig eq base_template' %}{{ admin.list.elements|length - 2 }}{% else %}{{ admin.list.elements|length - 1 }}{% endif %}">
+                    	<th colspan="{% if 'SonataAdminBundle::ajax_layout.html.twig' == base_template %}{{ admin.list.elements|length - 2 }}{% else %}{{ admin.list.elements|length - 1 }}{% endif %}">
                             {{ admin.datagrid.pager.page }} / {{ admin.datagrid.pager.lastpage }}
                             {% if admin.isGranted("EXPORT") %}
                                 -


### PR DESCRIPTION
the table footer colspan is not correct when use  SonataAdminBundle::ajax_layout.html.twig as base template.
