### PR TITLE
Fixed choice_list for ModelType

### DIFF
--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -53,12 +53,11 @@ class ModelType extends AbstractType
             'parent'            => 'choice',
             'preferred_choices' => array(),
             'choice_list'       => function (Options $options, $previousValue) {
-            
-                if ($previousValue instanceof ChoiceListInterface 
+                if ($previousValue instanceof ChoiceListInterface
                         && count($choices = $previousValue->getChoices())) {
                     return $choices;
                 }
-            
+
                 return new ModelChoiceList(
                     $options['model_manager'],
                     $options['class'],


### PR DESCRIPTION
This PR fixes a fatal error in the `getDefaultOptions()` method of the `ModelType`. The choice_list closure returned only a `ModelChoiceList` when the `$previousValue` was null, but this is an instance of a `ChoiceListInterface` now - with an empty `choices` array.
