### PR TITLE
Do not validate removed entities.

### DIFF
--- a/Form/EventListener/FormProxy.php
+++ b/Form/EventListener/FormProxy.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Sonata\AdminBundle\Form\EventListener;
+
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormView;
+
+class FormProxy implements \IteratorAggregate, FormInterface
+{
+    protected $form;
+
+    protected $bypassValidation;
+
+    public function __construct($form, $bypassValidation)
+    {
+        $this->form = $form;
+        $this->bypassValidation = $bypassValidation;
+    }
+
+    public function isValid()
+    {
+        if ($this->bypassValidation) {
+            return true;
+        }
+
+        return $this->__call('isValid', func_get_args());
+    }
+
+    public function getErrors()
+    {
+        if ($this->bypassValidation) {
+            return array();
+        }
+
+        return $this->__call('getErrors', func_get_args());
+    }
+
+    public function getIterator()
+    {
+        return $this->form;
+    }
+
+    public function __call($name, $arguments)
+    {
+        return call_user_func_array(array($this->form, $name), $arguments);
+    }
+
+    //Only proxied functions after this limit
+
+    public function setParent(FormInterface $parent = null)
+    {
+        return $this->__call('setParent', func_get_args());
+    }
+
+    public function getParent()
+    {
+        return $this->__call('getParent', func_get_args());
+    }
+
+    public function hasParent()
+    {
+        return $this->__call('hasParent', func_get_args());
+    }
+
+    public function add(FormInterface $child)
+    {
+        return $this->__call('add', func_get_args());
+    }
+
+    public function has($name)
+    {
+        return $this->__call('has', func_get_args());
+    }
+
+    public function remove($name)
+    {
+        return $this->__call('remove', func_get_args());
+    }
+
+    public function getChildren()
+    {
+        return $this->__call('getChildren', func_get_args());
+    }
+
+    public function hasChildren()
+    {
+        return $this->__call('hasChildren', func_get_args());
+    }
+
+    public function setData($appData)
+    {
+        return $this->__call('setData', func_get_args());
+    }
+
+    public function getData()
+    {
+        return $this->__call('getData', func_get_args());
+    }
+
+    public function getNormData()
+    {
+        return $this->__call('getNormData', func_get_args());
+    }
+
+    public function getClientData()
+    {
+        return $this->__call('getClientData', func_get_args());
+    }
+
+    public function getExtraData()
+    {
+        return $this->__call('getExtraData', func_get_args());
+    }
+
+    public function isBound()
+    {
+        return $this->__call('isBound', func_get_args());
+    }
+
+    public function getTypes()
+    {
+        return $this->__call('getTypes', func_get_args());
+    }
+
+    public function getName()
+    {
+        return $this->__call('getName', func_get_args());
+    }
+
+    public function addError(FormError $error)
+    {
+        return $this->__call('addError', func_get_args());
+    }
+
+    public function isRequired()
+    {
+        return $this->__call('isRequired', func_get_args());
+    }
+
+    public function isReadOnly()
+    {
+        return $this->__call('isReadOnly', func_get_args());
+    }
+
+    public function isEmpty()
+    {
+        return $this->__call('isEmpty', func_get_args());
+    }
+
+    public function isSynchronized()
+    {
+        return $this->__call('isSynchronized', func_get_args());
+    }
+
+    public function bind($data)
+    {
+        return $this->__call('bind', func_get_args());
+    }
+
+    public function hasAttribute($name)
+    {
+        return $this->__call('hasAttribute', func_get_args());
+    }
+
+    public function getAttribute($name)
+    {
+        return $this->__call('getAttribute', func_get_args());
+    }
+
+    public function getRoot()
+    {
+        return $this->__call('getRoot', func_get_args());
+    }
+
+    public function isRoot()
+    {
+        return $this->__call('isRoot', func_get_args());
+    }
+
+    public function createView(FormView $parent = null)
+    {
+        return $this->__call('createView', func_get_args());
+    }
+
+    public function offsetExists($offset)
+    {
+        return $this->__call('offsetExists', func_get_args());
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->__call('offsetGet', func_get_args());
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        return $this->__call('offsetSet', func_get_args());
+    }
+
+    public function offsetUnset($offset)
+    {
+        return $this->__call('offsetUnset', func_get_args());
+    }
+
+    public function count()
+    {
+        return $this->__call('count', func_get_args());
+    }
+}

--- a/Form/EventListener/ResizeFormListener.php
+++ b/Form/EventListener/ResizeFormListener.php
@@ -118,7 +118,7 @@ class ResizeFormListener implements EventSubscriberInterface
                     'property_path' => '['.$name.']',
                 ));
 
-                $form->add($this->factory->createNamed($this->type, $name, null, $options));
+                $form->add(new FormProxy($this->factory->createNamed($this->type, $name, null, $options), isset($value['_delete'])));
             }
 
             if (isset($value['_delete'])) {


### PR DESCRIPTION
When you edit a collection of entities, you can delete some of them only if they are valid. This an issue when you added a new entity by mistake and do not filled any value, but need now to delete it. With that PR, the deleted entities are no longer validated.

This patch is for 2.0 only and is very ugly as it wraps the whole FormInterface. This is due to Symfony 2.0 lacking this very crucial need to bypass validation of some part of the form. This feature were added to 2.1 through the option `cascade_validation` (it's sad such a useful and trivial feature becomes available only nowadays). 
