### PR TITLE
Enclose dropdown definitions in the topBarNav block.

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -84,18 +84,20 @@ file that was distributed with this source code.
                                 </a>
                             {% endblock %}
                             <ul class="nav">
-                                {% for group in admin_pool.dashboardgroups %}
-                                    <li class="dropdown">
-                                        <a href="#" class="dropdown-toggle">{{ group.label|trans({}, group.label_catalogue) }}</a>
-                                        <ul class="dropdown-menu">
-                                            {% for admin in group.items %}
-                                                {% if admin.hasroute('create') and admin.isGranted('CREATE') or admin.hasroute('list') and admin.isGranted('LIST') %}
-                                                    <li><a href="{{ admin.generateUrl('list')}}">{{ admin.label|trans({}, admin.translationdomain) }}</a></li>
-                                                {% endif %}
-                                            {% endfor %}
-                                        </ul>
-                                    </li>
-                                {% endfor %}
+                                {% block sonata_top_bar_nav %}
+                                    {% for group in admin_pool.dashboardgroups %}
+                                        <li class="dropdown">
+                                            <a href="#" class="dropdown-toggle">{{ group.label|trans({}, group.label_catalogue) }}</a>
+                                            <ul class="dropdown-menu">
+                                                {% for admin in group.items %}
+                                                    {% if admin.hasroute('create') and admin.isGranted('CREATE') or admin.hasroute('list') and admin.isGranted('LIST') %}
+                                                        <li><a href="{{ admin.generateUrl('list')}}">{{ admin.label|trans({}, admin.translationdomain) }}</a></li>
+                                                    {% endif %}
+                                                {% endfor %}
+                                            </ul>
+                                        </li>
+                                    {% endfor %}
+                                {% endblock %}
                             </ul>
 
                             <p class="pull-right">{% include admin_pool.getTemplate('user_block') %}</p>


### PR DESCRIPTION
Ease navigation bar customisation (eg: adding a new dropdown from a custom Sonata Block)
