### PR TITLE
Update form_types.rst

### DIFF
--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -222,9 +222,6 @@ btn_add and btn_catalogue:
   corresponding button. You can also specify a custom translation catalogue
   for this label, which defaults to ``SonataAdminBundle``.
 
-**TIP**: A jQuery event is fired after a row has been added (``sonata-admin-append-form-element``).
-You can listen to this event to trigger custom javascript (eg: add a calendar widget to a newly added date field)
-
 collection
 ^^^^^^^^^^
 


### PR DESCRIPTION
'sonata-admin-append-form-element' event for 'sonata_type_collection' field type is not triggered, due to base.js. It works only for 'collection'.