### PR TITLE
Wrong detection of request method causes that deleting an object does not work

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -211,7 +211,7 @@ class CRUDController extends Controller
             throw new AccessDeniedException();
         }
 
-        if ($this->getRequest()->getMethod() == 'DELETE') {
+        if ($this->getRequest()->getMethod() == 'POST') {
             try {
                 $this->admin->delete($object);
                 $this->get('session')->setFlash('sonata_flash_success', 'flash_delete_success');


### PR DESCRIPTION
`CRUDController:deleteAction` is checking that HTTP method is `DELETE` but instead `POST` is given, so an object never gets deleted.

The pull request fix this checking for `POST` instead than for `DELETE`, but surely this should be a temporary workaround because I think that the `getMethod()`  method should be returning `DELETE`. The form has the hidden `_method` element set to `DELETE` so I don't know where it is the problem. Maybe is it a Symfony bug?
