### PR TITLE
Update Resources/translations/SonataAdminBundle.zh_CN.xliff

### DIFF
--- a/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="zh_CN" datatype="plaintext" original="" >
+    <file source-language="en" datatype="plaintext" original="" >
         <body>
             <trans-unit id="action_delete">
                 <source>action_delete</source>


### PR DESCRIPTION
Correct the source-language value.

See docs about source-language:
http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#source-language

Also, zh_CN is not a valid language code, it will cause error if used.
