### PR TITLE
added a condition for 'add new' button 

### DIFF
--- a/Resources/views/CRUD/base_edit.html.twig
+++ b/Resources/views/CRUD/base_edit.html.twig
@@ -28,7 +28,7 @@ file that was distributed with this source code.
             {% if admin.hasroute('history') and admin.id(object) and admin.isGranted('EDIT', object) %}
                 <li class="btn sonata-action-element"><a href="{{ admin.generateObjectUrl('history', object) }}">{% trans from 'SonataAdminBundle' %}link_action_history{% endtrans %}</a></li>
             {% endif %}
-            {% if admin.hasroute('create') and admin.isGranted('CREATE')%}
+            {% if admin.hasroute('create') and admin.isGranted('CREATE') and admin.id(object)%}
                 <li class="btn sonata-action-element"><a href="{{ admin.generateUrl('create') }}">{% trans from 'SonataAdminBundle' %}link_action_create{% endtrans %}</a></li>
             {% endif %}
             {% if admin.hasroute('list') and admin.isGranted('LIST')%}


### PR DESCRIPTION
so the button will only display when you edit an entity and no longer is displayed when you are creating a new instance of the entity.

The 'create new' button on the create form causes problems when using a 'flow' form. 
When you override the create function in an admin's controller and use the admin's getPersistentParameters and getNewInstance functions. You can have additional forms a user needs to fill before displaying the original create form.
Because the admin's persistent parameters are filled based on request parameters the 'add new' button on a create form won't work properly, since the request parameters are still there you won't get redirected to the additional form.

In addition I don't think it makes much sense having the 'add new' button on a form while you are creating a new item.
