### PR TITLE
Fixed validation error message displaying in form

### DIFF
--- a/Validator/ErrorElement.php
+++ b/Validator/ErrorElement.php
@@ -110,11 +110,9 @@ class ErrorElement
      */
     protected function validate(Constraint $constraint)
     {
-        $validator = $this->constraintValidatorFactory->getInstance($constraint);
-        $value     = $this->getValue();
+        $subPath = (string) $this->getCurrentPropertyPath();
 
-        $validator->initialize($this->context);
-        $validator->validate($value, $constraint);
+        $this->context->validateValue($this->getValue(), $constraint, $subPath, $this->group);
     }
 
     /**
@@ -191,7 +189,9 @@ class ErrorElement
             $message    = isset($message[0]) ? $message[0] : 'error';
         }
 
-        $this->context->addViolationAtPath($this->getFullPropertyPath(), $message, $parameters, $value);
+        $subPath = (string) $this->getCurrentPropertyPath();
+
+        $this->context->addViolationAt($subPath, $message, $parameters, $value);
 
         $this->errors[] = array($message, $parameters, $value);
 


### PR DESCRIPTION
Now the error message is displayed next to the property form field when use assert<ConstrainName> method for validation
Removed deprecated method call.
