### PR TITLE
Display public field values in the list

### DIFF
--- a/Admin/BaseFieldDescription.php
+++ b/Admin/BaseFieldDescription.php
@@ -322,11 +322,14 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         $getters[] = 'get' . $camelizedFieldName;
         $getters[] = 'is' . $camelizedFieldName;
 
-
         foreach ($getters as $getter) {
             if (method_exists($object, $getter)) {
                 return call_user_func(array($object, $getter));
             }
+        }
+
+        if (isset($object->{$fieldName})) {
+            return $object->{$fieldName};
         }
 
         throw new NoValueException(sprintf('Unable to retrieve the value of `%s`', $this->getName()));


### PR DESCRIPTION
Enable public fields without getters to be displayed in the list.

Previously, when there was not getter method, the field would not have a value in the list, even if it was public. (BTW: The edit forms work without this patch because they use the Symfony2 Form mechanisms that look for getters first and then for public fields.)
