### PR TITLE
fixed selected datagrid-rows not lighting-up

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -125,15 +125,15 @@ body.sonata-bc {
     width: 75px;
 }
 
-.sonata-bc .zebra-striped tbody tr.sonata-ba-list-row-selected td, .sonata-bc .zebra-striped tbody tr.sonata-ba-list-row-selected th {
+.sonata-bc .table-striped tbody tr.sonata-ba-list-row-selected td, .sonata-bc .table-striped tbody tr.sonata-ba-list-row-selected th {
     background-color: #fcffc4;
 }
 
-.sonata-bc .zebra-striped tbody tr.sonata-ba-list-row-selected:nth-child(odd) td, .sonata-bc .zebra-striped tbody tr.sonata-ba-list-row-selected:nth-child(odd) th {
+.sonata-bc .table-striped tbody tr.sonata-ba-list-row-selected:nth-child(odd) td, .sonata-bc .table-striped tbody tr.sonata-ba-list-row-selected:nth-child(odd) th {
     background-color: #faff9e;
 }
 
-.sonata-bc .zebra-striped tbody tr.sonata-ba-list-row-selected:hover td, .sonata-bc .zebra-striped tbody tr.sonata-ba-list-row-selected:hover th {
+.sonata-bc .table-striped tbody tr.sonata-ba-list-row-selected:hover td, .sonata-bc .table-striped tbody tr.sonata-ba-list-row-selected:hover th {
     background-color: #fdffd8;
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |

zebra-striped is no longer used in any template
