### PR TITLE
Modify Getting Started documentation to be in line with symfony docs and have YAML examples.

### DIFF
--- a/Resources/doc/reference/getting_started.rst
+++ b/Resources/doc/reference/getting_started.rst
@@ -114,10 +114,11 @@ Step 4: Create admin service
 To notify your administration of your new admin class you need to create an
 admin service and link it into the framework by setting the sonata.admin tag.
 
-Create a new ``admin.xml`` file inside the ``MyBundle/Resources/config/`` folder:
+Create either a new ``admin.xml`` or ``admin.yml`` file inside the ``MyBundle/Resources/config/`` folder:
 
 .. code-block:: xml
 
+   <!-- MyBundle/Resources/config/admin.xml -->
    <container xmlns="http://symfony.com/schema/dic/services"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://symfony.com/schema/dic/services/services-1.0.xsd">
@@ -137,16 +138,56 @@ Create a new ``admin.xml`` file inside the ``MyBundle/Resources/config/`` folder
 
 .. code-block:: yaml
 
+   # MyBundle/Resources/config/admin.yml
+   services:
+       sonata.admin.tag:
+           class: YourNS\AdminBundle\Admin\BlogAdmin
+           tags:
+               - { name: sonata.admin, manager_type: orm, group: posts, label: "Blog" }
+           arguments:
+               - ~
+               - YourNS\AdminBundle\Entity\Course
+               - 'SonataAdminBundle:CRUD'
+           calls:
+               - [ setTranslationDomain, [YourNSAdminBundle]]
+
+Now include your new configuration file in the framework (make sure that your ``resource`` value has the
+correct file extension depending on the code block that you used above):
+
+.. code-block:: yaml
+
     # app/config/config.yml
     imports:
         - { resource: @MyBundle/Resources/config/admin.xml }
 
-Or you can load the file inside with the Bundle's extension file:
+Or you can load the file inside with the Bundle's extension file using the ``load()`` method as described
+in the `symfony cookbook`_.
 
 .. code-block:: php
+    
+    # YourNS/AdminBundle/DependencyInjection/YourNSAdminBundleExtension.php for XML configurations
 
-    $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
-    $loader->load('admin.xml');
+    use Symfony\Component\DependencyInjection\Loader;
+    use Symfony\Component\Config\FileLocator;
+
+    public function load(array $configs, ContainerBuilder $container) {
+        // ... 
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('admin.xml');
+    }
+
+.. code-block:: php
+    
+    # YourNS/AdminBundle/DependencyInjection/YourNSAdminBundleExtension.php for YAML configurations
+
+    use Symfony\Component\DependencyInjection\Loader;
+    use Symfony\Component\Config\FileLocator;
+
+    public function load(array $configs, ContainerBuilder $container) {
+        // ... 
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('admin.yml');
+    }
 
 Step 5: Configuration
 ---------------------
@@ -216,3 +257,5 @@ refer to the security section of this documentation for more information.
 
 That should be it! Read next sections fore more verbose documentation of the
 SonataAdminBundle and how to tweak it for your requirements.
+
+.. _`symfony cookbook`: http://symfony.com/doc/master/cookbook/bundles/extension.html#using-the-load-method


### PR DESCRIPTION
I've been setting up Sonata myself and had to slow down a bit in step 4, the admin service creation, because the examples were in XML not YAML.  The symfony docs use YAML so I figured I'd see if I could add them in.  I also updated the DependencyInjection code to be directly copy-pastable with the [symfony cookbook DI examples](http://symfony.com/doc/master/cookbook/bundles/extension.html#using-the-load-method) (mainly `use` the `Loader` class and reference `Loader\YamlFileLoader` instead of `use`ing `Loader\YamlFileLoader`).

I also updated the PHP code to say which files they come from and include the function signatures that they belong to.  I'm not sure what the standard is in terms of if to include the class that it came from also (i.e., should I put `class YourNSAdminBundleExtension extends Extension` at the top of the code fragment?).

Let me know if I didn't format this pull request correctly.  I know some groups like everything squashed to 1 commit, I couldn't find a contributions document quickly.
