### PR TITLE
Fix ResizeFormListener bug

### DIFF
--- a/Form/EventListener/ResizeFormListener.php
+++ b/Form/EventListener/ResizeFormListener.php
@@ -99,7 +99,7 @@ class ResizeFormListener implements EventSubscriberInterface
                 'property_path' => '[' . $name . ']',
             ));
 
-            $form->add($this->factory->createNamed($this->type, $name, $value, $options));
+            $form->add($this->factory->createNamed($name, $this->type, $value, $options));
         }
     }
 


### PR DESCRIPTION
I found this bug while trying to track down an issue with SonataMediaBundle. It appears that the `$name` and `$this->type` have been transposed.
