### PR TITLE
'decimal' is not allowed

### DIFF
--- a/Resources/doc/reference/field_types.rst
+++ b/Resources/doc/reference/field_types.rst
@@ -13,7 +13,7 @@ There are many field types that can be used in the list action or show action :
 * **text**: display a text
 * **trans**: translate the value with a provided ``catalogue`` option
 * **string**: display a text
-* **decimal**: display a number
+* **number**: display a number
 * **currency**: display a number with a provided ``currency`` option
 * **percent**: display a percentage
 * **choice**: uses the given value as index for the ``choices`` array and displays (and optionally translates) the matching value


### PR DESCRIPTION
Decimal is not an option for a Form in Symfony and when using it with FormMapper it raises this exception.

```
Uncaught PHP Exception Symfony\Component\Form\Exception\InvalidArgumentException: "Could not load type "decimal"" at /var/www/releases/20140521095534/vendor/symfony/symfony/src/Symfony/Component/Form/FormRegistry.php line 89 {"exception":"[object] (Symfony\\Component\\Form\\Exception\\InvalidArgumentException: Could not load type \"decimal\" at /var/www/releases/20140521095534/vendor/symfony/symfony/src/Symfony/Component/Form/FormRegistry.php:89)"} []
```
