### PR TITLE
Fixed deprecation call

### DIFF
--- a/Datagrid/Datagrid.php
+++ b/Datagrid/Datagrid.php
@@ -100,7 +100,7 @@ class Datagrid implements DatagridInterface
         }
 
         $this->formBuilder->add('_sort_by', 'hidden');
-        $this->formBuilder->get('_sort_by')->appendClientTransformer(new CallbackTransformer(
+        $this->formBuilder->get('_sort_by')->addViewTransformer(new CallbackTransformer(
             function($value) { return $value; },
             function($value) { return $value instanceof FieldDescriptionInterface ? $value->getName() : $value; }
         ));


### PR DESCRIPTION
The `appendClientTransformer` is deprecated as of Symfony 2.1 and will be removed in 2.3.
