### PR TITLE
Variable name in AddDependencyCallsCompilerPass

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -209,8 +209,8 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             }
         }
 
-        if (isset($service['label'])) {
-            $label = $service['label'];
+        if (isset($addServices['label'])) {
+            $label = $addServices['label'];
         } elseif (isset($attributes['label'])) {
             $label = $attributes['label'];
         } else {


### PR DESCRIPTION
This fixes a variable name issue $service should have been $addServices.

And I also wonder if $attributes should be leading (being the first if) instead of $addSeries as this seems to be the case with the other calls.