### PR TITLE
Fix for PR1345 - Form groups missing description

### DIFF
--- a/Mapper/BaseGroupedMapper.php
+++ b/Mapper/BaseGroupedMapper.php
@@ -67,6 +67,8 @@ abstract class BaseGroupedMapper extends BaseMapper
      */
     protected function addFieldToCurrentGroup($fieldName) 
     {
+        //Note this line must happen before the next line. 
+        //See https://github.com/sonata-project/SonataAdminBundle/pull/1351
         $currentGroup = $this->getCurrentGroupName();
         $groups = $this->getGroups();
         $groups[$currentGroup]['fields'][$fieldName] = $fieldName;
@@ -76,6 +78,9 @@ abstract class BaseGroupedMapper extends BaseMapper
     /**
      * Return the name of the currently selected group. The method also makes 
      * sure a valid group name is currently selected
+     * 
+     * Note that this can have the side effect to change the "group" value
+     * returned by the getGroup function
      * 
      * @return string
      */


### PR DESCRIPTION
This PR fixes the issue raised in PR1345. 
Basically the group was missing a description due to the way the current group name was determined. 
