### PR TITLE
Improved the jquery form hack to remove pre tags properly.

### DIFF
--- a/Resources/public/jquery/jquery.form.js
+++ b/Resources/public/jquery/jquery.form.js
@@ -437,7 +437,7 @@ $.fn.ajaxSubmit = function(options) {
                 // -- custom hack to make the ajax request works with non typed dataType
                 // author : Thomas Rabaix <thomas.rabaix@sonata-project.org>
                 // account for browsers injecting pre around json response
-                var matches = xhr.responseText.match(/^(<pre([^>]*)>|<body([^>]*)>)(.*)(<\/pre>|<\/body>)$/);
+                var matches = xhr.responseText.match(/^(<pre([^>]*)>|<body([^>]*)>)(.*)(<\/pre>|<\/body>)$/i);
 
                 if(matches && matches.length == 6){
                     xhr.responseText = matches[4];


### PR DESCRIPTION
Some browsers like ie7-8 add `<pre>` tags around text/plain ajax responses.
The regex detecting that, was case sensitive whereas the IEs print `<PRE>` and that could not matched.

As a result json responses in IE7-8 for file uploads using the jquery.form.js plugin appear as text in the popup.

[Example](http://imageshack.us/a/img189/9646/mediatd.jpg)
