### PR TITLE
Form label

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -10,8 +10,11 @@ file that was distributed with this source code.
 #}
 
 {# Labels #}
-{% block generic_label %}
+{% block form_label %}
 {% spaceless %}
+    {% if not compound %}
+        {% set attr = attr|merge({'for': id}) %}
+    {% endif %}
     {% if required %}
         {% set attr = attr|merge({'class': attr.class|default('') ~ ' required'}) %}
     {% endif %}

--- a/Resources/views/Form/silex_form_div_layout.html.twig
+++ b/Resources/views/Form/silex_form_div_layout.html.twig
@@ -38,8 +38,11 @@
 
 {# Labels #}
 
-{% block generic_label %}
+{% block form_label %}
 {% spaceless %}
+    {% if not compound %}
+        {% set attr = attr|merge({'for': id}) %}
+    {% endif %}
     {% if required %}
         {% set attr = attr|merge({'class': attr.class|default('') ~ ' required'}) %}
     {% endif %}


### PR DESCRIPTION
generic_label is no longer used, so overriding that block has no effect,
instead you need to override form_label.

Maybe this does not capture all cases but my forms look ok again
