### PR TITLE
Enable field_type overriding for NumberFilter.

### DIFF
--- a/Form/Type/Filter/NumberType.php
+++ b/Form/Type/Filter/NumberType.php
@@ -66,7 +66,7 @@ class NumberType extends AbstractType
 
         $builder
             ->add('type', 'choice', array('choices' => $choices, 'required' => false))
-            ->add('value', 'number', array('required' => false))
+            ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))
         ;
     }
 
@@ -77,7 +77,7 @@ class NumberType extends AbstractType
     public function getDefaultOptions(array $options)
     {
         $defaultOptions = array(
-            'field_type'       => 'text',
+            'field_type'       => 'number',
             'field_options'    => array()
         );
 


### PR DESCRIPTION
I need to display a number as a currency, but the following currently doesn't work when defining filters:

``` php
$datagridMapper->add('price',null,[],'money',['currency'=>'EUR'])
```

This allows `field_type` to be overridden by the admin configuration for numbers.

This PR requires sonata-project/SonataDoctrineORMAdminBundle#81.
