### PR TITLE
added missing option 'label_catalogue' for dashboard groups in di config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -77,6 +77,7 @@ class Configuration implements ConfigurationInterface
                                 ->fixXmlConfig('item_add')
                                 ->children()
                                     ->scalarNode('label')->end()
+                                    ->scalarNode('label_catalogue')->end()
                                     ->arrayNode('items')
                                         ->prototype('scalar')->end()
                                     ->end()


### PR DESCRIPTION
Setting the label_catalogue option for dashboard groups names is prepared in [DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php#L98](https://github.com/sonata-project/SonataAdminBundle/blob/ca755ce878ff1104283ace6d7a307acd9ffa3e4e/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php#L98) but you can't actually use it, because this option was missing in the DI configuration, so it always defaulted back to 'SonataAdminBundle'.

admin.yml snippet:

``` php
dashboard:
    groups:
        sng_users:          { label: backend.group.users, label_catalogue: CatalogueName }
        sng_institutions:   { label: backend.group.institutions, label_catalogue: CatalogueName }
```
