### PR TITLE
MergeCollectionListener fix

### DIFF
--- a/Form/EventListener/MergeCollectionListener.php
+++ b/Form/EventListener/MergeCollectionListener.php
@@ -37,8 +37,7 @@ class MergeCollectionListener implements EventSubscriberInterface
         $collection = $event->getForm()->getData();
         $data       = $event->getData();
         
-        if (spl_object_hash($collection) === spl_object_hash($data)) {
-            $event->setData($collection);
+        if ($collection === $data) {
             return;
         }
 


### PR DESCRIPTION
This PR adresses a problem for oneToMany relations in Symfony 2.1.
## Problem

When the `onBindNormData` method gets the `collection` data from the form and the `data` from the event, both return the same object. As a result, the entity is removed from the `$collection` instead of `$data` in line 50, when `->collectionRemoveElement($data, $entity)` is called.
## Solution

I've added a simple check for the equality of the `spl_object_hash`. If both collections are the same reference, the original collection is set as the data in the event.

I'm not 100% sure if this is a proper fix, because i don't really know the rationale behind the remove / add element logic in the Listener.

All i can say is that the rest of the admin forms in our app work as expected.
