### PR TITLE
deleteAction should use redirectTo to determine redirect url for easy overriding.

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -267,7 +267,7 @@ class CRUDController extends Controller
                 );
             }
 
-            return new RedirectResponse($this->admin->generateUrl('list'));
+            return $this->redirectTo($object);
         }
 
         return $this->render($this->admin->getTemplate('delete'), array(
@@ -380,6 +380,10 @@ class CRUDController extends Controller
                 $params['subclass'] = $this->get('request')->get('subclass');
             }
             $url = $this->admin->generateUrl('create', $params);
+        }
+
+        if ($this->getRestMethod() == 'DELETE') {
+            $url = $this->admin->generateUrl('list');
         }
 
         if (!$url) {


### PR DESCRIPTION
Currently you cannot easily override where the user is redirected after deleting an object. In our use case if the user deleted a "page" in the cms we want to redirect to a page where they can set up a url redirect.

Using redirectTo to determine the location to redirect is consistent with how the create/edit actions work.
