### PR TITLE
require security-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/http-foundation": ">=2.1,<2.3-dev",
         "symfony/form": ">=2.1,<2.3-dev",
         "symfony/validator": ">=2.1,<2.3-dev",
-        "symfony/security": ">=2.1,<2.3-dev",
+        "symfony/security-bundle": ">=2.1,<2.3-dev",
         "symfony/routing": ">=2.1,<2.3-dev",
         "symfony/config": ">=2.1,<2.3-dev",
         "symfony/console": ">=2.1,<2.3-dev",


### PR DESCRIPTION
as the bundle also requires some twig functions defined by the security bundle, like is_granted

see https://github.com/symfony-cmf/symfony-cmf-docs/pull/57#issuecomment-12213828
