### PR TITLE
Added sonata_page_content block to standard_layout.html.twig

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -175,99 +175,101 @@ file that was distributed with this source code.
         </div>
 
         <div class="container-fluid">
-            {% block notice %}
-                {% for notice_level in ['success','error','info', 'warning'] %}
-                    {% set session_var = 'sonata_flash_' ~ notice_level %}
-                    {% for flash in app.session.flashbag.get(session_var) %}
-                        <div class="alert {{ 'alert-' ~ notice_level }}">
-                            {{ flash|trans([], 'SonataAdminBundle') }}
-                        </div>
-                    {% endfor %}
-                {% endfor %}
-            {% endblock %}
-
-            <div class="row-fluid">
-                {% if _breadcrumb is not empty or action is defined %}
-                    <div class="span6">
-                        <ul class="breadcrumb">
-                            {% if _breadcrumb is empty %}
-                                {% if action is defined %}
-                                    {% for menu in admin.breadcrumbs(action) %}
-                                        {% if not loop.last  %}
-                                            <li>
-                                                {% if menu.uri is not empty %}
-                                                    <a href="{{ menu.uri }}">{{ menu.label }}</a>
-                                                {% else %}
-                                                    {{ menu.label }}
-                                                {% endif %}
-                                                <span class="divider">/</span>
-                                            </li>
-                                        {% else %}
-                                            <li class="active">{{ menu.label }}</li>
-                                        {% endif %}
-                                    {% endfor %}
-                                {% endif %}
-                            {% else %}
-                                {{ _breadcrumb|raw }}
-                            {% endif %}
-                        </ul>
-                    </div>
-                {% endif %}
-
-                {% if _actions is not empty %}
-                    <div class="span4 offset2">
-                        {{ _actions|raw }}
-                    </div>
-                {% endif %}
-            </div>
-
-            <div class="row-fluid">
-                {% if _side_menu is not empty %}
-                    <div class="sidebar span2">
-                        <div class="well sonata-ba-side-menu" style="padding: 8px 0;">{{ _side_menu|raw }}</div>
-                    </div>
-                {% endif %}
-
-                <div class="content {{ _side_menu is not empty ? ' span10' : 'span12' }}">
-                    {% block sonata_admin_content %}
-
-                        {% if _preview is not empty %}
-                            <div class="sonata-ba-preview">{{ _preview|raw }}</div>
-                        {% endif %}
-
-                        {% if _content is not empty %}
-                            <div class="sonata-ba-content">{{ _content|raw }}</div>
-                        {% endif %}
-
-                        {% if _show is not empty %}
-                            <div class="sonata-ba-show">{{ _show|raw }}</div>
-                        {% endif %}
-
-                        {% if _form is not empty %}
-                            <div class="sonata-ba-form">{{ _form|raw }}</div>
-                        {% endif %}
-
-                        {% if _list_table is not empty or _list_filters is not empty %}
-                            <div class="row-fluid">
-                                <div class="sonata-ba-list span10">
-                                    {{ _list_table|raw }}
-                                </div>
-                                <div class="sonata-ba-filter span2">
-                                    {{ _list_filters|raw }}
-                                </div>
+            {% block sonata_page_content %}
+                {% block notice %}
+                    {% for notice_level in ['success','error','info', 'warning'] %}
+                        {% set session_var = 'sonata_flash_' ~ notice_level %}
+                        {% for flash in app.session.flashbag.get(session_var) %}
+                            <div class="alert {{ 'alert-' ~ notice_level }}">
+                                {{ flash|trans([], 'SonataAdminBundle') }}
                             </div>
-                        {% endif %}
+                        {% endfor %}
+                    {% endfor %}
+                {% endblock %}
 
-                    {% endblock %}
-                </div>
-            </div>
-
-            {% block footer %}
                 <div class="row-fluid">
-                    <div class="span2 offset10 pull-right">
-                        <span class="label"><a href="http://sonata-project.org" rel="noreferrer" style="text-decoration: none; color: black">Sonata Project</a></span>
+                    {% if _breadcrumb is not empty or action is defined %}
+                        <div class="span6">
+                            <ul class="breadcrumb">
+                                {% if _breadcrumb is empty %}
+                                    {% if action is defined %}
+                                        {% for menu in admin.breadcrumbs(action) %}
+                                            {% if not loop.last  %}
+                                                <li>
+                                                    {% if menu.uri is not empty %}
+                                                        <a href="{{ menu.uri }}">{{ menu.label }}</a>
+                                                    {% else %}
+                                                        {{ menu.label }}
+                                                    {% endif %}
+                                                    <span class="divider">/</span>
+                                                </li>
+                                            {% else %}
+                                                <li class="active">{{ menu.label }}</li>
+                                            {% endif %}
+                                        {% endfor %}
+                                    {% endif %}
+                                {% else %}
+                                    {{ _breadcrumb|raw }}
+                                {% endif %}
+                            </ul>
+                        </div>
+                    {% endif %}
+
+                    {% if _actions is not empty %}
+                        <div class="span4 offset2">
+                            {{ _actions|raw }}
+                        </div>
+                    {% endif %}
+                </div>
+
+                <div class="row-fluid">
+                    {% if _side_menu is not empty %}
+                        <div class="sidebar span2">
+                            <div class="well sonata-ba-side-menu" style="padding: 8px 0;">{{ _side_menu|raw }}</div>
+                        </div>
+                    {% endif %}
+
+                    <div class="content {{ _side_menu is not empty ? ' span10' : 'span12' }}">
+                        {% block sonata_admin_content %}
+
+                            {% if _preview is not empty %}
+                                <div class="sonata-ba-preview">{{ _preview|raw }}</div>
+                            {% endif %}
+
+                            {% if _content is not empty %}
+                                <div class="sonata-ba-content">{{ _content|raw }}</div>
+                            {% endif %}
+
+                            {% if _show is not empty %}
+                                <div class="sonata-ba-show">{{ _show|raw }}</div>
+                            {% endif %}
+
+                            {% if _form is not empty %}
+                                <div class="sonata-ba-form">{{ _form|raw }}</div>
+                            {% endif %}
+
+                            {% if _list_table is not empty or _list_filters is not empty %}
+                                <div class="row-fluid">
+                                    <div class="sonata-ba-list span10">
+                                        {{ _list_table|raw }}
+                                    </div>
+                                    <div class="sonata-ba-filter span2">
+                                        {{ _list_filters|raw }}
+                                    </div>
+                                </div>
+                            {% endif %}
+
+                        {% endblock %}
                     </div>
                 </div>
+
+                {% block footer %}
+                    <div class="row-fluid">
+                        <div class="span2 offset10 pull-right">
+                            <span class="label"><a href="http://sonata-project.org" rel="noreferrer" style="text-decoration: none; color: black">Sonata Project</a></span>
+                        </div>
+                    </div>
+                {% endblock %}
             {% endblock %}
         </div>
     </body>


### PR DESCRIPTION
Diff with [white space ignored](https://github.com/sonata-project/SonataAdminBundle/pull/1711/files?w=1)

My use case:
I need to create special side box with custom content on the left and do not break any other SonataAdmin functionality (calling `parent()` after extending block). 

This block will also enable easier overloading the whole content of page (the top menu will still be available)

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
