### PR TITLE
Allow to use "addEntity" method, not "addEntities"

### DIFF
--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -164,7 +164,11 @@ class AdminHelper
         $method = sprintf('add%s', $this->camelize($mapping['fieldName']));
 
         if (!method_exists($object, $method)) {
-            throw new \RuntimeException(sprintf('Please add a method %s in the %s class!', $method, get_class($object)));
+            $method = rtrim($method, 's');
+
+            if (!method_exists($object, $method)) {
+                throw new \RuntimeException(sprintf('Please add a method %s in the %s class!', $method, get_class($object)));
+            }
         }
 
         $object->$method($instance);


### PR DESCRIPTION
I want to write

```
public function addPhone(Phone $phone)
{
    $this->phones[] = $phone;
}
```

instead of

```
public function addPhones(Phone $phone)
{
    $this->phones[] = $phone;
}
```

in my entity. See #1006
