### PR TITLE
Restored multiple level model class name support in base route generatio...

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -52,7 +52,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     const CONTEXT_MENU       = 'menu';
     const CONTEXT_DASHBOARD  = 'dashboard';
 
-    const CLASS_REGEX        = '@([A-Za-z0-9]*)\\\(Bundle\\\)?([A-Za-z0-9]+)Bundle\\\([A-Za-z0-9].*)\\\([A-Za-z0-9]*)$@';
+    const CLASS_REGEX        = '@([A-Za-z0-9]*)\\\(Bundle\\\)?([A-Za-z0-9]+)Bundle\\\(Entity|Document|Model|PHPCR|Doctrine\\\Phpcr)\\\(.*)@';
 
     /**
      * The class name managed by the admin class

--- a/Tests/Admin/BaseAdminTest.php
+++ b/Tests/Admin/BaseAdminTest.php
@@ -157,6 +157,18 @@ class BaseAdminTest extends \PHPUnit_Framework_TestCase
                 '/myapplication/my/post'
             ),
             array(
+                'MyApplication\MyBundle\Entity\Post\Category',
+                '/myapplication/my/post-category'
+            ),
+            array(
+                'MyApplication\MyBundle\Entity\Product\Category',
+                '/myapplication/my/product-category'
+            ),
+            array(
+                'MyApplication\MyBundle\Entity\Other\Product\Category',
+                '/myapplication/my/other-product-category'
+            ),
+            array(
                 'Symfony\Cmf\Bundle\FooBundle\Document\Menu', 
                 '/cmf/foo/menu'
             ),
@@ -167,6 +179,10 @@ class BaseAdminTest extends \PHPUnit_Framework_TestCase
             array(
                 'Symfony\Bundle\BarBarBundle\Doctrine\Phpcr\Menu', 
                 '/symfony/barbar/menu'
+            ),
+            array(
+                'Symfony\Bundle\BarBarBundle\Doctrine\Phpcr\Menu\Item',
+                '/symfony/barbar/menu-item'
             ),
         );
     }
@@ -214,6 +230,18 @@ class BaseAdminTest extends \PHPUnit_Framework_TestCase
                 'admin_myapplication_my_post'
             ),
             array(
+                'MyApplication\MyBundle\Entity\Post\Category',
+                'admin_myapplication_my_post_category'
+            ),
+            array(
+                'MyApplication\MyBundle\Entity\Product\Category',
+                'admin_myapplication_my_product_category'
+            ),
+            array(
+                'MyApplication\MyBundle\Entity\Other\Product\Category',
+                'admin_myapplication_my_other_product_category'
+            ),
+            array(
                 'Symfony\Cmf\Bundle\FooBundle\Document\Menu', 
                 'admin_cmf_foo_menu'
             ),
@@ -224,6 +252,10 @@ class BaseAdminTest extends \PHPUnit_Framework_TestCase
             array(
                 'Symfony\Bundle\BarBarBundle\Doctrine\Phpcr\Menu', 
                 'admin_symfony_barbar_menu'
+            ),
+            array(
+                'Symfony\Bundle\BarBarBundle\Doctrine\Phpcr\Menu\Item',
+                'admin_symfony_barbar_menu_item'
             ),
         );
     }


### PR DESCRIPTION
...n

In revision d7a0a9ce296284d800d22a652d2eecfcc4027ee1 the regex assumes there will only ever be one level.  This is a regression in functionality based on the previous regex before this revision.  Also, when model classes have different directory names but the same file name, the generated URL and route name will be ambiguous (i.e. does the URL `/myapplication/my/category` and route `admin_myapplication_my_category` relate to `Post\Category` or `Product\Category`?).  This change restores most of the previous regex to differentiate model classes in multilevel sub-directories.

/cc @rande
