### PR TITLE
fix incompatible annotation with doctrine

### DIFF
--- a/Admin/AdminExtensionInterface.php
+++ b/Admin/AdminExtensionInterface.php
@@ -24,9 +24,6 @@ use Knp\Menu\ItemInterface as MenuItemInterface;
 /**
  *
  */
-/** @noinspection PhpDocSignatureInspection */
-/** @noinspection PhpDocSignatureInspection */
-/** @noinspection PhpDocSignatureInspection */
 interface AdminExtensionInterface
 {
     /**


### PR DESCRIPTION
> [Doctrine\Common\Annotations\AnnotationException]
> [Semantical Error] The annotation "@noinspection" in class Sonata\AdminBundle\Admin\AdminExtensionInterface was never imported. Did you maybe forget to add a "use" statement for this annotation?
