### PR TITLE
Updated the minimum-stability requirement for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "sonata-project/exporter": "master-dev",
         "sonata-project/block-bundle": "2.0.*"
     },
+    "minimum-stability": "dev",
     "require-dev": {
         "jms/translation-bundle": "*"
     },


### PR DESCRIPTION
The minimum-stability of composer has been updated.

Now the travis tests for 2.0 should pass.
