### PR TITLE
Allow a custom template to be specified for a specific form group

### DIFF
--- a/Mapper/BaseGroupedMapper.php
+++ b/Mapper/BaseGroupedMapper.php
@@ -42,6 +42,7 @@ abstract class BaseGroupedMapper extends BaseMapper
             'fields'             => array(),
             'description'        => false,
             'translation_domain' => null,
+            'template' => 'SonataAdminBundle:CRUD:base_edit_form_group.html.twig',
         ), $groups[$name], $options);
         
         $this->setGroups($groups);

--- a/Resources/views/CRUD/base_edit_form.html.twig
+++ b/Resources/views/CRUD/base_edit_form.html.twig
@@ -29,21 +29,7 @@
 
                 <div class="tab-content">
                     {% for name, form_group in admin.formgroups %}
-                        <div class="tab-pane {% if loop.first %} active{% endif %}" id="{{ admin.uniqid }}_{{ loop.index }}">
-                            <fieldset>
-                                <div class="sonata-ba-collapsed-fields">
-                                    {% if form_group.description != false %}
-                                        <p>{{ form_group.description|raw }}</p>
-                                    {% endif %}
-
-                                    {% for field_name in form_group.fields %}
-                                        {% if admin.formfielddescriptions[field_name] is defined %}
-                                            {{ form_row(form[field_name])}}
-                                        {% endif %}
-                                    {% endfor %}
-                                </div>
-                            </fieldset>
-                        </div>
+                    {% include form_group.template %}
                     {% endfor %}
                 </div>
 

--- a/Resources/views/CRUD/base_edit_form_group.html.twig
+++ b/Resources/views/CRUD/base_edit_form_group.html.twig
@@ -1,0 +1,15 @@
+<div class="tab-pane {% if loop.first %} active{% endif %}" id="{{ admin.uniqid }}_{{ loop.index }}">
+    <fieldset>
+        <div class="sonata-ba-collapsed-fields">
+            {% if form_group.description != false %}
+                <p>{{ form_group.description|raw }}</p>
+            {% endif %}
+
+            {% for field_name in form_group.fields %}
+                {% if admin.formfielddescriptions[field_name] is defined %}
+                    {{ form_row(form[field_name])}}
+                {% endif %}
+            {% endfor %}
+        </div>
+    </fieldset>
+</div>

--- a/Tests/Form/FormMapperTest.php
+++ b/Tests/Form/FormMapperTest.php
@@ -31,6 +31,14 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
             $this->builder,
             $this->admin
         );
+
+        $this->defaultOptions = array(
+            'collapsed' => false,
+            'fields' => array(),
+            'description' => false,
+            'translation_domain' => null,
+            'template' => 'SonataAdminBundle:CRUD:base_edit_form_group.html.twig',
+        );
     }
 
     public function testWithNoOptions()
@@ -38,12 +46,8 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
         $this->admin->expects($this->once())
             ->method('setFormGroups')
             ->with(array(
-                'foobar' => array(
-                    'collapsed' => false,
-                    'fields' => array(),
-                    'description' => false,
-                    'translation_domain' => null,
-                )));
+                'foobar' => $this->defaultOptions
+            ));
 
         $this->formMapper->with('foobar');
     }
@@ -53,12 +57,10 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
         $this->admin->expects($this->once())
             ->method('setFormGroups')
             ->with(array(
-                'foobar' => array(
-                    'collapsed' => false,
-                    'fields' => array(),
-                    'description' => false,
+                'foobar' => array_merge($this->defaultOptions, array(
                     'translation_domain' => 'Foobar',
-                )));
+                ))
+            ));
 
         $this->formMapper->with('foobar', array(
             'translation_domain' => 'Foobar',
@@ -68,12 +70,9 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
     public function testWithFieldsCascadeTranslationDomain()
     {
         $formGroups = array(
-            'foobar' => array(
-                'collapsed' => false,
-                'fields' => array(),
-                'description' => false,
+            'foobar' => array_merge($this->defaultOptions, array(
                 'translation_domain' => 'Foobar',
-            )
+            ))
         );
 
         $this->admin->expects($this->exactly(2))


### PR DESCRIPTION
Use case (as breifly discussed in Zurich):
- In the CMF MenuBundle we need to be able to change the state of the form with javascript depending on the state of a checkbox (linkType).
- When the link type is changed we want to either hide or disable non-relevant fields within the group.
- As this is not something manageable with the form framework (AFAIK), we need to override the template
- Overriding the entire template involves lots of copy/paste

This PR enables the developer to just supply a template with the form group HTML only.

Example

``` php
$formMapper->with('form_group.foobar', array('template' => 'CmfMenuBundle:Admin:menu_node_group.html.twig'))
->add(...)
```

This is a BC change.
