### PR TITLE
Fix dashboard group names using parameters.

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -32,6 +32,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        $parameterBag = $container->getParameterBag();
         $groupDefaults = $admins = $classes = array();
 
         $pool = $container->getDefinition('sonata.admin.pool');
@@ -64,16 +65,17 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                 }
 
                 $groupName = isset($attributes['group']) ? $attributes['group'] : 'default';
+                $resolvedGroupName = $parameterBag->resolveValue($groupName);
                 $labelCatalogue = isset($attributes['label_catalogue']) ? $attributes['label_catalogue'] : 'SonataAdminBundle';
 
-                if (!isset($groupDefaults[$groupName])) {
-                    $groupDefaults[$groupName] = array(
+                if (!isset($groupDefaults[$resolvedGroupName])) {
+                    $groupDefaults[$resolvedGroupName] = array(
                         'label'           => $groupName,
                         'label_catalogue' => $labelCatalogue
                     );
                 }
 
-                $groupDefaults[$groupName]['items'][] = $id;
+                $groupDefaults[$resolvedGroupName]['items'][] = $id;
             }
         }
 


### PR DESCRIPTION
As pointed in sonata-project/SonataUserBundle#97 we currently can't define a dashboard group using a parameter and then configure that group in

``` sonata_admin:
    dashboard:
        groups:
            sonata_user:
                label: Some custom label
                #this custom configuration will prevent sonata_user panel
                #from being displayed
```

Indeed, in the top level dashboard group configuration, the group names are resolved, but aren't when defining an admin service (in the previous example, we have "sonata_user" on one hand and "%sonata.user.admin.groupname% on the other hand).

This should fix this issue more cleanly that the proposed sonata-project/SonataUserBundle#97 PR.
