### PR TITLE
Add persistent parameters to filter form as hidden inputs

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -171,6 +171,10 @@ file that was distributed with this source code.
 
                     <a class="btn" href="{{ admin.generateUrl('list', {filters: 'reset'}) }}">{{ 'link_reset_filter'|trans({}, 'SonataAdminBundle') }}</a>
                 </div>
+
+                {% for paramKey, paramValue in admin.persistentParameters %}
+                    <input type="hidden" name="{{ paramKey }}" value="{{ paramValue }}" />
+                {% endfor %}
             </fieldset>
         </form>
     {% endif %}


### PR DESCRIPTION
Filter's form is using `GET` method, so persistent parameters should be included to form as hidden input fields. 
Before this PR, persistent parameters were included only as query params in `action` url and were removed from url after submiting filter.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| BC breaks? | no |
| Tests pass? | yes |
| License | MIT |
