### PR TITLE
[select2] Apply select2 to fields after ajax reloading

### DIFF
--- a/Resources/public/base.js
+++ b/Resources/public/base.js
@@ -5,6 +5,7 @@ jQuery(document).ready(function() {
     }
 
     Admin.setup_select2(document);
+    jQuery(this).on('sonata.add_element', function() { Admin.setup_select2(document); });
     Admin.add_pretty_errors(document);
     Admin.add_filters(document);
     Admin.set_object_field_value(document);


### PR DESCRIPTION
Actually select2 is initialized only at the page load and miss any change after ajax changes.

I'm not sure if this is the correct place for add this, also the event only exists in sonata orm admin bundle.

I wait for your feedback/ideas for to do this better.
