### PR TITLE
Documentation. Small Change

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -49,6 +49,9 @@ Next, be sure to enable this bundles in your AppKernel.php file:
     {
         return array(
             // ...
+            new Sonata\BlockBundle\SonataBlockBundle(),
+            new Sonata\CacheBundle\SonataCacheBundle(),
+            new Sonata\jQueryBundle\SonatajQueryBundle(),
             new Sonata\AdminBundle\SonataAdminBundle(),
             // ...
         );


### PR DESCRIPTION
Added explicit help for the required bundles in the AppKernel file, for avoiding problems like http://stackoverflow.com/questions/11084858/symfony2-bin-vendors-install-cannot-import-resource-config-yml
