### PR TITLE
Allow to specify a translation_domain option in list, show and filter "add" method

### DIFF
--- a/Filter/Filter.php
+++ b/Filter/Filter.php
@@ -219,4 +219,12 @@ abstract class Filter implements FilterInterface
     {
         return $this->condition;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTranslationDomain()
+    {
+        return $this->getOption('translation_domain');
+    }
 }

--- a/Filter/FilterInterface.php
+++ b/Filter/FilterInterface.php
@@ -144,4 +144,9 @@ interface FilterInterface
      * @return string
      */
     public function getCondition();
+
+    /**
+     * @return string
+     */
+    public function getTranslationDomain();
 }

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -52,7 +52,7 @@ file that was distributed with this source code.
                                     {% spaceless %}
                                         <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}">
                                             {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters) }}">{% endif %}
-                                            {{ admin.trans(field_description.label) }}
+                                            {{ admin.trans(field_description.label, {}, field_description.translationDomain) }}
                                             {% if sortable %}</a>{% endif %}
                                         </th>
                                     {% endspaceless %}
@@ -156,7 +156,7 @@ file that was distributed with this source code.
                     <div>
                         {% for filter in admin.datagrid.filters %}
                             <div class="clearfix">
-                                <label for="{{ form.children[filter.formName].children['value'].vars.id }}">{{ admin.trans(filter.label) }}</label>
+                                <label for="{{ form.children[filter.formName].children['value'].vars.id }}">{{ admin.trans(filter.label, {}, filter.translationDomain) }}</label>
                                 {{ form_widget(form.children[filter.formName].children['type'], {'attr': {'class': 'span8 sonata-filter-option'}}) }}
                                 {{ form_widget(form.children[filter.formName].children['value'], {'attr': {'class': 'span8'}}) }}
                             </div>

--- a/Resources/views/CRUD/base_show_field.html.twig
+++ b/Resources/views/CRUD/base_show_field.html.twig
@@ -9,5 +9,5 @@ file that was distributed with this source code.
 
 #}
 
-<th>{% block name %}{{ admin.trans(field_description.label) }}{% endblock %}</th>
+<th>{% block name %}{{ admin.trans(field_description.label, {}, field_description.translationDomain) }}{% endblock %}</th>
 <td>{% block field %}{% if field_description.options.safe %}{{ value|raw }}{% else %}{{ value|nl2br }}{% endif %}{% endblock %}</td>


### PR DESCRIPTION
Examples :

```
$list->add('myfield', null, ['translation_domain' => 'MyDomain];
$show->add('myfield', null, ['translation_domain' => 'MyDomain];
$filter->add('myfield', null, ['translation_domain' => 'MyDomain];
```
