### PR TITLE
Replace concrete ConstraintValidatorFactory type hint by interface

### DIFF
--- a/Validator/InlineValidator.php
+++ b/Validator/InlineValidator.php
@@ -13,8 +13,8 @@ namespace Sonata\AdminBundle\Validator;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory;
 use Sonata\AdminBundle\Validator\ErrorElement;
+use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
 
 class InlineValidator extends ConstraintValidator
 {
@@ -24,7 +24,7 @@ class InlineValidator extends ConstraintValidator
      * @param \Symfony\Component\DependencyInjection\ContainerInterface            $container
      * @param \Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory $constraintValidatorFactory
      */
-    public function __construct(ContainerInterface $container, ConstraintValidatorFactory $constraintValidatorFactory)
+    public function __construct(ContainerInterface $container, ConstraintValidatorFactoryInterface $constraintValidatorFactory)
     {
         $this->container                  = $container;
         $this->constraintValidatorFactory = $constraintValidatorFactory;


### PR DESCRIPTION
With symfony 2.5 a [LegacyConstraintValidatorFactory](https://github.com/symfony/Validator/blob/master/LegacyConstraintValidatorFactory.php) is used as argument if the 2.4 API is used.

Using the corresponding interface as type hint fix a fatal error.

This PR is against the 2.2 branch, is it still maintained ?
