### PR TITLE
Fixed plurals and missing translations in batch actions for Slovak lang

### DIFF
--- a/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/Resources/translations/SonataAdminBundle.sk.xliff
@@ -184,7 +184,11 @@
             </trans-unit>
             <trans-unit id="message_batch_confirmation">
                 <source>message_batch_confirmation</source>
-                <target>Ste si istý, že chcete potvrdiť túto akciu a spustiť ju na všetky vybrané prvky?</target>
+                <target>Ste si istý, že chcete potvrdiť túto akciu a spustiť ju na všetky vybrané prvky?|Ste si istý, že chcete potvrdiť túto akciu a spustiť ju na %count% prvkov?</target>
+            </trans-unit>
+            <trans-unit id="message_batch_all_confirmation">
+                <source>message_batch_all_confirmation</source>
+                <target>Ste si istý, že chcete potvrdiť túto akciu a spustiť ju na všetky prvky?</target>
             </trans-unit>
             <trans-unit id="btn_execute_batch_action">
                 <source>btn_execute_batch_action</source>


### PR DESCRIPTION
Fixed plurals and added missing translations in batch actions for Slovak language
This was broken by PR #794
