### PR TITLE
Changed `pt_PT` translation file to `pt` and translated the new elements

### DIFF
--- a/Resources/translations/SonataAdminBundle.pt.xliff
+++ b/Resources/translations/SonataAdminBundle.pt.xliff
@@ -50,8 +50,8 @@
                 <source>link_action_list</source>
                 <target>Voltar à lista</target>
             </trans-unit>
-            <trans-unit id="link_action_view">
-                <source>link_action_view</source>
+            <trans-unit id="link_action_show">
+                <source>link_action_show</source>
                 <target>Ver</target>
             </trans-unit>
             <trans-unit id="link_action_edit">
@@ -190,6 +190,10 @@
                 <source>message_batch_confirmation</source>
                 <target>Tem a certeza de que deseja confirmar esta ação e executá-la para todos os elementos selecionados?</target>
             </trans-unit>
+            <trans-unit id="message_batch_all_confirmation">
+                <source>message_batch_all_confirmation</source>
+                <target>Tem a certeza que quer confirmar esta ação e executá-la para todos os elementos?</target>
+            </trans-unit>
             <trans-unit id="btn_execute_batch_action">
                 <source>btn_execute_batch_action</source>
                 <target>Sim, executar</target>
@@ -238,31 +242,101 @@
               <source>label_type_less_than</source>
               <target>&lt;</target>
             </trans-unit>
+            <trans-unit id="label_date_type_equal">
+              <source>label_date_type_equal</source>
+              <target>=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_greater_equal">
+              <source>label_date_type_greater_equal</source>
+              <target>&gt;=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_greater_than">
+              <source>label_date_type_greater_than</source>
+              <target>&gt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_less_equal">
+              <source>label_date_type_less_equal</source>
+              <target>&lt;=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_less_than">
+              <source>label_date_type_less_than</source>
+              <target>&lt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_null">
+              <source>label_date_type_null</source>
+              <target>está vazio</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_not_null">
+              <source>label_date_type_not_null</source>
+              <target>não está vazio</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_between">
+              <source>label_date_type_between</source>
+              <target>entre</target>
+            </trans-unit>
+            <trans-unit id="label_date_not_between">
+              <source>label_date_type_not_between</source>
+              <target>não entre os</target>
+            </trans-unit>
+            <trans-unit id="label_filters">
+              <source>label_filters</source>
+              <target>Filtros</target>
+            </trans-unit>
+
+            <trans-unit id="delete_or">
+              <source>delete_or</source>
+              <target>ou</target>
+            </trans-unit>
+
+            <trans-unit id="link_action_history">
+                <source>link_action_history</source>
+                <target>Revisões</target>
+            </trans-unit>
+            <trans-unit id="td_action">
+                <source>td_action</source>
+                <target>Ação</target>
+            </trans-unit>
+            <trans-unit id="td_revision">
+                <source>td_revision</source>
+                <target>Revisões</target>
+            </trans-unit>
+            <trans-unit id="td_timestamp">
+                <source>td_timestamp</source>
+                <target>Data</target>
+            </trans-unit>
+            <trans-unit id="td_username">
+                <source>td_username</source>
+                <target>Autor</target>
+            </trans-unit>
+            <trans-unit id="label_view_revision">
+                <source>label_view_revision</source>
+                <target>Ver Revisão</target>
+            </trans-unit>
 
             <trans-unit id="list_results_count">
                 <source>list_results_count</source>
-                <target>list_results_count|list_results_count</target>
+                <target>1 resultado|%count% resultados</target>
             </trans-unit>
             <trans-unit id="label_export_download">
                 <source>label_export_download</source>
-                <target>label_export_download</target>
+                <target>Download:</target>
             </trans-unit>
             <trans-unit id="loading_information">
                 <source>loading_information</source>
-                <target>Carregando informações…</target>
+                <target>Carregando informação…</target>
             </trans-unit>
 
             <trans-unit id="btn_preview">
                 <source>btn_preview</source>
-                <target>btn_preview</target>
+                <target>Visualizar</target>
             </trans-unit>
             <trans-unit id="btn_preview_approve">
                 <source>btn_preview_approve</source>
-                <target>btn_preview_approve</target>
+                <target>Aprovado</target>
             </trans-unit>
             <trans-unit id="btn_preview_decline">
                 <source>btn_preview_decline</source>
-                <target>btn_preview_decline</target>
+                <target>Rejeitar</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
- Changed the filename of `pt_PT` translations to `pt` because portuguese (pt) is the main language
- Added the new elements to the Portuguese Translation
