### PR TITLE
Show number of affected elements when seleting all elements

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -101,6 +101,7 @@ file that was distributed with this source code.
                                                 <label class="checkbox" for="{{ admin.uniqid }}_all_elements">
                                                     <input type="checkbox" name="all_elements" id="{{ admin.uniqid }}_all_elements">
                                                     {{ 'all_elements'|trans({}, 'SonataAdminBundle') }}
+                                                     ({{ admin.datagrid.pager.nbresults }})
                                                 </label>
 
                                                 <select name="action" style="width: auto; height: auto">


### PR DESCRIPTION
assuming i understood the checkbox for "all elements" correctly, this change will make it clear its not "all on this page" but really all elements everywhere.
