### PR TITLE
Updated German translation

### DIFF
--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -92,11 +92,11 @@
             </trans-unit>
             <trans-unit id="link_first_pager">
                 <source>link_first_pager</source>
-                <target>link_first_pager</target>
+                <target>Erste Seite</target>
             </trans-unit>
             <trans-unit id="link_last_pager">
                 <source>link_last_pager</source>
-                <target>link_last_pager</target>
+                <target>Letzte Seite</target>
             </trans-unit>
             <trans-unit id="Admin">
                 <source>Admin</source>
@@ -320,15 +320,15 @@
 
             <trans-unit id="btn_preview">
                 <source>btn_preview</source>
-                <target>btn_preview</target>
+                <target>Vorschau</target>
             </trans-unit>
             <trans-unit id="btn_preview_approve">
                 <source>btn_preview_approve</source>
-                <target>btn_preview_approve</target>
+                <target>Bestätigen</target>
             </trans-unit>
             <trans-unit id="btn_preview_decline">
                 <source>btn_preview_decline</source>
-                <target>btn_preview_decline</target>
+                <target>Ablehnen</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Translation message_batch_confirmation did not match the english equivalent. Furthermore the old translation caused a Exception:

An exception has been thrown during the rendering of a template ("Unable to choose a translation.") in SonataAdminBundle::standard_layout.html.twig at line 19.
