### PR TITLE
Fix Javascript error when SONATA_CONFIG is undefined

### DIFF
--- a/Resources/public/base.js
+++ b/Resources/public/base.js
@@ -1,6 +1,6 @@
 jQuery(document).ready(function() {
     jQuery('html').removeClass('no-js');
-    if (window.SONATA_CONFIG.CONFIRM_EXIT) {
+    if (window.SONATA_CONFIG && window.SONATA_CONFIG.CONFIRM_EXIT) {
         jQuery('.sonata-ba-form form').confirmExit();
     }
     Admin.add_pretty_errors(document);


### PR DESCRIPTION
Not sure if it is really an issue or a misconfiguration of mine, but `window.SONATA_CONFIG` is undefined, causing a Javascript error when accessing `CONFIRM_EXIT` property. 

In all cases, I think it is a good idea to make a test here, to avoid undesirable side effects.
