### PR TITLE
[select2] Enable search/autocomplete by default for all select fields

### DIFF
--- a/Resources/public/base.js
+++ b/Resources/public/base.js
@@ -27,7 +27,7 @@ var Admin = {
 
                 select.select2({
                     width: 'resolve',
-                    minimumResultsForSearch: 10,
+                    minimumResultsForSearch: 0,
                     allowClear: select.find('option[value=""]').length ? true : false
                 });
 


### PR DESCRIPTION
Enable search for all selects without care about the minimum items improves the productivity when use the keyboard for jump between fields (tab key) and use the alphanumerics keys for introduce values in all kind of values without to move the hands to the cursor keys (when search is not enable)
