### PR TITLE
Fixed dev dependencies in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "doctrine/common": ">=2.2,<3.0"
     },
     "require-dev": {
-        "jms/translation-bundle": "*",
+        "jms/translation-bundle": "*@dev",
         "sonata-project/intl-bundle": "2.1.*"
     },
     "suggest": {


### PR DESCRIPTION
Since jms/translation-bundle is only working with sf 2.2 from
version 1.1.x-dev, I updated the composer.json file.

Now the --dev requirements can be isntalled again.
