### PR TITLE
Typo in class name

### DIFF
--- a/Builder/ShowBuilderInterface.php
+++ b/Builder/ShowBuilderInterface.php
@@ -15,7 +15,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 
-interface ShowBuilderInterface extends BuilderInterfaces
+interface ShowBuilderInterface extends BuilderInterface
 {
     /**
      * @abstract


### PR DESCRIPTION
Interface 'Sonata\AdminBundle\Builder\BuilderInterfaces' not found in Sonata\AdminBundle\Builder\ShowBuilderInterface.php on line 19

BuilderInterfaces > BuilderInterface
