### PR TITLE
Added clear and clearExcept methods in RouteCollection

### DIFF
--- a/Resources/doc/reference/routing.rst
+++ b/Resources/doc/reference/routing.rst
@@ -84,7 +84,7 @@ Any registered route can be easily removed.
     }
 
 
-If you want to disable all default Sonata routes except few whitelisted ones, you can use ``removeAllExcept()`` method.
+If you want to disable all default Sonata routes except few whitelisted ones, you can use ``clearExcept()`` method.
 This method accepts an array of routes you want to keep active.
 
 .. code-block:: php
@@ -97,11 +97,11 @@ This method accepts an array of routes you want to keep active.
         protected function configureRoutes(RouteCollection $collection)
         {
             //Only `list` and `edit` route will be active
-            $collection->removeAllExcept(array('list', 'edit'));
+            $collection->clearExcept(array('list', 'edit'));
         }
     }
 
-If you want to remove all default routes, you can use ``removeAll()`` method.
+If you want to remove all default routes, you can use ``clear()`` method.
 
 .. code-block:: php
 
@@ -113,7 +113,7 @@ If you want to remove all default routes, you can use ``removeAll()`` method.
         protected function configureRoutes(RouteCollection $collection)
         {
             //All routes are removed
-            $collection->removeAll();
+            $collection->clear();
         }
     }
 

--- a/Route/RouteCollection.php
+++ b/Route/RouteCollection.php
@@ -143,7 +143,7 @@ class RouteCollection
      *
      * @return \Sonata\AdminBundle\Route\RouteCollection
      */
-    public function removeAllExcept(array $routeList)
+    public function clearExcept(array $routeList)
     {
         $routeCodeList = array();
         foreach ($routeList as $name) {
@@ -165,7 +165,7 @@ class RouteCollection
      *
      * @return \Sonata\AdminBundle\Route\RouteCollection
      */
-    public function removeAll()
+    public function clear()
     {
         $this->elements = array();
 

--- a/Tests/Route/RouteCollectionTest.php
+++ b/Tests/Route/RouteCollectionTest.php
@@ -66,7 +66,7 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
 
         $routeCollection->add('view');
         $routeCollection->add('edit');
-        $routeCollection->removeAll();
+        $routeCollection->clear();
         $this->assertFalse($routeCollection->has('create'));
         $this->assertFalse($routeCollection->has('view'));
         $this->assertFalse($routeCollection->has('edit'));
@@ -75,7 +75,7 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $routeCollection->add('view');
         $routeCollection->add('edit');
         $routeCollection->add('list');
-        $routeCollection->removeAllExcept(array('create','edit'));
+        $routeCollection->clearExcept(array('create','edit'));
         $this->assertTrue($routeCollection->has('create'));
         $this->assertTrue($routeCollection->has('edit'));
         $this->assertFalse($routeCollection->has('view'));


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Todo: -
License of the code: MIT
Documentation PR: included

Added methods clearAll and clearAllExcept in RouteCollection. These method were added in 2.0 baranch (named as removeAll and removeAllExcept), but are missing in master (see #942).
