### PR TITLE
Use the "groups" variable and not the "admin_pool.dashboardGroups"

### DIFF
--- a/Resources/views/Block/block_admin_list.html.twig
+++ b/Resources/views/Block/block_admin_list.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends 'SonataBlockBundle:Block:block_base.html.twig' %}
 
 {% block block %}
-    {% for group in admin_pool.dashboardGroups %}
+    {% for group in groups %}
         <table class="table table-bordered table-striped sonata-ba-list">
             <thead>
                 <tr>


### PR DESCRIPTION
Change was originally made in commit c536dd2a45 by oparadis, overwritten by commit 84b1bbd4a0
