### PR TITLE
BC break fix. get for forms is now getVar

### DIFF
--- a/Util/FormViewIterator.php
+++ b/Util/FormViewIterator.php
@@ -61,7 +61,7 @@ class FormViewIterator implements \RecursiveIterator
      */
     public function key()
     {
-        return $this->current()->get('id');
+        return $this->current()->getVar('id');
     }
 
     /**


### PR DESCRIPTION
This crashes at least when inserting a new many to many row with ajax (like media in galleries).
get($name) is now getVar($name) according to the 2.1 bc-breaking form changes.
