### PR TITLE
Fix firefox JS bug on viewing revision

### DIFF
--- a/Resources/views/CRUD/base_history.html.twig
+++ b/Resources/views/CRUD/base_history.html.twig
@@ -60,6 +60,7 @@ file that was distributed with this source code.
 
                 jQuery.ajax({
                     url: jQuery(this).attr('href'),
+                    dataType: 'html',
                     success: function(data) {
                         jQuery('#revision-detail').html(data);
                     }


### PR DESCRIPTION
Sometimes in Firefox, when pushing link "View Revision" in admin's "Revisions" view, one gets an exception "HierarchyRequestError: Node cannot be inserted at the specified point in the hierarchy". This PR fixes it.
