### PR TITLE
Fixed wrong handling with _per_page and _page datagrid parameters in php 5.3

### DIFF
--- a/Datagrid/Datagrid.php
+++ b/Datagrid/Datagrid.php
@@ -11,8 +11,6 @@
 
 namespace Sonata\AdminBundle\Datagrid;
 
-use Sonata\AdminBundle\Datagrid\PagerInterface;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
@@ -101,8 +99,8 @@ class Datagrid implements DatagridInterface
 
         $this->formBuilder->add('_sort_by', 'hidden');
         $this->formBuilder->get('_sort_by')->addViewTransformer(new CallbackTransformer(
-            function($value) { return $value; },
-            function($value) { return $value instanceof FieldDescriptionInterface ? $value->getName() : $value; }
+            function ($value) { return $value; },
+            function ($value) { return $value instanceof FieldDescriptionInterface ? $value->getName() : $value; }
         ));
 
         $this->formBuilder->add('_sort_order', 'hidden');
@@ -131,19 +129,30 @@ class Datagrid implements DatagridInterface
         }
 
         $maxPerPage = 25;
-        if (isset($this->values['_per_page']['value'])) {
-            $maxPerPage = $this->values['_per_page']['value'];
-        } elseif (isset($this->values['_per_page'])) {
-            $maxPerPage = $this->values['_per_page'];
+        if (isset($this->values['_per_page'])) {
+            // check for `is_array` can be safely removed if php 5.3 support will be dropped
+            if (is_array($this->values['_per_page'])) {
+                if (isset($this->values['_per_page']['value'])) {
+                    $maxPerPage = $this->values['_per_page']['value'];
+                }
+            } else {
+                $maxPerPage = $this->values['_per_page'];
+            }
         }
         $this->pager->setMaxPerPage($maxPerPage);
 
         $page = 1;
-        if (isset($this->values['_page']['value'])) {
-            $page = $this->values['_page']['value'];
-        } elseif (isset($this->values['_page'])) {
-            $page = $this->values['_page'];
+        if (isset($this->values['_page'])) {
+            // check for `is_array` can be safely removed if php 5.3 support will be dropped
+            if (is_array($this->values['_page'])) {
+                if (isset($this->values['_page']['value'])) {
+                    $page = $this->values['_page']['value'];
+                }
+            } else {
+                $page = $this->values['_page'];
+            }
         }
+
         $this->pager->setPage($page);
 
         $this->pager->setQuery($this->query);

--- a/Tests/Datagrid/DatagridTest.php
+++ b/Tests/Datagrid/DatagridTest.php
@@ -66,7 +66,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->formBuilder->expects($this->any())
             ->method('get')
-            ->will($this->returnCallback(function($name) use (& $formTypes) {
+            ->will($this->returnCallback(function ($name) use (& $formTypes) {
                 if (isset($formTypes[$name])) {
                     return $formTypes[$name];
                 }
@@ -80,7 +80,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->formBuilder->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function($name, $type, $options) use (& $formTypes, $eventDispatcher, $formFactory) {
+            ->will($this->returnCallback(function ($name, $type, $options) use (& $formTypes, $eventDispatcher, $formFactory) {
                 $formTypes[$name] = new FormBuilder($name, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Form\TestEntity', $eventDispatcher, $formFactory, $options);
 
                 return null;
@@ -93,7 +93,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->formBuilder->expects($this->any())
             ->method('getForm')
-            ->will($this->returnCallback(function() use ($form) {
+            ->will($this->returnCallback(function () use ($form) {
                 return $form;
             }));
 
@@ -371,7 +371,10 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_per_page'));
     }
 
-    public function testBuildPagerWithPage()
+    /**
+     * @dataProvider getBuildPagerWithPageTests
+     */
+    public function testBuildPagerWithPage($page, $perPage)
     {
         $sortBy = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $sortBy->expects($this->once())
@@ -388,7 +391,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('3'))
             ->will($this->returnValue(null));
 
-        $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, array('_sort_by'=>$sortBy, '_page'=>3, '_per_page'=>50));
+        $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, array('_sort_by'=>$sortBy, '_page'=>$page, '_per_page'=>$perPage));
 
         $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter->expects($this->once())
@@ -417,7 +420,21 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_per_page'));
     }
 
-    public function testBuildPagerWithPage2()
+    public function getBuildPagerWithPageTests()
+    {
+        // tests for php 5.3, because isset functionality was changed since php 5.4
+        return array(
+            array(3, 50),
+            array('3', '50'),
+            array(3, '50'),
+            array('3', 50),
+        );
+    }
+
+    /**
+     * @dataProvider getBuildPagerWithPage2Tests
+     */
+    public function testBuildPagerWithPage2($page, $perPage)
     {
         $this->pager->expects($this->once())
             ->method('setMaxPerPage')
@@ -430,8 +447,8 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(null));
 
         $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, array());
-        $this->datagrid->setValue('_per_page', null, 50);
-        $this->datagrid->setValue('_page', null, 3);
+        $this->datagrid->setValue('_per_page', null, $perPage);
+        $this->datagrid->setValue('_page', null, $page);
 
         $this->datagrid->buildPager();
 
@@ -440,5 +457,16 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_order'));
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_page'));
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_per_page'));
+    }
+
+    public function getBuildPagerWithPage2Tests()
+    {
+        // tests for php 5.3, because isset functionality was changed since php 5.4
+        return array(
+            array(3, 50),
+            array('3', '50'),
+            array(3, '50'),
+            array('3', 50),
+        );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #2292, #2288, #2313, #2335 |
| License | MIT |

This PR is using the fix from issue #2313 created by @Geckow
