### PR TITLE
Fixed an XSS vulnerability in the Twig Extension

### DIFF
--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -40,7 +40,7 @@ class SonataAdminExtension extends \Twig_Extension
         return array(
             'render_list_element'     => new \Twig_Filter_Method($this, 'renderListElement', array('is_safe' => array('html'))),
             'render_view_element'     => new \Twig_Filter_Method($this, 'renderViewElement', array('is_safe' => array('html'))),
-            'render_relation_element' => new \Twig_Filter_Method($this, 'renderRelationElement', array('is_safe' => array('html'))),
+            'render_relation_element' => new \Twig_Filter_Method($this, 'renderRelationElement'),
         );
     }
 


### PR DESCRIPTION
The `render_relation_element` filter (in contrast to the other two filters) does not use a template for rendering, but simply returns the `__toString()` value of the given object (that's the default behavior). However, the method was marked as HTML-safe. This leads to the fact that any string returned by `__toString()` (which often comes from direct user input) is output without any escaping. This makes the filter vulnerable to a Stored Cross-Site Scripting attack. The vulnerability has been fixed in this commit.

Attack vector example: I have a one-to-many relationship between `Parent` and `Child`. The `__toString()` method returns the name of the child, which is direct user input. In the `configureListFields` method of `ParentAdmin`, I want all the children to be listed: `$listMapper->add('children', 'orm_one_to_many');`. If an attacker enters `<script>alert('XSS');</script>` in the child name field, the script code is executed as soon as anybody views the `Parent` list. This is because the `render_relation_element` filter is marked as HTML safe.
