### PR TITLE
Adds a command to generates admin class for a given Doctrine entity

### DIFF
--- a/Command/CreateAdminClassCommand.php
+++ b/Command/CreateAdminClassCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Simon Cosandey <simon.cosandey@simseo.ch
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Command\Command;
+use Sensio\Bundle\GeneratorBundle\Command\GenerateDoctrineCommand;
+use Sensio\Bundle\GeneratorBundle\Command\Validators;
+use Sonata\AdminBundle\Generator\AdminGenerator;
+use Sonata\AdminBundle\Generator\ControllerGenerator;
+use Sonata\AdminBundle\Manipulator\ServicesManipulator;
+
+/**
+ * Generates a admin class for a given Doctrine entity.
+ *
+ * @author Simon Cosandey <simon.cosandey@simseo.ch>
+ */
+class CreateAdminClassCommand extends GenerateDoctrineCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setDefinition(array(
+                new InputArgument('entity', InputArgument::REQUIRED, 'The entity class name to initialize (shortcut notation)'),
+            ))
+            ->setDescription('Generates an admin class based on a Doctrine entity')
+            ->setHelp(<<<EOT
+The <info>sonata:admin:generate</info> command generates an admin class based on a Doctrine entity.
+
+<info>php app/console sonata:admin:generate AcmeBlogBundle:Post</info>
+EOT
+            )
+            ->setName('sonata:admin:generate')
+        ;
+    }
+
+    /**
+     * @see Command
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $entity = Validators::validateEntityName($input->getArgument('entity'));
+        list($bundle, $entity) = $this->parseShortcutNotation($entity);
+
+        $entityClass = $this->getContainer()->get('doctrine')->getEntityNamespace($bundle).'\\'.$entity;
+        $metadata = $this->getEntityMetadata($entityClass);
+        $bundle   = $this->getApplication()->getKernel()->getBundle($bundle);
+
+        $adminGenerator = new AdminGenerator($this->getContainer()->get('filesystem'),  __DIR__.'/../Resources/skeleton/admin');
+        $adminGenerator->generate($bundle, $entity, $metadata[0]);
+
+        $output->writeln(sprintf(
+            'The new %s.php class file has been created under %s.',
+            $adminGenerator->getClassName(),
+            $adminGenerator->getClassPath()
+        ));
+        
+        $controllerGenerator = new ControllerGenerator($this->getContainer()->get('filesystem'),  __DIR__.'/../Resources/skeleton/controller');
+        $controllerGenerator->generate($bundle, $entity, $metadata[0]);
+
+        $output->writeln(sprintf(
+            'The new %s.php class file has been created under %s.',
+            $controllerGenerator->getClassName(),
+            $controllerGenerator->getClassPath()
+        ));
+        
+        $serviceManipulator = new ServicesManipulator($bundle->getPath().'/Resources/config/services.yml');
+        if($serviceManipulator->addResource(
+                $bundle, 
+                $entity, 
+                $adminGenerator->getClassName()
+        ))
+        {
+            $output->writeln('le fichier services.yml a été mis à jour');
+        }
+        else
+        {
+            $output->writeln('erreur...');
+        }
+        
+        
+    }
+}

--- a/Generator/AdminGenerator.php
+++ b/Generator/AdminGenerator.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Simon Cosandey <simon.cosandey@simseo.ch>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Generator;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Sensio\Bundle\GeneratorBundle\Generator\Generator;
+
+/**
+ * Generates an admin class based on a Doctrine entity.
+ *
+ * @author Simon Cosandey <simon.cosandey@simseo.ch>
+ */
+class AdminGenerator extends Generator
+{
+    private $filesystem;
+    private $skeletonDir;
+    private $className;
+    private $classPath;
+
+    public function __construct(Filesystem $filesystem, $skeletonDir)
+    {
+        $this->filesystem = $filesystem;
+        $this->skeletonDir = $skeletonDir;
+    }
+
+    public function getClassName()
+    {
+        return $this->className;
+    }
+
+    public function getClassPath()
+    {
+        return $this->classPath;
+    }
+
+    /**
+     * Generates the admin class if it does not exist.
+     *
+     * @param BundleInterface   $bundle   The bundle in which to create the class
+     * @param string            $entity   The entity relative class name
+     * @param ClassMetadataInfo $metadata The entity metadata class
+     */
+    public function generate(BundleInterface $bundle, $entity, ClassMetadataInfo $metadata)
+    {
+        $parts       = explode('\\', $entity);
+        $entityClass = array_pop($parts);
+
+        $this->className = $entityClass.'Admin';
+        $dirPath         = $bundle->getPath().'/Admin';
+        $this->classPath = $dirPath.'/'.str_replace('\\', '/', $entity).'Admin.php';
+
+        if (file_exists($this->classPath)) {
+            throw new \RuntimeException(sprintf('Unable to generate the %s admin class as it already exists under the %s file', $this->className, $this->classPath));
+        }
+
+        if (count($metadata->identifier) > 1) {
+            throw new \RuntimeException('The admin generator does not support entity classes with multiple primary keys.');
+        }
+
+        $this->renderFile($this->skeletonDir, 'EntityAdmin.php', $this->classPath, array(
+            'dir'              => $this->skeletonDir,
+            'fields'           => $this->getFieldsFromMetadata($metadata),
+            'namespace'        => $bundle->getNamespace(),
+            'admin_class'       => $this->className,
+        ));
+    }
+
+    /**
+     * Returns an array of fields. Fields can be both column fields and
+     * association fields.
+     *
+     * @param ClassMetadataInfo $metadata
+     * @return array $fields
+     */
+    private function getFieldsFromMetadata(ClassMetadataInfo $metadata)
+    {
+        $fields = (array) $metadata->fieldNames;
+
+        // Remove the primary key field if it's not managed manually
+        if (!$metadata->isIdentifierNatural()) {
+            $fields = array_diff($fields, $metadata->identifier);
+        }
+
+        foreach ($metadata->associationMappings as $fieldName => $relation) {
+            if ($relation['type'] !== ClassMetadataInfo::ONE_TO_MANY) {
+                $fields[] = $fieldName;
+            }
+        }
+
+        return $fields;
+    }
+}

--- a/Generator/ControllerGenerator.php
+++ b/Generator/ControllerGenerator.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Simon Cosandey <simon.cosandey@simseo.ch>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Generator;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Sensio\Bundle\GeneratorBundle\Generator\Generator;
+
+/**
+ * Generates an controller class based on a Doctrine entity.
+ *
+ * @author Simon Cosandey <simon.cosandey@simseo.ch>
+ */
+class ControllerGenerator extends Generator
+{
+    private $filesystem;
+    private $skeletonDir;
+    private $className;
+    private $classPath;
+
+    public function __construct(Filesystem $filesystem, $skeletonDir)
+    {
+        $this->filesystem = $filesystem;
+        $this->skeletonDir = $skeletonDir;
+    }
+
+    public function getClassName()
+    {
+        return $this->className;
+    }
+
+    public function getClassPath()
+    {
+        return $this->classPath;
+    }
+
+    /**
+     * Generates the controller class if it does not exist.
+     *
+     * @param BundleInterface   $bundle   The bundle in which to create the class
+     * @param string            $entity   The entity relative class name
+     * @param ClassMetadataInfo $metadata The entity metadata class
+     */
+    public function generate(BundleInterface $bundle, $entity, ClassMetadataInfo $metadata)
+    {
+        $parts       = explode('\\', $entity);
+        $entityClass = array_pop($parts);
+
+        $this->className = $entityClass.'AdminController';
+        $dirPath         = $bundle->getPath().'/Controller';
+        $this->classPath = $dirPath.'/'.str_replace('\\', '/', $entity).'AdminController.php';
+
+        if (file_exists($this->classPath)) {
+            throw new \RuntimeException(sprintf('Unable to generate the %s controller class as it already exists under the %s file', $this->className, $this->classPath));
+        }
+
+        if (count($metadata->identifier) > 1) {
+            throw new \RuntimeException('The controller generator does not support entity classes with multiple primary keys.');
+        }
+
+
+        $this->renderFile($this->skeletonDir, 'AdminController.php', $this->classPath, array(
+            'dir'              => $this->skeletonDir,
+            'namespace'        => $bundle->getNamespace(),
+            'controller_class'       => $this->className,
+        ));
+    }
+}

--- a/Manipulator/ServicesManipulator.php
+++ b/Manipulator/ServicesManipulator.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Simon Cosandey <simon.cosandey@simseo.ch>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Manipulator;
+
+use Sensio\Bundle\GeneratorBundle\Manipulator\Manipulator;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+/**
+ * Changes the code of a YAML services file.
+ *
+ * @author Simon Cosandey <simon.cosandey@simseo.ch>
+ */
+class ServicesManipulator extends Manipulator
+{
+    
+    private $file;
+
+    /**
+     * Constructor.
+     *
+     * @param string $file The YAML service file path
+     * 
+     */
+    public function __construct($file)
+    {
+        $this->file = $file;
+    }
+
+    /**
+     * Adds a service definition at the bottom of the existing ones.
+     *
+     * @param BundleInterface $bundle
+     * @param string $entity
+     * @param string $adminClass
+     *
+     * @return Boolean true if it worked, false otherwise
+     *
+     */
+    public function addResource(BundleInterface $bundle, $entity, $adminClass)
+    {
+        $current = '';
+        $parts = explode('\\', $bundle->getNamespace() );
+        var_dump($parts);
+        if (file_exists($this->file)) {
+            $current = file_get_contents($this->file);
+            
+        } elseif (!is_dir($dir = dirname($this->file))) {
+            mkdir($dir, 0777, true);
+        }
+        
+        $code = sprintf("    %s.%s.admin.%s:\n",
+                strtolower( $parts[0]),
+                strtolower($parts[1]),
+                strtolower($entity)
+                );
+        
+        $code .= sprintf("        class: %s\Admin\%s\n", $bundle->getNamespace(), $adminClass);
+        $code .= sprintf("        tags:\n");
+        $code .= sprintf("            - { name: sonata.admin, manager_type: orm, group: admin, label: %s }\n", $entity);
+        $code .= sprintf("        arguments: [null, %s\Entity\%s, %s:%s]\n", $bundle->getNamespace(), $entity, $bundle->getName(), $adminClass);
+        $current .= "\n";
+        $current .= $code;
+
+        if (false === file_put_contents($this->file, $current)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Resources/skeleton/admin/EntityAdmin.php
+++ b/Resources/skeleton/admin/EntityAdmin.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace {{ namespace }}\Admin;
+
+use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Show\ShowMapper;
+
+class {{ admin_class }} extends Admin
+{
+     /**
+     * @param \Sonata\AdminBundle\Show\ShowMapper $showMapper
+     *
+     * @return void
+     */
+    protected function configureShowField(ShowMapper $showMapper)
+    {
+        $showMapper
+            {%- for field in fields %}
+
+            ->add('{{ field }}')
+
+        {%- endfor %}
+        
+        ;
+    }
+
+    /**
+     * @param \Sonata\AdminBundle\Form\FormMapper $formMapper
+     *
+     * @return void
+     */
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+
+       $formMapper
+            {%- for field in fields %}
+
+            ->add('{{ field }}')
+
+        {%- endfor %}
+        
+        ;
+    }
+
+    /**
+     * @param \Sonata\AdminBundle\Datagrid\ListMapper $listMapper
+     *
+     * @return void
+     */
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+            {%- for field in fields %}
+
+            ->add('{{ field }}')
+
+        {%- endfor %}
+        
+            ->add('_action', 'actions', array(
+                'actions' => array(
+                    'view' => array(),
+                    'edit' => array(),
+                    'delete' => array(),
+                )
+
+            ))
+        ;
+    }
+
+    /**
+     * @param \Sonata\AdminBundle\Datagrid\DatagridMapper $datagridMapper
+     *
+     * @return void
+     */
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $datagridMapper
+        {%- for field in fields %}
+
+            ->add('{{ field }}')
+
+        {%- endfor %}
+        ;
+    }
+}
+

--- a/Resources/skeleton/controller/AdminController.php
+++ b/Resources/skeleton/controller/AdminController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace {{ namespace }}\Controller;
+
+use Sonata\AdminBundle\Controller\CRUDController as Controller;
+
+class {{ controller_class }} extends Controller
+{
+
+}


### PR DESCRIPTION
This enhancement adds a command to create admin class  easily. by running the command:

```
php app/console sonata:admin:generate AcmeDemoBundle:Post
```

 the command created the admin class, the controller and set the definition of the service.
