### PR TITLE
Fix select2 width

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -85,7 +85,7 @@ var Admin = {
                 }
 
                 select.select2({
-                    width: 'resolve',
+                    dropdownAutoWidth: true,
                     minimumResultsForSearch: 10,
                     allowClear: allowClearEnabled
                 });


### PR DESCRIPTION
Hello,

I had issue with select2 width, the selected text wasn't fully shown.
![capture decran 2014-06-18 a 16 18 46](https://cloud.githubusercontent.com/assets/520893/3314958/1a28843e-f6f6-11e3-9405-bb1255866f4d.png)
I fixed that by using the property dropdownAutoWidth (When set to true attempts to automatically size the width of the dropdown based on content inside.) instead of width. 
![capture decran 2014-06-18 a 16 19 25](https://cloud.githubusercontent.com/assets/520893/3314973/3ec36552-f6f6-11e3-8660-abe607fcbe22.png)

The only problem that i found by using this property is on select field with empty values, the width of the input doesn't match the list and the width of the list is big.
![capture decran 2014-06-18 a 16 21 35](https://cloud.githubusercontent.com/assets/520893/3314980/60d2dc18-f6f6-11e3-9fc4-f5f205964d75.png)
Here you can see the behaviour with the property width on the same field:
![capture decran 2014-06-18 a 16 21 13](https://cloud.githubusercontent.com/assets/520893/3315006/b82970d0-f6f6-11e3-95d8-1ffe8bd64044.png)

I rather have this little issue than not displaying the selected name fully, maybe there is a way to fix this last width problem.
