### PR TITLE
Update troubleshooting.rst

### DIFF
--- a/Resources/doc/reference/troubleshooting.rst
+++ b/Resources/doc/reference/troubleshooting.rst
@@ -28,3 +28,26 @@ So in order to avoid any fatal error, you must return an empty string (or anythi
 
 
 .. _`__toString`: http://www.php.net/manual/en/language.oop5.magic.php#object.tostring
+
+
+Large filters and long urls problem
+-------------------
+
+If you will try to add hundreds filters to single admin class, you will get a problem - very long filter form url generated.
+In most cases you will get server response like *Error 400 Bad Request* OR *Error 414 Request-URI Too Long*. According to 
+http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
+"safe" url length is just around 2000 characters.
+You can fix this issue by adding simple JQuery code on your edit template
+
+.. code-block:: javascript
+
+    $(function() {
+        // Add class 'had-value-on-load' to inputs/selects with values.
+        $(".sonata-filter-form input").add(".sonata-filter-form select").each(function(){ if($(this).val()) { $(this).addClass('had-value-on-load')}})
+        // REMOVE ALL EMPTY INPUT FROM FILTER FORM (except inputs, which has class 'had-value-on-load')
+        $(".sonata-filter-form").submit(function() {
+            $(".sonata-filter-form input").add(".sonata-filter-form select").each(function(){ if(!$(this).val() && !$(this).hasClass('had-value-on-load')) { $(this).remove()}})
+        });
+    });
+
+


### PR DESCRIPTION
We have admin class with around 100 filters in it (yes, I know, it may sounds crazy, but filters are dynamically build and its very user-friendly. Also client wanted it :) ).
But when filter form is submitted - very long url is generated. I have created fast workaround for this issue.
Empty select/inputs just removed before form submit. 
It works with persisted filters as well (because non empty input/selects are marked).

@rande this code may be added for default template - it seems to be safe to use by default.
