### PR TITLE
Reduce the size of the Admin class

### DIFF
--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+use Knp\Menu\ItemInterface as MenuItemInterface;
+
+class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
+{
+    public function getBreadcrumbs($admin, $action)
+    {
+        $breadcrumbs = array();
+        if ($admin->isChild()) {
+            return $admin->getParent()->getBreadcrumbs($action);
+        }
+
+        $menu = $admin->buildBreadcrumbs($action);
+
+        do {
+            $breadcrumbs[] = $menu;
+        } while ($menu = $menu->getParent());
+
+        $breadcrumbs = array_reverse($breadcrumbs);
+        array_shift($breadcrumbs);
+
+        return $breadcrumbs;
+    }
+
+    /**
+     * Generates the breadcrumbs array.
+     *
+     * Note: the method will be called by the top admin instance (parent => child)
+     *
+     * @param Admin                        $admin
+     * @param string                       $action
+     * @param \Knp\Menu\ItemInterface|null $menu
+     *
+     * @return array
+     */
+    public function buildBreadcrumbs($admin, $action, MenuItemInterface $menu = null)
+    {
+        if (!$menu) {
+            $menu = $admin->getMenuFactory()->createItem('root');
+
+            $menu = $menu->addChild(
+                $admin->trans(
+                    $admin->getLabelTranslatorStrategy()->getLabel(
+                        'dashboard',
+                        'breadcrumb',
+                        'link'
+                    ),
+                    array(),
+                    'SonataAdminBundle'
+                ),
+                array('uri' => $admin->getRouteGenerator()->generate(
+                    'sonata_admin_dashboard'
+                ))
+            );
+        }
+
+        $menu = $menu->addChild(
+            $admin->trans(
+                $admin->getLabelTranslatorStrategy()->getLabel(sprintf(
+                    '%s_list',
+                    $admin->getClassnameLabel()
+                ), 'breadcrumb', 'link')
+            ),
+            array(
+                'uri' => $admin->hasRoute('list') && $admin->isGranted('LIST') ?
+                $admin->generateUrl('list') :
+                null,
+            )
+        );
+
+        $childAdmin = $admin->getCurrentChildAdmin();
+
+        if ($childAdmin) {
+            $id = $admin->getRequest()->get($admin->getIdParameter());
+
+            $menu = $menu->addChild(
+                $admin->toString($admin->getSubject()),
+                array('uri' => $admin->hasRoute('edit') && $admin->isGranted('EDIT') ?
+                    $admin->generateUrl('edit', array('id' => $id)) :
+                    null, )
+            );
+
+            return $childAdmin->buildBreadcrumbs($action, $menu);
+        }
+
+        if ($action === 'list' && $admin->isChild()) {
+            $menu->setUri(false);
+        } elseif ($action !== 'create' && $admin->hasSubject()) {
+            $menu = $menu->addChild($admin->toString($admin->getSubject()));
+        } else {
+            $menu = $menu->addChild(
+                $admin->trans(
+                    $admin->getLabelTranslatorStrategy()->getLabel(
+                        sprintf('%s_%s', $admin->getClassnameLabel(), $action),
+                        'breadcrumb',
+                        'link'
+                    )
+                )
+            );
+        }
+
+        return $menu;
+    }
+}

--- a/Admin/BreadcrumbsBuilderInterface.php
+++ b/Admin/BreadcrumbsBuilderInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+interface BreadcrumbsBuilderInterface
+{
+    /**
+     * Get breadcrumbs for $action.
+     *
+     * @param AdminInterface $admin
+     * @param string         $action the name of the action we want to get a
+     *                               breadcrumbs for
+     *
+     * @return array the breadcrumbs
+     */
+    public function getBreadcrumbs($admin, $action);
+}


### PR DESCRIPTION
A colleague of mine told me that the SRP was not taken into account when building this class. He was not wrong. This PR tries to move a lot of code out of the `Admin` class. The resulting component, named `BreadcrumbBuilder`, is still highly dependent on it though, because there are many things that need to be called : 

- the menu factory
- the label translator strategy
- the translation method
- the route generator
- the classname label getter
- the current child admin getter
- the routing methods
- the request getter
- the toString method
- the subject getter