### PR TITLE
Blocks everywhere

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -2421,4 +2421,13 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     {
         return $this->labelTranslatorStrategy;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlocks($position)
+    {
+        return array();
+    }
+
 }

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -546,5 +546,13 @@ interface AdminInterface
      *
      * @return null|string
      */
-    public function getTemplate($name);
+    function getTemplate($name);
+
+    /**
+     * Return an optional array of blocks for the given position of the block in the template
+     * @param string $position currently only 'left' is implemented
+     *
+     * @return array
+     */
+    function getBlocks($position);
 }

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -154,7 +154,22 @@ file that was distributed with this source code.
             {% endif%}
 
             <div class="row-fluid">
-                <div class="content {{ _side_menu is not empty ? ' span10' : 'span12' }}">
+                {% set _content_span = 12 %}
+
+                {% if admin is defined and admin.blocks('left') is not empty %}
+                    {% set _content_span = _content_span - 2 %}
+                    <div class="span2">
+                        {% for block in admin.blocks('left') %}
+                            {{ sonata_block_render(block) }}
+                        {% endfor %}
+                    </div>
+                {% endif %}
+
+                {% if _side_menu is not empty %}
+                    {% set _content_span = _content_span - 2 %}
+                {% endif %}
+
+                <div class="content span{{ _content_span }}">
 
                     {% if _preview is not empty %}
                         <div class="sonata-ba-preview">{{ _preview|raw }}</div>


### PR DESCRIPTION
By using blocks individual admin classes can add additional functionality to the pages.
Currently there is only an area to the left defined in the standard template but there could be others as well.

The admin classes simply need to implement the `getBlocks` method, e.g.

``` php
public function getBlocks($position)
{
    if ('left' == $position) {
        return array(array('type' => 'sonata_admin_doctrine_phpcr.tree_block'));
    }
}
```
