### PR TITLE
Translate toString

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -2541,7 +2541,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         }
 
         if (method_exists($object, '__toString') && null !== $object->__toString()) {
-            return (string) $object;
+            return $this->trans((string) $object);
         }
 
         return sprintf("%s:%s", ClassUtils::getClass($object), spl_object_hash($object));


### PR DESCRIPTION
This is useful when the object's `__toString()` actually returns a placeholder (for example, "New Gallery") that would benefit from being translated rather than used directly.
