### PR TITLE
Fixed setCurrentUri() in buildSideMenu()

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1335,7 +1335,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
 
         $menu = $this->menuFactory->createItem('root');
         $menu->setChildrenAttribute('class', 'nav nav-list');
-        $menu->setCurrentUri($this->getRequest()->getPathInfo());
+        $menu->setCurrentUri($this->getRequest()->getBaseUrl().$this->getRequest()->getPathInfo());
 
         $this->configureSideMenu($menu, $action, $childAdmin);
 


### PR DESCRIPTION
With this fix, the active side menu item is shown correctly even if
- the script name is in the URI (e.g., `app_dev.php`),
- the script directory is below the web root (e.g., `/backend/`) and
- the URI contains parameters (e.g., `?param1=value&param2=value`).
