### PR TITLE
[childAdmin] append the parent's id only if exist.

### DIFF
--- a/Route/DefaultRouteGenerator.php
+++ b/Route/DefaultRouteGenerator.php
@@ -57,7 +57,7 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
     public function generateMenuUrl(AdminInterface $admin, $name, array $parameters = array(), $absolute = false)
     {
         // if the admin is a child we automatically append the parent's id
-        if ($admin->isChild()) {
+        if ($admin->isChild() && $admin->hasRequest() && $admin->getRequest()->attributes->has($admin->getParent()->getIdParameter())) {
             // twig template does not accept variable hash key ... so cannot use admin.idparameter ...
             // switch value
             if (isset($parameters['id'])) {
@@ -65,7 +65,7 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
                 unset($parameters['id']);
             }
 
-            $parameters[$admin->getParent()->getIdParameter()] = $admin->getRequest()->get($admin->getParent()->getIdParameter());
+            $parameters[$admin->getParent()->getIdParameter()] = $admin->getRequest()->attributes->get($admin->getParent()->getIdParameter());
         }
 
         // if the admin is linked to a parent FieldDescription (ie, embedded widget)

--- a/Tests/Route/DefaultRouteGeneratorTest.php
+++ b/Tests/Route/DefaultRouteGeneratorTest.php
@@ -152,7 +152,9 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $parentAdmin->expects($this->never())->method('getPersistentParameters')->will($this->returnValue(array('from'=>'parent')));
 
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-        $request->expects($this->any())
+        $request->attributes = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $request->attributes->expects($this->any())->method('has')->will($this->returnValue(true));
+        $request->attributes->expects($this->any())
             ->method('get')
             ->will($this->returnCallback(function($key) {
                 if ($key == 'childId') {


### PR DESCRIPTION
Hi,
This allow to generate child route manually like:

``` twig
childAdmin.generateUrl('edit', { id: 1, childId: 3 })
```
