### PR TITLE
Wrong values for expanded boolean type radios.

### DIFF
--- a/Form/Type/BooleanType.php
+++ b/Form/Type/BooleanType.php
@@ -29,11 +29,12 @@ class BooleanType extends FormChoiceType
 
     public function getDefaultOptions(array $options)
     {
+        $expanded = $options['expanded'] == true;
         $options = parent::getDefaultOptions($options);
 
         $options['choices'] = array(
-            self::TYPE_YES  => $this->translator->trans('label_type_yes', array(), 'SonataAdminBundle'),
-            self::TYPE_NO   => $this->translator->trans('label_type_no', array(), 'SonataAdminBundle'),
+            ($expanded ? true : self::TYPE_YES)  => $this->translator->trans('label_type_yes', array(), 'SonataAdminBundle'),
+            ($expanded ? false : self::TYPE_NO)   => $this->translator->trans('label_type_no', array(), 'SonataAdminBundle'),
         );
 
         return $options;


### PR DESCRIPTION
True (1) or False (0) values for expanded boolean type radios.
