### PR TITLE
Updated translation to use the translator provided by the admin

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -29,7 +29,7 @@ file that was distributed with this source code.
         <label{% for attrname,attrvalue in attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>
             {{ widget|raw }}
             <span>
-                {% if not sonata_admin.admin%}
+                {% if not sonata_admin.admin %}
                     {{- label|trans({}, translation_domain) -}}
                 {% else %}
                     {{- label|trans({}, sonata_admin.admin.translationDomain) -}}
@@ -41,8 +41,8 @@ file that was distributed with this source code.
             {% if not sonata_admin.admin%}
                 {{- label|trans({}, translation_domain) -}}
             {% else %}
-                {{- label|trans({}, sonata_admin.admin.translationDomain) -}}
-            {% endif%}
+                {{ sonata_admin.admin.trans(label) }}
+            {% endif %}
             {{ required ? '*' : '' }}
         </label>
     {% endif %}


### PR DESCRIPTION
Before this fix the translations from the current admin translator where not used in the form.
