### PR TITLE
Fix sonata_block config doc

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -70,8 +70,8 @@ You will also need to alter your ``app/config/config.yml`` file :
             sonata.admin.block.admin_list:
                 contexts:   [admin]
 
-            sonata.block.service.text:
-            sonata.block.service.rss:
+            sonata.block.service.text: ~
+            sonata.block.service.rss: ~
 
 
 Now, install the assets from the bundles:


### PR DESCRIPTION
Missing `~` in config.yml. This causes the following error:

```
  [Symfony\Component\Config\Exception\FileLoaderLoadException]                                                                                                  
  Cannot import resource "/Users/dunglas/workspace/abc/app/config/config.yml" from "/Users/dunglas/workspace/abc/app/config/config_dev.yml".  

  [Symfony\Component\Yaml\Exception\ParseException]                                                                                           
  Indentation problem in "\/Users\/dunglas\/workspace\/abc\/app\/config\/config.yml" at line 84 (near "sonata.block.service.rss:").  
```
