### PR TITLE
Groups of permissions in role security handler

### DIFF
--- a/Security/Handler/RoleSecurityHandler.php
+++ b/Security/Handler/RoleSecurityHandler.php
@@ -40,19 +40,34 @@ class RoleSecurityHandler implements SecurityHandlerInterface
             $attributes = array($attributes);
         }
 
-        foreach ($attributes as $pos => $attribute) {
-            $attributes[$pos] = sprintf($this->getBaseRole($admin), $attribute);
-        }
+        $roles = $this->getAttributeRoles($admin, $attributes);
 
         try {
-            return $this->securityContext->isGranted($this->superAdminRoles) || $this->securityContext->isGranted($attributes);
+            return $this->securityContext->isGranted($this->superAdminRoles) || $this->securityContext->isGranted($roles);
         } catch (AuthenticationCredentialsNotFoundException $e) {
             return false;
         } catch (\Exception $e) {
             throw $e;
         }
     }
+    
+    /**
+     * Get roles for attributes from admin security infomation
+     */
+    private function getAttributeRoles(AdminInterface $admin, array $attributes)
+    {
+        $baseRole = $this->getBaseRole($admin);
 
+        $results = array();
+        foreach ($admin->getSecurityInformation() as $role => $permissions) {
+            if (count(array_intersect($attributes, $permissions)) > 0) {
+                $results[] = sprintf($baseRole, $role);
+            }
+        }
+
+        return $results;
+    }
+    
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
Q              A
Bug fix? 	no
New feature? 	yes
BC breaks? 	no
Tests pass? 	some tests are invalid, but not due to this pull

If you use the security handler based on the roles, you are intended to include into your role a lot of subroles. The total number of subroles to be distributed is the number of admin classes times the number of permissions. This is too much.

Now the role security handler does not use security information field of the admin class as well sonata_admin.security.infomation parameter does not affect. This pull allows to define groups of permissions in security information field and grant acces for these groups. The groups can be defined globally in sonata_admin.security.information parameter or locally by calling setSecurityInformation method of the admin class.

Before
a) config.yml

    sonata_admin:
        security:
            handler: sonata.admin.security.handler.role
            information:
                LIST: LIST
                SHOW: SHOW
                EDIT: EDIT
                CREATE: CREATE
                DELETE: DELETE
                OPERATOR: OPERATOR
                EXPORT: EXPORT
                MASTER: MASTER

b) security.yml

    security:
        role_hierarchy:
            ROLE_CLIENT:
                - ROLE_ADMIN_MAIN_SECTION_SHOW
                - ROLE_ADMIN_MAIN_SECTION_LIST
                - ROLE_ADMIN_MAIN_SECTION_EXPORT
            ROLE_STAFF:
                - ROLE_ADMIN_MAIN_SECTION_EDIT
                - ROLE_ADMIN_MAIN_SECTION_CREATE
                - ROLE_ADMIN_MAIN_SECTION_DELETE
                - ROLE_ADMIN_MAIN_SECTION_OPERATOR
                - ROLE_ADMIN_MAIN_SECTION_MASTER
        # times the number of admin class

After
a) config.yml

    sonata_admin:
        security:
            handler: sonata.admin.security.handler.role
            information:
                CLIENT : [LIST, SHOW, EXPORT]
                STAFF  : [EDIT, CREATE, DELETE, OPERATOR, MASTER]

b) security.yml

    security:
        role_hierarchy:
            ROLE_CLIENT:
                - ROLE_ADMIN_MAIN_SECTION_CLIENT # times the number of admin class
            ROLE_STAFF:
                - ROLE_ADMIN_MAIN_SECTION_STAFF
