### PR TITLE
Update Resources/views/Form/form_admin_fields.html.twig

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -133,7 +133,7 @@ file that was distributed with this source code.
                 {% endif %}
 
                 {% if sonata_admin.field_description.help %}
-                    <span class="help-block sonata-ba-field-help">{{ sonata_admin.field_description.help|raw }}</span>
+                    <span class="help-block sonata-ba-field-help">{{ sonata_admin.admin.trans(sonata_admin.field_description.help|raw) }}</span>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
Make the help message translateable throw the admin.trans function. 
I think that's the nicer solution because otherwise we have always the raw value.
