### PR TITLE
Fixed an ability to change doctrine_orm_date_range child field type

### DIFF
--- a/Form/Type/DateRangeType.php
+++ b/Form/Type/DateRangeType.php
@@ -34,8 +34,8 @@ class DateRangeType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('start', 'date', array_merge(array('required' => false), $options['field_options']));
-        $builder->add('end', 'date', array_merge(array('required' => false), $options['field_options']));
+        $builder->add('start', $options['field_type'], array_merge(array('required' => false), $options['field_options']));
+        $builder->add('end', $options['field_type'], array_merge(array('required' => false), $options['field_options']));
     }
 
     /**
@@ -52,7 +52,8 @@ class DateRangeType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'field_options'    => array()
+            'field_type'    => 'date',
+            'field_options' => array()
         ));
     }
 }

--- a/Form/Type/Filter/DateRangeType.php
+++ b/Form/Type/Filter/DateRangeType.php
@@ -52,7 +52,10 @@ class DateRangeType extends AbstractType
 
         $builder
             ->add('type', 'choice', array('choices' => $choices, 'required' => false))
-            ->add('value', 'sonata_type_date_range', array('field_options' => $options['field_options']))
+            ->add('value', 'sonata_type_date_range', array(
+                'field_type' => $options['field_type'],
+                'field_options' => $options['field_options']
+            ))
         ;
     }
 
@@ -62,7 +65,7 @@ class DateRangeType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'field_type'       => 'sonata_type_date_range',
+            'field_type'       => 'date',
             'field_options'    => array('format' => 'yyyy-MM-dd')
         ));
     }


### PR DESCRIPTION
Now it's possible to do like that

``` php
->add('date', 'doctrine_orm_date_range', array(), 'genemu_jquerydate', array(
    'widget' => 'single_text'
))
```

The only thing I didn't get is child field styling with span8.
