### PR TITLE
Dropdown menu is not rendered if there is only one item in group

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -95,16 +95,23 @@ file that was distributed with this source code.
                                     {% block sonata_top_bar_nav %}
                                         {% if app.security.token and is_granted('ROLE_SONATA_ADMIN') %}
                                             {% for group in admin_pool.dashboardgroups %}
-                                                <li class="dropdown">
-                                                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ group.label|trans({}, group.label_catalogue) }} <span class="caret"></span></a>
-                                                    <ul class="dropdown-menu">
-                                                        {% for admin in group.items %}
-                                                            {% if admin.hasroute('list') and admin.isGranted('LIST') %}
-                                                                <li><a href="{{ admin.generateUrl('list')}}">{{ admin.label|trans({}, admin.translationdomain) }}</a></li>
-                                                            {% endif %}
-                                                        {% endfor %}
-                                                    </ul>
-                                                </li>
+                                                {% if group.items|length > 1 %}
+                                                    <li class="dropdown">
+                                                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ group.label|trans({}, group.label_catalogue) }} <span class="caret"></span></a>
+                                                        <ul class="dropdown-menu">
+                                                            {% for admin in group.items %}
+                                                                {% if admin.hasroute('list') and admin.isGranted('LIST') %}
+                                                                    <li><a href="{{ admin.generateUrl('list')}}">{{ admin.label|trans({}, admin.translationdomain) }}</a></li>
+                                                                {% endif %}
+                                                            {% endfor %}
+                                                        </ul>
+                                                    </li>
+                                                {% else %}
+                                                    {% set admin = group.items[0] %}
+                                                    {% if admin.hasroute('list') and admin.isGranted('LIST') %}
+                                                        <li><a href="{{ admin.generateUrl('list')}}">{{ admin.label|trans({}, admin.translationdomain) }}</a></li>
+                                                    {% endif %}
+                                                {% endif %}
                                             {% endfor %}
                                         {% endif %}
                                     {% endblock %}


### PR DESCRIPTION
Small change to template which checks if there is only one item in group. If so the dropdown menu is not rendered and you can directly click on the link.

I've made this pull request to help with usability as future admins do not have to do two clicks and some mouse manipulation in case that there is only one item in the group.
