### PR TITLE
Update FormProxy:add declaration

### DIFF
--- a/Form/EventListener/FormProxy.php
+++ b/Form/EventListener/FormProxy.php
@@ -63,7 +63,7 @@ class FormProxy implements \IteratorAggregate, FormInterface
         return $this->__call('hasParent', func_get_args());
     }
 
-    public function add(FormInterface $child)
+    public function add($child, $type = null, array $options = array())
     {
         return $this->__call('add', func_get_args());
     }


### PR DESCRIPTION
FormProxy:add declaration does not follow symfony FormInterface:add declaration.

That causes that when using `sonata_collection_type` the `Add new` button raises an exception (detectable in the javascript console as HTML code) and does nothing.

The pull request fix this.
