### PR TITLE
Bug fix: postgresql error when deleting a medium reference in gallery edit (using SonataMediaBundle)

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -170,7 +170,9 @@ class HelperController
             $admin->setUniqid($uniqid);
         }
         
-        if(!$objectId){$objectId = NULL;}
+        if(!$objectId){
+            $objectId = null;
+        }
 
         $object = $admin->getObject($objectId);
 


### PR DESCRIPTION
Context: 
In SonataAdminBundle with SonataMediaMediaBundle, when deleting a reference of a medium in gallery edit (shown in screenshot below),  

![capture du 2013-05-08 09 34 20](https://f.cloud.github.com/assets/2612537/476178/66dbb6ac-b7b4-11e2-9f00-3ed9c3a3978f.png)

Fixed bug:
when postgresql is used 
"Invalid text representation: 7 ERROR:  invalid input syntax for integer: """

Exemple of Ajax request getting the error: 
/admin/core/get-short-object-description?objectId=&uniqid=s518a024845e25&code=sonata.media.admin.media
