### PR TITLE
Return back set maxPageLinks for datagrid Pager.

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -762,6 +762,8 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         // initialize the datagrid
         $this->datagrid = $this->getDatagridBuilder()->getBaseDatagrid($this, $filterParameters);
 
+        $this->datagrid->getPager()->setMaxPageLinks($this->maxPageLinks);
+
         $mapper = new DatagridMapper($this->getDatagridBuilder(), $this->datagrid, $this);
 
         // build the datagrid filter


### PR DESCRIPTION
Return back set maxPageLinks for datagrid Pager. Because now getLinks() method in Pager without parameter return empty array.
