### PR TITLE
item_adds bug fix

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -101,7 +101,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                 }
 
                 if (!empty($group['item_adds'])) {
-                    $group['items'] = array_merge($groupDefaults[$groupName]['items'], $group['item_adds']);
+                    $groups[$groupName]['items'] = array_merge($groups[$groupName]['items'], $group['item_adds']);
                 }
             }
         } else {


### PR DESCRIPTION
Right now, the dashboard groups config parameter 'item_adds' is not working at all , as documented here: https://github.com/sonata-project/SonataAdminBundle/pull/668

However, the above mentioned fix ignores the 'items' config option if the 'item_adds' exists, and just adds the specified admin mappings on top of the default one.

Tests for this can be found here: https://github.com/sonata-project/SonataAdminBundle/pull/1405
