### PR TITLE
Add batch blocks.

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -132,31 +132,37 @@ file that was distributed with this source code.
             </table>
 
             {% if batchactions|length > 0%}
-                <script type="text/javascript">
-                    jQuery(document).ready(function($){
-                       $('#list_batch_checkbox').click(function(){
-                           $(this).closest('table').find("td input[type='checkbox']").attr('checked', $(this).is(':checked')).parent().parent().toggleClass('sonata-ba-list-row-selected', $(this).is(':checked'));
-                       });
-                       $("td.sonata-ba-list-field-batch input[type='checkbox']").change(function(){
-                           $(this).parent().parent().toggleClass('sonata-ba-list-row-selected', $(this).is(':checked'));
-                       });
-                    });
-                </script>
+                {% block batch %}
+                    <script type="text/javascript">
+                        {% block batch_javascript %}
+                            jQuery(document).ready(function($){
+                               $('#list_batch_checkbox').click(function(){
+                                   $(this).closest('table').find("td input[type='checkbox']").attr('checked', $(this).is(':checked')).parent().parent().toggleClass('sonata-ba-list-row-selected', $(this).is(':checked'));
+                               });
+                               $("td.sonata-ba-list-field-batch input[type='checkbox']").change(function(){
+                                   $(this).parent().parent().toggleClass('sonata-ba-list-row-selected', $(this).is(':checked'));
+                               });
+                            });
+                        {% endblock %}
+                    </script>
 
-                <div class="actions sonata-ba-list-actions">
-                    <select name="action">
-                        {% for action, options in batchactions %}
-                            <option value="{{ action }}">{{ options.label }}</option>
-                        {% endfor %}
-                    </select>
+                    <div class="actions sonata-ba-list-actions">
+                        {% block batch_actions %}
+                            <select name="action">
+                                {% for action, options in batchactions %}
+                                    <option value="{{ action }}">{{ options.label }}</option>
+                                {% endfor %}
+                            </select>
 
-                    <label>
-                        <input type="checkbox" name="all_elements"/>
-                        {% trans from 'SonataAdminBundle' %}all_elements{% endtrans %}
-                    </label>
+                            <label>
+                                <input type="checkbox" name="all_elements"/>
+                                {% trans from 'SonataAdminBundle' %}all_elements{% endtrans %}
+                            </label>
 
-                    <input type="submit" class="btn primary" value="{% trans from 'SonataAdminBundle' %}btn_batch{% endtrans %}" />
-                </div>
+                            <input type="submit" class="btn primary" value="{% trans from 'SonataAdminBundle' %}btn_batch{% endtrans %}" />
+                        {% endblock %}
+                    </div>
+                {% endblock %}
             {% endif %}
         </form>
     {% else %}


### PR DESCRIPTION
The batch action selection template currently cannot be easily overridden (you have to override the whole `list_table` block). This PR adds two blocks: `batch_javascript` and `batch_actions`.

@rande: will you allow even finer granularity like `batch_all_element`, `batch_action_selection`, `batch_submit` ? I am in the following case: I want to generate bills for the selected customers through a batch action. Bills cover one month length, so when selecting the 'Generate Bill' action, a month selection is displayed to choose the needed month interval. Thus I'd need to override only a potential `batch_action_selection` from where I can call parent rendering and easily append content without needing to copy any html line from the original block template. This would ease maintenance of my private templates, no matter the official templates evolves.
