### PR TITLE
Fix argument notation, because it must be a service, not a string

### DIFF
--- a/Resources/doc/reference/architecture.rst
+++ b/Resources/doc/reference/architecture.rst
@@ -83,7 +83,7 @@ your ``Admin`` services. This is done using a ``call`` to the matching "setter":
                     - Acme\DemoBundle\Entity\Post
                     - ~
                 calls:
-                    - [ setLabelTranslatorStrategy, [sonata.admin.label.strategy.underscore]]
+                    - [ setLabelTranslatorStrategy, ["@sonata.admin.label.strategy.underscore"]]
 
 Here, we declare the same ``Admin`` service as in the :doc:`getting_started` chapter, but using a
 different label translator strategy, replacing the default one. Notice that


### PR DESCRIPTION
When following the referenced doc, an exception is trigged because the method expects an instance of LabelTranslatorStrategyInterface, but as are now, a string is passed
