### PR TITLE
Fixes child admins in the FieldDescription instances

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1257,7 +1257,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
             $admin = $pool->getAdminByClass($fieldDescription->getTargetEntity());
 
             // prefer a child, if attached.
-            if ($this->hasChild($admin->getCode())) {
+            if ($admin && $this->hasChild($admin->getCode())) {
                 $admin = $this->getChild($admin->getCode());
             }
         }


### PR DESCRIPTION
The child admin was never used if it wasn't explicitly attached to the field description instance. This fixes this.
