### PR TITLE
numbers in breadcrumbs

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -152,9 +152,9 @@ file that was distributed with this source code.
                         {% if _title is not empty %}
                             {{ _title|raw }}
                         {% elseif action is defined %}
-                            {% for label, uri in admin.breadcrumbs(action) %}
+                            {% for item in admin.breadcrumbs(action) %}
                                 {% if loop.last  %}
-                                    {{ label }}
+                                    {{ item.label }}
                                 {% endif %}
                             {% endfor %}
                         {% endif%}


### PR DESCRIPTION
This should solve the problem of the numbers in the breadcrumb and page title, when using the 2.0 branch and the knpmenu 1.1.x
