### PR TITLE
Update add_block.html.twig

### DIFF
--- a/Resources/views/Core/add_block.html.twig
+++ b/Resources/views/Core/add_block.html.twig
@@ -7,7 +7,7 @@
         {% if columnsCount > 1 %}style="width: {{ columnsCount*140 }}px;"{% endif %}
             >
         {% for group in admin_pool.dashboardgroups %}
-            {% set display = (group.roles is empty or is_granted('ROLE_SUPER_ADMIN') ) %}
+            {% set display = (group.roles is empty or is_granted('ROLE_SONATA_ADMIN') ) %}
             {% for role in group.roles if not display %}
                 {% set display = is_granted(role) %}
             {% endfor %}


### PR DESCRIPTION
At the original add_block.html.twig file it was used ROLE_SUPER_ADMIN, but in the standard_layout.html.twig it is used the ROLE_SONATA_ADMIN.

I suppose that the ROLE_SONATA_ADMIN should be the global role.

At my application broke the presentation of the logout screen when the user has the ROLE_SONATA_ADMIN but not the ROLE_SUPER_ADMIN.
