### PR TITLE
Hide actions if _actions is empty

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -245,7 +245,7 @@ file that was distributed with this source code.
                                                     {% endif %}
                                                 </div>
 
-                                                {% if _actions is not empty %}
+                                                {% if _actions|replace({ '<li>': '', '</li>': '' })|trim is not empty %}
                                                     <ul class="nav navbar-nav navbar-right">
                                                         <li class="dropdown sonata-actions">
                                                             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Actions <b class="caret"></b></a>


### PR DESCRIPTION
Added a replace function to check if the list is empty.

Now _actions included a string with li tags so this was never empty.
