### PR TITLE
bugfix: name of a field was added to the translation-catalogue when you used a translated label

### DIFF
--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -150,6 +150,7 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
         $this->addMessage($id, $domain);
+        return $id;
     }
 
     /**
@@ -158,6 +159,7 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {
         $this->addMessage($id, $domain);
+        return $id;
     }
 
     /**


### PR DESCRIPTION
added a return value to the trans and transChoice methods.

if you add a label in the configureFormFields-Method of your admin-class, the name of the field processed by the labelStrategy will still be added to the translation-catalogue. trans and transChoice have no return value, so in FormMapper isset($options['label']) will be false and labelStrategy will be used to get the label.
