### PR TITLE
ImmutableArrayType with optional parameters

### DIFF
--- a/Form/Type/ImmutableArrayType.php
+++ b/Form/Type/ImmutableArrayType.php
@@ -27,13 +27,13 @@ class ImmutableArrayType extends AbstractType
             if ($infos instanceof FormBuilderInterface) {
                 $builder->add($infos);
             } else {
-                list($name, $type, $options) = $infos;
+                list($name, $type, $options) = array_pad($infos, 3, null);
 
                 if (is_callable($options)) {
                     $options = $options($builder, $options);
                 }
 
-                $builder->add($name, $type, $options);
+                $builder->add($name, $type, $options ?: array());
             }
         }
     }


### PR DESCRIPTION
It leads to errors, if the `$infos` array has less than 3 parameters and because the last two parameters of `FormBuilderInterface::add()` are optional, they should be optional in `$infos` too.
