### PR TITLE
Move Twig Text extension to core bundle

### DIFF
--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -10,9 +10,5 @@
 
             <argument type="service" id="sonata.admin.pool" />
         </service>
-
-        <service id="sonata.admin.twig.extension.text" class="Twig_Extensions_Extension_Text">
-            <tag name="twig.extension"/>
-        </service>
     </services>
 </container>


### PR DESCRIPTION
This is related to PR https://github.com/sonata-project/SonataCoreBundle/pull/33

As the sandbox now uses new kernel notions, `SonataAdminBundle` is not loaded in `FrontKernel` and this Twig Text extension was loaded in `SonataAdminBundle`.
Problem is that some front-end bundles (like `ecommerce` bundles and `SonataNewsBundle`) uses `truncate()` method that needs Twig Text extension to be loaded.

So I've moved Twig Text extension to `SonataCoreBundle` as both front & admin bundles will need it (and this need is shared between multiple bundles).
