### PR TITLE
Fixed the KnpMenuBundle requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/console": ">=2.2,<2.3-dev",
         "symfony/twig-bridge": ">=2.2,<2.3-dev",
         "twig/twig": ">=1.12,<2.0-dev",
-        "knplabs/knp-menu-bundle": "1.1.x-dev",
+        "knplabs/knp-menu-bundle": "~1.1",
         "sonata-project/jquery-bundle": "1.8.*",
         "sonata-project/exporter": "1.*",
         "sonata-project/block-bundle": "2.2.*@dev",
@@ -46,8 +46,6 @@
     "target-dir": "Sonata/AdminBundle",
     "extra": {
         "branch-alias": {
-            "dev-2.0": "2.0.x-dev",
-            "dev-2.1": "2.1.x-dev",
             "dev-master": "2.2.x-dev"
         }
     }


### PR DESCRIPTION
There is no reason to forbid stable versions of the bundle.
Fixes #1205
