### PR TITLE
Wildcard not allowed in composer version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/config": ">=2.1,<2.3-dev",
         "symfony/console": ">=2.1,<2.3-dev",
         "twig/twig": ">=1.10,<2.0-dev",
-        "knplabs/knp-menu-bundle": ">=1.1.*,<2.0.x-dev ",
+        "knplabs/knp-menu-bundle": ">=1.1.0,<2.0.x-dev",
         "sonata-project/jquery-bundle": "dev-master",
         "sonata-project/exporter": "dev-master",
         "sonata-project/block-bundle": "dev-master"


### PR DESCRIPTION
As in subject, with composer version bb685d9.

```
[UnexpectedValueException]                  
Could not parse version constraint >=1.1.*
```
