### PR TITLE
Added ExplainAdminCommandTest

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1042,9 +1042,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns the list of available urls
-     *
-     * @return \Sonata\AdminBundle\Route\RouteCollection the list of available urls
+     * {@inheritdoc}
      */
     public function getRoutes()
     {
@@ -1183,9 +1181,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @param string $name
-     *
-     * @return null|string
+     * {@inheritdoc}
      */
     public function getTemplate($name)
     {
@@ -1430,7 +1426,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @param string $baseControllerName
+     * {@inheritdoc}
      */
     public function setBaseControllerName($baseControllerName)
     {
@@ -1438,7 +1434,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getBaseControllerName()
     {
@@ -1615,9 +1611,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * build and return the collection of form FieldDescription
-     *
-     * @return array collection of form FieldDescription
+     * {@inheritdoc}
      */
     public function getFormFieldDescriptions()
     {
@@ -1721,9 +1715,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns the collection of list FieldDescriptions
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getListFieldDescriptions()
     {
@@ -1817,9 +1809,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns the filter FieldDescription collection
-     *
-     * @return FieldDescriptionInterface[]
+     * {@inheritdoc}
      */
     public function getFilterFieldDescriptions()
     {
@@ -1880,9 +1870,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns true if the Admin class has an Parent Admin defined
-     *
-     * @return boolean
+     * {@inheritdoc}
      */
     public function isChild()
     {
@@ -2201,7 +2189,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @return \Sonata\AdminBundle\Builder\DatagridBuilderInterface
+     * {@inheritdoc}
      */
     public function getDatagridBuilder()
     {
@@ -2217,7 +2205,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @return \Sonata\AdminBundle\Builder\ListBuilderInterface
+     * {@inheritdoc}
      */
     public function getListBuilder()
     {

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -38,6 +38,8 @@ interface AdminInterface
     public function setFormContractor(FormContractorInterface $formContractor);
 
     /**
+     * Set ListBuilder
+     *
      * @param ListBuilderInterface $listBuilder
      *
      * @return void
@@ -45,11 +47,27 @@ interface AdminInterface
     public function setListBuilder(ListBuilderInterface $listBuilder);
 
     /**
+     * Get ListBuilder
+     *
+     * @return \Sonata\AdminBundle\Builder\ListBuilderInterface
+     */
+    public function getListBuilder();
+
+    /**
+     * Set DatagridBuilder
+     *
      * @param \Sonata\AdminBundle\Builder\DatagridBuilderInterface $datagridBuilder
      *
      * @return void
      */
     public function setDatagridBuilder(DatagridBuilderInterface $datagridBuilder);
+
+    /**
+     * Get DatagridBuilder
+     *
+     * @return \Sonata\AdminBundle\Builder\DatagridBuilderInterface
+     */
+    public function getDatagridBuilder();
 
     /**
      * @param \Symfony\Component\Translation\TranslatorInterface $translator
@@ -102,6 +120,20 @@ interface AdminInterface
     public function getDatagrid();
 
     /**
+     * Set base controller name
+     *
+     * @param string $baseControllerName
+     */
+    public function setBaseControllerName($baseControllerName);
+
+    /**
+     * Get base controller name
+     *
+     * @return string
+     */
+    public function getBaseControllerName();
+
+    /**
      * Generates the object url with the given $name
      *
      * @param string  $name
@@ -147,11 +179,20 @@ interface AdminInterface
     public function getFormBuilder();
 
     /**
+     * Return FormFieldDescription
+     *
      * @param string $name
      *
      * @return \Sonata\AdminBundle\Admin\FieldDescriptionInterface
      */
     public function getFormFieldDescription($name);
+
+    /**
+     * Build and return the collection of form FieldDescription
+     *
+     * @return array collection of form FieldDescription
+     */
+    public function getFormFieldDescriptions();
 
     /**
      * @return \Symfony\Component\HttpFoundation\Request
@@ -202,6 +243,13 @@ interface AdminInterface
     public function trans($id, array $parameters = array(), $domain = null, $locale = null);
 
     /**
+     * Returns the list of available urls
+     *
+     * @return \Sonata\AdminBundle\Route\RouteCollection the list of available urls
+     */
+    public function getRoutes();
+
+    /**
      * Return the parameter name used to represente the id in the url
      *
      * @return string
@@ -244,6 +292,13 @@ interface AdminInterface
      * @return void
      */
     public function addFilterFieldDescription($name, FieldDescriptionInterface $fieldDescription);
+
+    /**
+     * Returns the filter FieldDescription collection
+     *
+     * @return FieldDescriptionInterface[]
+     */
+    public function getFilterFieldDescriptions();
 
     /**
      * Returns a list depend on the given $object
@@ -460,6 +515,13 @@ interface AdminInterface
     public function getListFieldDescription($name);
 
     /**
+     * Returns the collection of list FieldDescriptions
+     *
+     * @return array
+     */
+    public function getListFieldDescriptions();
+
+    /**
      * @return void
      */
     public function configure();
@@ -582,6 +644,15 @@ interface AdminInterface
     public function setParent(AdminInterface $admin);
 
     /**
+     * Returns true if the Admin class has an Parent Admin defined
+     *
+     * @return boolean
+     */
+    public function isChild();
+
+    /**
+     * Returns template
+     *
      * @param string $name
      *
      * @return null|string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+### 2013-09-5
+* [BC BREAK] added ``getListBuilder``, ``getDatagridBuilder``, ``setBaseControllerName``,
+  ``getBaseControllerName``, ``getFormFieldDescriptions``, ``getRoutes``, ``getFilterFieldDescriptions``,
+  ``getListFieldDescriptions``, ``isChild`` to the AdminInterface
+  If you do not extend the Admin class, you need to add these methods to
+  your admin.
+
 ### 2013-08-30
 * [BC BREAK] added ``getLabel``, ``removeShowFieldDescription``, ``getShowGroups``,
   ``setShowGroups``, ``reorderShowGroup`` to the AdminInterface

--- a/Command/ExplainAdminCommand.php
+++ b/Command/ExplainAdminCommand.php
@@ -39,7 +39,7 @@ class ExplainAdminCommand extends ContainerAwareCommand
         $admin = $this->getContainer()->get($input->getArgument('admin'));
 
         if (!$admin instanceof \Sonata\AdminBundle\Admin\AdminInterface) {
-            throw new \RunTimeException(sprintf('service %s is not an admin class', $input->getArgument('admin')));
+            throw new \RunTimeException(sprintf('Service "%s" is not an admin class', $input->getArgument('admin')));
         }
 
         $output->writeln('<comment>AdminBundle Information</comment>');

--- a/Tests/Command/ExplainAdminCommandTest.php
+++ b/Tests/Command/ExplainAdminCommandTest.php
@@ -1,0 +1,265 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Command;
+
+use Sonata\AdminBundle\Command\ExplainAdminCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Application;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Route\RouteCollection;
+use Symfony\Component\Validator\MetadataFactoryInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
+use Sonata\AdminBundle\Builder\ListBuilderInterface;
+use Symfony\Component\Form\FormBuilder;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Symfony\Component\Validator\Mapping\ElementMetadata;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Email;
+
+/**
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Application
+     */
+    private $application;
+
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var Symfony\Component\Validator\MetadataFactoryInterface
+     */
+    private $validatorFactory;
+
+    protected function setUp()
+    {
+        $this->application = new Application();
+        $command = new ExplainAdminCommand();
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+
+        $this->admin->expects($this->any())
+            ->method('getCode')
+            ->will($this->returnValue('foo'));
+
+        $this->admin->expects($this->any())
+            ->method('getClass')
+            ->will($this->returnValue('Acme\Entity\Foo'));
+
+        $this->admin->expects($this->any())
+            ->method('getBaseControllerName')
+            ->will($this->returnValue('SonataAdminBundle:CRUD'));
+
+        $routeCollection = new RouteCollection('foo', 'fooBar', 'foo-bar', 'SonataAdminBundle:CRUD');
+        $routeCollection->add('list');
+        $routeCollection->add('edit');
+
+        $this->admin->expects($this->any())
+            ->method('getRoutes')
+            ->will($this->returnValue($routeCollection));
+
+        $fieldDescription1 = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+
+        $fieldDescription1->expects($this->any())
+            ->method('getType')
+            ->will($this->returnValue('text'));
+
+        $fieldDescription1->expects($this->any())
+            ->method('getTemplate')
+            ->will($this->returnValue('SonataAdminBundle:CRUD:foo_text.html.twig'));
+
+        $fieldDescription2 = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+
+        $fieldDescription2->expects($this->any())
+            ->method('getType')
+            ->will($this->returnValue('datetime'));
+
+        $fieldDescription2->expects($this->any())
+            ->method('getTemplate')
+            ->will($this->returnValue('SonataAdminBundle:CRUD:bar_datetime.html.twig'));
+
+        $this->admin->expects($this->any())
+            ->method('getListFieldDescriptions')
+            ->will($this->returnValue(array('fooTextField'=>$fieldDescription1, 'barDateTimeField'=>$fieldDescription2)));
+
+        $this->admin->expects($this->any())
+            ->method('getFilterFieldDescriptions')
+            ->will($this->returnValue(array('fooTextField'=>$fieldDescription1, 'barDateTimeField'=>$fieldDescription2)));
+
+        $this->admin->expects($this->any())
+            ->method('getFormTheme')
+            ->will($this->returnValue(array('FooBundle::bar.html.twig')));
+
+        $this->admin->expects($this->any())
+            ->method('getFormFieldDescriptions')
+            ->will($this->returnValue(array('fooTextField'=>$fieldDescription1, 'barDateTimeField'=>$fieldDescription2)));
+
+        $this->admin->expects($this->any())
+            ->method('isChild')
+            ->will($this->returnValue(true));
+
+        $this->admin->expects($this->any())
+            ->method('getParent')
+            ->will($this->returnCallback(function() {
+                $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+                $admin->expects($this->any())
+                    ->method('getCode')
+                    ->will($this->returnValue('foo_child'));
+
+                return $admin;
+            }));
+
+        $this->validatorFactory = $this->getMock('Symfony\Component\Validator\MetadataFactoryInterface');
+
+        //php 5.3 BC
+        $admin = $this->admin;
+        $validatorMetadata = $this->validatorFactory;
+
+        $container->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function($id) use ($container, $admin, $validatorMetadata) {
+                switch ($id) {
+                    case 'sonata.admin.pool':
+                        $pool = new Pool($container, '', '');
+                        $pool->setAdminServiceIds(array('acme.admin.foo', 'acme.admin.bar'));
+
+                        return $pool;
+                        break;
+
+                    case 'validator.mapping.class_metadata_factory':
+                        return $validatorMetadata;
+                        break;
+
+                    case 'acme.admin.foo':
+                        return $admin;
+                        break;
+                }
+
+                return null;
+            }));
+
+        $command->setContainer($container);
+
+        $this->application->add($command);
+    }
+
+    public function testExecute()
+    {
+        $metadata = $this->getMock('Symfony\Component\Validator\MetadataInterface');
+
+        $this->validatorFactory->expects($this->once())
+            ->method('getMetadataFor')
+            ->with($this->equalTo('Acme\Entity\Foo'))
+            ->will($this->returnValue($metadata));
+
+        $propertyMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\ElementMetadata');
+        $propertyMetadata->constraints = array(new NotNull(), new Length(array('min' => 2, 'max' => 50, 'groups' => array('create', 'edit'),)));
+        $metadata->properties = array('firstName' => $propertyMetadata);
+
+        $getterMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\ElementMetadata');
+        $getterMetadata->constraints = array(new NotNull(), new Email(array('groups' => array('registration', 'edit'),)));
+        $metadata->getters = array('email' => $getterMetadata);
+
+        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+
+        $this->admin->expects($this->any())
+            ->method('getModelManager')
+            ->will($this->returnValue($modelManager));
+
+//@todo Mock of \Traversable is available since Phpunit 3.8. This should be completed after stable release of Phpunit 3.8.
+//@see https://github.com/sebastianbergmann/phpunit-mock-objects/issues/103
+//        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+//
+//        $this->admin->expects($this->any())
+//            ->method('getFormBuilder')
+//            ->will($this->returnValue($formBuilder));
+
+        $datagridBuilder = $this->getMock('\Sonata\AdminBundle\Builder\DatagridBuilderInterface');
+
+        $this->admin->expects($this->any())
+            ->method('getDatagridBuilder')
+            ->will($this->returnValue($datagridBuilder));
+
+        $listBuilder = $this->getMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
+
+        $this->admin->expects($this->any())
+            ->method('getListBuilder')
+            ->will($this->returnValue($listBuilder));
+
+        $command = $this->application->find('sonata:admin:explain');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), 'admin'=>'acme.admin.foo'));
+
+        $this->assertEquals(sprintf(file_get_contents(__DIR__.'/../Fixtures/Command/explain_admin.txt'), get_class($this->admin), get_class($modelManager), get_class($datagridBuilder), get_class($listBuilder)), $commandTester->getDisplay());
+    }
+
+    public function testExecuteEmptyValidator()
+    {
+        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+
+        $this->admin->expects($this->any())
+            ->method('getModelManager')
+            ->will($this->returnValue($modelManager));
+
+//@todo Mock of \Traversable is available since Phpunit 3.8. This should be completed after stable release of Phpunit 3.8.
+//@see https://github.com/sebastianbergmann/phpunit-mock-objects/issues/103
+//        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+//
+//        $this->admin->expects($this->any())
+//            ->method('getFormBuilder')
+//            ->will($this->returnValue($formBuilder));
+
+        $datagridBuilder = $this->getMock('\Sonata\AdminBundle\Builder\DatagridBuilderInterface');
+
+        $this->admin->expects($this->any())
+            ->method('getDatagridBuilder')
+            ->will($this->returnValue($datagridBuilder));
+
+        $listBuilder = $this->getMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
+
+        $this->admin->expects($this->any())
+            ->method('getListBuilder')
+            ->will($this->returnValue($listBuilder));
+
+        $command = $this->application->find('sonata:admin:explain');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), 'admin'=>'acme.admin.foo'));
+
+        $this->assertEquals(sprintf(file_get_contents(__DIR__.'/../Fixtures/Command/explain_admin_empty_validator.txt'), get_class($this->admin), get_class($modelManager), get_class($datagridBuilder), get_class($listBuilder)), $commandTester->getDisplay());
+    }
+
+    public function testExecuteNonAdminService()
+    {
+        try {
+            $command = $this->application->find('sonata:admin:explain');
+            $commandTester = new CommandTester($command);
+            $commandTester->execute(array('command' => $command->getName(), 'admin'=>'nonexistent.service'));
+
+        } catch (\RuntimeException $e) {
+            $this->assertEquals('Service "nonexistent.service" is not an admin class', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('An expected exception has not been raised.');
+    }
+}

--- a/Tests/Fixtures/Command/explain_admin.txt
+++ b/Tests/Fixtures/Command/explain_admin.txt
@@ -1,0 +1,42 @@
+AdminBundle Information
+id                   : foo
+Admin                : %1$s
+Model                : Acme\Entity\Foo
+Controller           : SonataAdminBundle:CRUD
+Model Manager        : %2$s
+Form Builder         : Sonata\AdminBundle\Command\ExplainAdminCommand
+Datagrid Builder     : %3$s
+List Builder         : %4$s
+Parent          : foo_child
+
+Routes
+  - fooBar_list
+  - fooBar_edit
+
+Datagrid Columns
+  - fooTextField               text            SonataAdminBundle:CRUD:foo_text.html.twig
+  - barDateTimeField           datetime        SonataAdminBundle:CRUD:bar_datetime.html.twig
+
+Datagrid Filters
+  - fooTextField               text            SonataAdminBundle:CRUD:foo_text.html.twig
+  - barDateTimeField           datetime        SonataAdminBundle:CRUD:bar_datetime.html.twig
+
+Form theme(s)
+  - FooBundle::bar.html.twig
+
+Form Fields
+  - fooTextField               text            SonataAdminBundle:CRUD:foo_text.html.twig
+  - barDateTimeField           datetime        SonataAdminBundle:CRUD:bar_datetime.html.twig
+
+Validation Framework - http://symfony.com/doc/2.0/book/validation.html
+Properties constraints
+  - firstName
+    Symfony\Component\Validator\Constraints\NotNull                        Default
+    Symfony\Component\Validator\Constraints\Length                         create|edit
+
+Getters constraints
+  - email
+    Symfony\Component\Validator\Constraints\NotNull                        Default
+    Symfony\Component\Validator\Constraints\Email                          registration|edit
+
+done!

--- a/Tests/Fixtures/Command/explain_admin_empty_validator.txt
+++ b/Tests/Fixtures/Command/explain_admin_empty_validator.txt
@@ -1,0 +1,38 @@
+AdminBundle Information
+id                   : foo
+Admin                : %1$s
+Model                : Acme\Entity\Foo
+Controller           : SonataAdminBundle:CRUD
+Model Manager        : %2$s
+Form Builder         : Sonata\AdminBundle\Command\ExplainAdminCommand
+Datagrid Builder     : %3$s
+List Builder         : %4$s
+Parent          : foo_child
+
+Routes
+  - fooBar_list
+  - fooBar_edit
+
+Datagrid Columns
+  - fooTextField               text            SonataAdminBundle:CRUD:foo_text.html.twig
+  - barDateTimeField           datetime        SonataAdminBundle:CRUD:bar_datetime.html.twig
+
+Datagrid Filters
+  - fooTextField               text            SonataAdminBundle:CRUD:foo_text.html.twig
+  - barDateTimeField           datetime        SonataAdminBundle:CRUD:bar_datetime.html.twig
+
+Form theme(s)
+  - FooBundle::bar.html.twig
+
+Form Fields
+  - fooTextField               text            SonataAdminBundle:CRUD:foo_text.html.twig
+  - barDateTimeField           datetime        SonataAdminBundle:CRUD:bar_datetime.html.twig
+
+Validation Framework - http://symfony.com/doc/2.0/book/validation.html
+Properties constraints
+    no property constraints defined !!
+
+Getters constraints
+    no getter constraints defined !!
+
+done!


### PR DESCRIPTION
BC Break: some methods from Admin class are added to AdminInterface (needed to implement the tests properly).

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | no (fixed in #1616) |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
