### PR TITLE
ROLE changes

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -160,7 +160,7 @@ file that was distributed with this source code.
                         <section class="sidebar">
                             {% block sonata_side_nav %}
                                 {% block sonata_sidebar_search %}
-                                    {% if app.security.token and is_granted('ROLE_SONATA_ADMIN') %}
+                                    {% if app.security.token and is_granted('ROLE_ADMIN') %}
                                         <form action="{{ url('sonata_admin_search') }}" method="GET" class="sidebar-form" role="search">
                                             <div class="input-group custom-search-form">
                                                 <input type="text" name="q" value="{{ app.request.get('q') }}" class="form-control" placeholder="{{ 'search_placeholder'|trans({}, 'SonataAdminBundle') }}">
@@ -176,7 +176,7 @@ file that was distributed with this source code.
 
                                 {% block side_bar_before_nav %} {% endblock %}
                                 {% block side_bar_nav %}
-                                    {% if app.security.token and is_granted('ROLE_SONATA_ADMIN') %}
+                                    {% if app.security.token and is_granted('ROLE_ADMIN') %}
                                         <ul class="sidebar-menu">
                                             {% for group in admin_pool.dashboardgroups %}
                                                 {% set display = (group.roles is empty or is_granted('ROLE_SUPER_ADMIN') ) %}


### PR DESCRIPTION
change ROLE_SONATA_ADMIN to ROLE_ADMIN to being render after
installation with any user token that have ROLE_ADMIN permission .

because menu and search never shows until you have ROLE_SONATA_ADMIN permission .
or you can add note in documents "after installation you need grand/promote user to these rolls ." 
ROLE_SONATA_ADMIN
ROLE_SUPER_ADMIN
