### PR TITLE
Fixed error in documentation

### DIFF
--- a/Resources/doc/reference/advance.rst
+++ b/Resources/doc/reference/advance.rst
@@ -84,27 +84,27 @@ If you want to create your own RouteBuilder, you can do it using code like
 
 .. code-block:: php
 
-<?php
-namespace Acme\AdminBundle\Route;
-
-use Sonata\AdminBundle\Builder\RouteBuilderInterface;
-use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Model\AuditManagerInterface;
-use Sonata\AdminBundle\Route\PathInfoBuilder;
-use Sonata\AdminBundle\Route\RouteCollection;
-
-class EntityRouterBuilder extends PathInfoBuilder implements RouteBuilderInterface
-{
-    /**
-     * @param \Sonata\AdminBundle\Admin\AdminInterface $admin
-     * @param \Sonata\AdminBundle\Route\RouteCollection $collection
-     */
-    public function build(AdminInterface $admin, RouteCollection $collection)
-    {
-        parent::build($admin,$collection);
-        $collection->add('yourSubAction');
-    }
-}
+        <?php
+        namespace Acme\AdminBundle\Route;
+        
+        use Sonata\AdminBundle\Builder\RouteBuilderInterface;
+        use Sonata\AdminBundle\Admin\AdminInterface;
+        use Sonata\AdminBundle\Model\AuditManagerInterface;
+        use Sonata\AdminBundle\Route\PathInfoBuilder;
+        use Sonata\AdminBundle\Route\RouteCollection;
+        
+        class EntityRouterBuilder extends PathInfoBuilder implements RouteBuilderInterface
+        {
+            /**
+             * @param \Sonata\AdminBundle\Admin\AdminInterface $admin
+             * @param \Sonata\AdminBundle\Route\RouteCollection $collection
+             */
+            public function build(AdminInterface $admin, RouteCollection $collection)
+            {
+                parent::build($admin,$collection);
+                $collection->add('yourSubAction');
+            }
+        }
 
 
 If you want to modify the service that is going to be injected, add the following code to your


### PR DESCRIPTION
Fixed error in documentation.
Looks like admin->routerBuilder was renamed to routeBuilder, but documentation doesnt reflect it
