### PR TITLE
Removed translation as it belonged in SonataUserBundle

### DIFF
--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -2,10 +2,6 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff" >
         <body>
-            <trans-unit id="sonata_user">
-                <source>sonata_user</source>
-                <target>Gebruikersbeheer</target>
-            </trans-unit>
             <trans-unit id="action_delete">
                 <source>action_delete</source>
                 <target>Verwijderen</target>


### PR DESCRIPTION
I added the sontata_user translation to the translation file yesterday. But it belonged in the SonataUserBundle. I added the catalogue in another pull request. The translation can be removed from the SonataAdmin translation file.
