### PR TITLE
Persistent filters

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -205,6 +205,13 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     protected $label;
 
     /**
+     * Whether or not to persist the filters in the session
+     *
+     * @var boolean
+     */
+    protected $persistFilters = false;
+
+    /**
      * Array of routes related to this admin
      *
      * @var \Sonata\AdminBundle\Route\RouteCollection
@@ -683,10 +690,21 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
 
         // build the values array
         if ($this->hasRequest()) {
+            $filters = $this->request->query->get('filter', array());
+
+            // if persisting filters, save filters to session, or pull them out of session if no new filters set
+            if ($this->persistFilters) {
+                if ($filters == array()) {
+                    $filters = $this->request->getSession()->get($this->getCode().'.filter.parameters', array());
+                } else {
+                    $this->request->getSession()->set($this->getCode().'.filter.parameters', $filters);
+                }
+            }
+
             $parameters = array_merge(
                 $this->getModelManager()->getDefaultSortValues($this->getClass()),
                 $this->datagridValues,
-                $this->request->query->get('filter', array())
+                $filters
             );
 
             // always force the parent value
@@ -1374,6 +1392,14 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     public function getLabel()
     {
         return $this->label;
+    }
+
+    /**
+     * @param boolean $persist
+     */
+    public function setPersistFilters($persist)
+    {
+        $this->persistFilters = $persist;
     }
 
     /**

--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -205,6 +205,14 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         $definition->addMethodCall('setLabel', array($label));
 
+        if (isset($attributes['persist_filters'])) {
+            $persistFilters = (bool) $attributes['persist_filters'];
+        } else {
+            $persistFilters = (bool) $container->getParameter('sonata.admin.configuration.filters.persist');
+        }
+
+        $definition->addMethodCall('setPersistFilters', array($persistFilters));
+
         $this->fixTemplates($container, $definition);
 
         if ($container->hasParameter('sonata.admin.configuration.security.information') && !$definition->hasMethodCall('setSecurityInformation')) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -141,6 +141,9 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('delete')->defaultValue('SonataAdminBundle:CRUD:delete.html.twig')->cannotBeEmpty()->end()
                     ->end()
                 ->end()
+
+                ->scalarNode('persist_filters')->defaultValue(false)->cannotBeEmpty()->end()
+
             ->end()
         ->end();
 

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -124,5 +124,8 @@ class SonataAdminExtension extends Extension
         if (!isset($bundles['JMSTranslationBundle'])) {
             $container->removeDefinition('sonata.admin.translator.extractor.jms_translator_bundle');
         }
+
+        // set filter persistence
+        $container->setParameter('sonata.admin.configuration.filters.persist', $config['persist_filters']);
     }
 }

--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -45,6 +45,9 @@ Full Configuration Options
                 - { position: right, type: sonata.block.service.text, settings: { content: "<h2>Welcome to the Sonata Admin</h2> <p>This is a <code>sonata.block.service.text</code> from the Block Bundle, you can create and add new block in these area by configuring the <code>sonata_admin</code> section.</p> <br /> For instance, here a RSS feed parser (<code>sonata.block.service.rss</code>):"} }
                 - { position: right, type: sonata.block.service.rss, settings: { title: Sonata Project's Feeds, url: http://sonata-project.org/blog/archive.rss }}
 
+        # set to true to persist filter settings per admin module in the user's session
+        persist_filters: false
+
     sonata_block:
         default_contexts: [cms]
         blocks:


### PR DESCRIPTION
When clicking the "Back to List" button it returns to the list page without any of the filter parameters. This can be quite annoying if you have filtered, changed page or changed the sort options.

This PR adds the functionality to persist the filters in your session (per admin module). This can be configured globally in the config.yml like this:

sonata_admin:
    persist_filters: true # (default to false)

This setting can also be overridden in the admin service definition like this:

< tag name="sonata.admin" manager_type="orm" show_in_dashboard="true" group="%my.admin.test.groupname%" label="Test Admin" persist_filters="false" / > 
