### PR TITLE
Fix label_attr.class chaining

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -27,9 +27,9 @@ file that was distributed with this source code.
 
     {% set label_class = "" %}
     {% if sonata_admin.admin and sonata_admin.admin.getConfigurationPool().getOption('form_type') == 'horizontal' %}
-        {% set label_class = "control-label col-sm-3" %}
+        {% set label_class = " control-label col-sm-3" %}
     {% else %}
-        {% set label_class = "control-label" %}
+        {% set label_class = " control-label" %}
     {% endif%}
 
     {#{{ sonata_admin.admin.getConfigurationPool().getOption('form_type') }}#}


### PR DESCRIPTION
Label class provided in form mapping was chained to the default label class, without a whitespace
