### PR TITLE
Wrong colspan in ajax popup

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -71,7 +71,7 @@ file that was distributed with this source code.
 
                 {% block table_footer %}
                     <tr>
-                        <th colspan="{{ admin.list.elements|length - 1 }}">
+                        <th colspan="{{ admin.list.elements|length - (app.request.isXmlHttpRequest ? 2 : 1) }}">
                             {{ admin.datagrid.pager.page }} / {{ admin.datagrid.pager.lastpage }}
                             {% if admin.isGranted("EXPORT") %}
                                 -


### PR DESCRIPTION
on the many-to-one form type, when the list of related admin is opened in a popup, on the table footer there is a wrong colspan number due to the lack of the batch action column. This solves the problem by considering the type of the request.
