### PR TITLE
Improved ListMapper tests: cover deprecated view inline action

### DIFF
--- a/Tests/Datagrid/ListMapperTest.php
+++ b/Tests/Datagrid/ListMapperTest.php
@@ -116,6 +116,34 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('fooName', $fieldDescription->getOption('label'));
     }
 
+    public function testAddViewInlineActionException()
+    {
+        $this->setExpectedException('PHPUnit_Framework_Error', 'Inline action "view" is deprecated since version 2.2.4. Use inline action "show" instead.');
+
+        $this->assertFalse($this->listMapper->has('_action'));
+        $this->listMapper->add('_action', 'actions', array('actions'=>array('view'=>array())));
+    }
+
+    public function testAddViewInlineAction()
+    {
+        // ignore E_USER_DEPRECATED error
+        $previousErrorHandler = set_error_handler( function() {}, E_USER_DEPRECATED);
+
+        $this->assertFalse($this->listMapper->has('_action'));
+        $this->listMapper->add('_action', 'actions', array('actions'=>array('view'=>array())));
+
+        $this->assertTrue($this->listMapper->has('_action'));
+
+        $fieldDescription = $this->listMapper->get('_action');
+
+        $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
+        $this->assertEquals('_action', $fieldDescription->getName());
+        $this->assertCount(1, $fieldDescription->getOption('actions'));
+        $this->assertEquals(array('show'=>array()), $fieldDescription->getOption('actions'));
+
+        set_error_handler($previousErrorHandler);
+    }
+
     public function testAddRemove()
     {
         $this->assertFalse($this->listMapper->has('fooName'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
