### PR TITLE
Replaced dots with underscores in fields block names

### DIFF
--- a/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -98,8 +98,10 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             $baseName = str_replace('.', '_', $sonataAdmin['field_description']->getAdmin()->getCode());
             $baseType = $types[count($types) - 1];
 
+            $fieldName = str_replace('.', '_', $sonataAdmin['field_description']->getName());
+
             $types[] = sprintf('%s_%s', $baseName, $baseType);
-            $types[] = sprintf('%s_%s_%s', $baseName, $sonataAdmin['field_description']->getName(), $baseType);
+            $types[] = sprintf('%s_%s_%s', $baseName, $fieldName, $baseType);
             if ($sonataAdmin['block_name']) {
                 $types[] = $sonataAdmin['block_name'];
             }


### PR DESCRIPTION
Adding associated field in `configureFormFields()` related to a Bar entity with dot notation:

``` php
$formMapper->add('baz.name');
```

the last field block name generated is:

``` twig
sonata_admin_foo_bar_baz.name_text
```

the attached code replace dots with underscore, so result is:

``` twig
sonata_admin_foo_bar_baz_name_text
```

I tested this fix only on 2.0 branch but I think the same can be applied also on master.
