### PR TITLE
Fixed inline class name

### DIFF
--- a/Resources/doc/reference/getting_started.rst
+++ b/Resources/doc/reference/getting_started.rst
@@ -64,7 +64,7 @@ Step 3: Create Admin class
 
 Admin class represents mapping of your model and administration sections (forms,
 list, show). The easiest way to create an admin class for your model is to extend
-the Sonata\AdminBundle\Admin\Admin class. For filter, list and show views, you can
+the ``Sonata\AdminBundle\Admin\Admin`` class. For filter, list and show views, you can
 target a sub model property thanks to the dot-separated notation
 (eg: ``mySubModel.mySubSubModel.myProperty``).
 


### PR DESCRIPTION
Otherwise the name is displayed like this: `SonataAdminBundleAdminAdmin`
