### PR TITLE
Fix translation flash_batch_empty

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -454,7 +454,7 @@ class CRUDController extends Controller
         $datagrid->buildPager();
 
         if (true !== $nonRelevantMessage) {
-            $this->addFlash('sonata_flash_info', $nonRelevantMessage);
+            $this->addFlash('sonata_flash_info', $this->admin->trans($nonRelevantMessage, array(), 'SonataAdminBundle'));
 
             return new RedirectResponse($this->admin->generateUrl('list', array('filter' => $this->admin->getFilterParameters())));
         }


### PR DESCRIPTION
Hi,

I found a little bug when you doesn't select an element for a batch action in the list, it shows flash_batch_empty instead of the translated message.

Here you can see the message with the actual SonataAdminBundle:
![sonata translation error](https://cloud.githubusercontent.com/assets/520893/3906518/af1cb2bc-22f3-11e4-9220-75c9607f5f86.png)

And with my fix:
![sonata translation error fix](https://cloud.githubusercontent.com/assets/520893/3906517/ae04a5a6-22f3-11e4-8d00-dca956f224e3.png)

The test related to this might be broken (CRUDControllerTest line 2489), i tried to fix it but didn't find a way. The value returned by $this->session->getFlashBag()->get('sonata_flash_info') is NULL instead of the translated message.