### PR TITLE
Fix issue where "sonata_type_boolean" could not be binded to a Doctrine boolean

### DIFF
--- a/Form/Type/BooleanType.php
+++ b/Form/Type/BooleanType.php
@@ -21,7 +21,7 @@ class BooleanType extends AbstractType
 {
     const TYPE_YES = 1;
 
-    const TYPE_NO = 2;
+    const TYPE_NO = 0;
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Whith TYPE_NO = 2, it becomes "true" when casted to boolean by doctrine. I just tested it against symfony 2.3 and it works way better :)

Credit goes to @bactisme for pointing me that bug.
