### PR TITLE
Fixed the actions list for cases when the create action is unavailable

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -12,7 +12,11 @@ file that was distributed with this source code.
 {% extends base_template %}
 
 {% block actions %}
-    <li>{% include 'SonataAdminBundle:Core:create_button.html.twig' %}</li>
+{% spaceless %}
+    {% if admin.hasRoute('create') and admin.isGranted('CREATE')%}
+        <li>{% include 'SonataAdminBundle:Core:create_button.html.twig' %}</li>
+    {% endif %}
+{% endspaceless %}
 {% endblock %}
 
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active'}, 'list') }}{% endblock %}


### PR DESCRIPTION
If the Create action is unavailable for an Entity, user will see an empty menu row in the action's drop down. Invalid behavior was fixed.
