### PR TITLE
Trigger event before removing element

### DIFF
--- a/Resources/public/base.js
+++ b/Resources/public/base.js
@@ -154,9 +154,9 @@ var Admin = {
         jQuery(subject).on('click', '.sonata-collection-delete', function(event) {
             Admin.stopEvent(event);
 
-            jQuery(this).closest('.sonata-collection-row').remove();
-
             jQuery(this).trigger('sonata-collection-item-deleted');
+
+            jQuery(this).closest('.sonata-collection-row').remove();
         });
     },
 


### PR DESCRIPTION
The event must be triggered before the element is removed, else it won't work.
