### PR TITLE
Fix AddDependencyCallsCompilerPass when filtering out 'setTemplate'.

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -233,8 +233,8 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                 continue;
             }
 
-            if ($method[1] == 'setTemplate') {
-                $definedTemplates[$method[0]] = $method[1][0];
+            if ($method[0] == 'setTemplate') {
+                $definedTemplates[$method[1][0]] = $method[1][1];
                 continue;
             }
 


### PR DESCRIPTION
Trivial fix to make `setTemplate` work from within the services definition file.
