### PR TITLE
Wrapped the content in a "{% block %}" to allow for easier customization

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -173,6 +173,7 @@ file that was distributed with this source code.
                 {% endif %}
 
                 <div class="content {{ _side_menu is not empty ? ' span10' : 'span12' }}">
+                {% block sonata_admin_content %}
 
                     {% if _preview is not empty %}
                         <div class="sonata-ba-preview">{{ _preview|raw }}</div>
@@ -198,6 +199,8 @@ file that was distributed with this source code.
                             {{ _list_table|raw }}
                         </div>
                     {% endif %}
+
+                {% endblock %}
                 </div>
 
 


### PR DESCRIPTION
This simple change allows the "standard_layout.html.twig" to be reused more easily. e.g. for custom administration pages.

In a new controller you could now use something like the following:

```
public function indexAction()
{
    return [
        'admin_pool' => $this->get('sonata.admin.pool')
    ];
}
```

with a template as simple as this:

```
{% extends "SonataAdminBundle::standard_layout_utopolis.html.twig" %}

{% block content %}
...
{% endblock %}
```
