### PR TITLE
Update search.rst

### DIFF
--- a/Resources/doc/reference/search.rst
+++ b/Resources/doc/reference/search.rst
@@ -23,6 +23,17 @@ The default template values can be configured in the configuration section
                 # other configuration options
                 search:              SonataAdminBundle:Core:search.html.twig
                 search_result_block: SonataAdminBundle:Block:block_search_result.html.twig
+                
+You also need to configure the block in the sonata block config
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        sonata_block:
+            blocks:
+                sonata.admin.block.search_result:
+                contexts: [admin]
 
 You can also configure the block template per admin while defining the admin:
 


### PR DESCRIPTION
There was no documentation about how to define the block (atleast not that I found). This resulted in an error when you tried searching. 

'An exception has been thrown during the rendering of a template ("The block type sonata.admin.block.search_result does not exist") in SonataAdminBundle:Core:search.html.twig at line 48'

There is a summary of the issue here:
http://stackoverflow.com/questions/19551715/sonata-admin-search-feature
