### PR TITLE
Use ClassUtils::getClass instead of get_class

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -939,7 +939,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     public function getClass()
     {
         if ($this->hasSubject()) {
-            return get_class($this->getSubject());
+            return ClassUtils::getClass($this->getSubject());
         }
 
         if (!$this->hasActiveSubClass()) {


### PR DESCRIPTION
This is necessary to be able to use sonata_type_collection
together with generated proxy classes that extend the actual class,
e.g. to be able to embed the routes for a page in the cmf.

Otherwise the AdminType creates an ArrayToModelTransformer with the wrong
class, i.e. the proxy class, when there is already an element in the collection.
