### PR TITLE
Allow adding an extension to all admins

### DIFF
--- a/Resources/doc/reference/extensions.rst
+++ b/Resources/doc/reference/extensions.rst
@@ -31,6 +31,7 @@ There are two ways to configure your extensions and connect them to an admin.
 
 You can include this information in the service definition of your extension.
 Add the tag *sonata.admin.extension* and use the *target* attribute to point to the admin you want to modify.
+Set the *global* attribute to *true* and the extension will be added to all admins.
 
 .. configuration-block::
 
@@ -41,6 +42,11 @@ Add the tag *sonata.admin.extension* and use the *target* attribute to point to 
                 class: Acme\Demo\BlogBundle\Admin\Extension\PublishStatusAdminExtension
                 tags:
                     - { name: sonata.admin.extension, target: acme.demo.admin.article }
+
+            acme.demo.order.extension:
+                class: Acme\Demo\BlogBundle\Admin\Extension\OrderAdminExtension
+                tags:
+                    - { name: sonata.admin.extension, global: true }
 
 The second option is to add it to your config.yml file.
 

--- a/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -27,6 +27,8 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
     private $publishExtension;
     private $historyExtension;
     private $orderExtension;
+    private $securityExtension;
+    private $filterExtension;
 
     /**
      * Root name of the configuration
@@ -41,11 +43,13 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
 
         $this->extension = new SonataAdminExtension();
         $this->config    = $this->getConfig();
-        $this->root      = "sonata.admin";
+        $this->root      = 'sonata.admin';
 
         $this->publishExtension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
         $this->historyExtension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
         $this->orderExtension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $this->securityExtension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $this->filterExtension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
     }
 
     /**
@@ -216,6 +220,7 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($container->hasDefinition('sonata_extension_publish'));
         $this->assertTrue($container->hasDefinition('sonata_extension_history'));
         $this->assertTrue($container->hasDefinition('sonata_extension_order'));
+        $this->assertTrue($container->hasDefinition('sonata_extension_security'));
 
         $this->assertTrue($container->hasDefinition('sonata_post_admin'));
         $this->assertTrue($container->hasDefinition('sonata_article_admin'));
@@ -223,22 +228,26 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
 
         $def = $container->get('sonata_post_admin');
         $extensions = $def->getExtensions();
-        $this->assertCount(2, $extensions);
+        $this->assertCount(3, $extensions);
 
-        $this->assertInstanceOf(get_class($this->publishExtension), $extensions[0]);
-        $this->assertInstanceOf(get_class($this->historyExtension), $extensions[1]);
+        $this->assertInstanceOf(get_class($this->securityExtension), $extensions[0]);
+        $this->assertInstanceOf(get_class($this->publishExtension), $extensions[1]);
+        $this->assertInstanceOf(get_class($this->historyExtension), $extensions[2]);
 
         $def = $container->get('sonata_article_admin');
         $extensions = $def->getExtensions();
-        $this->assertCount(2, $extensions);
-        $this->assertInstanceOf(get_class($this->publishExtension), $extensions[0]);
-        $this->assertInstanceOf(get_class($this->orderExtension), $extensions[1]);
+        $this->assertCount(3, $extensions);
+        $this->assertInstanceOf(get_class($this->securityExtension), $extensions[0]);
+        $this->assertInstanceOf(get_class($this->publishExtension), $extensions[1]);
+        $this->assertInstanceOf(get_class($this->orderExtension), $extensions[2]);
 
         $def = $container->get('sonata_news_admin');
         $extensions = $def->getExtensions();
-        $this->assertCount(2, $extensions);
-        $this->assertInstanceOf(get_class($this->orderExtension), $extensions[0]);
-        $this->assertInstanceOf(get_class($this->historyExtension), $extensions[1]);
+        $this->assertCount(4, $extensions);
+        $this->assertInstanceOf(get_class($this->securityExtension), $extensions[0]);
+        $this->assertInstanceOf(get_class($this->orderExtension), $extensions[1]);
+        $this->assertInstanceOf(get_class($this->historyExtension), $extensions[2]);
+        $this->assertInstanceOf(get_class($this->filterExtension), $extensions[3]);
     }
 
     /**
@@ -318,6 +327,14 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
         $container
             ->register('sonata_extension_order')
             ->setClass(get_class($this->orderExtension));
+        $container
+            ->register('sonata_extension_security')
+            ->setClass(get_class($this->securityExtension))
+            ->addTag('sonata.admin.extension', array('global' => true));
+        $container
+            ->register('sonata_extension_filter')
+            ->setClass(get_class($this->filterExtension))
+            ->addTag('sonata.admin.extension', array('target' => 'sonata_news_admin'));
 
         return $container;
     }


### PR DESCRIPTION
This is currently not possible to add an extension to all admins. This PR adds this feature.
To use it, just tag an extension with `sonata.admin.extension` and a `global="true"` attribute.

The doc and tests have been updated accordingly.
