### PR TITLE
add removing hook "preRemove" & "preBatchRemove" for ListAction

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -586,6 +586,21 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         $this->postRemove($object);
     }
 
+
+    /**
+     * {@inheritdoc}
+     */
+    public function batchDelete($idx)
+    {
+        if(method_exists($this, 'preBatchRemove')){
+            $this->preBatchRemove($idx);
+        }else{
+            foreach((array)$idx as $id){
+                $this->preRemove($this->getObject((int)$id));
+            }
+        }
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -171,6 +171,7 @@ class CRUDController extends Controller
      * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
      *
      * @param \Sonata\AdminBundle\Datagrid\ProxyQueryInterface $query
+     * @param array $idx
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
@@ -182,6 +183,12 @@ class CRUDController extends Controller
 
         $modelManager = $this->admin->getModelManager();
         try {
+            // get idx
+            $args = func_get_args();
+            if(isset($args[1])){
+                $this->admin->batchDelete($args[1]);
+            }
+
             $modelManager->batchDelete($this->admin->getClass(), $query);
             $this->get('session')->setFlash('sonata_flash_success', 'flash_batch_delete_success');
         } catch ( ModelManagerException $e ) {
@@ -436,7 +443,7 @@ class CRUDController extends Controller
             $query = null;
         }
 
-        return call_user_func(array($this, $final_action), $query);
+        return call_user_func(array($this, $final_action), $query, $idx);
     }
 
     /**


### PR DESCRIPTION
I just got the same problem with [#issue 1314](https://github.com/sonata-project/SonataAdminBundle/issues/1314), and I added the removing hook.

You can put a function "preBatchRemove" in your Admin class, and it will be involved with a parameter `$idx` while you are deleting something in ListAction. 
```php
public function preBatchRemove($idx){
    foreach($idx as $id){
        // do sth ...
    }
}
```

<br />
if no function "preBatchRemove" created,  the "preRemove" will be involved as usual, maybe it's lack of performance, but anyway, it just works fine.
```php
public function preRemove($object){
   // ...
}
```

