### PR TITLE
Insecure content error

### DIFF
--- a/Resources/public/vendor/AdminLTE/css/AdminLTE.css
+++ b/Resources/public/vendor/AdminLTE/css/AdminLTE.css
@@ -1,6 +1,6 @@
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);
+@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);
 
-@import url(http://fonts.googleapis.com/css?family=Kaushan+Script);
+@import url(//fonts.googleapis.com/css?family=Kaushan+Script);
 /*! 
  *   AdminLTE v1.2
  *   Author: AlmsaeedStudio.com


### PR DESCRIPTION
Users get an insecure content error when loading an http enabled website using SonataAdminBundle. The cause is 2 http import URL's in AdminLTE. An update to these assets was done 23 days ago, but it seems like the URL's were not fixed then. Possible fix would be updating assets again, or manually removing the http path from the AdminLTE css.
