### PR TITLE
Improved the jquery.form hack to remove pre tags properly.

### DIFF
--- a/Resources/public/jquery/jquery.form.js
+++ b/Resources/public/jquery/jquery.form.js
@@ -439,11 +439,11 @@ $.fn.ajaxSubmit = function(options) {
                 // account for browsers injecting pre around json response
                 var matches = xhr.responseText.match(/^(<pre([^>]*)>|<body([^>]*)>)(.*)(<\/pre>|<\/body>)$/i);
 
-                if(matches && matches.length == 6){
+                if (matches && matches.length == 6) {
                     xhr.responseText = matches[4];
                 }
 
-                if(xhr.responseText[0] == '{') {
+                if (xhr.responseText.charAt(0) == '{') {
                     data = parseJSON(xhr.responseText);
                 }
                 // -- end custom hack


### PR DESCRIPTION
Some browsers like ie7-8 add `<pre>` tags around text/plain ajax responses.
The regex detecting that, was case sensitive whereas the IEs print `<PRE>` and that could not matched.

As a result json responses in IE7-8 for file uploads using the jquery.form.js plugin appear as text in the popup.

Must also be applied in master.

[Example](http://imageshack.us/a/img189/9646/mediatd.jpg)
