### PR TITLE
Increased width of date fields

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -265,7 +265,7 @@ body.sonata-bc {
 }
 
 .sonata-bc div.sonata-medium-date select {
-    width: 75px;
+    width: 85px;
 }
 
 .sonata-bc div.sonata-medium-date div {


### PR DESCRIPTION
At 75px the year was being replaced with "2..." after select2 added its "X". At 85px this doesn't happen any more.
