### PR TITLE
Add row selector for sonata_type_model_list

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -690,6 +690,19 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         foreach ($this->getExtensions() as $extension) {
             $extension->configureListFields($mapper);
         }
+
+        if ($this->hasRequest() && $this->getRequest()->isXmlHttpRequest()) {
+            $fieldDescription = $this->getModelManager()->getNewFieldDescriptionInstance($this->getClass(), 'select', array(
+                'label'    => false,
+                'code'     => '_select',
+                'sortable' => false,
+            ));
+
+            $fieldDescription->setAdmin($this);
+            $fieldDescription->setTemplate($this->getTemplate('select'));
+
+            $mapper->add($fieldDescription, 'select');
+        }
     }
 
     /**

--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -270,6 +270,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             'list_block'               => 'SonataAdminBundle:Block:block_admin_list.html.twig',
             'delete'                   => 'SonataAdminBundle:CRUD:delete.html.twig',
             'batch'                    => 'SonataAdminBundle:CRUD:list__batch.html.twig',
+            'select'                   => 'SonataAdminBundle:CRUD:list__select.html.twig',
             'batch_confirmation'       => 'SonataAdminBundle:CRUD:batch_confirmation.html.twig',
             'inner_list_row'           => 'SonataAdminBundle:CRUD:list_inner_row.html.twig',
             'base_list_field'          => 'SonataAdminBundle:CRUD:base_list_field.html.twig',

--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -165,6 +165,17 @@ body.sonata-bc {
     float: right
 }
 
+.sonata-bc .sonata-ba-list tr:hover td.sonata-ba-list-field.sonata-ba-list-field-select a {
+    visibility: visible;
+}
+
+.sonata-bc td.sonata-ba-list-field.sonata-ba-list-field-select {
+    text-align: center;
+}
+.sonata-bc td.sonata-ba-list-field.sonata-ba-list-field-select a {
+    visibility: hidden;
+}
+
 .sonata-bc div.sonata-ba-modal-edit-one-to-one td.sonata-ba-list-field-batch,
 .sonata-bc div.sonata-ba-modal-edit-one-to-one div.sonata-ba-list-actions,
 .sonata-bc div.sonata-ba-modal-edit-one-to-one th.sonata-ba-list-field-header-batch {

--- a/Resources/translations/SonataAdminBundle.bg.xliff
+++ b/Resources/translations/SonataAdminBundle.bg.xliff
@@ -342,6 +342,10 @@
                 <source>label_per_page</source>
                 <target>На страница</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/Resources/translations/SonataAdminBundle.ca.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>Per pàgina</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/Resources/translations/SonataAdminBundle.cs.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>Zobrazit nejvíce</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>Einträge pro Seite</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>Per page</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>Select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.es.xliff
+++ b/Resources/translations/SonataAdminBundle.es.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>Por página</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.eu.xliff
+++ b/Resources/translations/SonataAdminBundle.eu.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>label_per_page</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.fa.xliff
+++ b/Resources/translations/SonataAdminBundle.fa.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>در هر صفحه</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>Par page</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>Sélectionner</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>label_per_page</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.hu.xliff
+++ b/Resources/translations/SonataAdminBundle.hu.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>label_per_page</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>label_per_page</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/Resources/translations/SonataAdminBundle.ja.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>1ページの件数</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/Resources/translations/SonataAdminBundle.lb.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>label_per_page</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>Aantal per pagina</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>Na stronie</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pt.xliff
+++ b/Resources/translations/SonataAdminBundle.pt.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>label_per_page</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>label_per_page</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>Записей на страницу</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/Resources/translations/SonataAdminBundle.sk.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>Zobraziť najviac</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/Resources/translations/SonataAdminBundle.sl.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>label_per_page</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/Resources/translations/SonataAdminBundle.uk.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>Записів на сторінку</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -342,6 +342,10 @@
               <source>label_per_page</source>
               <target>label_per_page</target>
             </trans-unit>
+            <trans-unit id="list_select">
+              <source>list_select</source>
+              <target>list_select</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -32,6 +32,8 @@ file that was distributed with this source code.
                                     <th class="sonata-ba-list-field-header sonata-ba-list-field-header-batch">
                                       <input type="checkbox" id="list_batch_checkbox" />
                                     </th>
+                                {% elseif field_description.getOption('code') == '_select' %}
+                                    <th class="sonata-ba-list-field-header sonata-ba-list-field-header-select"></th>
                                 {% elseif field_description.name == '_action' and app.request.isXmlHttpRequest %}
                                         {# Action buttons disabled in ajax view! #}
                                 {% else %}

--- a/Resources/views/CRUD/list__select.html.twig
+++ b/Resources/views/CRUD/list__select.html.twig
@@ -1,0 +1,19 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends admin.getTemplate('base_list_field') %}
+
+{% block field %}
+    <a class="btn" href="#">
+        <i class="icon-arrow-right"></i>
+        {{ 'list_select'|trans({}, 'SonataAdminBundle') }}
+    </a>
+{% endblock %}


### PR DESCRIPTION
When opening a list from a `sonata_type_model_list` form field, this automatically add a "Choose" button for each row in the first column.

Choosing a row by clicking a link still works, but I think this way is less confusing.

![sonata_admin_choose](https://f.cloud.github.com/assets/663607/643819/313a97f8-d37e-11e2-8462-5e5d92e927c2.png)
