### PR TITLE
Resolve show_in_dashboard in parameter bag

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -58,7 +58,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                 $admins[] = $id;
                 $classes[$arguments[1]] = $id;
 
-                $showInDashboard = (boolean) (isset($attributes['show_in_dashboard']) ? $attributes['show_in_dashboard'] : true);
+                $showInDashboard = (boolean) (isset($attributes['show_in_dashboard']) ?  $parameterBag->resolveValue($attributes['show_in_dashboard']) : true);
                 if (!$showInDashboard) {
                     continue;
                 }


### PR DESCRIPTION
Resolve `show_in_dashboard` in the parameter bag.
I'm using this as part of a PR for SonataMediaBundle to allow admin panels to be configurable using config files.
