### PR TITLE
Check if route exists and is allowed for short object description

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -184,13 +184,11 @@ class HelperController
             }
         }
 
-        $url = $admin->generateUrl('edit', array('id' => $objectId));
-
         $htmlOutput = $this->twig->render($admin->getTemplate('short_object_description'),
             array(
+                'admin' => $admin,
                 'description' => $description,
                 'object' => $object,
-                'url' => $url
             )
         );
 

--- a/Resources/views/Helper/short-object-description.html.twig
+++ b/Resources/views/Helper/short-object-description.html.twig
@@ -1,3 +1,7 @@
 <span class="inner-field-short-description">
-    <a href="{{ url }}" target="new">{{ description }}</a>
+    {% if admin.hasRoute('edit') and admin.isGranted('EDIT') %}
+        <a href="{{ admin.generateObjectUrl('edit', object) }}" target="new">{{ description }}</a>
+    {% else %}
+        {{ description }}
+    {% endif %}
 </span>


### PR DESCRIPTION
If the edit route is not available, then show a simple text description.
