### PR TITLE
Fix download label/prompt showing when no export formats are configured

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -73,7 +73,7 @@ file that was distributed with this source code.
                     <tr>
                         <th colspan="{{ admin.list.elements|length - 1 }}">
                             {{ admin.datagrid.pager.page }} / {{ admin.datagrid.pager.lastpage }}
-                            {% if admin.isGranted("EXPORT") %}
+                            {% if admin.isGranted("EXPORT") and admin.getExportFormats()|length %}
                                 -
                                 {{ "label_export_download"|trans({}, "SonataAdminBundle") }}
                                 {% for format in admin.getExportFormats() %}


### PR DESCRIPTION
I disable all of the export formats a lot of the time - in which case I think the download label should be hidden. This makes that happen!

Replacement for https://github.com/sonata-project/SonataAdminBundle/pull/883
