### PR TITLE
Move 'jms/translation-bundle' composer dependency into dev requirements

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -135,7 +135,7 @@
         <mkdir dir="${dir.reports.test}" />
 
         <echo msg="Installing/Updating vendors..." />
-        <exec command="composer update" passthru="true"/>
+        <exec command="composer update --dev" passthru="true"/>
 
     </target>
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     "require": {
         "php": ">=5.3.2",
 
-        "jms/translation-bundle": "*",
         "symfony/symfony": "2.0.*",
 
         "symfony/framework-bundle": "2.0.*",
@@ -28,6 +27,9 @@
         "sonata-project/jquery-bundle": "master-dev",
         "sonata-project/exporter": "master-dev",
         "sonata-project/block-bundle": "2.0.*"
+    },
+    "require-dev": {
+        "jms/translation-bundle": "*"
     },
     "suggest": {
         "sonata-project/doctrine-orm-admin-bundle": "2.0.*",


### PR DESCRIPTION
Updated the composer.json and build.xml. Dependencies required for unit testing and code coverage are moved to "require-dev" and the phing build process uses the dev dependencies.
