### PR TITLE
Add base route code for routes with dots

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1087,7 +1087,12 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     {
         $this->buildRoutes();
 
-        if (! $this->isChild() && strpos($name, '.') !== false) {
+        if (
+            ! $this->isChild()
+            && strpos($name, '.') !== false
+            && strpos($name, $this->getBaseCodeRoute() . '|') !== 0
+            && strpos($name, $this->getBaseCodeRoute() . '.') !== 0
+        ) {
             $name = $this->getCode() . '|' . $name;
         }
 

--- a/Tests/Admin/BaseAdminTest.php
+++ b/Tests/Admin/BaseAdminTest.php
@@ -179,6 +179,7 @@ class BaseAdminTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($postAdmin->hasRoute('show'));
         $this->assertTrue($postAdmin->hasRoute('sonata.post.admin.post.show'));
         $this->assertTrue($postAdmin->hasRoute('sonata.post.admin.post|sonata.post.admin.comment.show'));
+        $this->assertTrue($postAdmin->hasRoute('sonata.post.admin.comment.list'));
 
         $this->assertFalse($postAdmin->hasRoute('sonata.post.admin.post|sonata.post.admin.comment.edit'));
         $this->assertFalse($commentAdmin->hasRoute('edit'));


### PR DESCRIPTION
Because routes to child pages did not pass the hasRoute() check. I made this change because I wanted to create an identifier link like this:

``` php
$listMapper->addIdentifier('title', null, ['route' => ['name' => 'bundle_name.admin.block.list']])
```

Where "bundle_name.admin.block" is a child admin. The route was correctly generated with:

``` php
$this->generateObjectUrl('bundle_name.admin.block.list', $this->getSubject());
```

But the hasRoute() method returned false. 
