### PR TITLE
Update jQuery reference to 1.8.3 to be in sync with jqueryBundle

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
         {% endblock %}
 
         {% block javascripts %}
-            <script src="{{ asset('bundles/sonatajquery/jquery-1.8.0.js') }}" type="text/javascript"></script>
+            <script src="{{ asset('bundles/sonatajquery/jquery-1.8.3.js') }}" type="text/javascript"></script>
             <script src="{{ asset('bundles/sonatajquery/jquery-ui-1.8.23.js') }}" type="text/javascript"></script>
             <script src="{{ asset('bundles/sonatajquery/jquery-ui-i18n.js') }}" type="text/javascript"></script>
 


### PR DESCRIPTION
The jQueryBundle was updated on the 1.8.X branch to use 1.8.3.  This requires an update to the standard_layout so that it can properly find the javascript.
