### PR TITLE
fixed deprectaion error

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -193,7 +193,7 @@ file that was distributed with this source code.
                     <div>
                         {% for filter in admin.datagrid.filters %}
                             <div class="clearfix">
-                                <label for="{{ form.children[filter.formName].children['value'].get('id') }}">{{ admin.trans(filter.label) }}</label>
+                                <label for="{{ form.children[filter.formName].children['value'].vars.id }}">{{ admin.trans(filter.label) }}</label>
                                 {{ form_widget(form.children[filter.formName].children['type'], {'attr': {'class': 'span8 sonata-filter-option'}}) }}
                                 {{ form_widget(form.children[filter.formName].children['value'], {'attr': {'class': 'span8'}}) }}
                             </div>


### PR DESCRIPTION
get() is deprecated since version 2.1 and will be removed in 2.3. Access the public property 'vars' instead. in /vendor/symfony/symfony/src/Symfony/Component/Form/FormView.php on line 116
