### PR TITLE
Alter block prefix generation

### DIFF
--- a/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -99,6 +99,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             // add a new block types, so the Admin Form element can be tweaked based on the admin code
             $block_prefixes    = $view->vars['block_prefixes'];
             $baseName = str_replace('.', '_', $sonataAdmin['field_description']->getAdmin()->getCode());
+            $uniqueId = array_pop($block_prefixes);
             $baseType = $block_prefixes[count($block_prefixes) - 1];
 
             $block_prefixes[] = sprintf('%s_%s', $baseName, $baseType);
@@ -106,6 +107,16 @@ class FormTypeFieldExtension extends AbstractTypeExtension
 
             if ($sonataAdmin['block_name']) {
                 $block_prefixes[] = $sonataAdmin['block_name'];
+            }
+
+            if (preg_match('/^_.*?_(.*)/', $uniqueId, $matches)) {
+                $block_prefixes[] = sprintf(
+                    '%s_%s_%s_%s',
+                    $baseName,
+                    $sonataAdmin['field_description']->getName(),
+                    $baseType,
+                    $matches[1]
+                );
             }
 
             $view->vars['block_prefixes'] = $block_prefixes;


### PR DESCRIPTION
I noticed a change in the block prefix generation when updating from a version of the bundle form a few weeks ago. Due to recent Symfony changes, `FormView::getVar('type')` var is no longer available, so it has been replaced with `FormView::vars['block_prefixes']` in `FormTypeFieldExtension::buildView`. The result using the old `type` var for a field in my project was as follows:

```
[0]: string(4) "form"
[1]: string(17) "sonata_type_admin"
[2]: string(49) "instantiate_admin_content_pages_sonata_type_admin"
[3]: string(56) "instantiate_admin_content_pages_slides_sonata_type_admin"
```

Using `block_prefixes` this has changed to the following:

```
[0]: string(4) "form"
[1]: string(17) "sonata_type_admin"
[2]: string(24) "_s502ba19c48d71_slides_0"
[3]: string(56) "instantiate_admin_content_pages__s502ba19c48d71_slides_0"
[4]: string(63) "instantiate_admin_content_pages_slides__s502ba19c48d71_slides_0"
```

Note that the 3rd element contains a unique form type reference. The code is currently using that element to build the last two elements. This has meant that we can no longer use our twig overrides that specifically target the form type on a given page and parent form. See [here](http://stackoverflow.com/a/11512244/1566374) for more detail on how we are using this.

I suspect that this change is accidental. The PR I have attached solves the problem by using the element before the one containing the unique reference; in the case above the 2nd element.

The result after my change:

```
[0]: string(4) "form"
[1]: string(17) "sonata_type_admin"
[2]: string(24) "_s502ba48c99af2_slides_0"
[3]: string(49) "instantiate_admin_content_pages_sonata_type_admin"
[4]: string(56) "instantiate_admin_content_pages_slides_sonata_type_admin"
```

This matches the previous behaviour.
