### PR TITLE
Field default translation catalogue

### DIFF
--- a/Resources/views/CRUD/list_trans.html.twig
+++ b/Resources/views/CRUD/list_trans.html.twig
@@ -11,5 +11,9 @@ file that was distributed with this source code.
 {% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
 
 {% block field%}
-    {{value|trans({}, field_description.options.catalogue)}}
+    {% if field_description.options.catalogue is not defined %}
+        {{value|trans}}
+    {% else %}
+        {{value|trans({}, field_description.options.catalogue)}}
+    {% endif %}
 {% endblock %}

--- a/Resources/views/CRUD/show_trans.html.twig
+++ b/Resources/views/CRUD/show_trans.html.twig
@@ -11,5 +11,9 @@ file that was distributed with this source code.
 {% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
 
 {% block field%}
-    {{value|trans({}, field_description.options.catalogue)}}
+    {% if field_description.options.catalogue is not defined %}
+        {{value|trans}}
+    {% else %}
+        {{value|trans({}, field_description.options.catalogue)}}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
The `show_trans.html.twig` and `list_trans.html.twig` template do require an explicit catalogue translation domain. This PR allows the user to use default translation domain (avoiding hardcoding it in the admin class) if `catalogue` is not defined.
