### PR TITLE
fix small CSS issue on .box-body

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -326,3 +326,7 @@ legend.sonata-ba-fieldset-collapsed-description + .sonata-ba-collapsed-fields {
 .form-horizontal .control-group {
     margin-bottom: 10px;
 }
+
+.box .box-body {
+    overflow: hidden;
+}

--- a/Resources/public/vendor/AdminLTE/css/AdminLTE.css
+++ b/Resources/public/vendor/AdminLTE/css/AdminLTE.css
@@ -1338,7 +1338,6 @@ body > .header .logo .icon {
   border-top-right-radius: 0;
   border-bottom-right-radius: 3px;
   border-bottom-left-radius: 3px;
-  overflow: hidden;
 }
 .box .box-body > table,
 .box .box-body > .table {


### PR DESCRIPTION
Tested with Firefox 25 on debian, the .box-body (that contain a form group) don't fit the content. This small fix force the div to extends and wrap all the content.
