### PR TITLE
Added ShowMapperTest, BaseMapperTest, BaseGroupedMapperTest

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -998,10 +998,10 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         if (!$this->hasActiveSubClass()) {
             return null;
         }
-        
+
         return $this->getClass();
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -1010,16 +1010,16 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         if (!$this->hasActiveSubClass()) {
             return null;
         }
-        
+
         $subClass = $this->getRequest()->query->get('subclass');
-        
+
         if(! $this->hasSubClass($subClass)){
             return null;
         }
-        
+
         return $subClass;
     }
-    
+
     /**
      * Returns the list of batchs actions
      *
@@ -1452,7 +1452,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getLabel()
     {
@@ -1527,7 +1527,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function getShowGroups()
     {
@@ -1535,7 +1535,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @param array $showGroups
+     * {@inheritdoc}
      */
     public function setShowGroups(array $showGroups)
     {
@@ -1543,8 +1543,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @param string $group
-     * @param array  $keys
+     * {@inheritdoc}
      */
     public function reorderShowGroup($group, array $keys)
     {
@@ -1712,11 +1711,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * remove a FieldDescription
-     *
-     * @param string $name
-     *
-     * @return void
+     * {@inheritdoc}
      */
     public function removeShowFieldDescription($name)
     {

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -219,6 +219,13 @@ interface AdminInterface
     public function addShowFieldDescription($name, FieldDescriptionInterface $fieldDescription);
 
     /**
+     * Remove a ShowFieldDescription
+     *
+     * @param string $name
+     */
+    public function removeShowFieldDescription($name);
+
+    /**
      * add a list FieldDescription
      *
      * @param string                                              $name
@@ -612,6 +619,28 @@ interface AdminInterface
     public function setFormGroups(array $formGroups);
 
     /**
+     * Returns the show groups
+     *
+     * @return array
+     */
+    public function getShowGroups();
+
+    /**
+     * Set the show groups
+     *
+     * @param array $showGroups
+     */
+    public function setShowGroups(array $showGroups);
+
+    /**
+     * Reorder items in showGroup
+     *
+     * @param string $group
+     * @param array  $keys
+     */
+    public function reorderShowGroup($group, array $keys);
+
+    /**
      * add a FieldDescription
      *
      * @param string                                              $name
@@ -657,12 +686,18 @@ interface AdminInterface
      * @return string the active sub class
      */
     public function getActiveSubClass();
-    
+
     /**
      * Returns the currently active sub class code
-     * 
+     *
      * @return string the code for active sub class
      */
     public function getActiveSubclassCode();
 
+    /**
+     * Returns Admin`s label
+     *
+     * @return string
+     */
+    public function getLabel();
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+### 2013-08-30
+* [BC BREAK] added ``getLabel``, ``removeShowFieldDescription``, ``getShowGroups``,
+  ``setShowGroups``, ``reorderShowGroup`` to the AdminInterface
+  If you do not extend the Admin class, you need to add these methods to
+  your admin.
+
 ### 2013-07-26
 
 * [BC BREAK] added alterNewInstance to AdminExtensionInterface
@@ -117,14 +123,14 @@ CHANGELOG
 * add country field type
 * refactor the form creation
 
-### 18/01/2011
+### 2011-01-18
 
 * respect symfony conventions
 * add new base edit template (standard and inline)
 * admin instances are not singletons anymore
 * add inline edition
 
-### 15/01/2011
+### 2011-01-15
 
 * respect symfony conventions
 * add a FieldDescription

--- a/Tests/Mapper/BaseGroupedMapperTest.php
+++ b/Tests/Mapper/BaseGroupedMapperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Mapper;
+
+use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
+
+/**
+ * Test for BaseGroupedMapper
+ *
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+class BaseGroupedMapperTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var BaseGroupedMapper
+     */
+    protected $baseGroupedMapper;
+
+    public function setUp()
+    {
+        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $builder = $this->getMock('Sonata\AdminBundle\Builder\BuilderInterface');
+
+        $this->baseGroupedMapper = $this->getMockForAbstractClass('Sonata\AdminBundle\Mapper\BaseGroupedMapper', array($builder, $admin));
+    }
+
+    public function testWith()
+    {
+        $this->assertEquals($this->baseGroupedMapper, $this->baseGroupedMapper->with('fooGroup'));
+    }
+
+    public function testEnd()
+    {
+        $this->assertEquals($this->baseGroupedMapper, $this->baseGroupedMapper->with('fooGroup'));
+    }
+}

--- a/Tests/Mapper/BaseMapperTest.php
+++ b/Tests/Mapper/BaseMapperTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Sonata\AdminBundle\Tests\Mapper;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Builder\BuilderInterface;
+use Sonata\AdminBundle\Mapper\BaseMapper;
+
+/**
+ * Test for BaseMapperTest
+ *
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+class BaseMapperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var BaseMapper
+     */
+    protected $baseMapper;
+
+    /**
+     * @var AdminInterface
+     */
+    protected $admin;
+
+    public function setUp()
+    {
+        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $builder = $this->getMock('Sonata\AdminBundle\Builder\BuilderInterface');
+
+        $this->baseMapper = $this->getMockForAbstractClass('Sonata\AdminBundle\Mapper\BaseMapper', array($builder, $this->admin));
+    }
+
+    public function testGetAdmin()
+    {
+        $this->assertEquals($this->admin, $this->baseMapper->getAdmin());
+    }
+}

--- a/Tests/Show/ShowMapperTest.php
+++ b/Tests/Show/ShowMapperTest.php
@@ -1,0 +1,190 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Show;
+
+use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Builder\ShowBuilderInterface;
+
+/**
+ * Test for ShowMapper
+ *
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+class ShowMapperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ShowMapper
+     */
+    protected $showMapper;
+
+    /**
+     * @var AdminInterface
+     */
+    protected $admin;
+
+    /**
+     * @var Sonata\AdminBundle\Builder\ShowBuilderInterface
+     */
+    protected $showBuilder;
+
+    /**
+     * @var FieldDescriptionCollection
+     */
+    protected $fieldDescriptionCollection;
+
+    /**
+     * @var array
+     */
+    protected $groups;
+
+    public function setUp()
+    {
+        $this->showBuilder = $this->getMock('Sonata\AdminBundle\Builder\ShowBuilderInterface');
+        $this->fieldDescriptionCollection = new FieldDescriptionCollection();
+        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+
+        $this->admin->expects($this->any())
+            ->method('getLabel')
+            ->will($this->returnValue('AdminLabel'));
+
+        $this->groups = array();
+
+        //php 5.3 BC
+        $groups = & $this->groups;
+
+        $this->admin->expects($this->any())
+            ->method('getShowGroups')
+            ->will($this->returnCallback(function() use (&$groups) {
+                return $groups;
+            }));
+
+        $this->admin->expects($this->any())
+            ->method('setShowGroups')
+            ->will($this->returnCallback(function($showGroups) use (&$groups) {
+                $groups = $showGroups;
+            }));
+
+      $this->admin->expects($this->any())
+            ->method('reorderShowGroup')
+            ->will($this->returnCallback(function($group, $keys) use (&$groups) {
+                $showGroups = $groups;
+                $showGroups[$group]['fields'] = array_merge(array_flip($keys), $showGroups[$group]['fields']);
+                $groups = $showGroups;
+            }));
+
+        $this->showBuilder->expects($this->any())
+            ->method('addField')
+            ->will($this->returnCallback(function($list, $type, $fieldDescription, $admin) {
+                $list->add($fieldDescription);
+            }));
+
+        $this->showMapper = new ShowMapper($this->showBuilder, $this->fieldDescriptionCollection, $this->admin);
+    }
+
+    public function testFluidInterface()
+    {
+        $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
+
+        $this->assertEquals($this->showMapper, $this->showMapper->add($fieldDescription));
+        $this->assertEquals($this->showMapper, $this->showMapper->remove('fooName'));
+        $this->assertEquals($this->showMapper, $this->showMapper->reorder(array()));
+    }
+
+    public function testGet()
+    {
+        $this->assertFalse($this->showMapper->has('fooName'));
+
+        $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
+
+        $this->showMapper->add($fieldDescription);
+        $this->assertEquals($fieldDescription, $this->showMapper->get('fooName'));
+    }
+
+    public function testAddRemove()
+    {
+        $this->assertFalse($this->showMapper->has('fooName'));
+
+        $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
+
+        $this->showMapper->add($fieldDescription);
+        $this->assertTrue($this->showMapper->has('fooName'));
+
+        $this->showMapper->remove('fooName');
+        $this->assertFalse($this->showMapper->has('fooName'));
+    }
+
+    public function testAddException()
+    {
+        try {
+            $this->showMapper->add(12345);
+        } catch (\RuntimeException $e) {
+            $this->assertContains('invalid state', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('Failed asserting that exception of type "\RuntimeException" is thrown.');
+    }
+
+    public function testReorder()
+    {
+        $this->assertEquals(array(), $this->admin->getShowGroups());
+
+        $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');
+        $fieldDescription2 = $this->getFieldDescriptionMock('fooName2', 'fooLabel2');
+        $fieldDescription3 = $this->getFieldDescriptionMock('fooName3', 'fooLabel3');
+        $fieldDescription4 = $this->getFieldDescriptionMock('fooName4', 'fooLabel4');
+
+        $this->showMapper->with('Group1');
+        $this->showMapper->add($fieldDescription1);
+        $this->showMapper->add($fieldDescription2);
+        $this->showMapper->add($fieldDescription3);
+        $this->showMapper->add($fieldDescription4);
+
+        $this->assertEquals(array(
+            'Group1' =>array(
+                'collapsed' => false,
+                'fields' => array('fooName1'=>'fooName1', 'fooName2'=>'fooName2', 'fooName3'=>'fooName3', 'fooName4'=>'fooName4'),
+                'description' => false,
+                'translation_domain' => null,
+       )), $this->admin->getShowGroups());
+
+        $this->showMapper->reorder(array('fooName3', 'fooName2', 'fooName1', 'fooName4'));
+
+        //print_r is used to compare order of items in associative arrays
+        $this->assertEquals(print_r(array(
+            'Group1' =>array(
+                'collapsed' => false,
+                'fields' => array('fooName3'=>'fooName3', 'fooName2'=>'fooName2', 'fooName1'=>'fooName1', 'fooName4'=>'fooName4'),
+                'description' => false,
+                'translation_domain' => null,
+       )), true), print_r($this->admin->getShowGroups(), true));
+    }
+
+    protected function getFieldDescriptionMock($name, $label)
+    {
+        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+
+        $fieldDescription->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue($name));
+
+        $fieldDescription->expects($this->any())
+            ->method('getLabel')
+            ->will($this->returnValue($label));
+
+        return $fieldDescription;
+    }
+}


### PR DESCRIPTION
Possible BC break: Added some methods to AdminInterface.
Reason: ShowMapper (and some other parts of SonataAdmin) is using them, so I think they belongs there. Creating valid unit tests without this change will be very complicated.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
