### PR TITLE
use Doctrine's inflector for proper singular

### DIFF
--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -10,6 +10,7 @@
 
 namespace Sonata\AdminBundle\Admin;
 
+use Doctrine\Common\Inflector\Inflector;
 use Doctrine\Common\Util\ClassUtils;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormView;
@@ -169,7 +170,11 @@ class AdminHelper
             $method = rtrim($method, 's');
 
             if (!method_exists($object, $method)) {
-                throw new \RuntimeException(sprintf('Please add a method %s in the %s class!', $method, ClassUtils::getClass($object)));
+                $method = sprintf('add%s', $this->camelize(Inflector::singularize($mapping['fieldName'])));
+
+                if (!method_exists($object, $method)) {
+                    throw new \RuntimeException(sprintf('Please add a method %s in the %s class!', $method, ClassUtils::getClass($object)));
+                }
             }
         }
 

--- a/Tests/Admin/AdminHelperTest.php
+++ b/Tests/Admin/AdminHelperTest.php
@@ -77,4 +77,44 @@ class AdminHelperTest extends \PHPUnit_Framework_TestCase
 
         $helper->addNewInstance($object, $fieldDescription);
     }
+
+    public function testAddNewInstancePlural()
+    {
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $pool = new Pool($container, 'title', 'logo.png');
+        $helper = new AdminHelper($pool);
+
+        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin->expects($this->once())->method('getNewInstance')->will($this->returnValue(new \stdClass()));
+
+        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription->expects($this->once())->method('getAssociationAdmin')->will($this->returnValue($admin));
+        $fieldDescription->expects($this->once())->method('getAssociationMapping')->will($this->returnValue(array('fieldName' => 'fooBars')));
+
+        $object = $this->getMock('sdtClass', array('addFooBar'));
+        $object->expects($this->once())->method('addFooBar');
+
+        $helper->addNewInstance($object, $fieldDescription);
+    }
+
+    public function testAddNewInstanceInflector()
+    {
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $pool = new Pool($container, 'title', 'logo.png');
+        $helper = new AdminHelper($pool);
+
+        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin->expects($this->once())->method('getNewInstance')->will($this->returnValue(new \stdClass()));
+
+        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription->expects($this->once())->method('getAssociationAdmin')->will($this->returnValue($admin));
+        $fieldDescription->expects($this->once())->method('getAssociationMapping')->will($this->returnValue(array('fieldName' => 'entries')));
+
+        $object = $this->getMock('sdtClass', array('addEntry'));
+        $object->expects($this->once())->method('addEntry');
+
+        $helper->addNewInstance($object, $fieldDescription);
+    }
 }


### PR DESCRIPTION
This change allows you to have "correct" addXXX methods in your classes, i.e. addEntry instead of addEntrie.
