### PR TITLE
Added field positioning functionality to FormMapper.

### DIFF
--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -26,7 +26,16 @@ class FormMapper
 
     protected $admin;
 
+    protected $currentField;
+
+    protected $currentFieldPosition;
+
     protected $currentGroup;
+
+    const FIRST = 'first';
+    const BEFORE = 'before';
+    const AFTER = 'after';
+    const LAST = 'last';
 
     /**
      * @param \Sonata\AdminBundle\Builder\FormContractorInterface $formContractor
@@ -61,7 +70,7 @@ class FormMapper
 
         $this->admin->setFormGroups($formGroups);
 
-        $this->currentGroup = $name;
+        $this->setCurrentGroup($name);
 
         return $this;
     }
@@ -71,51 +80,86 @@ class FormMapper
      */
     public function end()
     {
-        $this->currentGroup = null;
+        if ($this->getCurrentField()) {
+            $this
+                ->setCurrentField(null)
+                ->setCurrentFieldPosition(null)
+            ;
+        } else {
+            $this->setCurrentGroup(null);
+        }
 
         return $this;
     }
-    
+
+    public function first()
+    {
+        return $this->setCurrentFieldPosition($this::FIRST);
+    }
+
+    public function before($field = null)
+    {
+        return $this
+            ->setCurrentField($field)
+            ->setCurrentFieldPosition($this::BEFORE)
+        ;
+    }
+
+    public function after($field = null)
+    {
+        return $this
+            ->setCurrentField($field)
+            ->setCurrentFieldPosition($this::AFTER)
+        ;
+    }
+
+    public function last()
+    {
+        return $this->setCurrentFieldPosition($this::LAST);
+    }
+
     /**
-     * @param string $key field name
+     * @param string $field field name
      * @param string $position first, last, before, after
      * @param string $target field name
      *
      * @return \Sonata\AdminBundle\Form\FormMapper
      */
-    public function move($key, $position, $target = null)
+    public function move($field, $position, $target = null)
     {
+        $groups = $this->admin->getFormGroups();
+
         $fields = array_diff(
-            array_keys($this->admin->getFormGroups()[$this->currentGroup]['fields']),
-            array($key)
+            array_keys($groups[$this->currentGroup]['fields']),
+            array($field)
         );
 
         switch ($position) {
-            case 'first':
+            case $this::FIRST:
                 $offset = 0;
 
                 break;
 
-            case 'before':
+            case $this::BEFORE:
                 if ($target) {
                     $offset = array_search($target, $fields);
                 }
 
                 break;
 
-            case 'after':
+            case $this::AFTER:
                 if ($target) {
                     $offset = array_search($target, $fields) + 1;
                 }
 
                 break;
 
-            case 'last':
+            case $this::LAST:
                 $offset = count($fields);
         }
 
         if (isset($offset)) {
-            array_splice($fields, $offset, 0, $key);
+            array_splice($fields, $offset, 0, $field);
         }
 
         return $this->reorder($fields);
@@ -191,6 +235,15 @@ class FormMapper
             if (null !== $help) {
                 $this->admin->getFormFieldDescription($name)->setHelp($help);
             }
+        }
+
+        if ($this->getCurrentFieldPosition()) {
+            $this->move($name, $this->getCurrentFieldPosition(), $this->getCurrentField());
+
+            $this
+                ->setCurrentField($name)
+                ->setCurrentFieldPosition($this::AFTER)
+            ;
         }
 
         return $this;
@@ -269,6 +322,42 @@ class FormMapper
                 $this->admin->getFormFieldDescription($name)->setHelp($help);
             }
         }
+
+        return $this;
+    }
+
+    protected function getCurrentField()
+    {
+        return $this->currentField;
+    }
+
+    protected function setCurrentField($field)
+    {
+        $this->currentField = $field;
+
+        return $this;
+    }
+
+    protected function getCurrentFieldPosition()
+    {
+        return $this->currentFieldPosition;
+    }
+
+    protected function setCurrentFieldPosition($position)
+    {
+        $this->currentFieldPosition = $position;
+
+        return $this;
+    }
+
+    protected function getCurrentGroup()
+    {
+        return $this->currentGroup;
+    }
+
+    protected function setCurrentGroup($group)
+    {
+        $this->currentGroup = $group;
 
         return $this;
     }


### PR DESCRIPTION
At the moment, in order to reorder fields, you have to pull out of a list of all fields, reorder them manually, and pass them back to the reorder method.

This is less than convenient, so I wrote a few basic move methods that wrap all of that up for you.

This adds support for moving fields to the first or last position, as well as before and after other fields. This is especially useful when extending other admins, and thus you can't simply specify the fields in the correct order in the first place.

Example usage:

``` php
$formMapper
    ->add('amount')
    ->add('unit')
    ->add('name')

    ->move('amount', $formMapper::AFTER, 'name')
;
```

or

``` php
$formMapper
    ->after('name')
        ->add('amount')
        ->add('unit')
        ->add('name')
    ->end()
    ->before('unit')
        ->add('another_field')
    ->end()
    ->with('Prices')
        ->first()
            ->add('and_another')
        ->end()
    ->end()
    // ..etc.
;
```

**Update**: Switched out magic strings for constants and added wrapping methods for adding fields at a particular location.
