### PR TITLE
2.0

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -209,6 +209,8 @@ class CRUDController extends Controller
                 $this->get('session')->setFlash('sonata_flash_success', 'flash_delete_success');
             } catch ( ModelManagerException $e ) {
                 $this->get('session')->setFlash('sonata_flash_error', 'flash_delete_error');
+            } catch ( \Exception $e ) {
+                $this->get('session')->setFlash('sonata_flash_error', $e->getMessage());
             }
 
             return new RedirectResponse($this->admin->generateUrl('list'));


### PR DESCRIPTION
Hi,

I wanted to display an error message from the preRemove method of my Admin subclass and display this message as a flash error message and I figured out this could not be done hence my little tweaking around the code.

This is the reason behind my pull request :

```
public function preRemove($object)
{
    if ($object->isMainNode())
    {
        $error               = 'A main node cannot be deleted.';
        $ErrorMessage = $this->getTranslator()->trans($error, array(), $this->getTranslationDomain());

        throw new \Exception($ErrorMessage);
    }
}
```

This is my first pull request ever, thanks for telling if anything is wrong as to how I proceeded
Thanks a lot for reading,
