### PR TITLE
Set min-height on sonata_type_model_list css

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -366,6 +366,7 @@ legend.sonata-ba-fieldset-collapsed-description + .sonata-ba-collapsed-fields {
 
 .sonata-bc .field-short-description {
     min-width: 250px;
+    min-height: 18px;
     display: block;
     float: left;
     background: #fefefe;


### PR DESCRIPTION
If no element is selected, the span height is incorrect :

![sonata_type_model_list](https://f.cloud.github.com/assets/663607/642324/83345a08-d356-11e2-93a5-267b3c31d563.png)
