### PR TITLE
Remove fixed width for admin block on dashboard

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -66,10 +66,6 @@
     margin-left: 0px;
 }
 
-.sonata-bc table.sonata-ba-list {
-    width: 500px;
-}
-
 .sonata-bc div.sonata-ba-field-inline-table input.title {
     width: 100px;
 }


### PR DESCRIPTION
The fixed width breaks the dashboard on smaller screen sizes, as it overlaps with any blocks that may be to the right of it.
