### PR TITLE
Fixed exporter dependency for 2.1.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "twig/twig": ">=1.10,<2.0-dev",
         "knplabs/knp-menu-bundle": ">=1.1.0,<2.0.x-dev",
         "sonata-project/jquery-bundle": "1.8.*",
-        "sonata-project/exporter": "1.*",
+        "sonata-project/exporter": "1.2.*",
         "sonata-project/block-bundle": "2.1.*",
         "doctrine/common": ">=2.2,<3.0"
     },


### PR DESCRIPTION
Exporter 1.3 relies on PropertyAccess, which wasn't added until Symfony2.2.

Required 1.2.*.
