### PR TITLE
exclude classes that not exist from loading

### DIFF
--- a/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -96,6 +96,9 @@ class ExtensionCompilerPass implements CompilerPassInterface
                     }
                 } else {
                     $class = $this->getManagedClass($admin, $container);
+                    if (!class_exists($class)) {
+                        continue;
+                    }
                     $classReflection = new \ReflectionClass($class);
                     $subjectReflection = new \ReflectionClass($subject);
                 }


### PR DESCRIPTION
As discussed some minutes ago with @rande the admin-bundle tries to load extension classes even if the do not exist. 
This PR's solves that by skipping those extensions. 
