### PR TITLE
Fixing sonata-collection-item-deleted custom event

### DIFF
--- a/Resources/public/base.js
+++ b/Resources/public/base.js
@@ -178,9 +178,9 @@ var Admin = {
         jQuery(subject).on('click', '.sonata-collection-delete', function(event) {
             Admin.stopEvent(event);
 
-            jQuery(this).closest('.sonata-collection-row').remove();
-
             jQuery(this).trigger('sonata-collection-item-deleted');
+
+            jQuery(this).closest('.sonata-collection-row').remove();
         });
     },
 


### PR DESCRIPTION
Event must be called before row is removed, or else event is never called
