### PR TITLE
confirm exit does not work correctly for multiple forms

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -12,7 +12,7 @@
 jQuery(document).ready(function() {
     jQuery('html').removeClass('no-js');
     if (window.SONATA_CONFIG && window.SONATA_CONFIG.CONFIRM_EXIT) {
-        jQuery('.sonata-ba-form form').confirmExit();
+        jQuery('.sonata-ba-form form').each( function () { $(this).confirmExit(); } );
     }
 
     Admin.setup_per_page_switcher(document);


### PR DESCRIPTION
The confirm exit solution does not work correctly for multiple forms on one page because the serialized data are generated over an collection and not over the single forms.
