### PR TITLE
Fix empty items in add_block

### DIFF
--- a/Resources/views/Core/add_block.html.twig
+++ b/Resources/views/Core/add_block.html.twig
@@ -16,7 +16,7 @@
             {% set item_count = 0 %}
             {% if display %}
                 {% for admin in group.items if item_count == 0 %}
-                    {% if admin.hasroute('list') and admin.isGranted('LIST') %}
+                    {% if admin.hasroute('create') and admin.isGranted('CREATE') %}
                         {% set item_count = item_count+1 %}
                     {% endif %}
                 {% endfor %}


### PR DESCRIPTION
When we calculate the menu items, we check the access "LIST", but lower when display it, check the access "CREATE" and print link to "CREATE" action - it is a bug.
