### PR TITLE
Fix breadcrumbs for custom routes when subject is empty

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -2014,8 +2014,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
             $menu = $menu->addChild($this->toString($this->getSubject()));
         } elseif ($action != 'list') {
             $menu = $menu->addChild(
-//                $this->trans($this->getLabelTranslatorStrategy()->getLabel(sprintf('%s_%s', $this->getClassnameLabel(), $action), 'breadcrumb', 'link'))
-                  $this->toString($this->getSubject())
+                $this->trans($this->getLabelTranslatorStrategy()->getLabel(sprintf('%s_%s', $this->getClassnameLabel(), $action), 'breadcrumb', 'link'))
             );
         } else {
             $menu->getBreadcrumbsArray();


### PR DESCRIPTION
Hi. When I open my custom routes, there is no label in breadcrumbs for it, because subject is empty.
