### PR TITLE
Field help text escaping change

### DIFF
--- a/Resources/views/CRUD/base_standard_edit_field.html.twig
+++ b/Resources/views/CRUD/base_standard_edit_field.html.twig
@@ -23,7 +23,7 @@ file that was distributed with this source code.
         {% block field %}{{ form_widget(field_element) }}{% endblock %}
 
         {% if field_description.help %}
-            <span class="help-inline">{% block help %}{{ field_description.help }}{% endblock %}</span>
+            <span class="help-inline">{% block help %}{{ field_description.help|raw }}{% endblock %}</span>
         {% endif %}
 
         <div class="sonata-ba-field-error-messages">

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -125,7 +125,7 @@ file that was distributed with this source code.
                 {% endif %}
 
                 {% if sonata_admin.field_description.help %}
-                    <span class="help-block sonata-ba-field-help">{{ sonata_admin.field_description.help }}</span>
+                    <span class="help-block sonata-ba-field-help">{{ sonata_admin.field_description.help|raw }}</span>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
I had a need to use HTML in the field description help parameter. It was escaped by default so I have added `|raw` to prevent it removing the HTML. I can't see this causing a security risk unless you are populating the help parameter with user input - a reasonably rare scenario I imagine. This gives you far more flexibility, for instance, I needed a line break.
