### PR TITLE
Support for class-level validation

### DIFF
--- a/Validator/ErrorElement.php
+++ b/Validator/ErrorElement.php
@@ -147,6 +147,10 @@ class ErrorElement
      */
     protected function getValue()
     {
+        if ($this->current == '') {
+            return $this->subject;
+        }
+
         $propertyAccessor = PropertyAccess::getPropertyAccessor();
         return $propertyAccessor->getValue($this->subject, $this->getCurrentPropertyPath());
     }


### PR DESCRIPTION
This allows for

```
$errorElement->addConstraint(new UniqueEntity(['fields' => 'email']));
```

and similar code without an enclosing ->with().
