### PR TITLE
Fix navbar layout issue in IE8

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -1,6 +1,10 @@
-@media (min-width: 979px) {
+body.sonata-bc {
+    padding-top: 60px;
+}
+
+@media (max-width: 978px) {
     body.sonata-bc {
-        padding-top: 60px;
+        padding-top: 0;
     }
 }
 


### PR DESCRIPTION
This PR fixes a problem with the navbar layout being broken if the brand also contains text.
Furthermore it adds missing "top-padding" in IE 
