### PR TITLE
Fix double delete confirmation 2.0

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -137,9 +137,6 @@ file that was distributed with this source code.
                        $('#list_batch_checkbox').click(function(){
                            $(this).closest('table').find("td input[type='checkbox']").attr('checked', $(this).is(':checked')).parent().parent().toggleClass('sonata-ba-list-row-selected', $(this).is(':checked'));
                        });
-                       $('.delete_link').click(function(e){
-                          if (!confirm('{% trans from 'SonataAdminBundle' %}confirm_msg{% endtrans %}')) e.preventDefault();
-                       });
                        $("td.sonata-ba-list-field-batch input[type='checkbox']").change(function(){
                            $(this).parent().parent().toggleClass('sonata-ba-list-row-selected', $(this).is(':checked'));
                        });


### PR DESCRIPTION
As discussed in #504 you get asked twice a delete confirmation when using the default `delete` `_action`. This commit remove the useless javascript confirmation.

Should i also create a separate PR to fix this against the master branch or do you cherry-pick 2.0 patch to master by yourself ?
