### PR TITLE
Moved documentation for default list view sorting

### DIFF
--- a/Resources/doc/reference/action_list.rst
+++ b/Resources/doc/reference/action_list.rst
@@ -3,8 +3,8 @@ The List View
 
 .. note::
 
-    This document is a stub representing a new work in progress. If you're reading 
-    this you can help contribute, **no matter what your experience level with Sonata 
+    This document is a stub representing a new work in progress. If you're reading
+    this you can help contribute, **no matter what your experience level with Sonata
     is**. Check out the `issues on Github`_ for more information about how to get involved.
 
 This document will cover the List view which you use to browse the objects in your
@@ -36,9 +36,42 @@ To do:
 Customising the sort order
 --------------------------
 
+Configure the default ordering in the list view
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Configuring the default ordering column can simply be achieved by overriding
+the ``datagridValues`` array property. All three keys ``_page``, ``_sort_order`` and
+``_sort_by`` can be omitted.
+
+.. code-block:: php
+
+    <?php
+
+    use Sonata\AdminBundle\Admin\Admin;
+
+    class PageAdmin extends Admin
+    {
+        // ...
+
+        /**
+         * Default Datagrid values
+         *
+         * @var array
+         */
+        protected $datagridValues = array(
+            '_page' => 1,            // display the first page (default = 1)
+            '_sort_order' => 'DESC', // reverse order (default = 'ASC')
+            '_sort_by' => 'updated'  // name of the ordered field
+                                     // (default = the model's id field, if any)
+
+            // the '_sort_by' key can be of the form 'mySubModel.mySubSubModel.myField'.
+        );
+
+        // ...
+    }
+
 To do:
 
-- how to set the default sort order
 - how to sort by multiple fields (this might be a separate recipe?)
 
 

--- a/Resources/doc/reference/advance.rst
+++ b/Resources/doc/reference/advance.rst
@@ -127,41 +127,6 @@ To create your own RouteBuilder create the PHP class and register it as a servic
     </service>
 
 
-Configure the default page and ordering in the list view
---------------------------------------------------------
-
-Configuring the default page and ordering column can simply be achieved by overriding
-the ``datagridValues`` array property. All three keys ``_page``, ``_sort_order`` and
-``_sort_by`` can be omitted.
-
-.. code-block:: php
-
-    <?php
-
-    use Sonata\AdminBundle\Admin\Admin;
-
-    class PageAdmin extends Admin
-    {
-        // ...
-
-        /**
-         * Default Datagrid values
-         *
-         * @var array
-         */
-        protected $datagridValues = array(
-            '_page' => 1,            // display the first page (default = 1)
-            '_sort_order' => 'DESC', // reverse order (default = 'ASC')
-            '_sort_by' => 'updated'  // name of the ordered field 
-                                     // (default = the model's id field, if any)
-    
-            // the '_sort_by' key can be of the form 'mySubModel.mySubSubModel.myField'.
-        );
-
-        // ...
-    }
-
-
 Inherited classes
 -----------------
 


### PR DESCRIPTION
There was a "to do" item to document default sorting of list views. This was already documented elsewhere.
