### PR TITLE
Update Resources/translations/SonataAdminBundle.zh_CN.xliff

### DIFF
--- a/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="zh_CN" datatype="plaintext" original="" >
+    <file source-language="zh" datatype="plaintext" original="" >
         <body>
             <trans-unit id="action_delete">
                 <source>action_delete</source>


### PR DESCRIPTION
Fixed the bug:

> 'zh_CN' is not a valid value of the atomic type 'xs:language'.
