### PR TITLE
Added getName() for form types where they were missing

### DIFF
--- a/Form/Type/BooleanType.php
+++ b/Form/Type/BooleanType.php
@@ -46,4 +46,12 @@ class BooleanType extends FormChoiceType
             )
         ));
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'sonata_type_boolean';
+    }
 }

--- a/Form/Type/EqualType.php
+++ b/Form/Type/EqualType.php
@@ -46,4 +46,12 @@ class EqualType extends FormChoiceType
             )
         ));
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'sonata_type_equal';
+    }
 }

--- a/Form/Type/TranslatableChoiceType.php
+++ b/Form/Type/TranslatableChoiceType.php
@@ -81,4 +81,12 @@ class TranslatableChoiceType extends ChoiceType
 
         parent::buildForm($builder, $options);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'sonata_type_translatable_choice';
+    }
 }


### PR DESCRIPTION
This feature was introduced in: https://github.com/symfony/symfony/commit/6489a65960a05b6a5a4f5c5074b941a6765c6381
