### PR TITLE
Remove http: from import url's in AdminLTE.css

### DIFF
--- a/Resources/public/vendor/AdminLTE/css/AdminLTE.css
+++ b/Resources/public/vendor/AdminLTE/css/AdminLTE.css
@@ -1,6 +1,6 @@
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);
+@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);
 
-@import url(http://fonts.googleapis.com/css?family=Kaushan+Script);
+@import url(//fonts.googleapis.com/css?family=Kaushan+Script);
 /*! 
  *   AdminLTE v1.0
  *   Author: AlmsaeedStudio.com


### PR DESCRIPTION
When running Sonata Admin on an https secured site the http url's in AdminLTE.css cause security errors. Removing the http: portion from the import url's solves the problem. Alternatively, AdminLTE could be updated to the latest version (1.2) where the problem is already fixed.
