### PR TITLE
Update standard_layout for non-logged in users

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -151,22 +151,24 @@ file that was distributed with this source code.
                                 {% endblock sonata_breadcrumb %}
 
                                 {% block sonata_top_nav_menu %}
-                                    <ul class="nav navbar-top-links navbar-right">
-                                        <li class="dropdown">
-                                            <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-                                                <i class="fa fa-plus-square fa-fw"></i> <i class="fa fa-caret-down"></i>
-                                            </a>
-                                            {% include admin_pool.getTemplate('add_block') %}
-                                        </li>
-                                        <li class="dropdown">
-                                            <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-                                                <i class="fa fa-user fa-fw"></i> <i class="fa fa-caret-down"></i>
-                                            </a>
-                                            <ul class="dropdown-menu dropdown-user">
-                                                {% include admin_pool.getTemplate('user_block') %}
-                                            </ul>
-                                        </li>
-                                    </ul>
+                                    {% if app.security.token and is_granted('ROLE_SONATA_ADMIN') %}
+                                        <ul class="nav navbar-top-links navbar-right">
+                                            <li class="dropdown">
+                                                <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+                                                    <i class="fa fa-plus-square fa-fw"></i> <i class="fa fa-caret-down"></i>
+                                                </a>
+                                                {% include admin_pool.getTemplate('add_block') %}
+                                            </li>
+                                            <li class="dropdown">
+                                                <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+                                                    <i class="fa fa-user fa-fw"></i> <i class="fa fa-caret-down"></i>
+                                                </a>
+                                                <ul class="dropdown-menu dropdown-user">
+                                                    {% include admin_pool.getTemplate('user_block') %}
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    {% endblock %}
                                 {% endblock %}
                             </div>
 


### PR DESCRIPTION
The sonata_top_nav_menu (add_block + user_block) was drawn all the time for my login page after the update, so I just added a quick check to remove it.

My login page extends base_template as my project only consists of an admin section, and therefore my login page is now slightly weird as it contains a blank sidebar. Should I be making a new base_template or improving standard_layout so that it looks normal for users that are not logged in? (Remove the 250px margin and sidebar if user is not logged in?)
