### PR TITLE
Set flash messages in create and edit actions only if it's not an Ajax request

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -43,7 +43,7 @@ class CRUDController extends Controller
         // response is rendered through an iframe (used by the jquery.form.js plugin)
         //  => don't know yet if it is the best solution
         if ($this->get('request')->get('_xml_http_request')
-           && strpos($this->get('request')->headers->get('Content-Type'), 'multipart/form-data') === 0) {
+            && strpos($this->get('request')->headers->get('Content-Type'), 'multipart/form-data') === 0) {
             $headers['Content-Type'] = 'text/plain';
         } else {
             $headers['Content-Type'] = 'application/json';
@@ -267,7 +267,7 @@ class CRUDController extends Controller
 
             $isFormValid = $form->isValid();
 
-             // persist if the form was valid and if in preview mode the preview was approved
+            // persist if the form was valid and if in preview mode the preview was approved
             if ($isFormValid && (!$this->isInPreviewMode() || $this->isPreviewApproved())) {
                 $this->admin->update($object);
                 $this->get('session')->setFlash('sonata_flash_success', 'flash_edit_success');
@@ -285,7 +285,9 @@ class CRUDController extends Controller
 
             // show an error message if the form failed validation
             if (!$isFormValid) {
-                $this->get('session')->setFlash('sonata_flash_error', 'flash_edit_error');
+                if (!$this->isXmlHttpRequest()) {
+                    $this->get('session')->setFlash('sonata_flash_error', 'flash_edit_error');
+                }
             } elseif ($this->isPreviewRequested()) {
                 // enable the preview template if the form was valid and preview was requested
                 $templateKey = 'preview';
@@ -472,7 +474,9 @@ class CRUDController extends Controller
 
             // show an error message if the form failed validation
             if (!$isFormValid) {
-                $this->get('session')->setFlash('sonata_flash_error', 'flash_create_error');
+                if (!$this->isXmlHttpRequest()) {
+                    $this->get('session')->setFlash('sonata_flash_error', 'flash_create_error');
+                }
             } elseif ($this->isPreviewRequested()) {
                 // pick the preview template if the form was valid and preview was requested
                 $templateKey = 'preview';


### PR DESCRIPTION
Hey,

I noticed that error flash messages in the `createAction` and the `editAction` in `CRUDController` are set even if the request is an Ajax request. For the "success" flash messages, the behavior is correct, because the response is returned before the flash is set:

```
public function createAction()
{
    // [SNIP]
    if ($this->isXmlHttpRequest()) {
        return $this->renderJson(array(
            'result' => 'ok',
            'objectId' => $this->admin->getNormalizedIdentifier($object)
        ));
    }

    $this->get('session')->setFlash('sonata_flash_success','flash_create_success');
```

However, the error flash messages are always set when the form is not valid:

```
if (!$isFormValid) {
    $this->get('session')->setFlash('sonata_flash_error', 'flash_create_error');
```

So when a form containing errors is submitted via Ajax, the modal form dialog is closed and the parent form is reloaded in the browser, the error flash message appears on top even though it does not have anything to do with the parent form.

I fixed this bug and tested the code.
