### PR TITLE
bug with variable widget_type

### DIFF
--- a/Resources/views/Form/filter_admin_fields.html.twig
+++ b/Resources/views/Form/filter_admin_fields.html.twig
@@ -33,20 +33,20 @@ file that was distributed with this source code.
 {% block choice_widget_expanded %}
     {% spaceless %}
         {% set label_attr = label_attr|merge({'class': (label_attr.class|default(''))}) %}
-        {% set label_attr = label_attr|merge({'class': (label_attr.class ~ ' ' ~ (widget_type != '' ? (multiple ? 'checkbox' : 'radio') ~ '-' ~ widget_type : ''))}) %}
+        {% set label_attr = label_attr|merge({'class': (label_attr.class ~ ' ' ~ (widget_type is defined and widget_type != '' ? (multiple ? 'checkbox' : 'radio') ~ '-' ~ widget_type : ''))}) %}
         {% if expanded %}
             {% set attr = attr|merge({'class': attr.class|default('')}) %}
             <div {{ block('widget_container_attributes') }}>
         {% endif %}
         {% for child in form %}
-            {% if widget_type != 'inline' %}
+            {% if widget_type is defined and widget_type != 'inline' %}
                 <div class="{{ multiple ? 'checkbox' : 'radio' }}">
             {% endif %}
             <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
             {{ form_widget(child, {'attr': {'class': attr.widget_class|default('')}}) }}
             {{ child.vars.label|trans({}, translation_domain) }}
             </label>
-            {% if widget_type != 'inline' %}
+            {% if widget_type is defined and widget_type != 'inline' %}
                 </div>
             {% endif %}
         {% endfor %}
@@ -66,13 +66,13 @@ file that was distributed with this source code.
             <div class="checkbox">
         {% endif %}
 
-        {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes and label_render %}
+        {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes and label_render is defined %}
             <label class="{% if inline is defined and inline %}checkbox-inline{% endif %}">
         {% endif %}
 
         <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}/>
         {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes %}
-            {% if label_render and widget_checkbox_label in ['both', 'widget'] %}
+            {% if label_render is defined and widget_checkbox_label in ['both', 'widget'] %}
                 {{ label|trans({}, translation_domain) }}
                 </label>
             {% endif %}


### PR DESCRIPTION
Variable “widget_type” does not exist in SonataAdminBundle:Form:filter_admin_fields.html.twig
- http://stackoverflow.com/questions/23004015/variable-widget-type-does-not-exist-in-sonataadminbundleformfilter-admin-fie
- http://stackoverflow.com/questions/22985378/sonata-admin-filters-should-looks-like-set-of-checkboxes-but-got-error
