### PR TITLE
Added $admin->setRequest($request) lines to HelperController

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -110,6 +110,7 @@ class HelperController
         $uniqid    = $request->get('uniqid');
 
         $admin = $this->pool->getInstance($code);
+        $admin->setRequest($request);
 
         if ($uniqid) {
             $admin->setUniqid($uniqid);
@@ -156,6 +157,7 @@ class HelperController
         $uniqid   = $request->get('uniqid');
 
         $admin = $this->pool->getInstance($code);
+        $admin->setRequest($request);
 
         if (!$admin) {
             throw new NotFoundHttpException();
@@ -205,6 +207,7 @@ class HelperController
         $context    = $request->get('context');
 
         $admin       = $this->pool->getInstance($code);
+        $admin->setRequest($request);
 
         // alter should be done by using a post method
         if ($request->getMethod() != 'POST') {


### PR DESCRIPTION
Prevents "The Request object has not been set" errors.

I stumbled upon this error when using "sonata_type_model_list", because after selecting an object, an ajax request is made to "admin/core/get-short-object-description", which resolves to "getShortObjectDescriptionAction()".
However, I added the "setRequest" line to the other functions in the HelperController as well.
