### PR TITLE
Supporting mapping by uid

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1686,7 +1686,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     {
         if ($this->subject === null && $this->request) {
             $id = $this->request->get($this->getIdParameter());
-            if (!preg_match('#^[0-9A-Fa-f]+$#', $id)) {
+            if (!preg_match('#^[0-9A-Fa-f-]+$#', $id)) {
                 $this->subject = false;
             } else {
                 $this->subject = $this->getModelManager()->find($this->class, $id);


### PR DESCRIPTION
If use the uid (/admin/categories/ec6b7cd1-2281-4b82-aaf0-5126e317933f/categories_json/list), instead of id (/admin/categories/56/categories_json/list), then the expression does not work.