### PR TITLE
Allow read-only fields when editing collections of entities.

### DIFF
--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -85,16 +85,18 @@ class AdminHelper
      * @throws \RuntimeException
      *
      * @param \Sonata\AdminBundle\Admin\AdminInterface $admin
+     * @param object                                   $subject
      * @param string                                   $elementId
      *
      * @return array
      */
-    public function appendFormFieldElement(AdminInterface $admin, $elementId)
+    public function appendFormFieldElement(AdminInterface $admin, $subject, $elementId)
     {
         // retrieve the subject
         $formBuilder = $admin->getFormBuilder();
 
         $form = $formBuilder->getForm();
+        $form->setData($subject);
         $form->bindRequest($admin->getRequest());
 
         // get the field element
@@ -138,6 +140,7 @@ class AdminHelper
         $data[$childFormBuilder->getName()][] = $value;
 
         $finalForm = $admin->getFormBuilder()->getForm();
+        $finalForm->setData($subject);
 
         // bind the data
         $finalForm->setData($form->getData());

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -80,7 +80,7 @@ class HelperController
 
         $admin->setSubject($subject);
 
-        list($fieldDescription, $form) = $this->helper->appendFormFieldElement($admin, $elementId);
+        list($fieldDescription, $form) = $this->helper->appendFormFieldElement($admin, $subject, $elementId);
 
         $view = $this->helper->getChildFormView($form->createView(), $elementId);
 


### PR DESCRIPTION
Currently when you edit collections of sub entities (in a inline table for example), you cannot use read only fields, otherwise the previously held and valid read only value will be set to the default value returned by the associated `DataTransformer` when adding new rows.

This patch first populate the old persisted value to the `Form`, then populate form data, so that read only fieldis don't get erased by default values (using exactly the same pattern used `CRUDController::editAction`).
