### PR TITLE
Added missing plural forms

### DIFF
--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -192,7 +192,7 @@
             </trans-unit>
             <trans-unit id="message_batch_confirmation">
                 <source>message_batch_confirmation</source>
-                <target>Jeste li sigurni da želite izvršiti ovu naredbu nad odabranim unosima?</target>
+                <target>Jeste li sigurni da želite izvršiti ovu naredbu nad odabranim unosom?|Jeste li sigurni da želite izvršiti ovu naredbu na %count% odabranih unosa?|Jeste li sigurni da želite izvršiti ovu naredbu na %count% odabrana unosa?</target>
             </trans-unit>
             <trans-unit id="btn_execute_batch_action">
                 <source>btn_execute_batch_action</source>


### PR DESCRIPTION
There were 2 additional plural forms for translation key "message_batch_confirmation"
