### PR TITLE
Update recipe_file_uploads.rst

### DIFF
--- a/Resources/doc/cookbook/recipe_file_uploads.rst
+++ b/Resources/doc/cookbook/recipe_file_uploads.rst
@@ -56,7 +56,7 @@ upload timestamp.
               type:         integer
               generator:    { strategy: AUTO }
           fields:
-            file:
+            filename:
               type:         string
               length:       100
             updated:        # changed when files are uploaded, to force preUpdate and postUpdate to fire


### PR DESCRIPTION
We have to change field name from 'file' into 'filename' while we need field 'file' to be not mapped. Field 'file' is only temporary to store UploadedFile instance.
