### PR TITLE
[WIP] Add class column

### DIFF
--- a/Admin/ClassFieldDescription.php
+++ b/Admin/ClassFieldDescription.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) 2010-2011 Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+class ClassFieldDescription extends BaseFieldDescription
+{
+    function __construct() {
+        $this->name = 'class';
+    }
+
+    function setAssociationMapping($associationMapping)
+    {
+        // TODO: Implement setAssociationMapping() method.
+    }
+
+    function getTargetEntity()
+    {
+        // TODO: Implement getTargetEntity() method.
+    }
+
+    function setFieldMapping($fieldMapping)
+    {
+        // TODO: Implement setFieldMapping() method.
+    }
+
+    function setParentAssociationMappings(array $parentAssociationMappings)
+    {
+        // TODO: Implement setParentAssociationMappings() method.
+    }
+
+    function isIdentifier()
+    {
+        // TODO: Implement isIdentifier() method.
+    }
+
+    function getValue($object)
+    {
+        return array_search(get_class($object), $this->getOption('classes', array()));
+    }
+}


### PR DESCRIPTION
This PR replaces sonata-project/SonataDoctrineORMAdminBundle#125.

As @rande suggested, I created a new custom column type. You can use as follow:

``` php
<?php
$list->add(new ClassFieldDescription(), null, array(
    'classes' => $this->getSubClasses(),
));
```

I am not satisfied with the new `ClassFieldDescription` class. I think some refactoring should be done. So I just submit this PR to show a working POC and start a discussion about how to process and have a cleaner implementation.
