### PR TITLE
Throw http not found exception instead of runtime

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -391,8 +391,10 @@ class CRUDController extends Controller
      */
     public function batchAction()
     {
-        if ($this->getRestMethod() != 'POST') {
-            throw new \RuntimeException('invalid request type, POST expected');
+        $restMethod = $this->getRestMethod();
+
+        if ('POST' !== $restMethod) {
+            throw $this->createNotFoundException(sprintf('Invalid request type "%s", POST expected', $restMethod));
         }
 
         // check the csrf token


### PR DESCRIPTION
Avoids a 500 server error.
