### PR TITLE
Add a new html_attributes to work with angular.js

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -18,7 +18,7 @@ file that was distributed with this source code.
 {% set _title        = block('title') %}
 {% set _breadcrumb   = block('breadcrumb') %}
 <!DOCTYPE html>
-<html class="no-js" {% block html_attributes %}{% endblock %}>
+<html {% block html_attributes %}class="no-js"{% endblock %}>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 


### PR DESCRIPTION
Angular JS require to add a new attribute ng-app to the html tag.

This new block allow us to add it, for example :

{% block html_attributes %}ng-app="PrestaCMS.Page"{% endblock %}
