### PR TITLE
Apply select2 on appended form element

### DIFF
--- a/Resources/public/base.js
+++ b/Resources/public/base.js
@@ -14,6 +14,10 @@ jQuery(document).ready(function() {
     Admin.setup_inline_form_errors(document);
 });
 
+jQuery(document).on('sonata-admin-append-form-element', function(e) {
+    Admin.setup_select2(e.target);
+});
+
 var Admin = {
 
     setup_select2: function(subject) {


### PR DESCRIPTION
For example : when adding an element to a multiple select, select2 is not correctly refreshed and the new option does not appear : 

![select2-multiple](https://f.cloud.github.com/assets/663607/1481232/b2f91e7c-46c4-11e3-88d7-ae7aeb908b68.jpg)
