### PR TITLE
Fix dashboard group names using parameters - Issue 922

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -31,6 +31,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        $parameterBag = $container->getParameterBag();
         $groupDefaults = $admins = $classes = array();
 
         $pool = $container->getDefinition('sonata.admin.pool');
@@ -62,18 +63,18 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     continue;
                 }
 
-                $groupName = isset($attributes['group']) ? $attributes['group'] : 'default';
+                $resolvedGroupName = isset($attributes['group']) ? $parameterBag->resolveValue($attributes['group']) : 'default';
                 $labelCatalogue = isset($attributes['label_catalogue']) ? $attributes['label_catalogue'] : 'SonataAdminBundle';
 
-                if (!isset($groupDefaults[$groupName])) {
-                    $groupDefaults[$groupName] = array(
-                        'label'           => $groupName,
+                if (!isset($groupDefaults[$resolvedGroupName])) {
+                    $groupDefaults[$resolvedGroupName] = array(
+                        'label'           => $resolvedGroupName,
                         'label_catalogue' => $labelCatalogue,
                         'roles' => array()
                     );
                 }
 
-                $groupDefaults[$groupName]['items'][] = $id;
+                $groupDefaults[$resolvedGroupName]['items'][] = $id;
             }
         }
 
@@ -82,32 +83,33 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             $groups = $dashboardGroupsSettings;
 
             foreach ($dashboardGroupsSettings as $groupName => $group) {
-                if (!isset($groupDefaults[$groupName])) {
-                    $groupDefaults[$groupName] = array(
+                $resolvedGroupName = $parameterBag->resolveValue($groupName);
+                if (!isset($groupDefaults[$resolvedGroupName])) {
+                    $groupDefaults[$resolvedGroupName] = array(
                         'items' => array(),
-                        'label' => $groupName,
+                        'label' => $resolvedGroupName,
                         'roles' => array()
                     );
                 }
 
                 if (empty($group['items'])) {
-                    $groups[$groupName]['items'] = $groupDefaults[$groupName]['items'];
+                    $groups[$resolvedGroupName]['items'] = $groupDefaults[$resolvedGroupName]['items'];
                 }
 
                 if (empty($group['label'])) {
-                    $groups[$groupName]['label'] = $groupDefaults[$groupName]['label'];
+                    $groups[$resolvedGroupName]['label'] = $groupDefaults[$resolvedGroupName]['label'];
                 }
 
                 if (empty($group['label_catalogue'])) {
-                    $groups[$groupName]['label_catalogue'] = 'SonataAdminBundle';
+                    $groups[$resolvedGroupName]['label_catalogue'] = 'SonataAdminBundle';
                 }
 
                 if (!empty($group['item_adds'])) {
-                    $groups[$groupName]['items'] = array_merge($groups[$groupName]['items'], $group['item_adds']);
+                    $groups[$resolvedGroupName]['items'] = array_merge($groups[$resolvedGroupName]['items'], $group['item_adds']);
                 }
 
                 if (empty($group['roles'])) {
-                    $groups[$groupName]['roles'] = $groupDefaults[$groupName]['roles'];
+                    $groups[$resolvedGroupName]['roles'] = $groupDefaults[$resolvedGroupName]['roles'];
                 }
             }
         } else {

--- a/Resources/doc/reference/dashboard.rst
+++ b/Resources/doc/reference/dashboard.rst
@@ -106,6 +106,9 @@ The provided labels are actually translated by ``SonataAdminBundle``, using the 
 ``label_catalogue``. So, you can use the above examples to support multilanguage
 in your project.
 
+.. note::
+    You can use ``parameters`` as group names in both scenarios.
+
 Using the ``config.yml``
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -114,6 +114,35 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass::process
+     */
+    public function testProcessGroupNameAsParameter()
+    {
+        $config = array(
+            'dashboard' => array(
+                'groups' => array(
+                    '%sonata.admin.parameter.groupname%' => array(
+                    ),
+                )
+            )
+        );
+        
+        $container = $this->getContainer();
+        $container->setParameter('sonata.admin.parameter.groupname', 'resolved_group_name');
+        
+        $this->extension->load(array($config), $container);
+
+        $compilerPass = new AddDependencyCallsCompilerPass();
+        $compilerPass->process($container);
+        $container->compile();
+        
+        $adminGroups = $container->get('sonata.admin.pool')->getAdminGroups();
+
+        $this->assertArrayHasKey('resolved_group_name', $adminGroups);
+        $this->assertFalse(array_key_exists('%sonata.admin.parameter.groupname%', $adminGroups));
+    }
+
+    /**
      * @return array
      */
     protected function getConfig()


### PR DESCRIPTION
This PR addresses the same problem as the following issue:
https://github.com/sonata-project/SonataAdminBundle/pull/922

As SonataUser uses a parameter for a group name, it's not possible to then configure that group in the sonata_admin->dashboard->groups section of config.yml by using neither sonata_user nor the %sonata.user.admin.groupname% parameters. Trying to do using the parameter version might lead to a crash if SonataAdmin is defined before SonataUser in AppKernel.

This PR is an adaptation of the above mentioned PR to resolve group names as parameters, in order to resolve the above mentioned issue. Docs and tests added.
