### PR TITLE
Equal Form Type added

### DIFF
--- a/Form/Type/EqualType.php
+++ b/Form/Type/EqualType.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Sonata\AdminBundle\Form\Type;
+
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class EqualType extends FormChoiceType
+{
+    const TYPE_IS_EQUAL = 1;
+
+    const TYPE_IS_NOT_EQUAL = 2;
+
+    protected $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function getDefaultOptions(array $options)
+    {
+        $options = parent::getDefaultOptions($options);
+
+        $options['choices'] = array(
+            self::TYPE_IS_EQUAL     => $this->translator->trans('label_type_equals', array(), 'SonataAdminBundle'),
+            self::TYPE_IS_NOT_EQUAL => $this->translator->trans('label_type_not_equals', array(), 'SonataAdminBundle'),
+        );
+
+        return $options;
+    }
+}

--- a/Resources/config/form_types.xml
+++ b/Resources/config/form_types.xml
@@ -49,6 +49,11 @@
             <argument type="service" id="translator" />
         </service>
 
+        <service id="sonata.admin.form.type.equal" class="Sonata\AdminBundle\Form\Type\EqualType">
+            <tag name="form.type" alias="sonata_type_equal" />
+            <argument type="service" id="translator" />
+        </service>
+
         <!-- Form Extension -->
         <service id="sonata.admin.form.extension.field" class="Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension">
             <tag name="form.type_extension" alias="field" />

--- a/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/Resources/translations/SonataAdminBundle.ca.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>és igual a</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>label_type_not_equals</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/Resources/translations/SonataAdminBundle.cs.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>rovná se</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>nerovná se</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>ist gleich</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>ist nicht gleich</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>is equal to</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>is not equal to</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.es.xliff
+++ b/Resources/translations/SonataAdminBundle.es.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>es igual a</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>no es igual a</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>est égal à</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>n'est pas égal à</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>jednako</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>nije jednako</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -210,6 +210,10 @@
                 <source>label_type_equals</source>
                 <target>è uguale a</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>non è uguale a</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
                 <source>label_type_equal</source>
                 <target>=</target>

--- a/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/Resources/translations/SonataAdminBundle.ja.xliff
@@ -34,6 +34,10 @@
                 <source>btn_update_and_return_to_list</source>
                 <target>更新して一覧に戻る</target>
             </trans-unit>
+            <trans-unit id="link_delete">
+                <source>link_delete</source>
+                <target>削除</target>
+            </trans-unit>
             <trans-unit id="link_action_create">
                 <source>link_action_create</source>
                 <target>新規作成</target>
@@ -118,9 +122,187 @@
                 <source>action_show</source>
                 <target>表示</target>
             </trans-unit>
+            <trans-unit id="all_elements">
+                <source>all_elements</source>
+                <target>すべての要素</target>
+            </trans-unit>
+            <trans-unit id='flash_batch_empty'>
+              <source>flash_batch_empty</source>
+              <target>アクションは中止されました。どの項目ここで選択されていません。</target>
+            </trans-unit>
+            <trans-unit id='flash_create_success'>
+              <source>flash_create_success</source>
+              <target>アイテムが正常に作成されました。</target>
+            </trans-unit>
+            <trans-unit id='flash_create_error'>
+              <source>flash_create_error</source>
+              <target>エラーは、アイテムの作成中に発生しました。</target>
+            </trans-unit>
+            <trans-unit id='flash_edit_success'>
+              <source>flash_edit_success</source>
+              <target>アイテムが正常に更新されました。</target>
+            </trans-unit>
+            <trans-unit id='flash_edit_error'>
+              <source>flash_edit_error</source>
+              <target>エラーは、アイテムの更新中に発生しました。</target>
+            </trans-unit>
+            <trans-unit id='flash_batch_delete_success'>
+              <source>flash_batch_delete_success</source>
+              <target>選択した項目が正常に削除されました。</target>
+            </trans-unit>
+            <trans-unit id='flash_batch_delete_error'>
+              <source>flash_batch_delete_error</source>
+              <target>エラーは、選択したアイテムの削除中に発生しました。</target>
+            </trans-unit>
+            <trans-unit id='flash_delete_error'>
+              <source>flash_delete_error</source>
+              <target>flash_delete_error</target>
+            </trans-unit>
+            <trans-unit id='flash_delete_success'>
+              <source>flash_delete_success</source>
+              <target>flash_delete_success</target>
+            </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
                 <source>breadcrumb.link_dashboard</source>
                 <target>&#8962;</target>
+            </trans-unit>
+            <trans-unit id="title_delete">
+                <source>title_delete</source>
+                <target>title_delete</target>
+            </trans-unit>
+            <trans-unit id="message_delete_confirmation">
+                <source>message_delete_confirmation</source>
+                <target>message_delete_confirmation</target>
+            </trans-unit>
+            <trans-unit id="btn_delete">
+                <source>btn_delete</source>
+                <target>はい、削除する</target>
+            </trans-unit>
+            <trans-unit id="title_batch_confirmation">
+                <source>title_batch_confirmation</source>
+                <target>title_batch_confirmation</target>
+            </trans-unit>
+            <trans-unit id="message_batch_confirmation">
+                <source>message_batch_confirmation</source>
+                <target>message_batch_confirmation</target>
+            </trans-unit>
+            <trans-unit id="btn_execute_batch_action">
+                <source>btn_execute_batch_action</source>
+                <target>はい、次のコマンドを実行</target>
+            </trans-unit>
+            <trans-unit id="label_type_yes">
+              <source>label_type_yes</source>
+              <target>はい</target>
+            </trans-unit>
+            <trans-unit id="label_type_no">
+              <source>label_type_no</source>
+              <target>いいえ</target>
+            </trans-unit>
+            <trans-unit id="label_type_contains">
+              <source>label_type_contains</source>
+              <target>label_type_contains</target>
+            </trans-unit>
+            <trans-unit id="label_type_not_contains">
+              <source>label_type_not_contains</source>
+              <target>が含まれていません</target>
+            </trans-unit>
+            <trans-unit id="label_type_equals">
+              <source>label_type_equals</source>
+              <target>label_type_equals</target>
+            </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>label_type_not_equals</target>
+            </trans-unit>
+            <trans-unit id="label_type_equal">
+              <source>label_type_equal</source>
+              <target>=</target>
+            </trans-unit>
+            <trans-unit id="label_type_greater_equal">
+              <source>label_type_greater_equal</source>
+              <target>&gt;=</target>
+            </trans-unit>
+            <trans-unit id="label_type_greater_than">
+              <source>label_type_greater_than</source>
+              <target>&gt;</target>
+            </trans-unit>
+            <trans-unit id="label_type_less_equal">
+              <source>label_type_less_equal</source>
+              <target>&lt;=</target>
+            </trans-unit>
+            <trans-unit id="label_type_less_than">
+              <source>label_type_less_than</source>
+              <target>&lt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_equal">
+              <source>label_date_type_equal</source>
+              <target>=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_greater_equal">
+              <source>label_date_type_greater_equal</source>
+              <target>&gt;=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_greater_than">
+              <source>label_date_type_greater_than</source>
+              <target>&gt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_less_equal">
+              <source>label_date_type_less_equal</source>
+              <target>&lt;=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_less_than">
+              <source>label_date_type_less_than</source>
+              <target>&lt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_null">
+              <source>label_date_type_null</source>
+              <target>label_date_type_null</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_not_null">
+              <source>label_date_type_not_null</source>
+              <target>label_date_type_not_null</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_between">
+              <source>label_date_type_between</source>
+              <target>label_date_type_between</target>
+            </trans-unit>
+            <trans-unit id="label_date_not_between">
+              <source>label_date_type_not_between</source>
+              <target>label_date_type_not_between</target>
+            </trans-unit>
+            <trans-unit id="label_filters">
+              <source>label_filters</source>
+              <target>label_filters</target>
+            </trans-unit>
+
+            <trans-unit id="delete_or">
+              <source>delete_or</source>
+              <target>delete_or</target>
+            </trans-unit>
+
+            <trans-unit id="link_action_history">
+                <source>link_action_history</source>
+                <target>link_action_history</target>
+            </trans-unit>
+            <trans-unit id="td_action">
+                <source>td_action</source>
+                <target>アクション</target>
+            </trans-unit>
+            <trans-unit id="td_revision">
+                <source>td_revision</source>
+                <target>リビジョン</target>
+            </trans-unit>
+            <trans-unit id="td_timestamp">
+                <source>td_timestamp</source>
+                <target>日付</target>
+            </trans-unit>
+            <trans-unit id="td_username">
+                <source>td_username</source>
+                <target>作成者</target>
+            </trans-unit>
+            <trans-unit id="label_view_revision">
+                <source>label_view_revision</source>
+                <target>label_view_revision</target>
             </trans-unit>
 
             <trans-unit id="list_results_count">

--- a/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/Resources/translations/SonataAdminBundle.lb.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>ass gläich</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>label_type_not_equals</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -210,6 +210,10 @@
                 <source>label_type_equals</source>
                 <target>is gelijk aan</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>is niet gelijk aan</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
                 <source>label_type_equal</source>
                 <target>=</target>

--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>jest równe</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>nie jest równe</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>é igual a</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>não é igual a</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.pt_PT.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_PT.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>é igual a</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>não é igual a</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>равен</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>не равен</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/Resources/translations/SonataAdminBundle.sk.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>sa rovná</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>sa nerovná</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/Resources/translations/SonataAdminBundle.sl.xliff
@@ -210,6 +210,10 @@
               <source>label_type_equals</source>
               <target>je točno enako</target>
             </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>ni enako</target>
+            </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>
               <target>=</target>

--- a/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/Resources/translations/SonataAdminBundle.uk.xliff
@@ -208,7 +208,11 @@
             </trans-unit>
             <trans-unit id="label_type_equals">
               <source>label_type_equals</source>
-              <target>label_type_equals</target>
+              <target>дорівнює</target>
+            </trans-unit>
+            <trans-unit id="label_type_not_equals">
+              <source>label_type_not_equals</source>
+              <target>не дорівнює</target>
             </trans-unit>
             <trans-unit id="label_type_equal">
               <source>label_type_equal</source>


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Fixes the following tickets: -
Todo: -

This Equal Type will replace the default operator_type "sonata_type_boolean" in ModelFilter (this will be another PR on DoctrineORMAdminBundle). After this change ModelFilter will make more sense.
