### PR TITLE
Remove non-Mopa compatibility layer when Mopa is actually installed.

### DIFF
--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -154,6 +154,11 @@ BOOM
             $container->removeDefinition('sonata.admin.translator.extractor.jms_translator_bundle');
         }
 
+        //remove non-Mopa compatibility layer
+        if (isset($bundles['MopaBootstrapBundle'])) {
+            $container->removeDefinition('sonata.admin.form.extension.field.mopa');
+        }
+
         // set filter persistence
         $container->setParameter('sonata.admin.configuration.filters.persist', $config['persist_filters']);
 


### PR DESCRIPTION
Currently the admin bundle overrides Mopa css-defaults IF Mopa is registered before the Admin. This commit make the Bundle registration order irrelevant.

See: https://github.com/sonata-project/SonataAdminBundle/issues/2128
