### PR TITLE
Implemented ConstraintValidator::validate()

### DIFF
--- a/Validator/InlineValidator.php
+++ b/Validator/InlineValidator.php
@@ -33,7 +33,7 @@ class InlineValidator extends ConstraintValidator
     /**
      * {@inheritDoc}
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         $errorElement = new ErrorElement(
             $value,
@@ -55,7 +55,5 @@ class InlineValidator extends ConstraintValidator
         }
 
         call_user_func($function, $errorElement, $value);
-
-        return true;
     }
 }


### PR DESCRIPTION
Since version 2.1 of `symfony/validator`, `ConstraintValidator::isValid()`
is deprecated an triggers an `E_DEPRECATED` error.

Unfortunately the error handling in some circumstances triggers
`SIGSEGV` in PHP-FPM (I havn't been able to pinpoint the exact cause).

Now `isValid()` is just a BC wrapper for `validate()` not triggering any
errors.

This fixes https://github.com/sonata-project/SonataAdminBundle/issues/1282
