### PR TITLE
Added support for Sensio Generator 2.2 (to not break support for Symfony 2.2 projects 

### DIFF
--- a/Generator/AbstractBcGenerator.php
+++ b/Generator/AbstractBcGenerator.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Sonata\AdminBundle\Generator;
+
+use Sensio\Bundle\GeneratorBundle\Generator\Generator;
+
+/**
+ * Class that fixes backward incompatible changes between Sensio Generator 2.2 and 2.3.
+ * This class should be removed if support for Symfony 2.2 (and Sensio Generator 2.2) will be dropped.
+ *
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+abstract class AbstractBcGenerator extends Generator
+{
+    /**
+     * @var array
+     */
+    private $skeletonDirs;
+
+    /**
+     * @var boolean
+     */
+    private $bcEnabled = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSkeletonDirs($skeletonDirs)
+    {
+        $this->skeletonDirs = is_array($skeletonDirs) ? $skeletonDirs : array($skeletonDirs);
+
+        $this->bcEnabled = false;
+
+        if (method_exists(get_parent_class(get_parent_class($this)), 'setSkeletonDirs')) {
+            //Sensio Generator >=2.3
+            parent::setSkeletonDirs($skeletonDirs);
+        } else {
+            //Sensio Generator 2.2
+            $this->bcEnabled = true;
+        }
+    }
+
+    /**
+     * Set backward compatibility with Sensio Generator 2.2.*
+     *
+     * @param boolean $bcEnabled
+     */
+    public function setBc($bcEnabled)
+    {
+        $this->bcEnabled = $bcEnabled;
+    }
+
+    protected function renderBc($template, $parameters)
+    {
+        if ($this->bcEnabled) {
+            //Sensio Generator 2.2
+            return $this->render($this->skeletonDirs, $template, $parameters);
+        } else {
+            //Sensio Generator >=2.3
+            return $this->render($template, $parameters);
+        }
+    }
+
+    protected function renderFileBc($template, $target, $parameters)
+    {
+        if ($this->bcEnabled) {
+            //Sensio Generator 2.2
+            return $this->renderFile($this->skeletonDirs, $template, $target, $parameters);
+        } else {
+            //Sensio Generator >=2.3
+            return $this->renderFile($template, $target, $parameters);
+        }
+    }
+}

--- a/Generator/AdminGenerator.php
+++ b/Generator/AdminGenerator.php
@@ -15,12 +15,13 @@ namespace Sonata\AdminBundle\Generator;
 use Sensio\Bundle\GeneratorBundle\Generator\Generator;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Sonata\AdminBundle\Generator\AbstractBcGenerator;
 
 /**
  * @author Marek Stipek <mario.dweller@seznam.cz>
  * @author Simon Cosandey <simon.cosandey@simseo.ch>
  */
-class AdminGenerator extends Generator
+class AdminGenerator extends AbstractBcGenerator
 {
     /** @var ModelManagerInterface */
     private $modelManager;
@@ -61,7 +62,7 @@ class AdminGenerator extends Generator
             ));
         }
 
-        $this->renderFile('Admin.php.twig', $this->file, array(
+        $this->renderFileBc('Admin.php.twig', $this->file, array(
             'classBasename' => array_pop($parts),
             'namespace' => implode('\\', $parts),
             'fields' => $this->modelManager->getExportFields($modelClass)

--- a/Generator/ControllerGenerator.php
+++ b/Generator/ControllerGenerator.php
@@ -14,12 +14,13 @@ namespace Sonata\AdminBundle\Generator;
 
 use Sensio\Bundle\GeneratorBundle\Generator\Generator;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Sonata\AdminBundle\Generator\AbstractBcGenerator;
 
 /**
  * @author Marek Stipek <mario.dweller@seznam.cz>
  * @author Simon Cosandey <simon.cosandey@simseo.ch>
  */
-class ControllerGenerator extends Generator
+class ControllerGenerator extends AbstractBcGenerator
 {
     /** @var string|null */
     private $class;
@@ -58,7 +59,7 @@ class ControllerGenerator extends Generator
             ));
         }
 
-        $this->renderFile('AdminController.php.twig', $this->file, array(
+        $this->renderFileBc('AdminController.php.twig', $this->file, array(
             'classBasename' => array_pop($parts),
             'namespace' => implode('\\', $parts)
         ));

--- a/Tests/Fixtures/Generator/GeneratorBc22.php
+++ b/Tests/Fixtures/Generator/GeneratorBc22.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Generator;
+
+use Sonata\AdminBundle\Generator\AbstractBcGenerator;
+
+class GeneratorBc22 extends AbstractBcGenerator
+{
+    protected function render($skeletonDir, $template, $parameters)
+    {
+        if ($skeletonDir === array('path/to/templates') && $template === 'test.html.twig' && $parameters === array('foo' => 'bar')) {
+            return 'Result OK';
+        }
+
+        return 'Result invalid';
+    }
+
+    protected function renderFile($skeletonDir, $template, $target, $parameters)
+    {
+        if ($this->render($skeletonDir, $template, $parameters) === 'Result OK' && $target === 'target_file') {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Tests/Fixtures/Generator/GeneratorBc23.php
+++ b/Tests/Fixtures/Generator/GeneratorBc23.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Generator;
+
+use Sonata\AdminBundle\Generator\AbstractBcGenerator;
+
+class GeneratorBc23 extends AbstractBcGenerator
+{
+    private $skeletonDirs;
+
+    public function setSkeletonDirs($skeletonDirs)
+    {
+        $this->skeletonDirs = array($skeletonDirs);
+    }
+
+    protected function render($template, $parameters)
+    {
+        if ($this->skeletonDirs === array('path/to/templates') && $template === 'test.html.twig' && $parameters === array('foo' => 'bar')) {
+            return 'Result OK';
+        }
+
+        return 'Result invalid';
+    }
+
+    protected function renderFile($template, $target, $parameters)
+    {
+        if ($this->render($template, $parameters) === 'Result OK' && $target === 'target_file') {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Tests/Generator/AbstractBcGeneratorTest.php
+++ b/Tests/Generator/AbstractBcGeneratorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Generator;
+
+use Sonata\AdminBundle\Tests\Fixtures\Generator\GeneratorBc22;
+use Sonata\AdminBundle\Tests\Fixtures\Generator\GeneratorBc23;
+
+/**
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+class AbstractBcGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    private static $errorReportingBackup;
+
+    public static function setUpBeforeClass()
+    {
+        //Disable E_STRICT errors for this test only
+        self::$errorReportingBackup = error_reporting();
+        error_reporting(self::$errorReportingBackup ^ E_STRICT);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        //Restore error reporting
+        error_reporting(self::$errorReportingBackup);
+    }
+
+    public function testRenderBc()
+    {
+        $skeletonDir = 'path/to/templates';
+        $template = 'test.html.twig';
+        $parameters = array('foo' => 'bar');
+
+        $generator22 = new GeneratorBc22();
+        $generator22->setSkeletonDirs($skeletonDir);
+        $generator22->setBc(true);
+        $this->assertEquals('Result OK', $this->callMethod($generator22, 'renderBc', array($template, $parameters)));
+
+        $generator23 = new GeneratorBc23();
+        $generator23->setSkeletonDirs($skeletonDir);
+        $generator23->setBc(false);
+        $this->assertEquals('Result OK', $this->callMethod($generator23, 'renderBc', array($template, $parameters)));
+    }
+
+    public function testRenderFileBc()
+    {
+        $skeletonDir = 'path/to/templates';
+        $template = 'test.html.twig';
+        $parameters = array('foo' => 'bar');
+        $target = 'target_file';
+
+        $generator22 = new GeneratorBc22();
+        $generator22->setSkeletonDirs($skeletonDir);
+        $generator22->setBc(true);
+        $this->assertTrue($this->callMethod($generator22, 'renderFileBc', array($template, $target, $parameters)));
+
+        $generator23 = new GeneratorBc23();
+        $generator23->setSkeletonDirs($skeletonDir);
+        $generator23->setBc(false);
+        $this->assertTrue($this->callMethod($generator23, 'renderFileBc', array($template, $target, $parameters)));
+    }
+
+    protected function callMethod($obj, $name, array $args)
+    {
+        $class = new \ReflectionClass($obj);
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($obj, $args);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/config": "~2.2",
         "symfony/console": "~2.2",
         "symfony/twig-bridge": "~2.2",
-        "sensio/generator-bundle": "~2.3",
+        "sensio/generator-bundle": "~2.2",
         "twig/twig": "~1.12",
         "knplabs/knp-menu-bundle": "~1.1",
         "sonata-project/jquery-bundle": "1.8.*",


### PR DESCRIPTION
Symfony 2.2 projects has dependency on Sensio Generator 2.2. Current master of Sonata should support Symfony 2.2 and 2.3 projects, because we have no branch for 2.2. This will fix the problem with different incompatible versions of SensioGenerator.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
