### PR TITLE
don't show 'first' when link is same as 'previous' button

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -139,7 +139,7 @@ file that was distributed with this source code.
                             <td colspan="{{ admin.list.elements|length }}">
                                 <div class="pagination pagination-centered">
                                     <ul>
-                                        {% if admin.datagrid.pager.page != 1  %}
+                                        {% if admin.datagrid.pager.page > 2  %}
                                             <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, 1)) }}" title="{{ 'link_first_pager'|trans({}, 'SonataAdminBundle') }}">&laquo;</a></li>
                                         {% endif %}
 


### PR DESCRIPTION
figured later i should have fixed the 'first' button as well, no point in showing it when the back button points to the same page.
