### PR TITLE
standard_layout.html.twig: Do not display the group label if no item in group is available

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -126,10 +126,20 @@ file that was distributed with this source code.
                                             {% for group in admin_pool.dashboardgroups %}
                                                 {% set display = (group.roles is empty or is_granted('ROLE_SUPER_ADMIN') ) %}
                                                 {% for role in group.roles if not display %}
-                                                    {% set display = is_granted(role)%}
+                                                    {% set display = is_granted(role) %}
                                                 {% endfor %}
 
+                                                {# Do not display the group label if no item in group is available #}
+                                                {% set item_count = 0 %}
                                                 {% if display %}
+                                                    {% for admin in group.items if item_count == 0 %}
+                                                        {% if admin.hasroute('list') and admin.isGranted('LIST') %}
+                                                            {% set item_count = item_count+1 %}
+                                                        {% endif %}
+                                                    {% endfor %}
+                                                {% endif %}
+
+                                                {% if display and (item_count > 0) %}
                                                 <li class="dropdown">
                                                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ group.label|trans({}, group.label_catalogue) }} <span class="caret"></span></a>
                                                     <ul class="dropdown-menu">


### PR DESCRIPTION
This PR fixes the bug of displaying empty group in top menu with no items: ![sonata_empty_group_label](https://f.cloud.github.com/assets/960844/1260978/75fe86d8-2c20-11e3-94dd-81e03181712d.jpg)

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
