### PR TITLE
Add a length class to breadcrumb

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -125,7 +125,7 @@ file that was distributed with this source code.
                                 {% block sonata_breadcrumb %}
                                     {% if _breadcrumb is not empty or action is defined %}
                                         <div class="col-md-6">
-                                            <ol class="nav navbar-top-links breadcrumb">
+                                            <ol class="nav navbar-top-links breadcrumb col-md-12">
                                                 {% if _breadcrumb is empty %}
                                                     {% if action is defined %}
                                                         {% for menu in admin.breadcrumbs(action) %}


### PR DESCRIPTION
Using SonataUserBundle, i noticed the breadcrumb wasn't full length so it would be useful to add a col-md-12 on it.

Without it the breadcrumb bar becomes taller and goes over the content block like in the screenshot : 

Before :
![image](https://cloud.githubusercontent.com/assets/3241292/2611834/016705d8-bbaf-11e3-9ee0-ecc6fb9c3ba5.png)

After : 
![image](https://cloud.githubusercontent.com/assets/3241292/2611841/2ecd51d0-bbaf-11e3-871a-58b3201245ff.png)
