### PR TITLE
Add setDefaultOptions methods to DateRangeType and DateTimeRangeType

### DIFF
--- a/Form/Type/DateRangeType.php
+++ b/Form/Type/DateRangeType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class DateRangeType extends AbstractType
 {
@@ -44,5 +45,15 @@ class DateRangeType extends AbstractType
     public function getName()
     {
         return 'sonata_type_date_range';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'field_options'    => array()
+        ));
     }
 }

--- a/Form/Type/DateTimeRangeType.php
+++ b/Form/Type/DateTimeRangeType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class DateTimeRangeType extends AbstractType
 {
@@ -44,5 +45,15 @@ class DateTimeRangeType extends AbstractType
     public function getName()
     {
         return 'sonata_type_datetime_range';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'field_options'    => array()
+        ));
     }
 }


### PR DESCRIPTION
On adding 

->add('created_at', 'doctrine_orm_datetime_range')

or 

->add('created_at', 'doctrine_orm_date_range')

to my configureDatagridFilters function in my Admin class I had the error:

"The option "field_options" does not exist."

I fixed this by adding setDefaultOptions methods to DateRangeType and DateTimeRangeType
