### PR TITLE
callback-arguments within ImmutableArrayType

### DIFF
--- a/Form/Type/ImmutableArrayType.php
+++ b/Form/Type/ImmutableArrayType.php
@@ -28,9 +28,10 @@ class ImmutableArrayType extends AbstractType
                 $builder->add($infos);
             } else {
                 list($name, $type, $options) = $infos;
+                $extra = array_slice($infos, 3);
 
                 if (is_callable($options)) {
-                    $options = $options($builder, $options);
+                    $options = $options($builder, $name, $type, $extra);
                 }
 
                 $builder->add($name, $type, $options);


### PR DESCRIPTION
If you use a callback as third "argument" of a field within `immutable_array`, it previously passes the callback itself to the callback, which doesn't make much sense. It passes now `$name`, `$type` and remaining values of the original array.

```
$optionsCallback = function ($builder, $name, $type, $extra) {
    // $name == 'ttl';
    // $type == 'text';
    // $extra == array('foo', 'bar')
}

$form->add('options', 'sonata_type_immutable_array', array(
    'keys' => array(
        array('ttl',        'text', $optionsCallback, 'foo', 'bar')
    )
));
```
