### PR TITLE
Fix #1879

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -21,6 +21,9 @@ for older versions:
 
     Please provide a version constraint for the sonata-project/admin-bundle requirement: dev-master
 
+.. note::
+    Since dev-master is not a stable version you will need to add :mod:`sonata-project/core-bundle:dev-master` too. `More information <http://stackoverflow.com/a/20784251/842697>`_.
+
 Selecting and downloading a storage bundle
 ------------------------------------------
 


### PR DESCRIPTION
I'm not used to rst and I'm not sure that the `:mod:` notacion (extracted from [collective.developermanual](https://github.com/collective/collective.developermanual/blob/master/source/reference_manuals/active/writing/writing.rst#other-sphinx-and-restructured-text-source-snippets)) was correct. If it's wrong, please tell me how to fix it. 
