### PR TITLE
Czech translation fix

### DIFF
--- a/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/Resources/translations/SonataAdminBundle.cs.xliff
@@ -24,7 +24,7 @@
             </trans-unit>
             <trans-unit id="btn_create_and_return_to_list">
                 <source>btn_create_and_return_to_list</source>
-                <target>Create and return to list</target>
+                <target>Vytvořit a zpět do seznamu</target>
             </trans-unit>
             <trans-unit id="btn_filter">
                 <source>btn_filter</source>


### PR DESCRIPTION
Fix  for key "btn_create_and_return_to_list".
String was translated into English not Czech.
