### PR TITLE
Route collection: new methods - removeAll and removeAllExcept

### DIFF
--- a/Route/RouteCollection.php
+++ b/Route/RouteCollection.php
@@ -135,6 +135,42 @@ class RouteCollection
     }
 
     /**
+     * Remove all routes except routes in $routeList
+     *
+     * @param array $routeList
+     *
+     * @return \Sonata\AdminBundle\Route\RouteCollection
+     */
+    public function removeAllExcept(array $routeList)
+    {
+        $routeCodeList = array();
+        foreach ($routeList as $name) {
+            $routeCodeList[] = $this->getCode($name);
+        }
+
+        $elements = $this->elements;
+        foreach ($elements as $key => $element) {
+            if (!in_array($key, $routeCodeList)) {
+                unset($this->elements[$key]);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove all routes
+     *
+     * @return \Sonata\AdminBundle\Route\RouteCollection
+     */
+    public function removeAll()
+    {
+        $this->elements = array();
+
+        return $this;
+    }
+
+    /**
      * Convert a word in to the format for a symfony action action_name => actionName
      *
      * @param string $action Word to actionify


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Fixes the following tickets: -
Todo: -
License of the code: MIT

These methods may be used to remove all unneeded routes at once.

It has also safety impact: these methods should be used to safely remove all uneeded and properly untested routes that will be added in new version of Sonata.
