### PR TITLE
Remove 'nav navbar-nav' class

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1429,7 +1429,6 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         $this->loaded['tab_menu'] = true;
 
         $menu = $this->menuFactory->createItem('root');
-        $menu->setChildrenAttribute('class', 'nav navbar-nav');
 
         // Prevents BC break with KnpMenuBundle v1.x
         if (method_exists($menu, "setCurrentUri")) {


### PR DESCRIPTION
At the moment, ``Admin`` forces to use ``nav navbar-nav``:

```php
$menu->setChildrenAttribute('class', 'nav navbar-nav');
```

I think this should be delegated to the corresponding template. When you want to change the way the menu is rendered, you should only need to change the template.

Example: I want to render this menu as a vertical menu (like before).  I use Braincrafted Bootstrap and have in my template:
```jinja
{% block side_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'style': 'list'}) }}{% endblock %}
```
Now this is rendered as: ``<ul class="nav navbar-nav nav-list nav"></ul>``. How to remove ``nav navbar-nav``?