### PR TITLE
Breadcrumb correction: Loop changed for item 'item'. 

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -110,11 +110,11 @@ file that was distributed with this source code.
                 <ul class="breadcrumb">
                     {% if _breadcrumb is empty %}
                         {% if action is defined %}
-                            {% for label, uri in admin.breadcrumbs(action) %}
+                            {% for item in admin.breadcrumbs(action) %}
                                 {% if not loop.last  %}
-                                    <li><a href="{{ uri }}">{{ label }}</a><span class="divider">/</span></li>
+                                    <li><a href="{{ item.uri }}">{{ item.label }}</a><span class="divider">/</span></li>
                                 {% else %}
-                                    <li class="active">{{ label }}</li>
+                                    <li class="active">{{ item.label }}</li>
                                 {% endif %}
                             {% endfor %}
                         {% endif %}


### PR DESCRIPTION
Resolve this error:.. "An exception has been thrown during the rendering of a template ("Notice: Array to string conversion in SonataAdminBundle::standard_layout.html.twig at line 115").
