### PR TITLE
Added blocks to allow standard layout titles to be overridden

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -49,21 +49,23 @@ file that was distributed with this source code.
         {% endblock %}
 
         <title>
-            {{ 'Admin'|trans({}, 'SonataAdminBundle') }}
+            {% block head_title %}
+                {{ 'Admin'|trans({}, 'SonataAdminBundle') }}
 
-            {% if _title is not empty %}
-                {{ _title|raw }}
-            {% else %}
-                {% if action is defined %}
-                    -
-                    {% for label, uri in admin.breadcrumbs(action) %}
-                        {% if not loop.first  %}
-                            &gt;
-                        {% endif %}
-                        {{ label }}
-                    {% endfor %}
-                {% endif %}
-            {% endif%}
+                {% if _title is not empty %}
+                    {{ _title|raw }}
+                {% else %}
+                    {% if action is defined %}
+                        -
+                        {% for label, uri in admin.breadcrumbs(action) %}
+                            {% if not loop.first  %}
+                                &gt;
+                            {% endif %}
+                            {{ label }}
+                        {% endfor %}
+                    {% endif %}
+                {% endif%}
+            {% endblock %}
         </title>
     </head>
     <body class="sonata-bc {% if _side_menu is empty %}sonata-ba-no-side-menu{% endif %}">
@@ -159,15 +161,17 @@ file that was distributed with this source code.
             {% if _title is not empty or action is defined %}
                 <div class="page-header">
                     <h1>
-                        {% if _title is not empty %}
-                            {{ _title|raw }}
-                        {% elseif action is defined %}
-                            {% for label, uri in admin.breadcrumbs(action) %}
-                                {% if loop.last  %}
-                                    {{ label }}
-                                {% endif %}
-                            {% endfor %}
-                        {% endif%}
+                        {% block page_title %}
+                            {% if _title is not empty %}
+                                {{ _title|raw }}
+                            {% elseif action is defined %}
+                                {% for label, uri in admin.breadcrumbs(action) %}
+                                    {% if loop.last  %}
+                                        {{ label }}
+                                    {% endif %}
+                                {% endfor %}
+                            {% endif%}
+                        {% endblock %}
                     </h1>
                 </div>
             {% endif%}


### PR DESCRIPTION
I was trying to integrate some pages that use Sonata with pages that don't; I want the Sonata heading bar on my non-Sonata pages too. This mostly worked but I also wanted to be able to set the page title without copying and pasting the whole template.

To allow this, I have added `{% block head_title %}` and `{% block page_title %}`.

(I didn't use 'title' because that's probably already used by people in their template hierarchy). Let me know if I should do this differently. :)
