### PR TITLE
Fix content type return if xmlHttpRequest in retrieveFormFieldElementAction

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -138,8 +138,9 @@ class HelperController
         $extension = $this->twig->getExtension('form');
         $extension->initRuntime($this->twig);
         $extension->setTheme($view, $admin->getFormTheme());
+
         if ($request->isXmlHttpRequest()) {
-        	return new JsonResponse($extension->renderWidget($view), 200);
+        	return new JsonResponse($extension->renderWidget($view));
         }
         
         return new Response($extension->renderWidget($view));


### PR DESCRIPTION
- Ensure that a json response is returned, jQuery Form Plugin expects an xml, json or script response, an html response will not trigger the success callback function.
- Add ->renderer before setTheme and renderWidget due to change in Twig FormExtension
