### PR TITLE
Removed cannotBeEmpty() condition on persist_filters

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -170,7 +170,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
 
-                ->scalarNode('persist_filters')->defaultValue(false)->cannotBeEmpty()->end()
+                ->scalarNode('persist_filters')->defaultValue(false)->end()
 
             ->end()
         ->end();


### PR DESCRIPTION
The default value of this setting is false. If you actually put

```
persist_filters: false
```

in your YML file you get an error due to the `cannotBeEmpty()` condition, which I think is not needed here.
