### PR TITLE
Minor improvements in translation messages in sonata_type_model_autocomplete

### DIFF
--- a/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -86,17 +86,17 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
         }
         if ($this->multiple) {
             if (substr(get_class($entityOrCollection), -1 * strlen($this->className)) == $this->className) {
-                throw new \InvalidArgumentException('A multiple selection must be passed a collection not a single value.');
+                throw new \InvalidArgumentException('A multiple selection must be passed a collection not a single value. Make sure that form option "multiple=false" is set for many-to-one relation and "multiple=true" is set for many-to-many or one-to-many relations.');
             } elseif ($entityOrCollection instanceof \ArrayAccess) {
                 $collection = $entityOrCollection;
             } else {
-                throw new \InvalidArgumentException('A multiple selection must be passed a collection not a single value.');
+                throw new \InvalidArgumentException('A multiple selection must be passed a collection not a single value. Make sure that form option "multiple=false" is set for many-to-one relation and "multiple=true" is set for many-to-many or one-to-many relations.');
             }
         } else {
             if (substr(get_class($entityOrCollection), -1 * strlen($this->className)) == $this->className) {
                 $collection = array($entityOrCollection);
             } elseif ($entityOrCollection instanceof \ArrayAccess) {
-                throw new \InvalidArgumentException('A single selection must be passed a single value not a collection.');
+                throw new \InvalidArgumentException('A single selection must be passed a single value not a collection. Make sure that form option "multiple=false" is set for many-to-one relation and "multiple=true" is set for many-to-many or one-to-many relations.');
             } else {
                 $collection = array($entityOrCollection);
             }

--- a/Tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
@@ -160,6 +160,25 @@ class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('identifiers' => array(123), 'labels' => array('bazz')), $transformer->transform($entity));
     }
 
+    /**
+     * @expectedException        \RuntimeException
+     * @expectedExceptionMessage Callback in "to_string_callback" option doesn`t contain callable function.
+     */
+    public function testTransformToStringCallbackException()
+    {
+        $entity = new Foo();
+        $entity->setBar('example');
+        $entity->setBaz('bazz');
+
+        $this->modelManager->expects($this->once())
+            ->method('getIdentifierValues')
+            ->will($this->returnValue(array(123)));
+
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', false, '987654');
+
+        $transformer->transform($entity);
+    }
+
     public function testTransformMultiple()
     {
         $entity1 = new Foo();
@@ -202,5 +221,53 @@ class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('identifiers' => array(), 'labels' => array()), $transformer->transform('0'));
 
         $this->assertEquals(array('identifiers' => array(123, 456, 789), 'labels' => array('foo', 'bar', 'baz')), $transformer->transform($collection));
+    }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage A multiple selection must be passed a collection not a single value. Make sure that form option "multiple=false" is set for many-to-one relation and "multiple=true" is set for many-to-many or one-to-many relations.
+     */
+    public function testTransformCollectionException()
+    {
+        $entity = new Foo();
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', true);
+        $transformer->transform($entity);
+    }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage A multiple selection must be passed a collection not a single value. Make sure that form option "multiple=false" is set for many-to-one relation and "multiple=true" is set for many-to-many or one-to-many relations.
+     */
+    public function testTransformArrayAccessException()
+    {
+        $entity = new FooArrayAccess();
+        $entity->setBar('example');
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\FooArrayAccess', 'bar', true);
+        $transformer->transform($entity);
+    }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage A single selection must be passed a single value not a collection. Make sure that form option "multiple=false" is set for many-to-one relation and "multiple=true" is set for many-to-many or one-to-many relations.
+     */
+    public function testTransformEntityException()
+    {
+        $entity1 = new Foo();
+        $entity1->setBar('foo');
+
+        $entity2 = new Foo();
+        $entity2->setBar('bar');
+
+        $entity3 = new Foo();
+        $entity3->setBar('baz');
+
+        $collection = new ArrayCollection();
+        $collection[] = $entity1;
+        $collection[] = $entity2;
+        $collection[] = $entity3;
+
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', false);
+
+        $transformer->transform($collection);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

Added info about form option `multiple` in the error messages to help users understand the error, refs #1764
