### PR TITLE
The preg_replace() /e modifier is deprecated from php5.5.0. Instead, use the preg_replace_callback() function. 

### DIFF
--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\FormView;
 use Sonata\AdminBundle\Exception\NoValueException;
 use Sonata\AdminBundle\Util\FormViewIterator;
 use Sonata\AdminBundle\Util\FormBuilderIterator;
+use Sonata\AdminBundle\Admin\BaseFieldDescription;
 
 class AdminHelper
 {
@@ -185,6 +186,6 @@ class AdminHelper
      */
     public function camelize($property)
     {
-        return preg_replace(array('/(^|_| )+(.)/e', '/\.(.)/e'), array("strtoupper('\\2')", "'_'.strtoupper('\\1')"), $property);
+        return BaseFieldDescription::camelize($property);
     }
 }

--- a/Admin/BaseFieldDescription.php
+++ b/Admin/BaseFieldDescription.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Admin;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Exception\NoValueException;
+use Symfony\Component\DependencyInjection\Container;
 
 /**
  * A FieldDescription hold the information about a field. A typical
@@ -402,7 +403,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
      */
     public static function camelize($property)
     {
-        return preg_replace(array('/(^|_| )+(.)/e', '/\.(.)/e'), array("strtoupper('\\2')", "'_'.strtoupper('\\1')"), $property);
+        return Container::camelize($property);
     }
 
     /**

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -20,6 +20,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sonata\AdminBundle\Exception\ModelManagerException;
 use Symfony\Component\HttpFoundation\Request;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Admin\BaseFieldDescription;
 
 class CRUDController extends Controller
 {
@@ -401,7 +402,7 @@ class CRUDController extends Controller
             throw new \RuntimeException(sprintf('The `%s` batch action is not defined', $action));
         }
 
-        $camelizedAction = \Sonata\AdminBundle\Admin\BaseFieldDescription::camelize($action);
+        $camelizedAction = BaseFieldDescription::camelize($action);
         $isRelevantAction = sprintf('batchAction%sIsRelevant', ucfirst($camelizedAction));
 
         if (method_exists($this, $isRelevantAction)) {

--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Sonata\AdminBundle\Admin\BaseFieldDescription;
 
 /**
  * Add all dependencies to the Admin class, this avoid to write too many lines
@@ -140,7 +141,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         );
 
         foreach ($keys as $key) {
-            $method = 'set'.$this->camelize($key);
+            $method = 'set' . BaseFieldDescription::camelize($key);
             if (!isset($attributes[$key]) || $definition->hasMethodCall($method)) {
                 continue;
             }
@@ -188,7 +189,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $definition->addMethodCall('setManagerType', array($manager_type));
 
         foreach ($defaultAddServices as $attr => $addServiceId) {
-            $method = 'set'.$this->camelize($attr);
+            $method = 'set' . BaseFieldDescription::camelize($attr);
 
             if (isset($addServices[$attr]) || !$definition->hasMethodCall($method)) {
                 $definition->addMethodCall($method, array(new Reference(isset($addServices[$attr]) ? $addServices[$attr] : $addServiceId)));
@@ -277,17 +278,5 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         ), $definedTemplates);
 
         $definition->addMethodCall('setTemplates', array($definedTemplates));
-    }
-
-    /**
-     * method taken from PropertyPath
-     *
-     * @param  $property
-     *
-     * @return mixed
-     */
-    protected function camelize($property)
-    {
-        return preg_replace(array('/(^|_)+(.)/e', '/\.(.)/e'), array("strtoupper('\\2')", "'_'.strtoupper('\\1')"), $property);
     }
 }


### PR DESCRIPTION
Use Symfony\Component\DependencyInjection\Container::camelize instead.
