### PR TITLE
Documentation - Field types

### DIFF
--- a/Resources/doc/reference/field_types.rst
+++ b/Resources/doc/reference/field_types.rst
@@ -13,7 +13,7 @@ There are many field types that can be used in the list action or show action :
 * **text**: display a text
 * **trans**: translate the value with a provided ``catalogue`` option
 * **string**: display a text
-* **decimal**: display a number
+* **integer**: display a number
 * **currency**: display a number with a provided ``currency`` option
 * **percent**: display a percentage
 * **choice**: uses the given value as index for the ``choices`` array and displays (and optionally translates) the matching value


### PR DESCRIPTION
```
->add('IntegerTypeField','integer',array(
                'label'=>'int.label',
                'help' =>'int.help',
                 )
       )
```

SonataAdmin reports that there is no 'decimal' type - 'integer' works as expected and as 'decimal' is described.
