### PR TITLE
set x-editable container to body

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -114,6 +114,7 @@ var Admin = {
         jQuery('.x-editable', subject).editable({
             emptyclass: 'editable-empty btn btn-sm',
             emptytext: '<i class="glyphicon glyphicon-edit"></i>',
+            container: 'body',
             success: function(response) {
                 if('KO' === response.status) {
                     return response.message;


### PR DESCRIPTION
because there is an issue on iOS (maybe some other small screen devices) when using the .table-responsive class for the admin list. part of the popover is hidden because of overflow hidden.
