### PR TITLE
Cascade form groups on FormMapper::remove call

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1577,6 +1577,20 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function removeFieldFromFormGroup($key)
+    {
+        foreach ($this->formGroups as $name => $formGroup) {
+            unset($this->formGroups[$name]['fields'][$key]);
+
+            if (empty($this->formGroups[$name]['fields'])) {
+                unset($this->formGroups[$name]);
+            }
+        }
+    }
+
+    /**
      * @param array $group
      * @param array $keys
      */

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -824,6 +824,15 @@ interface AdminInterface
     public function setFormGroups(array $formGroups);
 
     /**
+     * Remove a form group field
+     *
+     * @param $key
+     *
+     * @return void
+     */
+    public function removeFieldFromFormGroup($key);
+
+    /**
      * Returns the show groups
      *
      * @return array
@@ -854,6 +863,15 @@ interface AdminInterface
      * @return void
      */
     public function addFormFieldDescription($name, FieldDescriptionInterface $fieldDescription);
+
+    /**
+     * Remove a FieldDescription
+     *
+     * @param string $name
+     *
+     * @return void
+     */
+    public function removeFormFieldDescription($name);
 
     /**
      * Returns true if this admin uses ACL

--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -157,6 +157,7 @@ class FormMapper extends BaseGroupedMapper
     public function remove($key)
     {
         $this->admin->removeFormFieldDescription($key);
+        $this->admin->removeFieldFromFormGroup($key);
         $this->formBuilder->remove($key);
 
         return $this;

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1139,4 +1139,31 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         return $tagAdmin;
     }
+
+    public function testRemoveFieldFromFormGroup()
+    {
+        $formGroups = array(
+            'foobar' => array(
+                'fields' => array(
+                    'foo' => 'foo',
+                    'bar' => 'bar',
+                ),
+            )
+        );
+
+        $admin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin->setFormGroups($formGroups);
+
+        $admin->removeFieldFromFormGroup('foo');
+        $this->assertEquals($admin->getFormGroups(), array(
+            'foobar' => array(
+                'fields' => array(
+                    'bar' => 'bar',
+                ),
+            )
+        ));
+
+        $admin->removeFieldFromFormGroup('bar');
+        $this->assertEquals($admin->getFormGroups(), array());
+    }
 }

--- a/Tests/Form/FormMapperTest.php
+++ b/Tests/Form/FormMapperTest.php
@@ -113,4 +113,14 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
         ->add('foo', 'bar')
         ->end();
     }
+
+    public function testRemoveCascadeRemoveFieldFromFormGroup()
+    {
+        $this->admin->expects($this->once())
+            ->method('removeFieldFromFormGroup')
+            ->with('foo')
+        ;
+
+        $this->formMapper->remove('foo');
+    }
 }


### PR DESCRIPTION
Currently, when a form field is removed, the corresponding form group field is not removed. Moreover, when a form group has not more fields, it is not removed as well. This PR fixes this, and consequently fixes empty form tabs :

![capture](https://f.cloud.github.com/assets/663607/1782004/bdbe9b4e-68a1-11e3-9fe0-6690b94e7451.PNG)
![capture](https://f.cloud.github.com/assets/663607/1782008/e5161cd0-68a1-11e3-8177-41b46d51a96f.PNG)
