### PR TITLE
CRUDControllerTest: added test for editAction

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -2555,11 +2555,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returning true will enable preview mode for
-     * the target entity and show a preview button
-     * when editing/creating an entity
-     *
-     * @return boolean
+     * {@inheritdoc}
      */
     public function supportsPreviewMode()
     {

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -518,6 +518,15 @@ interface AdminInterface
     public function getLabelTranslatorStrategy();
 
     /**
+     * Returning true will enable preview mode for
+     * the target entity and show a preview button
+     * when editing/creating an entity
+     *
+     * @return boolean
+     */
+    public function supportsPreviewMode();
+
+    /**
      * add an Admin child to the current one
      *
      * @param \Sonata\AdminBundle\Admin\AdminInterface $child

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+### 2013-10-01
+
+* [BC BREAK] added ``supportsPreviewMode`` to the AdminInterface
+  If you do not extend the Admin class, you need to add this method to
+  your admin.
+
 ### 2013-09-30
 
 * [BC BREAK] added ``getFilterParameters`` to the AdminInterface

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -305,7 +305,6 @@ class CRUDController extends Controller
             // persist if the form was valid and if in preview mode the preview was approved
             if ($isFormValid && (!$this->isInPreviewMode() || $this->isPreviewApproved())) {
                 $this->admin->update($object);
-                $this->addFlash('sonata_flash_success', 'flash_edit_success');
 
                 if ($this->isXmlHttpRequest()) {
                     return $this->renderJson(array(
@@ -313,6 +312,8 @@ class CRUDController extends Controller
                         'objectId'  => $this->admin->getNormalizedIdentifier($object)
                     ));
                 }
+
+                $this->addFlash('sonata_flash_success', 'flash_edit_success');
 
                 // redirect to edit mode
                 return $this->redirectTo($object);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes (flash messages should not be added in ajax request) |
| New feature? | no |
| BC breaks? | yes (added `supportsPreviewMode` to the AdminInterface) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
