### PR TITLE
Refactored add_block.html.twig - fixed CS and bugs

### DIFF
--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -128,6 +128,10 @@ body > .header .logo {
     min-width:100px;
 }
 
+.dropdown-add .dropdown-menu > li > a {
+    white-space: normal;
+}
+
 /* top right */
 
 .navbar-static-top {

--- a/Resources/views/Core/add_block.html.twig
+++ b/Resources/views/Core/add_block.html.twig
@@ -1,57 +1,62 @@
 {% block user_block %}
-    {% set itemsPerColumn = admin_pool.getOption('dropdown_number_groups_per_colums') %}
-    {% set columnsCount = (admin_pool.dashboardgroups|length / itemsPerColumn)|round %}
+    {% set items_per_column = admin_pool.getOption('dropdown_number_groups_per_colums') %}
+    {% set groups = [] %}
 
+    {% for group in admin_pool.dashboardgroups %}
+        {% set display_group = false %}
 
-    <ul class="dropdown-menu{% if columnsCount > 1 %} multi-column{% endif %} dropdown-add"
-        {% if columnsCount > 1 %}style="width: {{ columnsCount*140 }}px;"{% endif %}
+        {% for admin in group.items if display_group == false %}
+            {% if admin.hasRoute('create') and admin.isGranted('CREATE') %}
+                {% set display_group = true %}
+                {% set groups = [group]|merge(groups) %}
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+
+    {% set column_count = (groups|length / items_per_column)|round(0, 'ceil') %}
+
+    <div class="dropdown-menu multi-column dropdown-add"
+        {% if column_count > 1 %}style="width: {{ column_count*140 }}px;"{% endif %}
             >
-        {% for group in admin_pool.dashboardgroups %}
+        {% for group in groups|reverse %}
             {% set display = (group.roles is empty or is_granted('ROLE_SONATA_ADMIN') ) %}
             {% for role in group.roles if not display %}
                 {% set display = is_granted(role) %}
             {% endfor %}
 
-            {# Do not display the group label if no item in group is available #}
-            {% set item_count = 0 %}
             {% if display %}
-                {% for admin in group.items if item_count == 0 %}
-                    {% if admin.hasroute('list') and admin.isGranted('LIST') %}
-                        {% set item_count = item_count+1 %}
-                    {% endif %}
-                {% endfor %}
-            {% endif %}
 
-            {% if display and (item_count > 0) %}
-                {% if columnsCount > 1 and loop.index0 % itemsPerColumn == 0 %}
+                {% if loop.first or loop.index0 % items_per_column == 0 %}
                     {% if loop.first %}
-                        <div class="row">
+                        <div class="container-fluid">
+                            <div class="row">
+                    {% else %}
+                        </ul>
                     {% endif %}
-                    <div class="col-md-{{ (12/columnsCount)|round }}">
-                    <ul class="dropdown-menu">
+
+                    <ul class="dropdown-menu{% if column_count > 1 %} col-md-{{ (12/column_count)|round }}{% endif %}">
                 {% endif %}
 
+                {% if loop.index0 % items_per_column != 0 %}
+                    <li role="presentation" class="divider"></li>
+                {% endif %}
                 <li role="presentation" class="dropdown-header">{{ group.label|trans({}, group.label_catalogue) }}</li>
+
                 {% for admin in group.items %}
-                    {% if admin.hasroute('create') and admin.isGranted('CREATE') %}
+                    {% if admin.hasRoute('create') and admin.isGranted('CREATE') %}
                         <li role="presentation">
                             <a role="menuitem" tabindex="-1" href="{{ admin.generateUrl('create')}}">{{ admin.label|trans({}, admin.translationdomain) }}</a>
                         </li>
                     {% endif %}
                 {% endfor %}
 
-                {% if not loop.last and loop.index % itemsPerColumn != 0 %}
-                    <li role="presentation" class="divider"></li>
-                {% endif %}
-
-            {% if loop.length > itemsPerColumn and loop.index % itemsPerColumn == 0 %}
-                </ul>
-                </div>
-            {% endif %}
-                {% if loop.length > itemsPerColumn and loop.last %}
+                {% if loop.last %}
+                            </ul>
+                        </div>
                     </div>
                 {% endif %}
+
             {% endif %}
         {% endfor %}
-    </ul>
+    </div>
 {% endblock %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #2312, #2248, #2277 |
| License | MIT |

This PR fixes these issues with add_block.html twig template (it renders the top right menu with links for quicker move to create form of admins):
-  fixed Twig CS
- invalid html tags (`ul` replaced with `div`, because `div` cannot be child of `ul`)
- fixed checking wrong LIST permission instead of CREATE when counting items of group
- fixed overflowing too long texts out of the menu
- fixed wrongly closed html tags
- fixed counting of columns (avoid empty column if no group is available)
- fixed (not) displaying group that does not have any item
