### PR TITLE
fix buildBreadcrumb if action is not list and has no subject

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1995,10 +1995,16 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
             }
 
         } elseif ($action != 'list') {
-            $breadcrumbs = $child->getBreadcrumbsArray(
-//                $this->trans($this->getLabelTranslatorStrategy()->getLabel(sprintf('%s_%s', $this->getClassnameLabel(), $action), 'breadcrumb', 'link'))
-                  $this->toString($this->getSubject())
-            );
+            if ($this->hasSubject()) {
+                $breadcrumbs = $child->getBreadcrumbsArray(
+                    $this->toString($this->getSubject())
+                );
+                
+            } else {
+                $breadcrumbs = $child->getBreadcrumbsArray(
+                    $this->trans($this->getLabelTranslatorStrategy()->getLabel(sprintf('%s_%s', $this->getClassnameLabel(), $action), 'breadcrumb', 'link'))
+                );
+            }            
         } else {
             $breadcrumbs = $child->getBreadcrumbsArray();
         }


### PR DESCRIPTION
This is causing an error on the SonataMediaBundle for the view action of the media admin, somehow there is no subject then.

related to: https://github.com/symfony-cmf/cmf-sandbox/pull/159
