### PR TITLE
Fixing empty form label

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -12,6 +12,9 @@ file that was distributed with this source code.
 {# Labels #}
 {% block form_label %}
 {% spaceless %}
+    {% if label is empty %}
+        {% set label = name|humanize %}
+    {% endif %}
     {% if not compound %}
         {% set attr = attr|merge({'for': id}) %}
     {% endif %}


### PR DESCRIPTION
Before adding this fix I had an empty field instead of the form label: http://cl.ly/image/2F203w3N1l3L
