### PR TITLE
Add default value for "input_type" option

### DIFF
--- a/Form/Type/Filter/DateRangeType.php
+++ b/Form/Type/Filter/DateRangeType.php
@@ -65,7 +65,8 @@ class DateRangeType extends AbstractType
     {
         $resolver->setDefaults(array(
             'field_type'       => 'sonata_type_date_range',
-            'field_options'    => array('format' => 'yyyy-MM-dd')
+            'field_options'    => array('format' => 'yyyy-MM-dd'),
+            'input_type'       => 'datetime',
         ));
     }
 }

--- a/Form/Type/Filter/DateTimeRangeType.php
+++ b/Form/Type/Filter/DateTimeRangeType.php
@@ -65,7 +65,8 @@ class DateTimeRangeType extends AbstractType
     {
         $resolver->setDefaults(array(
             'field_type'       => 'sonata_type_datetime_range',
-            'field_options'    => array('date_format' => 'yyyy-MM-dd')
+            'field_options'    => array('date_format' => 'yyyy-MM-dd'),
+            'input_type'       => 'datetime',
         ));
     }
 }

--- a/Form/Type/Filter/DateTimeType.php
+++ b/Form/Type/Filter/DateTimeType.php
@@ -81,7 +81,8 @@ class DateTimeType extends AbstractType
     {
         $resolver->setDefaults(array(
             'field_type'       => 'datetime',
-            'field_options'    => array('date_format' => 'yyyy-MM-dd')
+            'field_options'    => array('date_format' => 'yyyy-MM-dd'),
+            'input_type'       => 'datetime',
         ));
     }
 }

--- a/Form/Type/Filter/DateType.php
+++ b/Form/Type/Filter/DateType.php
@@ -81,7 +81,8 @@ class DateType extends AbstractType
     {
         $resolver->setDefaults(array(
             'field_type'       => 'date',
-            'field_options'    => array('date_format' => 'yyyy-MM-dd')
+            'field_options'    => array('date_format' => 'yyyy-MM-dd'),
+            'input_type'       => 'datetime',
         ));
     }
 }


### PR DESCRIPTION
Added default value for "input_type" option as described here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/2.0/Resources/doc/reference/filter_field_definition.rst

This fixes #905.

Please note: Specifying "timestamp" as value for "input_type" as described in the above documentation, doesn't seem to do anything.
