### PR TITLE
[WIP]Moved CSS class "sonata-bc"  from <body> to <div>

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -8,7 +8,7 @@ html, body {
     vertical-align: baseline;
 }
 
-.sonata-bc .sonata-ba-content {
+.sonata-bc .sonata-ba-container {
     padding-top: 60px;
 }
 

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -122,7 +122,7 @@ file that was distributed with this source code.
                 </div>
             </div>
 
-            <div class="container-fluid sonata-ba-content">
+            <div class="container-fluid sonata-ba-container">
                 {% if _breadcrumb is not empty or action is defined %}
                     <ul class="breadcrumb">
                         {% if _breadcrumb is empty %}


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Fixes the following tickets: #965
Todo: -
License of the code: MIT

If sonata-bc class is in `body` element, it breaks third party css/js solutions, for example CKEditor (overlay dialogs and windows).
This change was tested in IE9 (+IE8, +IE7 by compatibility mode), FF 15 and Chrome 22.

Todo: content loaded by ajax has invalid style
