### PR TITLE
Added diff method to AuditReaderInterface

### DIFF
--- a/Model/AuditReaderInterface.php
+++ b/Model/AuditReaderInterface.php
@@ -38,4 +38,12 @@ interface AuditReaderInterface
      * @param string $id
      */
     public function findRevisions($className, $id);
+
+    /**
+     * @param string $className
+     * @param int $id
+     * @param int $oldRevision
+     * @param int $newRevision
+     */
+    public function diff($className, $id, $oldRevision, $newRevision);
 }


### PR DESCRIPTION
This PR must wait for this PR on the SonataDoctrineORMAdminBundle:
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/365

This change was implemented in the following PR but is removed because it is no longer needed there:
https://github.com/sonata-project/SonataAdminBundle/pull/2266
