### PR TITLE
Now, in editing admin forms, collapsed fieldsets are open when containing errors.

### DIFF
--- a/Resources/public/base.js
+++ b/Resources/public/base.js
@@ -81,7 +81,8 @@ var Admin = {
      * @param subject
      */
     add_collapsed_toggle: function(subject) {
-        jQuery('fieldset.sonata-ba-fielset-collapsed div.sonata-ba-collapsed-fields').hide();
+        jQuery('fieldset.sonata-ba-fielset-collapsed').has('.error').addClass('sonata-ba-collapsed-fields-close');
+        jQuery('fieldset.sonata-ba-fielset-collapsed div.sonata-ba-collapsed-fields').not(':has(.error)').hide();
         jQuery('fieldset legend a.sonata-ba-collapsed', subject).live('click', function(event) {
             event.preventDefault();
 


### PR DESCRIPTION
Functional adding : now, in editing admin forms, collapsed fieldsets are open when containing errors.
I think it is more convenient for the correction of a form in error.
