### PR TITLE
Fix for the top-bar navigation

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -87,7 +87,7 @@ file that was distributed with this source code.
 
                                 {% block sonata_top_bar_nav %}
                                     {# There is no hasRole in a TokenInterface ... #}
-                                    {% if app.security and is_granted('ROLE_SONATA_ADMIN') %}
+                                    {% if app.security.token and is_granted('ROLE_SONATA_ADMIN') %}
                                         {% for group in admin_pool.dashboardgroups %}
                                             <li class="dropdown">
                                                 <a href="#" class="dropdown-toggle">{{ group.label|trans({}, group.label_catalogue) }}</a>


### PR DESCRIPTION
Fix for the top-bar navigation. Now the security check made to know if the user has roles with the 'is_granted' twig function.

It closes issues #817 and #813
