### PR TITLE
Fix generateObjectUrl()

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1124,15 +1124,22 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     {
         $parameters['id'] = $this->getUrlsafeIdentifier($object);
 
-        return $this->generateUrl($name, $parameters, $absolute);
+        $pool = $this->getConfigurationPool();
+        $admin = $pool->getAdminByClass(get_class($object));
+
+        return $this->generateUrl($name, $parameters, $absolute, $admin);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function generateUrl($name, array $parameters = array(), $absolute = false)
+    public function generateUrl($name, array $parameters = array(), $absolute = false, $admin = false)
     {
-        return $this->routeGenerator->generateUrl($this, $name, $parameters, $absolute);
+        if (!$admin) {
+            $admin = $this;
+        }
+
+        return $this->routeGenerator->generateUrl($admin, $name, $parameters, $absolute);
     }
 
     /**

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -116,10 +116,11 @@ interface AdminInterface
      * @param string $name
      * @param array  $parameters
      * @param bool   $absolute
+     * @param mixed  $admin
      *
      * @return string return a complete url
      */
-    public function generateUrl($name, array $parameters = array(), $absolute = false);
+    public function generateUrl($name, array $parameters = array(), $absolute = false, $admin = false);
 
     /**
      * @return \Sonata\AdminBundle\Model\ModelManagerInterface;


### PR DESCRIPTION
generateObjectUrl() now works correctly when you specify an entity other than the entity of the current admin class.

For example :
In FooAdmin.php

```
generateObjectUrl('list', $bar); // will generate /admin/acme/core/bar/1/list
// previously it generated /admin/acme/core/foo/1/list
```
