### PR TITLE
added a check if form_group.description is defined at line 35

### DIFF
--- a/Resources/views/CRUD/base_edit_form.html.twig
+++ b/Resources/views/CRUD/base_edit_form.html.twig
@@ -32,7 +32,7 @@
                         <div class="tab-pane {% if loop.first %} active{% endif %}" id="{{ admin.uniqid }}_{{ name|sonata_slugify }}">
                             <fieldset>
                                 <div class="sonata-ba-collapsed-fields">
-                                    {% if form_group.description != false %}
+                                    {% if form_group.description is defined and form_group.description != false %}
                                         <p>{{ form_group.description|raw }}</p>
                                     {% endif %}
 


### PR DESCRIPTION
As I faced an error saying "Key "description" for array with keys "fields" does not exist in SonataAdminBundle:CRUD:base_edit_form.html.twig at line 35"
using admin bundle with the media bundle, this change fixes the bug.
