### PR TITLE
Fixed issue with filtering on sub-entities

### DIFF
--- a/Filter/Filter.php
+++ b/Filter/Filter.php
@@ -54,7 +54,7 @@ abstract class Filter implements FilterInterface
            get bound, the default dataMapper is a PropertyPathMapper).
            So use this trick to avoid any issue.
         */
-        return str_replace('.', '~', $this->name);
+        return str_replace('.', '__', $this->name);
     }
 
     /**


### PR DESCRIPTION
Adding filter on sub-entities wase't possible due to ~ is a illegal char in symfony2 
