### PR TITLE
Removed uniqid from template block prefixes

### DIFF
--- a/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -99,11 +99,13 @@ class FormTypeFieldExtension extends AbstractTypeExtension
 
             // add a new block types, so the Admin Form element can be tweaked based on the admin code
             $block_prefixes    = $view->vars['block_prefixes'];
-            $baseName = str_replace('.', '_', $sonataAdmin['field_description']->getAdmin()->getCode());
-            $baseType = $block_prefixes[count($block_prefixes) - 1];
+            $baseName = str_replace('.', '_', $sonataAdmin['admin']->getCode());
+            $baseType = $block_prefixes[count($block_prefixes) - 2];
+            $blockSuffix = preg_replace("#^_([a-z0-9]{14})_(.++)$#", "\$2", array_pop($block_prefixes));
 
             $block_prefixes[] = sprintf('%s_%s', $baseName, $baseType);
-            $block_prefixes[] = sprintf('%s_%s_%s', $baseName, $sonataAdmin['field_description']->getName(), $baseType);
+            $block_prefixes[] = sprintf('%s_%s_%s', $baseName, $sonataAdmin['name'], $baseType);
+            $block_prefixes[] = sprintf('%s_%s_%s_%s', $baseName, $sonataAdmin['name'], $baseType, $blockSuffix);
 
             if ($sonataAdmin['block_name']) {
                 $block_prefixes[] = $sonataAdmin['block_name'];


### PR DESCRIPTION
Block prefix are generated as discussed on issue #939 [comment](https://github.com/sonata-project/SonataAdminBundle/pull/939#issuecomment-7885475), fixing BC break with 2.0 branch. 
