### PR TITLE
buildShow correctly detects and avoids entering a loop, in line with other buildXXX methods.

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -610,8 +610,8 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
             return;
         }
 
-        $collection = new FieldDescriptionCollection();
-        $mapper = new ShowMapper($this->showBuilder, $collection, $this);
+        $this->show = new FieldDescriptionCollection();
+        $mapper = new ShowMapper($this->showBuilder, $this->show, $this);
 
         $this->configureShowField($mapper); // deprecated, use configureShowFields instead
         $this->configureShowFields($mapper);
@@ -619,8 +619,6 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         foreach ($this->getExtensions() as $extension) {
             $extension->configureShowFields($mapper);
         }
-
-        $this->show = $collection;
     }
 
     /**


### PR DESCRIPTION
Minor change to the way Admin::buildShow works so that it can correctly detect and avoid entering a tight loop.

Info:

buildList, buildForm etc all set $this->[datagrid|list|etc] early on in
the method, meaning the return statement in the top of the methods can
correctly detect and return when the method is called again from within
itself.

buildShow was not setting $this->show  until the of the method, which left
it susceptible to entering a loop, which ultimately causes an exception
from showMapper as it tries to re-add already existing fields.
