### PR TITLE
Removed ActionBlockService line

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -72,7 +72,6 @@ You will also need to alter your ``app/config/config.yml`` file :
                 contexts:   [admin]
 
             sonata.block.service.text:
-            sonata.block.service.action:
             sonata.block.service.rss:
 
 


### PR DESCRIPTION
Removed sonata.block.service.action, because it is removed from the SonataBlockBundle, see https://github.com/sonata-project/SonataBlockBundle/pull/16 .
