### PR TITLE
Specify an error massage by adding throw StringCastException

### DIFF
--- a/Form/ChoiceList/ModelChoiceList.php
+++ b/Form/ChoiceList/ModelChoiceList.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Util\ClassUtils;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Form\Exception\InvalidArgumentException;
+use Symfony\Component\Form\Exception\RuntimeException;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 
@@ -140,7 +141,7 @@ class ModelChoiceList extends SimpleChoiceList
                 try {
                     $value = (string) $entity;
                 } catch (\Exception $e) {
-                    throw new StringCastException(sprintf("Unable to convert the entity %s to String, entity must have a '__toString()' method defined", ClassUtils::getClass($entity)));
+                    throw new RuntimeException(sprintf("Unable to convert the entity %s to String, entity must have a '__toString()' method defined", ClassUtils::getClass($entity)), 0, $e);
                 }
             }
 


### PR DESCRIPTION
I found that there are many people searching on the internet when they got the error:

```
ContextErrorException: Catchable Fatal Error: Object of class Acme\Bundle\DemoBundle\Entity\Roles could not be converted to string in /Applications/XAMPP/xamppfiles/htdocs/symfony/vendor/sonata-project/admin-bundle/Sonata/AdminBundle/Form/ChoiceList/ModelChoiceList.php line 142

```

So now, the type of error is specified clearly. It helps beginner people a lot to understand what's going on and fix it easily. 

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
