### PR TITLE
[WIP] Fixed getting wrong subject in sonata_type_collection.

### DIFF
--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -34,9 +34,7 @@ class AdminType extends AbstractType
             $builder->add('_delete', 'checkbox', array('required' => false, 'mapped' => false));
         }
 
-        if (!$admin->hasSubject()) {
-            $admin->setSubject($builder->getData());
-        }
+        $admin->setSubject($builder->getData());
 
         $admin->defineFormBuilder($builder);
 


### PR DESCRIPTION
This is additional fix for wrong subject problem (the first fix did @rande: 013456608134c704edb01ff9487d8a664200af11)

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1568 #991 #1313 maybe #1515 |
| License | MIT |
| Doc PR | - |

@vhpoet @camilleb @idhard @caponica  Can you please test the latest SonataAdmin code with this PR if it solves your problem with wrong subject returned by getSubject method in collection?
