### PR TITLE
fix output breadcrumbs in standart_layout.html.twig

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -59,11 +59,11 @@ file that was distributed with this source code.
             {% else %}
                 {% if action is defined %}
                     -
-                    {% for label, uri in admin.breadcrumbs(action) %}
+                    {% for item in admin.breadcrumbs(action) %}
                         {% if not loop.first  %}
                             &gt;
                         {% endif %}
-                        {{ label }}
+                        {{ item.label }}
                     {% endfor %}
                 {% endif %}
             {% endif%}
@@ -112,11 +112,11 @@ file that was distributed with this source code.
                 <ul class="breadcrumb">
                     {% if _breadcrumb is empty %}
                         {% if action is defined %}
-                            {% for label, uri in admin.breadcrumbs(action) %}
+                            {% for item in admin.breadcrumbs(action) %}
                                 {% if not loop.last  %}
-                                    <li><a href="{{ uri }}">{{ label }}</a><span class="divider">/</span></li>
+                                    <li><a href="{{ item.uri }}">{{ item.label }}</a><span class="divider">/</span></li>
                                 {% else %}
-                                    <li class="active">{{ label }}</li>
+                                    <li class="active">{{ item.label }}</li>
                                 {% endif %}
                             {% endfor %}
                         {% endif %}
@@ -148,9 +148,9 @@ file that was distributed with this source code.
                         {% if _title is not empty %}
                             {{ _title|raw }}
                         {% elseif action is defined %}
-                            {% for label, uri in admin.breadcrumbs(action) %}
+                            {% for item in admin.breadcrumbs(action) %}
                                 {% if loop.last  %}
-                                    {{ label }}
+                                    {{ item.label }}
                                 {% endif %}
                             {% endfor %}
                         {% endif%}


### PR DESCRIPTION
 in standart_layout.html.twig fix for cycle for breadcrumbs. Now admin.breadcrumbs(action) return arrays in array of breadcrumbs items, so it's doesn't work in old for cycle realisation. Now it's work.
