### PR TITLE
minor stylefix for base_list template

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -154,7 +154,7 @@ file that was distributed with this source code.
                                 {% endfor %}
                             </select>
 
-                            <label>
+                            <label class="checkbox">
                                 <input type="checkbox" name="all_elements"/>
                                 {% trans from 'SonataAdminBundle' %}all_elements{% endtrans %}
                             </label>


### PR DESCRIPTION
minor stylefix for base_list template, to correctly display the "All elements" checkbox.
