### PR TITLE
Use getTranslationDomain() in trans/tranchoice

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -2102,7 +2102,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
      */
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
-        $domain = $domain ?: $this->translationDomain;
+        $domain = $domain ?: $this->getTranslationDomain();
 
         if (!$this->translator) {
             return $id;
@@ -2124,7 +2124,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
      */
     public function transChoice($id, $count, array $parameters = array(), $domain = null, $locale = null)
     {
-        $domain = $domain ?: $this->translationDomain;
+        $domain = $domain ?: $this->getTranslationDomain();
 
         if (!$this->translator) {
             return $id;


### PR DESCRIPTION
Allows to override the getTranslationDomain() method in admins.
