### PR TITLE
Add datagrid pager serialization config

### DIFF
--- a/Resources/config/serializer/Datagrid.Pager.xml
+++ b/Resources/config/serializer/Datagrid.Pager.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="Sonata\AdminBundle\Datagrid\Pager" exclusion-policy="all" xml-root-name="pager">
+        <property name="page"
+                  type="integer"
+                  expose="true"
+                  since-version="1.0"
+                  read-only="true"
+                  groups="sonata_api_read,sonata_search" />
+        <property name="lastPage"
+                  type="integer"
+                  expose="true"
+                  since-version="1.0"
+                  read-only="true"
+                  groups="sonata_api_read,sonata_search" />
+        <property name="maxPerPage"
+                  serialized-name="per_page"
+                  method="getMaxPerPage"
+                  type="integer"
+                  expose="true"
+                  since-version="1.0"
+                  read-only="true"
+                  groups="sonata_api_read,sonata_search" />
+        <property name="nbResults"
+                  serialized-name="total"
+                  method="getNbResults"
+                  type="integer"
+                  expose="true"
+                  since-version="1.0"
+                  read-only="true"
+                  groups="sonata_api_read,sonata_search" />
+        <property name="results"
+                  serialized-name="entries"
+                  expose="true"
+                  since-version="1.0"
+                  read-only="true"
+                  groups="sonata_api_read,sonata_search"
+                  access-type="public_method"
+                  accessor-getter="getResults" />
+    </class>
+</serializer>


### PR DESCRIPTION
I've added datagrid pager serialization config because I plan to return a pager instead of a raw collection for all paginable API resources.

I also had to configure jms serializer to tell it to load this config:

```
jms_serializer:
    metadata:
        directories:
            - { path: %kernel.root_dir%/../vendor/sonata-project/admin-bundle/Resources/config/serializer, namespace_prefix: 'Sonata\AdminBundle\Datagrid' }
```
