### PR TITLE
Better german translation for reset filters

### DIFF
--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="link_reset_filter">
                 <source>link_reset_filter</source>
-                <target>Löschen</target>
+                <target>Zurücksetzen</target>
             </trans-unit>
             <trans-unit id="title_create">
                 <source>title_create</source>


### PR DESCRIPTION
Löschen means delete, which is quite confusing when in the middle of everything you can click delete and don't know what you are deleting. Zurücksetzen is much closer to Reset. its a bit long i admit, but i can't think of a shorter word that would not be confusing.
