### PR TITLE
Minor documentation fixes

### DIFF
--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -9,7 +9,7 @@ Configuration options
         * ``sonata.admin.security.handler.acl`` : Use this service if you want ACL
 
 * ``title`` : The admin's title, can be the client name for instance (default: Sonata Admin)
-* ``title_logo`` : logo to use, must be an image with a height of 28px (default : /bundles/sonataadmin/logo_title.png)
+* ``title_logo`` : logo to use, must be an image with a height of 28px (default : bundles/sonataadmin/logo_title.png)
 
 Please see :doc:`templates` for more information on how to configure default templates.
 
@@ -24,7 +24,7 @@ Full Configuration Options
             handler: sonata.admin.security.handler.role
 
         title:      Sonata Project
-        title_logo: /bundles/sonataadmin/logo_title.png
+        title_logo: bundles/sonataadmin/logo_title.png
         templates:
             # default global templates
             layout:  SonataAdminBundle::standard_layout.html.twig

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -70,8 +70,8 @@ You will also need to alter your ``app/config/config.yml`` file :
             sonata.admin.block.admin_list:
                 contexts:   [admin]
 
-            sonata.block.service.text:
-            sonata.block.service.rss:
+            sonata.block.service.text: ~
+            sonata.block.service.rss: ~
 
 
 Now, install the assets from the bundles:


### PR DESCRIPTION
Fixed an invalid config.yml sample code in Resources/doc/reference/installation.rst and fixed the default value for title logo in Resources/doc/reference/configuration.rst.

Starting the title_logo with / makes the asset url generated wrong when the project is not in the root of the webserver, so the doc is a bit confusing.
