### PR TITLE
fixed knplabs/knp-menu-bundle version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 
         "symfony/framework-bundle": "2.0.*",
         "symfony/security-bundle": "2.0.*",
-        "knplabs/knp-menu-bundle": "1.1.*",
+        "knplabs/knp-menu-bundle": "v1.1.*",
         "sonata-project/jquery-bundle": "master-dev",
         "sonata-project/exporter": "master-dev",
         "sonata-project/block-bundle": "2.0.*"


### PR DESCRIPTION
> Your requirements could not be solved to an installable set of packages.
> 
>  Problem 1
> - Can only install one of: knplabs/knp-menu-bundle v1.1.0, knplabs/knp-menu-bundle dev-master.
> - Can only install one of: knplabs/knp-menu-bundle dev-master, knplabs/knp-menu-bundle v1.1.0.
> - sonata-project/admin-bundle dev-master requires knplabs/knp-menu-bundle 1.1.\* -> satisfiable by knplabs/knp-menu-bundle v1.1.0.
> - Installation request for sonata-project/admin-bundle dev-master -> satisfiable by sonata-project/admin-bundle dev-master.
> - Installation request for knplabs/knp-menu-bundle dev-master -> satisfiable by knplabs/knp-menu-bundle dev-master.
