### PR TITLE
Fix block_name field descriptor always set to false

### DIFF
--- a/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -59,6 +59,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             $sonataAdmin['name']              = $fieldDescription->getName();
             $sonataAdmin['edit']              = $fieldDescription->getOption('edit', 'standard');
             $sonataAdmin['inline']            = $fieldDescription->getOption('inline', 'natural');
+            $sonataAdmin['block_name']        = $fieldDescription->getOption('block_name', false);
             $sonataAdmin['class']             = $this->getClass($builder);
 
             $builder->setAttribute('sonata_admin_enabled', true);


### PR DESCRIPTION
In `buildForm` method of `FormTypeFieldExtension` class, `block_name` is always set to `false`.
This modification allow to set this option among field description in a form mapper, and will be exposed as block name by `buildView` method.

Example:

``` php
$formMapper
    ->add('foo', null, array(), array('block_name' => 'my_foo_bar');
    ->end();
```

Will be available as:

``` twig
{% block my_foo_bar_widget %}
    {# something #}
{% endblock %}
```
