### PR TITLE
Fix history actions permissions check

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -640,16 +640,16 @@ class CRUDController extends Controller
      */
     public function historyAction($id = null)
     {
-        if (false === $this->admin->isGranted('EDIT')) {
-            throw new AccessDeniedException();
-        }
-
         $id = $this->get('request')->get($this->admin->getIdParameter());
 
         $object = $this->admin->getObject($id);
 
         if (!$object) {
             throw new NotFoundHttpException(sprintf('unable to find the object with id : %s', $id));
+        }
+
+        if (false === $this->admin->isGranted('EDIT', $object)) {
+            throw new AccessDeniedException();
         }
 
         $manager = $this->get('sonata.admin.audit.manager');
@@ -680,16 +680,16 @@ class CRUDController extends Controller
      */
     public function historyViewRevisionAction($id = null, $revision = null)
     {
-        if (false === $this->admin->isGranted('EDIT')) {
-            throw new AccessDeniedException();
-        }
-
         $id = $this->get('request')->get($this->admin->getIdParameter());
 
         $object = $this->admin->getObject($id);
 
         if (!$object) {
             throw new NotFoundHttpException(sprintf('unable to find the object with id : %s', $id));
+        }
+
+        if (false === $this->admin->isGranted('EDIT', $object)) {
+            throw new AccessDeniedException();
         }
 
         $manager = $this->get('sonata.admin.audit.manager');

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -1536,6 +1536,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
+        $this->admin->expects($this->any())
+            ->method('getObject')
+            ->will($this->returnValue(new \StdClass()));
+
         $this->admin->expects($this->once())
             ->method('isGranted')
             ->with($this->equalTo('EDIT'))
@@ -1547,11 +1551,6 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
     public function testHistoryActionNotFoundException()
     {
         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
-
-        $this->admin->expects($this->once())
-            ->method('isGranted')
-            ->with($this->equalTo('EDIT'))
-            ->will($this->returnValue(true));
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -1880,6 +1879,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
+        $this->admin->expects($this->any())
+            ->method('getObject')
+            ->will($this->returnValue(new \StdClass()));
+
         $this->admin->expects($this->once())
             ->method('isGranted')
             ->with($this->equalTo('EDIT'))
@@ -1893,11 +1896,6 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the object with id : 123');
 
         $this->request->query->set('id', 123);
-
-        $this->admin->expects($this->once())
-            ->method('isGranted')
-            ->with($this->equalTo('EDIT'))
-            ->will($this->returnValue(true));
 
         $this->admin->expects($this->once())
             ->method('getObject')


### PR DESCRIPTION
This PR fixes the permissions check in the history actions. Basically it's called later with the object as parameter.

This PR is on the 2.2 branch but I'm not sure it's still maintained, do I need to do it on the master branch ?
