### PR TITLE
Wrong variable being used, which causes a fatal error.

### DIFF
--- a/Util/AdminObjectAclManipulator.php
+++ b/Util/AdminObjectAclManipulator.php
@@ -64,7 +64,7 @@ class AdminObjectAclManipulator
         $objectIdentity = ObjectIdentity::fromDomainObject($data->getObject());
         $acl = $data->getSecurityHandler()->getObjectAcl($objectIdentity);
         if (!$acl) {
-            $acl = $this->getSecurityHandler()->createAcl($objectIdentity);
+            $acl = $data->getSecurityHandler()->createAcl($objectIdentity);
         }
 
         $data->setAcl($acl);


### PR DESCRIPTION
createForm method was trying to access getSecurityHandler() from itself, when it should have been using the data object since that object actually has the method, whereas AdminObjectAclManipulator doesn't.
