### PR TITLE
Add dashboard group filtering in admin list block

### DIFF
--- a/Block/AdminListBlockService.php
+++ b/Block/AdminListBlockService.php
@@ -48,10 +48,20 @@ class AdminListBlockService extends BaseBlockService
     {
         $settings = array_merge($this->getDefaultSettings(), $block->getSettings());
 
+        $dashboardGroups = $this->pool->getDashboardGroups();
+
+        $visibleGroups = array();
+        foreach ($dashboardGroups as $name => $dashboardGroup) {
+            if (!$settings['groups'] || in_array($name, $settings['groups'])) {
+                $visibleGroups[] = $dashboardGroup;
+            }
+        }
+
         return $this->renderResponse('SonataAdminBundle:Block:block_admin_list.html.twig', array(
-            'block'     => $block,
-            'settings'  => $settings,
-            'admin_pool' => $this->pool
+            'block'         => $block,
+            'settings'      => $settings,
+            'admin_pool'    => $this->pool,
+            'groups'        => $visibleGroups
         ), $response);
     }
 
@@ -84,6 +94,8 @@ class AdminListBlockService extends BaseBlockService
      */
     function getDefaultSettings()
     {
-        return array();
+        return array(
+            'groups' => false
+        );
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -94,7 +94,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('type')->cannotBeEmpty()->end()
                                     ->arrayNode('settings')
                                         ->useAttributeAsKey('id')
-                                        ->prototype('scalar')->defaultValue(array())->end()
+                                        ->prototype('variable')->defaultValue(array())->end()
                                     ->end()
                                     ->scalarNode('position')->defaultValue('right')->end()
                                 ->end()

--- a/Resources/doc/reference/dashboard.rst
+++ b/Resources/doc/reference/dashboard.rst
@@ -95,3 +95,28 @@ Add some items to a group
 .. image:: ../images/dashboard.png
            :alt: Dashboard
            :width: 200
+
+Display two blocks with different dashboard groups
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+    sonata_admin:
+        dashboard
+            blocks:
+                # display two dashboard blocks
+                - { position: left,  type: sonata.admin.block.admin_list, settings: { groups: [sonata_page1, sonata_page2] } }
+                - { position: right, type: sonata.admin.block.admin_list, settings: { groups: [sonata_page3] } }
+
+            groups:
+                sonata_page1:
+                    items:
+                        - sonata.page.admin.myitem1
+                sonata_page2:
+                    items:
+                        - sonata.page.admin.myitem2
+                        - sonata.page.admin.myitem3
+                sonata_page3:
+                    items:
+                        - sonata.page.admin.myitem4

--- a/Resources/views/Block/block_admin_list.html.twig
+++ b/Resources/views/Block/block_admin_list.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends 'SonataBlockBundle:Block:block_base.html.twig' %}
 
 {% block block %}
-    {% for group in admin_pool.dashboardGroups %}
+    {% for group in groups %}
         <table class="zebra-striped sonata-ba-list bordered-table">
             <thead>
                 <tr>


### PR DESCRIPTION
It allows configuring multiple dashboard blocks in the admin configuration file and define for each block which groups must be included.

The documentation has been updated to provide an example with 2 blocks.
