### PR TITLE
Added head_title block to standard_layout.html.twig

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -54,6 +54,7 @@ file that was distributed with this source code.
         {% endblock %}
 
         <title>
+        {% block sonata_head_title %}
             {{ 'Admin'|trans({}, 'SonataAdminBundle') }}
 
             {% if _title is not empty %}
@@ -72,6 +73,7 @@ file that was distributed with this source code.
                     {% endfor %}
                 {% endif %}
             {% endif%}
+        {% endblock %}
         </title>
     </head>
     <body {% block body_attributes %}class="sonata-bc skin-black fixed"{% endblock %}>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

This will help to easily overload the title of html page.
