### PR TITLE
Fixes strlen() problem inside reverseTransform($newId)

### DIFF
--- a/Form/DataTransformer/ModelToIdTransformer.php
+++ b/Form/DataTransformer/ModelToIdTransformer.php
@@ -40,7 +40,9 @@ class ModelToIdTransformer implements DataTransformerInterface
      */
     public function reverseTransform($newId)
     {
-        if (!isset($newId) || strlen($newId) === 0) {
+        if (!isset($newId) || 
+            (is_array($newId) && sizeof($newId)==0) || 
+            (!is_array($newId) && strlen($newId) === 0)) {
             return null;
         }
 


### PR DESCRIPTION
I received this error after upgrading from e99449c to 9d7591a.
`Warning: strlen() expects parameter 1 to be string, array given in /app/cache/dev/classes.php line 12487`
After looking in the code I saw that it was related to the 'ModelToIdTransformer' class.

The parameter $newId can be an array. strlen($x) throws an exception if this happens. 
I just add some type checking and now everything works as expected.
Maybe somebody could merge this.

Info: I use the SonataAdminBundle a lot. I got this error while creating a new entry in the backend and try to save it.  If I edit a existing model and save it I get NO error. 
There are 1:m and m:n relations inside this specific entity. Therefore I could not figure out which foreign key or else broke the code.
