### PR TITLE
Autocomplete custom data function

### DIFF
--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -34,7 +34,9 @@ class ModelAutocompleteType extends AbstractType
     {
         $builder->addViewTransformer(new ModelToIdPropertyTransformer($options['model_manager'], $options['class'], $options['property'], $options['multiple'], $options['to_string_callback']), true);
 
-        $builder->add('title', 'text', array('attr'=>array('class'=>'span5'), 'property_path' => '[labels][0]'));
+        $attr = $options['attr'];
+        $attr['class'] = empty($attr['class']) ? 'span5' : ($attr['class'] . ' span5');
+        $builder->add('title', 'text', array('attr'=>$attr, 'property_path' => '[labels][0]'));
         $builder->add('identifiers', 'collection', array('type'=>'hidden', 'allow_add' => true, 'allow_delete' => true));
 
         $builder->setAttribute('property', $options['property']);

--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -65,8 +65,10 @@ class ModelAutocompleteType extends AbstractType
         $view->vars['req_param_name_search'] = $options['req_param_name_search'];
         $view->vars['req_param_name_page_number'] = $options['req_param_name_page_number'];
         $view->vars['req_param_name_items_per_page'] = $options['req_param_name_items_per_page'];
+        $view->vars['custom_data_function_block'] = $options['custom_data_function_block'];
 
         // dropdown list css class
+        $view->vars['dropdown_auto_width'] = $options['dropdown_auto_width'];
         $view->vars['dropdown_css_class'] = $options['dropdown_css_class'];
     }
 
@@ -95,8 +97,10 @@ class ModelAutocompleteType extends AbstractType
             'req_param_name_search'           => 'q',
             'req_param_name_page_number'      => '_page',
             'req_param_name_items_per_page'   => '_per_page',
+            'custom_data_function_block'      => null,
 
             // dropdown list css class
+            'dropdown_auto_width'             => false,
             'dropdown_css_class'              => 'sonata-autocomplete-dropdown',
         ));
 

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -239,8 +239,12 @@ req_param_name_items_per_page
   defaults to "_per_page".  Ajax request parameter name which contains the limit of
   items per page.
 
-custom_data_function_block
-  defaults to `null`. This is an advanced option which lets you customise the function which populates the `data` sent by the ajax call. To use this option you need to be using a customised version of `form_admin_fields` (see the Configuration section of your Sonata storage bundle for more details) and then add a named block to your custom template. Pass the name of that block into this option and it will be used to build the AJAX function. To see how the default implementation works, look at the `sonata_type_model_autocomplete_widget` and `sonata_type_model_autocomplete_widget_default_data_object` blocks in `form_admin_fields.html.twig`, noting that the default data is part of `sonata_type_model_autocomplete_widget_default_data_object` so you can include this in your customised block if required.
+custom_data_function_block (advanced)
+  defaults to ``null``. This is an advanced option which lets you customise the function which populates the ``data`` sent by the Select2 ajax call.
+  
+  To use this option you need to be using a customised version of ``form_admin_fields`` (see the Configuration section of your Sonata storage bundle for more details) and then add a named block to your custom template. Pass the name of that block into this option and it will be used to build the AJAX function. To see how the default implementation works, look at the ``sonata_type_model_autocomplete_widget`` and ``sonata_type_model_autocomplete_widget_default_data_object`` blocks in ``form_admin_fields.html.twig``, noting that the default data is part of ``sonata_type_model_autocomplete_widget_default_data_object`` so you can include this in your customised block if required.
+  
+  Complete example:
 
 .. code-block:: yaml
 
@@ -270,14 +274,13 @@ custom_data_function_block
     {% extends 'SonataDoctrineORMAdminBundle:Form:form_admin_fields.html.twig' %}
 
     {% block transfer_arrival_flight_auto_complete_data_function %}
-        // put some custom code here
+        // put some custom JavaScript code here
         var foo = $('#{{ form.identifiers.vars.id }}').closest('.foo1').find('select.foo2 :selected').val();
 
         return {
             'foo': foo, // add your custom value, then render the default data block
             {{ block('sonata_type_model_autocomplete_widget_default_data_object') }}
         };
-      
     {% endblock %}
 
 sonata_type_admin

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -242,7 +242,7 @@ req_param_name_items_per_page
 custom_data_function_block (advanced)
   defaults to ``null``. This is an advanced option which lets you customise the function which populates the ``data`` sent by the Select2 ajax call.
   
-  To use this option you need to be using a customised version of ``form_admin_fields`` (see the Configuration section of your Sonata storage bundle for more details) and then add a named block to your custom template. Pass the name of that block into this option and it will be used to build the AJAX function. To see how the default implementation works, look at the ``sonata_type_model_autocomplete_widget`` and ``sonata_type_model_autocomplete_widget_default_data_object`` blocks in ``form_admin_fields.html.twig``, noting that the default data is part of ``sonata_type_model_autocomplete_widget_default_data_object`` so you can include this in your customised block if required.
+  For this option to work, you need to be using a customised version of ``form_admin_fields`` (see the Configuration section of your Sonata storage bundle for more details) and then add a named block to your custom template. Pass the name of that block into this option and it will be used by Select2 to build the data to send in the AJAX request. To see how the default implementation works, look at the blocks called ``sonata_type_model_autocomplete_widget`` and ``sonata_type_model_autocomplete_widget_default_data_object`` in the template ``form_admin_fields.html.twig``, noting that the default data is part of ``sonata_type_model_autocomplete_widget_default_data_object`` so you can include this in your customised block if required.
   
   Complete example:
 

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -224,6 +224,8 @@ route
   The route ``name`` with ``parameters`` that is used as target url for ajax
   requests.
 
+dropdown_auto_width
+  defaults to false. Set to true to enable the `dropdownAutoWidth` Select2 option, which allows the drop downs to be wider than the parent input, sized according to their content.
 dropdown_css_class
   defaults to "sonata-autocomplete-dropdown". CSS class of dropdown list.
 
@@ -236,6 +238,47 @@ req_param_name_page_number
 req_param_name_items_per_page
   defaults to "_per_page".  Ajax request parameter name which contains the limit of
   items per page.
+
+custom_data_function_block
+  defaults to `null`. This is an advanced option which lets you customise the function which populates the `data` sent by the ajax call. To use this option you need to be using a customised version of `form_admin_fields` (see the Configuration section of your Sonata storage bundle for more details) and then add a named block to your custom template. Pass the name of that block into this option and it will be used to build the AJAX function. To see how the default implementation works, look at the `sonata_type_model_autocomplete_widget` and `sonata_type_model_autocomplete_widget_default_data_object` blocks in `form_admin_fields.html.twig`, noting that the default data is part of `sonata_type_model_autocomplete_widget_default_data_object` so you can include this in your customised block if required.
+
+.. code-block:: yaml
+
+    # config.yml, define a custom form template
+    sonata_doctrine_orm_admin:
+        templates:
+            form:
+                - YourBundle:Form:form_admin_fields.html.twig
+
+.. code-block:: php
+
+    # FooAdmin.php
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->add('bar', sonata_type_model_autocomplete', array(
+                'property'      => 'title',
+                'custom_data_function_block' => 'foo_bar_auto_complete_data_function',
+            ))
+        ;
+    }
+
+.. code-block:: html+jinja
+
+    {# YourBundle:Form:form_admin_fields.html.twig #}
+    
+    {% extends 'SonataDoctrineORMAdminBundle:Form:form_admin_fields.html.twig' %}
+
+    {% block transfer_arrival_flight_auto_complete_data_function %}
+        // put some custom code here
+        var foo = $('#{{ form.identifiers.vars.id }}').closest('.foo1').find('select.foo2 :selected').val();
+
+        return {
+            'foo': foo, // add your custom value, then render the default data block
+            {{ block('sonata_type_model_autocomplete_widget_default_data_object') }}
+        };
+      
+    {% endblock %}
 
 sonata_type_admin
 ^^^^^^^^^^^^^^^^^

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -278,29 +278,13 @@ file that was distributed with this source code.
                     dataType: 'json',
                     quietMillis: 100,
                     data: function (term, page) { // page is the one-based page number tracked by Select2
-                        return {
-                                //search term
-                                "{{ req_param_name_search }}": term,
-
-                                // page size
-                                "{{ req_param_name_items_per_page }}": {{ items_per_page }},
-
-                                // page number
-                                "{{ req_param_name_page_number }}": page,
-
-                                // admin
-                                'uniqid': "{{ sonata_admin.admin.root.uniqid }}",
-                                'code':   "{{ sonata_admin.admin.root.code }}",
-                                'field':  "{{ name }}"
-
-                                // other parameters
-                                {% if req_params is not empty %},
-                                    {%- for key, value in req_params -%}
-                                        "{{- key|e('js') -}}": "{{- value|e('js') -}}"
-                                        {%- if not loop.last -%}, {% endif -%}
-                                    {%- endfor -%}
-                                {% endif %}
+                        {% if custom_data_function_block|default(false) %}
+                            {{ block(custom_data_function_block) }}
+                        {% else %}
+                            return {
+                                {{ block('sonata_type_model_autocomplete_widget_default_data_object') }}
                             };
+                        {% endif %}
                     },
                     results: function (data, page) {
                         // notice we return the value of more so Select2 knows if more results can be loaded
@@ -331,6 +315,7 @@ file that was distributed with this source code.
                 formatSelection: function (item) {
                     return {% block sonata_type_model_autocomplete_selection_format %}item.label{% endblock %};// format selected item '<b>'+item.label+'</b>';
                 },
+                dropdownAutoWidth: {{ dropdown_auto_width ? 'true' : 'false' }},
                 dropdownCssClass: "{{ dropdown_css_class }}",
                 escapeMarkup: function (m) { return m; } // we do not want to escape markup since we are displaying html in results
             });
@@ -376,3 +361,26 @@ file that was distributed with this source code.
     </script>
 {% endspaceless %}
 {% endblock sonata_type_model_autocomplete_widget %}
+
+{% block sonata_type_model_autocomplete_widget_default_data_object %}
+    //search term
+    "{{ req_param_name_search }}": term,
+
+    // page size
+    "{{ req_param_name_items_per_page }}": {{ items_per_page }},
+
+    // page number
+    "{{ req_param_name_page_number }}": page,
+
+    // other parameters
+    {% if req_params is not empty %}
+        {%- for key, value in req_params -%}
+            "{{- key|e('js') -}}": "{{- value|e('js') -}}",
+        {%- endfor -%}
+    {% endif %}
+
+    // admin
+    'uniqid': "{{ sonata_admin.admin.root.uniqid }}",
+    'code':   "{{ sonata_admin.admin.code }}",
+    'field':  "{{ name }}"
+{% endblock %}

--- a/Tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/Tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -13,7 +13,7 @@ namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 
-use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
+use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ModelAutocompleteTypeTest extends TypeTestCase
@@ -45,6 +45,9 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $this->assertEquals('q', $options['req_param_name_search']);
         $this->assertEquals('_page', $options['req_param_name_page_number']);
         $this->assertEquals('_per_page', $options['req_param_name_items_per_page']);
+
+        $this->assertNull($options['custom_data_function_block']);
+        $this->assertFalse($options['dropdown_auto_width']);
         $this->assertEquals('sonata-autocomplete-dropdown', $options['dropdown_css_class']);
     }
 }


### PR DESCRIPTION
This update allows the user to customise what data is sent in the AJAX call, enabling (for example) sending back data from other fields on the form. It follows on from the (minor) changes in #2305, which are included in this PR (they affect lines 37-39 of ModelAutocompleteType.php).

Added new `custom_data_function_block` option in ModelAutocompleteType
Added new `dropdown_auto_width` option in ModelAutocompleteType
Added related getDefaultOptions test and documentation
Updated form_admin_fields.html.twig to render effects of new options
