### PR TITLE
Remove error div if replaced by a popover

### DIFF
--- a/Resources/public/base.js
+++ b/Resources/public/base.js
@@ -41,7 +41,7 @@ var Admin = {
             }
 
             var message = jQuery('div.sonata-ba-field-error-messages', element).html();
-            jQuery('div.sonata-ba-field-error-messages', element).html('');
+            jQuery('div.sonata-ba-field-error-messages', element).remove();
 
             if (!message || message.length == 0) {
                 return;


### PR DESCRIPTION
Avoids an unwanted margin under the div.
