### PR TITLE
Removed trash icon in batch confirmation template

### DIFF
--- a/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/Resources/views/CRUD/batch_confirmation.html.twig
@@ -40,7 +40,7 @@ file that was distributed with this source code.
                     {{ form_rest(form) }}
                 </div>
 
-                <button type="submit" class="btn btn-danger"><i class="icon-trash icon-white"></i> {{ 'btn_execute_batch_action'|trans({}, 'SonataAdminBundle') }}</button>
+                <button type="submit" class="btn btn-danger">{{ 'btn_execute_batch_action'|trans({}, 'SonataAdminBundle') }}</button>
 
                 {% if admin.hasRoute('list') and admin.isGranted('LIST') %}
                     {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes? |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

Batch confirmation can be used for many actions (enabling/disabling/moving etc.) and in these cases the trash icons in batch confirmation dialog seems weird. It can be solved with custom template but it`s unproductive to create custom template if not using default batch delete action.
