### PR TITLE
Allow user to alter query, idx before executre a batch actions

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Admin;
 
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\PropertyAccess\PropertyPath;
@@ -674,6 +675,13 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
      */
     public function postRemove($object)
     {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preBatchAction($actionName, ProxyQueryInterface $query, array & $idx, $allElements)
+    {
+    }
 
     /**
      * build the view FieldDescription array

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
 use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 use Sonata\AdminBundle\Builder\RouteBuilderInterface;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
@@ -715,6 +716,16 @@ interface AdminInterface
      * @return mixed
      */
     public function postRemove($object);
+
+    /**
+     * Call before the batch action, allow you to alter the query and the idx
+     *
+     * @param string              $actionName
+     * @param ProxyQueryInterface $query
+     * @param array               $idx
+     * @param bool                $allElements
+     */
+    public function preBatchAction($actionName, ProxyQueryInterface $query, array & $idx, $allElements);
 
     /**
      * Return array of filter parameters.

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -474,6 +474,8 @@ class CRUDController extends Controller
         $query->setFirstResult(null);
         $query->setMaxResults(null);
 
+        $this->admin->preBatchAction($action, $query, $idx, $allElements);
+
         if (count($idx) > 0) {
             $this->admin->getModelManager()->addIdentifiersToQuery($this->admin->getClass(), $query, $idx);
         } elseif (!$allElements) {

--- a/Resources/doc/reference/batch_actions.rst
+++ b/Resources/doc/reference/batch_actions.rst
@@ -136,6 +136,29 @@ This method may return three different values:
         return count($selectedIds) > 0;
     }
 
+(Optional) Executing a pre batch hook
+-------------------------------------
+
+In your admin class you can create a ``preBacthAction`` method to execute something before doing the batch action.
+The main purpose of this method is to alter the query or the list of selected id.
+
+.. code-block:: php
+
+    <?php
+
+    // In your Admin class
+
+    public function preBatchAction($actionName, ProxyQueryInterface $query, array & $idx, $allElements)
+    {
+        // altering the query or the idx array
+        $foo = $query->getParameter('foo')->getValue();
+
+        // Doing something with the foo object
+        // ...
+
+        $query->setParameter('foo', $bar);
+    }
+
 
 Define the core action logic
 ----------------------------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| Doc PR | n/a |

My need: when I apply a batch delete action on my entities, I need to check a status field in one of my related entity, if those field contains "online", I need to duplicate all of the entities with the same related entity (Version) and apply the batch action to the new entities.
Currently the only way to do that is to redefine the batchAction method and to call my method in this action.
