### PR TITLE
Add callback_with_admin option to ModelAutocompleteType

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -328,7 +328,6 @@ class HelperController
 
         $property           = $formAutocomplete->getConfig()->getAttribute('property');
         $callback           = $formAutocomplete->getConfig()->getAttribute('callback');
-        $callbackWithAdmin  = $formAutocomplete->getConfig()->getAttribute('callback_with_admin');
         $minimumInputLength = $formAutocomplete->getConfig()->getAttribute('minimum_input_length');
         $itemsPerPage       = $formAutocomplete->getConfig()->getAttribute('items_per_page');
         $reqParamPageNumber = $formAutocomplete->getConfig()->getAttribute('req_param_name_page_number');
@@ -343,18 +342,12 @@ class HelperController
         $targetAdmin = $fieldDescription->getAssociationAdmin();
         $datagrid = $targetAdmin->getDatagrid();
 
-        if ($callbackWithAdmin !== null) {
-            if (!is_callable($callbackWithAdmin)) {
-                throw new \RuntimeException('CallbackWithAdmin does not contain callable function.');
-            }
-
-            call_user_func($callbackWithAdmin, $datagrid, $property, $searchText, $admin);
-        } elseif ($callback !== null) {
+        if ($callback !== null) {
             if (!is_callable($callback)) {
                 throw new \RuntimeException('Callback does not contain callable function.');
             }
 
-            call_user_func($callback, $datagrid, $property, $searchText);
+            call_user_func($callback, $targetAdmin, $property, $searchText);
         } else {
             if (is_array($property)) {
                 // multiple properties

--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -39,7 +39,6 @@ class ModelAutocompleteType extends AbstractType
 
         $builder->setAttribute('property', $options['property']);
         $builder->setAttribute('callback', $options['callback']);
-        $builder->setAttribute('callback_with_admin', $options['callback_with_admin']);
         $builder->setAttribute('minimum_input_length', $options['minimum_input_length']);
         $builder->setAttribute('items_per_page', $options['items_per_page']);
         $builder->setAttribute('req_param_name_page_number', $options['req_param_name_page_number']);
@@ -79,7 +78,6 @@ class ModelAutocompleteType extends AbstractType
             'model_manager'                   => null,
             'class'                           => null,
             'callback'                        => null,
-            'callback_with_admin'             => null,
             'multiple'                        => false,
 
             'placeholder'                     => '',

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -176,31 +176,18 @@ model_manager
 
 callback
   defaults to null. Callable function that can be used to modify the query which is used to retrieve autocomplete items.
+  The callback should receive three parameters - the Admin instance, the property (or properties) defined as searchable and the 
+  search value entered by the user.
+  
+  From the ``$admin`` parameter it is possible to get the ``Datagrid`` and the ``Request``:
 
 .. code-block:: php
 
     $formMapper
         ->add('category', 'sonata_type_model_autocomplete', array(
             'property'=>'title',
-            'callback' => function ($datagrid, $property, $value) {
-                $queryBuilder = $datagrid->getQuery();
-                $queryBuilder->andWhere($queryBuilder->getRootAlias() . '.enabled=1 ');
-                $datagrid->setValue($property, null, $value);
-            },
-        )
-    );
-
-callback_with_admin
-  defaults to null. Callable function that can be used to modify the query which is used to retrieve autocomplete items. 
-  Compared to ``callback``, this function also receives the Admin as a parameter and the current request can be accessed
-  within the function using ``$admin->getRequest()``.
-
-.. code-block:: php
-
-    $formMapper
-        ->add('category', 'sonata_type_model_autocomplete', array(
-            'property'=>'title',
-            'callback' => function ($datagrid, $property, $value, $admin) {
+            'callback' => function ($admin, $property, $value) {
+                $datagrid = $admin->getDatagrid();
                 $queryBuilder = $datagrid->getQuery();
                 $queryBuilder
                     ->andWhere($queryBuilder->getRootAlias() . '.foo=:barValue')

--- a/Tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/Tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -34,7 +34,6 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $this->assertEquals('Foo', $options['class']);
         $this->assertEquals('bar', $options['property']);
         $this->assertNull($options['callback']);
-        $this->assertNull($options['callback_with_admin']);
 
         $this->assertEquals('', $options['placeholder']);
         $this->assertEquals(3, $options['minimum_input_length']);


### PR DESCRIPTION
Options and test added to ModelAutocompleteType classes, handler added to HelperController and related documentation added in form_types.rst.

This work is intended to be combined with #2311 so you can customise the data function, send some extra parameters in the AJAX request and then pass the admin through to a callback_with_admin method which can use the extra request data to update the QueryBuilder and modify the results in the datagrid.
