### PR TITLE
merge knp-menu dependency fix from 2.0 to master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 
         "symfony/framework-bundle": "2.0.*",
         "symfony/security-bundle": "2.0.*",
-        "knplabs/knp-menu-bundle": "master-dev",
+        "knplabs/knp-menu-bundle": "1.1.*",
         "sonata-project/jquery-bundle": "master-dev",
         "sonata-project/exporter": "master-dev",
         "sonata-project/block-bundle": "2.0.*"


### PR DESCRIPTION
The KnpMenu library will break BC in a few days.
