### PR TITLE
Extensible model choice list

### DIFF
--- a/Form/ChoiceList/ModelChoiceList.php
+++ b/Form/ChoiceList/ModelChoiceList.php
@@ -42,7 +42,7 @@ class ModelChoiceList extends SimpleChoiceList
      *
      * @var mixed
      */
-    private $entities = array();
+    protected $entities = array();
 
     /**
      * Contains the query builder that builds the query for fetching the

--- a/Form/ChoiceList/ModelChoiceList.php
+++ b/Form/ChoiceList/ModelChoiceList.php
@@ -124,8 +124,8 @@ class ModelChoiceList extends SimpleChoiceList
     {
         if (is_array($choices)) {
             $entities = $choices;
-        } elseif ($this->query) {
-            $entities = $this->getModelManager()->executeQuery($this->query);
+        } elseif ($this->getQuery()) {
+            $entities = $this->getModelManager()->executeQuery($this->getQuery());
         } else {
             $entities = $this->getModelManager()->findBy($this->class);
         }
@@ -214,6 +214,17 @@ class ModelChoiceList extends SimpleChoiceList
         }
 
         return $this->getModelManager()->find($this->getClass(), $key);
+    }
+
+    /**
+     * Returns the query builder that builds the query for fetching the
+     * entities
+     *
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    public function getQuery()
+    {
+        return $this->query;
     }
 
     /**

--- a/Form/ChoiceList/ModelChoiceList.php
+++ b/Form/ChoiceList/ModelChoiceList.php
@@ -117,6 +117,8 @@ class ModelChoiceList extends SimpleChoiceList
      * @param $choices
      *
      * @return array An array of choices
+     *
+     * @throws \Symfony\Component\Form\Exception\RuntimeException
      */
     protected function load($choices)
     {

--- a/Form/ChoiceList/ModelChoiceList.php
+++ b/Form/ChoiceList/ModelChoiceList.php
@@ -125,9 +125,9 @@ class ModelChoiceList extends SimpleChoiceList
         if (is_array($choices)) {
             $entities = $choices;
         } elseif ($this->query) {
-            $entities = $this->modelManager->executeQuery($this->query);
+            $entities = $this->getModelManager()->executeQuery($this->query);
         } else {
-            $entities = $this->modelManager->findBy($this->class);
+            $entities = $this->getModelManager()->findBy($this->class);
         }
 
         $choices = array();
@@ -147,7 +147,7 @@ class ModelChoiceList extends SimpleChoiceList
                 }
             }
 
-            if (count($this->identifier) > 1) {
+            if (count($this->getIdentifier()) > 1) {
                 // When the identifier consists of multiple field, use
                 // naturally ordered keys to refer to the choices
                 $choices[$key] = $value;
@@ -204,7 +204,7 @@ class ModelChoiceList extends SimpleChoiceList
     public function getEntity($key)
     {
 
-        if (count($this->identifier) > 1) {
+        if (count($this->getIdentifier()) > 1) {
             // $key is a collection index
             $entities = $this->getEntities();
 
@@ -213,7 +213,7 @@ class ModelChoiceList extends SimpleChoiceList
             return isset($this->entities[$key]) ? $this->entities[$key] : null;
         }
 
-        return $this->modelManager->find($this->class, $key);
+        return $this->getModelManager()->find($this->getClass(), $key);
     }
 
     /**


### PR DESCRIPTION
Hi guys,

It should be possible to extends from `Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList`. At the moment it's not possible, essentially due to the private `$entities` property that is modified in the `load` method.

Let's say I want to change the way the choices are built  (group them by type, or filter them, etc...) and I want  to preserve the current behaviour i.e. the way entity collection is populated.

The only commit mandatory here is to change `$entities` property visibility from private to protected.
The others are just some refactoring for consistency's sake : 
* php doc fix
* add a missing getter
* use already defined getters in the class

Cheers.