### PR TITLE
Improve form errors popovers and colors

### DIFF
--- a/Resources/public/base.js
+++ b/Resources/public/base.js
@@ -34,32 +34,30 @@ var Admin = {
      */
     add_pretty_errors: function(subject) {
         jQuery('div.sonata-ba-field-error', subject).each(function(index, element) {
-            var input = jQuery('input, textarea, select', element);
+            var input = jQuery(':input', element);
 
-            var message = jQuery('div.sonata-ba-field-error-messages', element).html();
-            jQuery('div.sonata-ba-field-error-messages', element).html('');
-            if (!message) {
-                message = '';
-            }
-
-            if (message.length == 0) {
+            if (!input.length) {
                 return;
             }
 
-            var target;
+            var message = jQuery('div.sonata-ba-field-error-messages', element).html();
+            jQuery('div.sonata-ba-field-error-messages', element).html('');
 
-            /* Hack to handle qTip on select */
-            if(jQuery(input).is('select')) {
-                input.wrap('<span></span>');
-                target = input.parent();
+            if (!message || message.length == 0) {
+                return;
             }
-            else {
-                target = input;
+
+            var target = input,
+                fieldShortDescription = input.closest('.field-container').find('.field-short-description')
+            ;
+
+            if (fieldShortDescription.length) {
+                target = fieldShortDescription;
             }
 
             target.popover({
                 content: message,
-                trigger:'focus',
+                trigger: 'hover',
                 html: true,
                 placement: 'right',
                 template: '<div class="popover"><div class="arrow"></div><div class="popover-inner"><div class="popover-content alert-error"><p></p></div></div></div>'

--- a/Resources/public/css/colors.css
+++ b/Resources/public/css/colors.css
@@ -48,3 +48,7 @@ div.sonata-ba-field-error textarea{
 div.sonata-ba-field-error select{
     border: 1px solid #f79992;
 }
+
+div.sonata-ba-field-error .field-short-description {
+    border: 1px solid #B94A48;
+}


### PR DESCRIPTION
I removed the qtip specific code as popovers work on select elements.

But I had to add a new specific code to correctly handle popovers on `sonata_type_model_list` fields. I had to replace the "focus" trigger with a "hover" one, else the popover won't show (tell me if you prefer to keep focus on other inputs).

I also added a red border to `sonata_type_model_list` fields if there is an error.

![error](https://f.cloud.github.com/assets/663607/911319/ff91e432-fde8-11e2-831c-3c2d0b5c7460.png)
