### PR TITLE
Add: missing dependency to Twig extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "symfony/class-loader":"~2.2",
         "sensio/generator-bundle": "~2.2",
         "twig/twig": "~1.12",
+        "twig/extensions": "~1.0",
         "knplabs/knp-menu-bundle": "~1.1",
         "sonata-project/jquery-bundle": "1.8.*",
         "sonata-project/exporter": "1.*",


### PR DESCRIPTION
Necessary because of [this](https://github.com/sonata-project/SonataAdminBundle/blob/master/Resources/config/twig.xml#L14)
