### PR TITLE
RoleSecurityHandler - Passing the current object to voters

### DIFF
--- a/Security/Handler/RoleSecurityHandler.php
+++ b/Security/Handler/RoleSecurityHandler.php
@@ -45,7 +45,8 @@ class RoleSecurityHandler implements SecurityHandlerInterface
         }
 
         try {
-            return $this->securityContext->isGranted($this->superAdminRoles) || $this->securityContext->isGranted($attributes);
+            return $this->securityContext->isGranted($this->superAdminRoles)
+                || $this->securityContext->isGranted($attributes, $object);
         } catch (AuthenticationCredentialsNotFoundException $e) {
             return false;
         } catch (\Exception $e) {


### PR DESCRIPTION
As for ACL handler, why not passing the current object to voters ?

See my nice monologue https://github.com/sonata-project/SonataAdminBundle/issues/1458
