### PR TITLE
make sure subject is set even if data on form is not set on build time

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -462,6 +462,14 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
+    public function reConfigureFormFields(Form $form)
+    {
+
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function configureListFields(ListMapper $list)
     {
 

--- a/Form/EventListener/SetSubjectEventListener.php
+++ b/Form/EventListener/SetSubjectEventListener.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Sonata\AdminBundle\Form\EventListener;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * Set the admin's subject in the event.
+ *
+ * @author Uwe Jäger <uwej711@googlemail.com>
+ */
+class SetSubjectEventListener implements EventSubscriberInterface
+{
+    /** @var AdminInterface */
+    protected $admin;
+
+    /**
+     * @param AdminInterface $admin
+     */
+    public function __construct(AdminInterface $admin)
+    {
+        $this->admin = $admin;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FormEvents::PRE_SET_DATA    => 'preSetData',
+        );
+    }
+
+    public function preSetData(FormEvent $event)
+    {
+        $this->admin->setSubject($event->getData());
+    }
+}

--- a/Form/EventListener/SetSubjectEventListener.php
+++ b/Form/EventListener/SetSubjectEventListener.php
@@ -44,6 +44,9 @@ class SetSubjectEventListener implements EventSubscriberInterface
 
     public function preSetData(FormEvent $event)
     {
-        $this->admin->setSubject($event->getData());
+        if (null !== $event->getData()) {
+            $this->admin->setSubject($event->getData());
+            $this->admin->reConfigureFormFields($event->getForm());
+        }
     }
 }

--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
+use Sonata\AdminBundle\Form\EventListener\SetSubjectEventListener;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -34,11 +35,8 @@ class AdminType extends AbstractType
             $builder->add('_delete', 'checkbox', array('required' => false, 'mapped' => false));
         }
 
-        if (!$admin->hasSubject()) {
-            $admin->setSubject($builder->getData());
-        }
-
         $admin->defineFormBuilder($builder);
+        $builder->addEventSubscriber(new SetSubjectEventListener($admin));
 
         $builder->addModelTransformer(new ArrayToModelTransformer($admin->getModelManager(), $admin->getClass()));
     }

--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -29,7 +29,7 @@ class AdminType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $admin = $this->getAdmin($options);
+        $admin =  clone $this->getAdmin($options);
 
         if ($options['delete'] && $admin->isGranted('DELETE')) {
             $builder->add('_delete', 'checkbox', array('required' => false, 'mapped' => false));


### PR DESCRIPTION
Currently the subject is not set for sonata_type_admin admins since the CRUDController first creates the form and sets the data afterwards. Note that this also always sets the admin, even if it has been set before.

see https://github.com/sonata-project/SonataAdminBundle/pull/1710
and https://github.com/sonata-project/SonataAdminBundle/issues/1568

Feedback welcome!