### PR TITLE
Use AdminInterface instead of Admin in configureSideMenu()

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -466,7 +466,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
-    protected function configureSideMenu(MenuItemInterface $menu, $action, Admin $childAdmin = null)
+    protected function configureSideMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
     {
 
     }


### PR DESCRIPTION
Without using AdminInterface, this breaks when using an extended Admin class and configureSideMenu(). 

buildSideMenu() and getSideMenu() already only require AdminInterface.
