### PR TITLE
fix css on datetime widget

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -251,6 +251,10 @@
     height: 125px;
 }
 
+.sonata-bc div.sonata-medium-date {
+    overflow: hidden;
+}
+
 .sonata-bc div.sonata-medium-date select {
     width: 75px;
 }


### PR DESCRIPTION
Just a small fix on DateTime widget. You can find a sample attached to this pull request.

From this:
![Screen Shot 2013-01-17 at 10 25 10 AM](https://f.cloud.github.com/assets/182844/74300/0f0f7b94-6088-11e2-92e5-1c6200e80307.png)

To this:
![Screen Shot 2013-01-17 at 10 24 42 AM](https://f.cloud.github.com/assets/182844/74301/0f34a8e2-6088-11e2-91fb-937f8123aa34.png)
