### PR TITLE
Fixing problem in master-detail form -OneToMany- in PostgreSQL when you ...

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -67,12 +67,12 @@ class HelperController
             $admin->setUniqid($uniqid);
         }
 
-        $subject = $admin->getModelManager()->find($admin->getClass(), $objectId);
-        if ($objectId && !$subject) {
-            throw new NotFoundHttpException;
-        }
-
-        if (!$subject) {
+        if ($objectId) {
+            $subject = $admin->getModelManager()->find($admin->getClass(), $objectId);
+            if (!$subject) {
+                throw new NotFoundHttpException(sprintf('Unable to find the object id: %s, class: %s', $objectId, $admin->getClass()));
+            }   
+        } else {
             $subject = $admin->getNewInstance();
         }
 


### PR DESCRIPTION
_Problem adding detail when master detail has not been created first._

In postgreSQL when I'm adding a new master data and I tried to add details records (without first save the master) it gives me an error like this:

http://www.flickr.com/photos/55302734@N07/6918997782/in/photostream

That is reported also here.

https://github.com/sonata-project/SonataAdminBundle/issues/259
