### PR TITLE
Use relative paths for fonts.googleapis.com

### DIFF
--- a/Resources/public/vendor/AdminLTE/css/AdminLTE.css
+++ b/Resources/public/vendor/AdminLTE/css/AdminLTE.css
@@ -1,6 +1,6 @@
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);
+@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);
 
-@import url(http://fonts.googleapis.com/css?family=Kaushan+Script);
+@import url(//fonts.googleapis.com/css?family=Kaushan+Script);
 /*! 
  *   AdminLTE v1.2
  *   Author: AlmsaeedStudio.com


### PR DESCRIPTION
As describe in issue #2135, fonts should be imported with a relative path in case the server is running under https.
