### PR TITLE
Follow on to pull request #1033 - update label on add, reorder elements on delete

### DIFF
--- a/Resources/public/base.js
+++ b/Resources/public/base.js
@@ -164,6 +164,7 @@ var Admin = {
             var parts = container.attr('id').split('_');
             var nameRegexp = new RegExp(parts[parts.length-1]+'\\]\\[__name__','g');
             proto = proto.replace(nameRegexp, parts[parts.length-1]+']['+(container.children().length - 1));
+            proto = proto.replace(/__name__label__/, (container.children().length - 1));
             jQuery(proto).insertBefore(jQuery(this).parent());
             
             jQuery(this).trigger('sonata-collection-item-added');
@@ -172,8 +173,20 @@ var Admin = {
         jQuery(subject).on('click', '.sonata-collection-delete', function(event) {
             Admin.stopEvent(event);
 
+            var container = jQuery(this).closest('[data-prototype]');
             jQuery(this).closest('.sonata-collection-row').remove();
             
+            // Adjust indexes after delete
+            container.find('.sonata-collection-row').each(
+                function (idx, ele) {
+                    var input = jQuery(ele).find('input');
+                    var label = jQuery(ele).find('label');
+                    label.html(label.html().replace(/\d+/,idx));
+                    label.attr('for', label.attr('for').replace(/_\d+$/,'_' + idx));
+                    input.attr('name', input.attr('name').replace(/\[\d+\]$/, '[' + idx + ']'));
+                    input.attr('id', label.attr('for'));
+            });
+
             jQuery(this).trigger('sonata-collection-item-deleted');
         });
     }


### PR DESCRIPTION
Per ivan1986's comment on 1033, we need a way to reorder elements on delete.  This fixes that problem.

https://github.com/sonata-project/SonataAdminBundle/pull/1033#issuecomment-10543565

Also this fixes the label on add, so that the label reflects the new element number.

It's unclear whether non-numeric attribute indexes are allowed (or even attribute indexes that are out of order on purpose), but as of the previous code, it seems to be designed for only numerically indexed attributes.
