### PR TITLE
adjust class_regex

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -52,7 +52,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     const CONTEXT_MENU       = 'menu';
     const CONTEXT_DASHBOARD  = 'dashboard';
 
-    const CLASS_REGEX        = '@([A-Za-z0-9]*)\\\(Bundle\\\)?([A-Za-z0-9]+)Bundle\\\(Entity|Document|Model|PHPCR|Phpcr|Doctrine\\Orm|Doctrine\\Phpcr|Doctrine\\MongoDB|Doctrine\\CouchDB)\\\(.*)@';
+    const CLASS_REGEX        = '@([A-Za-z0-9]*)\\\(Bundle\\\)?([A-Za-z0-9]+)Bundle\\\(Entity|Document|Model|PHPCR|Phpcr|Doctrine\\\Orm|Doctrine\\\Phpcr|Doctrine\\\MongoDB|Doctrine\\\CouchDB)\\\(.*)@';
 
     /**
      * The class name managed by the admin class


### PR DESCRIPTION
follow up of #1677

if we want to explicitly list cases, we should add more Doctrine\ options:
-    Doctrine\Orm
-    Doctrine\MongoDB
-    Doctrine\CouchDB

see http://symfony.com/doc/current/cookbook/doctrine/mapping_model_classes.html and for a concrete example https://github.com/FriendsOfSymfony/FOSUserBundle/tree/master/Doctrine

i guess that was the reason why @dantleech made this a generic match everything. but i see that breaks another feature. adding the other Doctrine... cases should cover at least the rest of the standard situations.
