### PR TITLE
Corrected baseRoutePattern example

### DIFF
--- a/Resources/doc/reference/routing.rst
+++ b/Resources/doc/reference/routing.rst
@@ -53,7 +53,7 @@ use the following code:
     <?php
     class FooAdmin extends Admin
     {
-        protected $baseRouteName = 'foo';
+        protected $baseRoutePattern = 'foo';
     }
 
 You will then have route URLs like ``http://yourdomain.com/admin/foo/list`` and 


### PR DESCRIPTION
The example for the base route pattern used a wrong property ($baseRouteName instead of $baseRoutePattern).
