### PR TITLE
Fixed setting 'compound' option of sonata_type_model

### DIFF
--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -65,7 +65,23 @@ class ModelType extends AbstractType
     {
         $resolver->setDefaults(array(
             'compound'          => function (Options $options) {
-                return isset($options['multiple']) ? $options['multiple'] : false;
+                if (isset($options['multiple']) && $options['multiple']) {
+                    if (isset($options['expanded']) && $options['expanded']) {
+                        //checkboxes
+                        return true;
+                    }
+
+                    //select tag (with multiple attribute)
+                    return false;
+                }
+
+                if (isset($options['expanded']) && $options['expanded']) {
+                    //radio buttons
+                    return true;
+                }
+
+                //select tag
+                return false;
             },
 
             'template'          => 'choice',

--- a/Tests/Form/Type/ModelTypeTest.php
+++ b/Tests/Form/Type/ModelTypeTest.php
@@ -44,4 +44,44 @@ class ModelTypeTest extends TypeTestCase
         $this->assertEquals('SonataAdminBundle', $options['btn_catalogue']);
         $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList', $options['choice_list']);
     }
+
+    /**
+     * @dataProvider getCompundOptionTests
+     */
+    public function testCompundOption($expectedCompound, $multiple, $expanded)
+    {
+        $type = new ModelType();
+        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $optionResolver = new OptionsResolver();
+
+        $type->setDefaultOptions($optionResolver);
+
+        $options = $optionResolver->resolve(array('model_manager' => $modelManager, 'choices' => array(), 'multiple'=>$multiple, 'expanded'=>$expanded));
+
+        $this->assertEquals($expectedCompound, $options['compound']);
+        $this->assertEquals('choice', $options['template']);
+        $this->assertEquals($multiple, $options['multiple']);
+        $this->assertEquals($expanded, $options['expanded']);
+        $this->assertInstanceOf('Sonata\AdminBundle\Model\ModelManagerInterface', $options['model_manager']);
+        $this->assertNull($options['class']);
+        $this->assertNull($options['property']);
+        $this->assertNull($options['query']);
+        $this->assertEquals(0, count($options['choices']));
+        $this->assertEquals(0, count($options['preferred_choices']));
+        $this->assertEquals('link_add', $options['btn_add']);
+        $this->assertEquals('link_list', $options['btn_list']);
+        $this->assertEquals('link_delete', $options['btn_delete']);
+        $this->assertEquals('SonataAdminBundle', $options['btn_catalogue']);
+        $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList', $options['choice_list']);
+    }
+
+    public function getCompundOptionTests()
+    {
+        return array(
+            array(true, true, true), //checkboxes
+            array(false, true, false), //select tag (with multiple attribute)
+            array(true, false, true), //radio buttons
+            array(false, false, false), //select tag
+        );
+    }
 }


### PR DESCRIPTION
This PR fixes bugs with `sonata_type_model` that occurs with options 
- `multiple=true` + `expanded=false` - instead of multiple select no data were displayed,
- `multiple=false` + `expanded=true` - instead of radio buttons exception `You cannot add children to a simple form...` occurs.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
