### PR TITLE
"Loading information" added to translation messages

### DIFF
--- a/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/Resources/translations/SonataAdminBundle.ca.xliff
@@ -307,6 +307,10 @@
                 <source>label_export_download</source>
                 <target>Exportar: </target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>S'està carregant informació…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/Resources/translations/SonataAdminBundle.cs.xliff
@@ -309,6 +309,10 @@
                 <source>label_export_download</source>
                 <target>Stáhnout: </target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Načítání informací…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -305,6 +305,10 @@
                 <source>label_export_download</source>
                 <target>Download: </target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Informationen werden geladen…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -309,6 +309,10 @@
                 <source>label_export_download</source>
                 <target>Download : </target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Loading information…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.es.xliff
+++ b/Resources/translations/SonataAdminBundle.es.xliff
@@ -309,6 +309,10 @@
                 <source>label_export_download</source>
                 <target>Exportar: </target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Andmete laadimine…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -267,7 +267,10 @@
                 <source>label_export_download</source>
                 <target>Export : </target>
             </trans-unit>
-
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Chargement des informations…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -248,6 +248,10 @@
                 <source>label_export_download</source>
                 <target>label_export_download</target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Učitavanje podataka…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -303,6 +303,10 @@
                 <source>label_export_download</source>
                 <target>Esporta in formato</target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Caricamento informazioni…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/Resources/translations/SonataAdminBundle.ja.xliff
@@ -131,6 +131,10 @@
                 <source>label_export_download</source>
                 <target>label_export_download</target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>情報を読み込んでいます…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/Resources/translations/SonataAdminBundle.lb.xliff
@@ -247,6 +247,10 @@
                 <source>label_export_download</source>
                 <target>Download : </target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>loading_information …</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -123,6 +123,10 @@
                 <source>label_export_download</source>
                 <target>label_export_download</target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Laden van informatie…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -309,6 +309,10 @@
                 <source>label_export_download</source>
                 <target>Eksportuj : </target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Ładowanie informacji…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -239,6 +239,10 @@
                 <source>label_export_download</source>
                 <target>label_export_download</target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Carregando informações…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pt_PT.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_PT.xliff
@@ -239,6 +239,10 @@
                 <source>label_export_download</source>
                 <target>label_export_download</target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Carregando informações…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -309,6 +309,10 @@
                 <source>label_export_download</source>
                 <target>Экспорт: </target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Загрузка информации…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/Resources/translations/SonataAdminBundle.sk.xliff
@@ -309,6 +309,10 @@
                 <source>label_export_download</source>
                 <target>Exportovať: </target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Načítavajú sa informácie…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/Resources/translations/SonataAdminBundle.sl.xliff
@@ -309,6 +309,10 @@
                 <source>label_export_download</source>
                 <target>Prenesi izvoz</target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Nalaganje informacij…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/Resources/translations/SonataAdminBundle.uk.xliff
@@ -309,6 +309,10 @@
                 <source>label_export_download</source>
                 <target>Експорт:</target>
             </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Завантаження інформації…</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Fixes the following tickets: -
Todo: -

See also: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/55
