### PR TITLE
Fix of spaces in tab id's

### DIFF
--- a/Resources/views/CRUD/base_edit_form.html.twig
+++ b/Resources/views/CRUD/base_edit_form.html.twig
@@ -17,14 +17,14 @@
                 <div class="tabbable">
                     <ul class="nav nav-tabs">
                         {% for name, form_group in admin.formgroups %}
-                            <li class="{% if loop.first %}active{% endif %}"><a href="#{{ name }}" data-toggle="tab">{{ name }}</a></li>
+                            <li class="{% if loop.first %}active{% endif %}"><a href="#{{ name|replace({' ': '_'}) }}" data-toggle="tab">{{ name }}</a></li>
                         {% endfor %}
                     </ul>
             {% endblock %}
 
                 <div class="tab-content">
                     {% for name, form_group in admin.formgroups %}
-                        <div class="tab-pane {% if loop.first %} active{% endif %}" id="{{ name }}">
+                        <div class="tab-pane {% if loop.first %} active{% endif %}" id="{{ name|replace({' ': '_'}) }}">
                             <fieldset>
                                 <div class="sonata-ba-collapsed-fields">
                                     {% if form_group.description != false %}


### PR DESCRIPTION
Id should not contain spaces. But group name can and often contain spaces inside
