### PR TITLE
Knp-Menu-Bundle version is fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/config": ">=2.1,<2.3-dev",
         "symfony/console": ">=2.1,<2.3-dev",
         "twig/twig": ">=1.10,<2.0-dev",
-        "knplabs/knp-menu-bundle": "1.1.*",
+        "knplabs/knp-menu-bundle": ">=1.1.*,<2.0.x-dev ",
         "sonata-project/jquery-bundle": "dev-master",
         "sonata-project/exporter": "dev-master",
         "sonata-project/block-bundle": "dev-master"


### PR DESCRIPTION
Changing version of knp-menu-bundle

version 1.1.0 of knp-menu-bundle is dependant on oldest version of SymfonyFrameworkBundle and composer will not update SymfonyFrameworkBundle
