### PR TITLE
don't use iCheck in bootstrap button group

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -103,7 +103,7 @@ var Admin = {
     },
     setup_icheck: function(subject) {
         if (window.SONATA_CONFIG && window.SONATA_CONFIG.USE_ICHECK) {
-            jQuery("input[type='checkbox'], input[type='radio']", subject).iCheck({
+            jQuery("input[type='checkbox']:not('label.btn>input'), input[type='radio']:not('label.btn>input')", subject).iCheck({
                 checkboxClass: 'icheckbox_minimal',
                 radioClass: 'iradio_minimal'
             });


### PR DESCRIPTION
prevent iCheck on bootstrap 3 button groups

before:
![bildschirmfoto 2014-05-04 um 11 28 29](https://cloud.githubusercontent.com/assets/241080/2872663/81970f86-d370-11e3-86a8-898b58350f04.png)

after:
![bildschirmfoto 2014-05-04 um 11 41 36](https://cloud.githubusercontent.com/assets/241080/2872664/83b8bd1e-d370-11e3-9ee9-33a2c65040ab.png)
