### PR TITLE
Allowed dropdown navigation in case of no user management

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -83,22 +83,20 @@ file that was distributed with this source code.
                                     {{ admin_pool.title }}
                                 </a>
                             {% endblock %}
-                            {% if app.user %}
-                                <ul class="nav">
-                                    {% for group in admin_pool.dashboardgroups %}
-                                        <li class="dropdown">
-                                            <a href="#" class="dropdown-toggle">{{ group.label|trans({}, group.label_catalogue) }}</a>
-                                            <ul class="dropdown-menu">
-                                                {% for admin in group.items %}
-                                                    {% if admin.hasroute('create') and admin.isGranted('CREATE') or admin.hasroute('list') and admin.isGranted('LIST') %}
-                                                        <li><a href="{{ admin.generateUrl('list')}}">{{ admin.label|trans({}, admin.translationdomain) }}</a></li>
-                                                    {% endif %}
-                                                {% endfor %}
-                                            </ul>
-                                        </li>
-                                    {% endfor %}
-                                </ul>
-                            {% endif %}
+                            <ul class="nav">
+                                {% for group in admin_pool.dashboardgroups %}
+                                    <li class="dropdown">
+                                        <a href="#" class="dropdown-toggle">{{ group.label|trans({}, group.label_catalogue) }}</a>
+                                        <ul class="dropdown-menu">
+                                            {% for admin in group.items %}
+                                                {% if admin.hasroute('create') and admin.isGranted('CREATE') or admin.hasroute('list') and admin.isGranted('LIST') %}
+                                                    <li><a href="{{ admin.generateUrl('list')}}">{{ admin.label|trans({}, admin.translationdomain) }}</a></li>
+                                                {% endif %}
+                                            {% endfor %}
+                                        </ul>
+                                    </li>
+                                {% endfor %}
+                            </ul>
 
                             <p class="pull-right">{% include admin_pool.getTemplate('user_block') %}</p>
                         {% endif %}


### PR DESCRIPTION
Currently, top navigation menu is rendering only if user management is enabled. I suppose it's a bug.
