### PR TITLE
Fix for "Create and add another" button when using inherited classes

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -303,7 +303,11 @@ class CRUDController extends Controller
         }
 
         if ($this->get('request')->get('btn_create_and_create')) {
-            $url = $this->admin->generateUrl('create');
+            $params = array();
+            if ($this->admin->hasActiveSubClass()) {
+                $params['subclass'] = $this->get('request')->get('subclass');
+            }
+            $url = $this->admin->generateUrl('create', $params);
         }
 
         if (!$url) {


### PR DESCRIPTION
Related to recently submitted PR #815. Thanks to @michelsalib and @rande for getting this very useful feature implemented.

When you click the "Create and add another" it currently does not append the "?subclass=xx" to the url and you get an error on the subsequent page. This PR should fix this.
