### PR TITLE
fixed dutch translation for batch action confirmation messages

### DIFF
--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -184,7 +184,11 @@
             </trans-unit>
             <trans-unit id="message_batch_confirmation">
                 <source>message_batch_confirmation</source>
-                <target>Weet je zeker dat voor alle geselecteerde items het handeling moet worden uitgevoerd?</target>
+                <target>Weet je zeker dat de handeling moet worden uitgevoerd voor het geselecteerde item?|Weet je zeker dat voor de %count% geselecteerde items de handeling moet worden uitgevoerd?</target>
+            </trans-unit>
+            <trans-unit id="message_batch_all_confirmation">
+                <source>message_batch_all_confirmation</source>
+                <target>Weet je zeker dat voor alle items de handeling moet worden uitgevoerd?</target>
             </trans-unit>
             <trans-unit id="btn_execute_batch_action">
                 <source>btn_execute_batch_action</source>


### PR DESCRIPTION
For the dutch translation I:
- Updated the message_batch_confirmation to fix the following error: 
  An exception has been thrown during the rendering of a template ("Unable to choose a translation for ....
  This might still happen for other translations?!
- Added a translation for message_batch_all_confirmation.
