### PR TITLE
Add \DateTime fields display in list CRUD template

### DIFF
--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -146,6 +146,7 @@ class SonataAdminExtension extends \Twig_Extension
         $value = null;
         try {
             $value = $fieldDescription->getValue($object);
+            $value = $value instanceof \DateTime ? $value->format('Y-m-d H:i:s') : $value;
         } catch (NoValueException $e) {
             if ($fieldDescription->getAssociationAdmin()) {
                 $value = $fieldDescription->getAssociationAdmin()->getNewInstance();


### PR DESCRIPTION
When trying to display a DateTime field in a list, I had the following error:

```
An exception has been thrown during the rendering of a template ("Catchable Fatal Error: Object of class DateTime could not be converted to string in /Users/vincent/dev/perso/frequence3/app/cache/dev/twig/d0/dd/b5d4f7105e7dee556992ae0c4e9a.php line 54") in "SonataAdminBundle:CRUD:list.html.twig".
```

So I have added a default format `Y-m-d H:i:s` in the Twig extension.
I would have liked to use the `SonataIntlBundle` to fix it but it is declare as a "suggest" package in the `composer.json` file.

Let me know if there is a better way to fix it.

Thank you!
