### PR TITLE
Allows to hide a field during an AJAX context

### DIFF
--- a/Resources/doc/reference/action_list.rst
+++ b/Resources/doc/reference/action_list.rst
@@ -117,6 +117,8 @@ Available types and associated options
 +-----------+----------------+-----------------------------------------------------------------------+
 | array     |                | Displays an array                                                     |
 +-----------+----------------+-----------------------------------------------------------------------+
+| boolean   | ajax_hidden    | Yes/No; ajax_hidden allows to hide list field during an AJAX context. |
++-----------+----------------+-----------------------------------------------------------------------+
 | boolean   | editable       | Yes/No; editable allows to edit directly from the list if authorized. |
 +-----------+----------------+-----------------------------------------------------------------------+
 | choice    | choices        | Possible choices                                                      |

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -43,7 +43,9 @@ file that was distributed with this source code.
                                 {% elseif field_description.getOption('code') == '_select' %}
                                     <th class="sonata-ba-list-field-header sonata-ba-list-field-header-select"></th>
                                 {% elseif field_description.name == '_action' and app.request.isXmlHttpRequest %}
-                                        {# Action buttons disabled in ajax view! #}
+                                    {# Action buttons disabled in ajax view! #}
+                                {% elseif field_description.getOption('ajax_hidden') == true and app.request.isXmlHttpRequest %}
+                                    {# Disable fields with 'ajax_hidden' option set to true #}
                                 {% else %}
                                     {% set sortable = false %}
                                     {% if field_description.options.sortable is defined and field_description.options.sortable %}

--- a/Resources/views/CRUD/base_list_inner_row.html.twig
+++ b/Resources/views/CRUD/base_list_inner_row.html.twig
@@ -12,6 +12,8 @@ file that was distributed with this source code.
 {% for field_description in admin.list.elements %}
     {% if field_description.name == '_action' and app.request.isXmlHttpRequest %}
         {# Action buttons disabled in ajax view! #}
+    {% elseif field_description.getOption('ajax_hidden') == true and app.request.isXmlHttpRequest %}
+        {# Disable fields with 'ajax_hidden' option set to true #}
     {% else %}
         {{ object|render_list_element(field_description) }}
     {% endif %}


### PR DESCRIPTION
When request is an AJAX request (with modals), I've added a `ajax_hidden` option to hide fields.

Here are the use cases:

| Option value | Field displayed in AJAX? |
| --- | --- |
| not filled | Yes |
| false | Yes |
| true | No |

Here is how to use:

``` php
/**
 * {@inheritdoc}
 */
protected function configureListFields(ListMapper $listMapper)
{
    $listMapper
        ->add('myfield', 'string', array('ajax_hidden' => true))
    ;
}
```
