### PR TITLE
Fixed breadcrumb

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1993,11 +1993,6 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
                     $this->trans($this->getLabelTranslatorStrategy()->getLabel(sprintf('%s_%s', $this->getClassnameLabel(), $action), 'breadcrumb', 'link'))
                 );
             }
-        } elseif ($action != 'list' && $this->hasSubject()) {
-            $breadcrumbs = $child->getBreadcrumbsArray(
-                $this->trans($this->getLabelTranslatorStrategy()->getLabel(sprintf('%s_%s', $this->getClassnameLabel(), $action), 'breadcrumb', 'link')),
-                $this->toString($this->getSubject())
-            );
         } elseif ($action != 'list') {
             $breadcrumbs = $child->getBreadcrumbsArray(
                 $this->trans($this->getLabelTranslatorStrategy()->getLabel(sprintf('%s_%s', $this->getClassnameLabel(), $action), 'breadcrumb', 'link'))


### PR DESCRIPTION
When fix for #1226 was applied, you got same breadcrumb for edit, show, create, etc.... pages. Instead of current action (labelclassname_edit, label_classname_delete) only subjects __toString is given to breadcrumb.
