### PR TITLE
Fix/ A reference to a non-existent key in array

### DIFF
--- a/Resources/views/CRUD/base_edit_form.html.twig
+++ b/Resources/views/CRUD/base_edit_form.html.twig
@@ -32,7 +32,7 @@
                         <div class="tab-pane {% if loop.first %} active{% endif %}" id="{{ admin.uniqid }}_{{ name|sonata_slugify }}">
                             <fieldset>
                                 <div class="sonata-ba-collapsed-fields">
-                                    {% if form_group.description != false %}
+                                    {% if form_group.description is defined %}
                                         <p>{{ form_group.description|raw }}</p>
                                     {% endif %}
 


### PR DESCRIPTION
Key "description" for array with keys "fields" does not exist in SonataAdminBundle:CRUD:base_edit_form.html.twig at line 35
