### PR TITLE
Fix "many" parent append

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -844,7 +844,14 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
 
             $object = $this->getSubject();
 
-            $propertyAccessor->setValue($object, $propertyPath, $parent);
+            $value = $propertyAccessor->getValue($object, $propertyPath);
+
+            if (is_array($value) || ($value instanceof \Traversable && $value instanceof \ArrayAccess)) {
+                $value[] = $parent;
+                $propertyAccessor->setValue($object, $propertyPath, $value);
+            } else {
+                $propertyAccessor->setValue($object, $propertyPath, $parent);
+            }
         }
 
         $this->form = $this->getFormBuilder()->getForm();

--- a/Tests/Fixtures/Admin/TagAdmin.php
+++ b/Tests/Fixtures/Admin/TagAdmin.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Admin;
+
+use Sonata\AdminBundle\Admin\Admin;
+
+class TagAdmin extends Admin
+{
+    public function getParentAssociationMapping()
+    {
+        if ($this->getParent() instanceof PostAdmin) {
+            return 'posts';
+        }
+    }
+}
+

--- a/Tests/Fixtures/Bundle/Entity/Post.php
+++ b/Tests/Fixtures/Bundle/Entity/Post.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+class Post
+{
+    private $tags;
+
+    public function __construct()
+    {
+        $this->tags = new ArrayCollection();
+    }
+
+    public function setTags($tags)
+    {
+        $this->tags = $tags;
+    }
+
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    public  function addTag(Tag $tag)
+    {
+        $tag->addPost($this);
+        $this->tags[] = ($tag);
+    }
+
+    public function removePost(Tag $tag)
+    {
+        $tag->removePost($this);
+        $this->tags->removeElement($tag);
+    }
+}

--- a/Tests/Fixtures/Bundle/Entity/Tag.php
+++ b/Tests/Fixtures/Bundle/Entity/Tag.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+class Tag
+{
+    private $posts;
+
+    public function __construct()
+    {
+        $this->posts = new ArrayCollection();
+    }
+
+    public function setPosts($posts)
+    {
+        $this->posts = $posts;
+    }
+
+    public function getPosts()
+    {
+        return $this->posts;
+    }
+
+    public  function addPost(Post $post)
+    {
+        $this->posts[] = $post;
+    }
+
+    public function removePost(Post $post)
+    {
+        $this->posts->removeElement($post);
+    }
+}

--- a/Tests/Form/Builder/FormBuilder.php
+++ b/Tests/Form/Builder/FormBuilder.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Builder;
+
+use Symfony\Component\Form\Test\FormBuilderInterface;
+
+/**
+ * Class FormBuilder
+ *
+ * Used to avoid an issue when to mocking FormBuilderInterface directly
+ *
+ * @see https://github.com/sebastianbergmann/phpunit-mock-objects/issues/103
+ */
+abstract class FormBuilder implements FormBuilderInterface
+{
+}


### PR DESCRIPTION
Example : We have a many-to-many relation between `Post` and `Tag`. `TagAdmin` is a child of `PostAdmin`, and the `TagAdmin::getParentAssociationMapping()` method will return `posts`.

Currently, as `parent` is `Post` object, the `propertyAccessor` will call `$tag->setPosts($post);` which is incorrect. This PR appends the parent as an array if necessary, so the `propertyAccessor` will call `$tag->addPost($post)` instead.
