### PR TITLE
remove IDE / OS specific ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.idea
-.DS_Store
 build
 phpunit.xml
 Resources/doc/_build/*


### PR DESCRIPTION
These have nothing to do in a repository, they should be ignored
globally. What if everyone does the same with their custom IDE / OS ?

A good solution is to [use the `core.excludesfile` configuration option](https://github.com/greg0ire/dotfiles/commit/4118cb18dc85d7f601eb9f6da25400aed1132452#diff-6cb0f77b38346e0fed47293bdc6430c6R32). Also, if you need to exclude a file just for one repository, and don't want to put the ignore rules under version control, you can write in the `.git/info/exclude` file.
