### PR TITLE
Fixed "Could not be converted to string" exception on delete page

### DIFF
--- a/Resources/views/CRUD/delete.html.twig
+++ b/Resources/views/CRUD/delete.html.twig
@@ -33,7 +33,7 @@ file that was distributed with this source code.
 
         <h1>{{ 'title_delete'|trans({}, 'SonataAdminBundle') }}</h1>
 
-        {{ 'message_delete_confirmation'|trans({'%object%': object}, 'SonataAdminBundle') }}
+        {{ 'message_delete_confirmation'|trans(object.__toString is defined ? {'%object%': object} : {}, 'SonataAdminBundle') }}
 
         <div class="well form-actions">
             <form method="POST" action="{{ admin.generateObjectUrl('delete', object) }}">


### PR DESCRIPTION
Fixed "Could not be converted to string" exception on delete page if no _toString method was defined in an Entity. Variable %object% is not used in any of default translations, but I didn't remove it, maybe someone uses it in custom translations.
