### PR TITLE
Fixed the list filter layout

### DIFF
--- a/Resources/public/base.js
+++ b/Resources/public/base.js
@@ -94,9 +94,9 @@ var Admin = {
     },
 
     add_filters: function(subject) {
-        jQuery('div.filter_container .sonata-filter-option', subject).hide();
+        jQuery('div.filter_container.inactive', subject).hide();
         jQuery('fieldset.filter_legend', subject).click(function(event) {
-           jQuery('div.filter_container .sonata-filter-option', jQuery(event.target).parent()).toggle();
+           jQuery('div.filter_container', jQuery(event.target).parent()).toggle();
         });
     },
 

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -186,29 +186,31 @@ file that was distributed with this source code.
 
 {% block list_filters %}
     {% if admin.datagrid.filters %}
-        <form class="sonata-filter-form {{ admin.isChild and 1 == admin.datagrid.filters|length ? 'hide' : '' }}" action="{{ admin.generateUrl('list') }}" method="GET">
+        <form class="sonata-filter-form {{ admin.isChild and 1 == admin.datagrid.filters|length ? 'hide' : '' }} form-horizontal" action="{{ admin.generateUrl('list') }}" method="GET">
             <fieldset class="filter_legend">
                 <legend class="filter_legend {{ admin.datagrid.hasActiveFilters ? 'active' : 'inactive' }}">{{ 'label_filters'|trans({}, 'SonataAdminBundle') }}</legend>
 
                 <div class="filter_container {{ admin.datagrid.hasActiveFilters ? 'active' : 'inactive' }}">
-                    <div>
-                        {% for filter in admin.datagrid.filters %}
-                            <div class="clearfix">
-                                <label for="{{ form.children[filter.formName].children['value'].vars.id }}">{{ admin.trans(filter.label) }}</label>
-                                {{ form_widget(form.children[filter.formName].children['type'], {'attr': {'class': 'span8 sonata-filter-option'}}) }}
-                                {{ form_widget(form.children[filter.formName].children['value'], {'attr': {'class': 'span8'}}) }}
+                    {% for filter in admin.datagrid.filters %}
+                        <div class="control-group">
+                            <label class="control-label" for="{{ form.children[filter.formName].children['value'].vars.id }}">{{ admin.trans(filter.label) }}</label>
+
+                            <div class="controls">
+                                {{ form_widget(form.children[filter.formName].children['type']) }}
+                                {{ form_widget(form.children[filter.formName].children['value']) }}
                             </div>
-                        {% endfor %}
-                    </div>
+                        </div>
+                    {% endfor %}
 
                     <input type="hidden" name="filter[_page]" id="filter__page" value="1" />
 
                     {% set foo = form.children['_page'].setRendered() %}
                     {{ form_rest(form) }}
 
-                    <input type="submit" class="btn btn-primary" value="{{ 'btn_filter'|trans({}, 'SonataAdminBundle') }}" />
-
-                    <a class="btn" href="{{ admin.generateUrl('list', {filters: 'reset'}) }}">{{ 'link_reset_filter'|trans({}, 'SonataAdminBundle') }}</a>
+                    <div class="well form-actions">
+                        <input type="submit" class="btn btn-primary" value="{{ 'btn_filter'|trans({}, 'SonataAdminBundle') }}" />
+                        <a class="btn" href="{{ admin.generateUrl('list', {filters: 'reset'}) }}">{{ 'link_reset_filter'|trans({}, 'SonataAdminBundle') }}</a>
+                    </div>
                 </div>
             </fieldset>
         </form>


### PR DESCRIPTION
Fixed the broken list filter layout. Right now, not all fields are hidden when klicking the Filter heading. Now, all fields are hidden / shown when klicking the heading.

This fix is related to pull request https://github.com/sonata-project/SonataAdminBundle/pull/1241 and issue https://github.com/sonata-project/SonataAdminBundle/issues/1219.
![filter-open](https://f.cloud.github.com/assets/2149539/332648/29ac9fd4-9c35-11e2-8337-d270ac6d7eb2.png)
