### PR TITLE
Pass admin through to autocompleteItems callback:

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -344,10 +344,10 @@ class HelperController
 
         if ($callback !== null) {
             if (!is_callable($callback)) {
-                throw new \RuntimeException('Callback doesn`t contain callable function.');
+                throw new \RuntimeException('Callback does not contain callable function.');
             }
 
-            call_user_func($callback, $datagrid, $property, $searchText);
+            call_user_func($callback, $targetAdmin, $property, $searchText);
         } else {
             if (is_array($property)) {
                 // multiple properties

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -176,15 +176,23 @@ model_manager
 
 callback
   defaults to null. Callable function that can be used to modify the query which is used to retrieve autocomplete items.
+  The callback should receive three parameters - the Admin instance, the property (or properties) defined as searchable and the 
+  search value entered by the user.
+  
+  From the ``$admin`` parameter it is possible to get the ``Datagrid`` and the ``Request``:
 
 .. code-block:: php
 
     $formMapper
         ->add('category', 'sonata_type_model_autocomplete', array(
             'property'=>'title',
-            'callback' => function ($datagrid, $property, $value) {
+            'callback' => function ($admin, $property, $value) {
+                $datagrid = $admin->getDatagrid();
                 $queryBuilder = $datagrid->getQuery();
-                $queryBuilder->andWhere($queryBuilder->getRootAlias() . '.enabled=1 ');
+                $queryBuilder
+                    ->andWhere($queryBuilder->getRootAlias() . '.foo=:barValue')
+                    ->setParameter('barValue', $admin->getRequest()->get('bar'))
+                ;
                 $datagrid->setValue($property, null, $value);
             },
         )


### PR DESCRIPTION
~ modified HelperController::retrieveAutocompleteItemsAction() to pass $targetAdmin through to callback instead of $datagrid
~ updated documentation of the callback
