### PR TITLE
Ascending arrow sort correction

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -217,7 +217,7 @@
 	margin-top: -3px;
 }
 
-.sonata-bc th.sonata-ba-list-field-header-order-desc.sonata-ba-list-field-order-active,
+.sonata-bc th.sonata-ba-list-field-header-order-desc.sonata-ba-list-field-order-active:before,
 .sonata-bc th.sonata-ba-list-field-header-order-asc.sonata-ba-list-field-order-active:hover:before {
 	content: "";
 	display: block;


### PR DESCRIPTION
The ascending sort arrow wasn't displaying properly:

![Ascending arrow](http://i.imgur.com/mIlPW.png)

It should be:

![Corrected arrow](http://i.imgur.com/p9CfM.png)
