### PR TITLE
allow multiple filter type tags

### DIFF
--- a/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
+++ b/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
@@ -32,11 +32,11 @@ class AddFilterTypeCompilerPass implements CompilerPassInterface
         $types      = array();
 
         foreach ($container->findTaggedServiceIds('sonata.admin.filter.type') as $id => $attributes) {
-            $name = $attributes[0]['alias'];
-
             $container->getDefinition($id)->setScope(ContainerInterface::SCOPE_PROTOTYPE);
 
-            $types[$name] = $id;
+            foreach ($attributes as $eachTag) {
+                $types[$eachTag['alias']] = $id;
+            }
         }
 
         $definition->replaceArgument(1, $types);


### PR DESCRIPTION
This allows multiple tags to assign types with the filter class.

For example:

``` yaml
services:
    sonata.admin.propel.filter.type.string:
        class: Sonata\PropelAdminBundle\Filter\StringFilter
        tags:
            - { name: 'sonata.admin.filter.type', alias: 'propel_string' }
            - { name: 'sonata.admin.filter.type', alias: 'propel_varchar' }
            - { name: 'sonata.admin.filter.type', alias: 'propel_longvarchar' }
            - { name: 'sonata.admin.filter.type', alias: 'propel_text' }
```
