### PR TITLE
Add missing $userManager variable

### DIFF
--- a/Resources/doc/reference/saving_hooks.rst
+++ b/Resources/doc/reference/saving_hooks.rst
@@ -59,7 +59,7 @@ solve the issue by using the ``preUpdate`` saving hook.
                 ->with('General')
                     ->add('username')
                     ->add('email')
-                    ->add('plainPassword', 'text')
+                    ->add('plainPassword', 'password', array('required' => false))
                 ->end()
                 ->with('Groups')
                     ->add('groups', 'sonata_type_model', array('required' => false))


### PR DESCRIPTION
Also a typo was fixed and it would probably be better to use for `password` the following: `->add('plainPassword', 'password', ['required' => false])` as you wouldn't really want to show the password to everyone and you might not want to change it.
