### PR TITLE
FormTypes should extend abstract type

### DIFF
--- a/Form/Type/BooleanType.php
+++ b/Form/Type/BooleanType.php
@@ -11,12 +11,12 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Translation\TranslatorInterface;
 
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
-class BooleanType extends FormChoiceType
+class BooleanType extends AbstractType
 {
     const TYPE_YES = 1;
 

--- a/Form/Type/EqualType.php
+++ b/Form/Type/EqualType.php
@@ -11,12 +11,12 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Translation\TranslatorInterface;
 
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
-class EqualType extends FormChoiceType
+class EqualType extends AbstractType
 {
     const TYPE_IS_EQUAL = 1;
 


### PR DESCRIPTION
Bit of a weird one this - if I set expanded to true when using boolean type, I get an UnrecognisedTypeException from the ChoiceToBooleanArray transformer, it's getting passed null when it should be passed an array. Digging deeper, it appears the transformer is being added twice. BooleanType currently extends ChoiceType - but the sf docs say it should extend AbstractType: http://symfony.com/doc/master/cookbook/form/create_custom_field_type.html#defining-the-field-type

Currently using my own copy of the class, with the parent changed to AbstractType - which seems to work fine everywhere else and resolves this issue.

Are you happy for me to submit a PR for this? Or is there a reason it's been done this way?
