### PR TITLE
Update RoleSecurityHandler.php

### DIFF
--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -222,7 +222,7 @@ btn_add and btn_catalogue:
   corresponding button. You can also specify a custom translation catalogue
   for this label, which defaults to ``SonataAdminBundle``.
 
-**TIP**: A jQuery event is fired after a row has been added (``sonata-admin-append-form-element``).
+**TIP**: A jQuery event is fired after a row has been added (``sonata.add_element``).
 You can listen to this event to trigger custom javascript (eg: add a calendar widget to a newly added date field)
 
 collection

--- a/Security/Handler/RoleSecurityHandler.php
+++ b/Security/Handler/RoleSecurityHandler.php
@@ -45,8 +45,8 @@ class RoleSecurityHandler implements SecurityHandlerInterface
         }
 
         try {
-            return $this->securityContext->isGranted($this->superAdminRoles)
-                || $this->securityContext->isGranted($attributes, $object);
+            return $this->securityContext->isGranted($attributes, $object)
+                || $this->securityContext->isGranted($this->superAdminRoles);
         } catch (AuthenticationCredentialsNotFoundException $e) {
             return false;
         } catch (\Exception $e) {


### PR DESCRIPTION
Just call the isGranted with object first than without it. I'm using "strategy: unanimous" and I was with the same problem reported in this issue: https://github.com/sonata-project/SonataAdminBundle/issues/1458 and PR: https://github.com/sonata-project/SonataAdminBundle/pull/1507 but I'm using "sonata.admin.security.handler.role". I'm coding a custom voter and I was receiving a NULL object without this code modification.