### PR TITLE
Missing translations

### DIFF
--- a/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/Resources/translations/SonataAdminBundle.ca.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filtra</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Actualitza</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Actualitza</target>

--- a/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/Resources/translations/SonataAdminBundle.cs.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filtrovat</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Aktualizovat</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Aktualizovat</target>

--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filtern</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Speichern</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Speichern</target>

--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filter</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Update</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Update</target>

--- a/Resources/translations/SonataAdminBundle.es.xliff
+++ b/Resources/translations/SonataAdminBundle.es.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filtrar</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Actualizar</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Actualizar</target>

--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filtrer</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Mettre à jour</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Mettre à jour</target>

--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filtriraj</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Promijeni</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Promijeni</target>

--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filtra</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Aggiorna</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Aggiorna</target>

--- a/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/Resources/translations/SonataAdminBundle.ja.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>絞り込み</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>更新</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>更新</target>

--- a/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/Resources/translations/SonataAdminBundle.lb.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filteren</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Späicheren</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Späicheren</target>

--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filter</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Bijwerken</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Bijwerken</target>

--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filtruj</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Zapisz zmiany</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Zapisz zmiany</target>

--- a/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filtrar</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Atualizar</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Atualizar</target>

--- a/Resources/translations/SonataAdminBundle.pt_PT.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_PT.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filtrar</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Atualizar</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Atualizar</target>

--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Фильтровать</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Сохранить</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Сохранить</target>

--- a/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/Resources/translations/SonataAdminBundle.sk.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Filter</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Aktualizovať</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Aktualizovať</target>

--- a/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/Resources/translations/SonataAdminBundle.sl.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Prikaži</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Posodobi</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Posodobi</target>

--- a/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/Resources/translations/SonataAdminBundle.uk.xliff
@@ -26,6 +26,10 @@
                 <source>btn_filter</source>
                 <target>Фільтрувати</target>
             </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Зберегти</target>
+            </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
                 <target>Зберегти</target>


### PR DESCRIPTION
See

https://github.com/sonata-project/SonataAdminBundle/blob/2.0/Resources/views/CRUD/base_edit.html.twig#L89

and two lines below.

Translations keyed by 'btn_update' and 'btn_create' are used (when its an ajax request). But these don't exist in any of the translation files. 

At the moment, 'btn_update_and_edit' and 'btn_create_and_edit' would do the job in their place - however, not sure as to the correctness of this, as you can't control the copy of these buttons separately. So wondering instead whether adding these new keys to the translation files is the way to go? 

If a maintainer can offer an opinion on which way to do, I can PR it for you if you like.
