### PR TITLE
Fix css of list box on small screens (added scrollbar)

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -339,5 +339,6 @@ legend.sonata-ba-fieldset-collapsed-description + .sonata-ba-collapsed-fields {
 }
 
 .box .box-body {
-    overflow: hidden;
+    overflow-x: auto;
+    overflow-y: hidden;
 }


### PR DESCRIPTION
In the List View, it's impossible to access the right part of the table on small screens / small browser width so adding a scrollbar is the easiest way to fix this.
