### PR TITLE
Changed current URI in side menu

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1321,7 +1321,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
 
         $menu = $this->menuFactory->createItem('root');
         $menu->setChildrenAttribute('class', 'nav nav-list');
-        $menu->setCurrentUri($this->getRequest()->getRequestUri());
+        $menu->setCurrentUri($this->getRequest()->getPathInfo());
 
         $this->configureSideMenu($menu, $action, $childAdmin);
 


### PR DESCRIPTION
Changed $this->getRequest()->getRequestUri() to $this->getRequest()->getPathInfo(), to make page current also when additional request parameters (filters, info about parent admin) are present in URI.
