### PR TITLE
Added custom labels and possibility to remove button sonata_type form types

### DIFF
--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -13,7 +13,10 @@ namespace Sonata\AdminBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 use Sonata\AdminBundle\Form\DataTransformer\ArrayToModelTransformer;
@@ -41,13 +44,28 @@ class AdminType extends AbstractType
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['btn_add'] = $options['btn_add'];
+        $view->vars['btn_list'] = $options['btn_list'];
+        $view->vars['btn_delete'] = $options['btn_delete'];
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'delete' => true,
-            'auto_initialize' => false
+            'delete'          => function (Options $options) {
+                return ($options['btn_delete'] !== false);
+            },
+            'auto_initialize' => false,
+            'btn_add'         => 'link_add',
+            'btn_list'        => 'link_list',
+            'btn_delete'      => 'link_delete'
         ));
     }
 

--- a/Form/Type/CollectionType.php
+++ b/Form/Type/CollectionType.php
@@ -14,6 +14,8 @@ namespace Sonata\AdminBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -37,6 +39,14 @@ class CollectionType extends AbstractType
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['btn_add'] = $options['btn_add'];
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
@@ -45,6 +55,7 @@ class CollectionType extends AbstractType
             'modifiable'    => false,
             'type'          => 'text',
             'type_options'  => array(),
+            'btn_add'       => 'link_add',
         ));
     }
 

--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -15,6 +15,8 @@ namespace Sonata\AdminBundle\Form\Type;
 use Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -46,6 +48,16 @@ class ModelType extends AbstractType
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['btn_add'] = $options['btn_add'];
+        $view->vars['btn_list'] = $options['btn_list'];
+        $view->vars['btn_delete'] = $options['btn_delete'];
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
@@ -64,6 +76,9 @@ class ModelType extends AbstractType
             'query'             => null,
             'choices'           => null,
             'preferred_choices' => array(),
+            'btn_add'           => 'link_add',
+            'btn_list'          => 'link_list',
+            'btn_delete'        => 'link_delete',
             'choice_list'       => function (Options $options, $previousValue) {
                 if ($previousValue instanceof ChoiceListInterface && count($choices = $previousValue->getChoices())) {
                     return $choices;

--- a/Form/Type/ModelTypeList.php
+++ b/Form/Type/ModelTypeList.php
@@ -47,6 +47,9 @@ class ModelTypeList extends AbstractType
             // set the correct edit mode
             $view->vars['sonata_admin']['edit'] = 'list';
         }
+        $view->vars['btn_add'] = $options['btn_add'];
+        $view->vars['btn_list'] = $options['btn_list'];
+        $view->vars['btn_delete'] = $options['btn_delete'];
     }
 
     /**
@@ -58,6 +61,9 @@ class ModelTypeList extends AbstractType
             'model_manager'     => null,
             'class'             => null,
             'parent'            => 'text',
+            'btn_add'           => 'link_add',
+            'btn_list'          => 'link_list',
+            'btn_delete'        => 'link_delete',
         ));
     }
 

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -80,6 +80,10 @@ class
   calculated from the linked Admin class. You usually should not need to set
   this manually.
 
+btn_add, btn_list and btn_delete:
+  The labels on the ``add``, ``list`` and ``delete`` buttons can be customized
+  with these parameters. Setting any of them to ``false`` will hide the 
+  corresponding button.
 
 sonata_type_admin
 ^^^^^^^^^^^^^^^^^
@@ -145,6 +149,11 @@ delete
   defaults to true and indicates that a 'delete' checkbox should be shown allowing
   the user to delete the linked object.
 
+btn_add, btn_list and btn_delete:
+  The labels on the ``add``, ``list`` and ``delete`` buttons can be customized
+  with these parameters. Setting any of them to ``false`` will hide the 
+  corresponding button.
+
 
 sonata_type_collection
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -172,6 +181,13 @@ to the underlying forms.
             ;
         }
     }
+    
+The available options (which can be passed as a third parameter to ``FormMapper::add()``) are:
+
+btn_add:
+  The label on the ``add`` button can be customized
+  with this parameters. Setting it to ``false`` will hide the 
+  corresponding button.
 
 **TIP**: A jQuery event is fired after a row has been added (``sonata-collection-item-added``)
 or deleted (``sonata-collection-item-deleted``). You can bind to these events to trigger custom

--- a/Tests/Form/Type/AdminTypeTest.php
+++ b/Tests/Form/Type/AdminTypeTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Type;
+
+use Sonata\AdminBundle\Form\Type\AdminType;
+use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AdminTypeTest extends TypeTestCase
+{
+    public function testGetDefaultOptions()
+    {
+        $type = new AdminType();
+
+        $optionResolver = new OptionsResolver();
+
+        $type->setDefaultOptions($optionResolver);
+
+        $options = $optionResolver->resolve();
+
+        $this->assertTrue($options['delete']);
+        $this->assertFalse($options['auto_initialize']);
+        $this->assertEquals('link_add', $options['btn_add']);
+        $this->assertEquals('link_list', $options['btn_list']);
+        $this->assertEquals('link_delete', $options['btn_delete']);
+    }
+}

--- a/Tests/Form/Type/CollectionTypeTest.php
+++ b/Tests/Form/Type/CollectionTypeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Type;
+
+use Sonata\AdminBundle\Form\Type\CollectionType;
+use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CollectionTypeTest extends TypeTestCase
+{
+    public function testGetDefaultOptions()
+    {
+        $type = new CollectionType();
+
+        $optionResolver = new OptionsResolver();
+
+        $type->setDefaultOptions($optionResolver);
+
+        $options = $optionResolver->resolve();
+
+        $this->assertFalse($options['modifiable']);
+        $this->assertEquals('text', $options['type']);
+        $this->assertEquals(0, count($options['type_options']));
+        $this->assertEquals('link_add', $options['btn_add']);
+    }
+}

--- a/Tests/Form/Type/ModelTypeListTest.php
+++ b/Tests/Form/Type/ModelTypeListTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Type;
+
+use Sonata\AdminBundle\Form\Type\ModelTypeList;
+use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ModelTypeListTest extends TypeTestCase
+{
+    public function testGetDefaultOptions()
+    {
+        $type = new ModelTypeList();
+
+        $optionResolver = new OptionsResolver();
+
+        $type->setDefaultOptions($optionResolver);
+
+        $options = $optionResolver->resolve();
+
+        $this->assertNull($options['model_manager']);
+        $this->assertNull($options['class']);
+        $this->assertEquals('link_add', $options['btn_add']);
+        $this->assertEquals('link_list', $options['btn_list']);
+        $this->assertEquals('link_delete', $options['btn_delete']);
+    }
+}

--- a/Tests/Form/Type/ModelTypeTest.php
+++ b/Tests/Form/Type/ModelTypeTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Type;
+
+use Sonata\AdminBundle\Form\Type\ModelType;
+
+use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ModelTypeTest extends TypeTestCase
+{
+    public function testGetDefaultOptions()
+    {
+        $type = new ModelType();
+        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $optionResolver = new OptionsResolver();
+
+        $type->setDefaultOptions($optionResolver);
+
+        $options = $optionResolver->resolve(array('model_manager' => $modelManager, 'choices' => array()));
+
+        $this->assertFalse($options['compound']);
+        $this->assertEquals('choice', $options['template']);
+        $this->assertFalse($options['multiple']);
+        $this->assertFalse($options['expanded']);
+        $this->assertInstanceOf('Sonata\AdminBundle\Model\ModelManagerInterface', $options['model_manager']);
+        $this->assertNull($options['class']);
+        $this->assertNull($options['property']);
+        $this->assertNull($options['query']);
+        $this->assertEquals(0, count($options['choices']));
+        $this->assertEquals(0, count($options['preferred_choices']));
+        $this->assertEquals('link_add', $options['btn_add']);
+        $this->assertEquals('link_list', $options['btn_list']);
+        $this->assertEquals('link_delete', $options['btn_delete']);
+        $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList', $options['choice_list']);
+    }
+}


### PR DESCRIPTION
On 'sonata_type' form fields, add the possibility of changing the "add new", "list" and "delete" buttons labels, when they are present. If set to false, the button is not displayed. Defaults were added so that no BC ocurrs. Docs updated. 

These changes are also affect SonataDoctrineORMAdminBundle, so the corresponding PR will also need to be merged on it in too.

https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/231
