### PR TITLE
[WIP] Minor improvemnts in sonata_type_model_autocomplete

### DIFF
--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -55,6 +55,7 @@ class ModelAutocompleteType extends AbstractType
         $view->vars['multiple'] = $options['multiple'];
         $view->vars['minimum_input_length'] = $options['minimum_input_length'];
         $view->vars['items_per_page'] = $options['items_per_page'];
+        $view->vars['width'] = $options['width'];
 
         // ajax parameters
         $view->vars['url'] = $options['url'];
@@ -64,8 +65,10 @@ class ModelAutocompleteType extends AbstractType
         $view->vars['req_param_name_page_number'] = $options['req_param_name_page_number'];
         $view->vars['req_param_name_items_per_page'] = $options['req_param_name_items_per_page'];
 
-        // dropdown list css class
+        // CSS classes
+        $view->vars['container_css_class'] = $options['container_css_class'];
         $view->vars['dropdown_css_class'] = $options['dropdown_css_class'];
+        $view->vars['dropdown_item_css_class'] = $options['dropdown_item_css_class'];
     }
 
     /**
@@ -80,6 +83,7 @@ class ModelAutocompleteType extends AbstractType
             'class'                           => null,
             'callback'                        => null,
             'multiple'                        => false,
+            'width'                           => '',
 
             'placeholder'                     => '',
             'minimum_input_length'            => 3, //minimum 3 chars should be typed to load ajax data
@@ -95,8 +99,10 @@ class ModelAutocompleteType extends AbstractType
             'req_param_name_page_number'      => '_page',
             'req_param_name_items_per_page'   => '_per_page',
 
-            // dropdown list css class
-            'dropdown_css_class'              => 'sonata-autocomplete-dropdown',
+            // CSS classes
+            'container_css_class'             => '',
+            'dropdown_css_class'              => '',
+            'dropdown_item_css_class'         => '',
         ));
 
         $resolver->setRequired(array('property'));

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -176,9 +176,9 @@ model_manager
 
 callback
   defaults to null. Callable function that can be used to modify the query which is used to retrieve autocomplete items.
-  The callback should receive three parameters - the Admin instance, the property (or properties) defined as searchable and the 
+  The callback should receive three parameters - the Admin instance, the property (or properties) defined as searchable and the
   search value entered by the user.
-  
+
   From the ``$admin`` parameter it is possible to get the ``Datagrid`` and the ``Request``:
 
 .. code-block:: php
@@ -232,8 +232,17 @@ route
   The route ``name`` with ``parameters`` that is used as target url for ajax
   requests.
 
+width
+  defaults to "". Controls the width style attribute of the Select2 container div.
+
+container_css_class
+  defaults to "". Css class that will be added to select2's container tag.
+
 dropdown_css_class
-  defaults to "sonata-autocomplete-dropdown". CSS class of dropdown list.
+  defaults to "". CSS class of dropdown list.
+
+dropdown_item_css_class
+  defaults to "". CSS class of dropdown item.
 
 req_param_name_search
   defaults to "q". Ajax request parameter name which contains the searched text.
@@ -354,7 +363,7 @@ btn_add and btn_catalogue:
 **TIP**: A jQuery event is fired after a row has been added (``sonata-admin-append-form-element``).
 You can listen to this event to trigger custom javascript (eg: add a calendar widget to a newly added date field)
 
-**TIP**: Setting the 'required' option to true does not cause a requirement of 'at least one' child entity. 
+**TIP**: Setting the 'required' option to true does not cause a requirement of 'at least one' child entity.
 Setting the 'required' option to false causes all nested form fields to become not required as well.
 
 sonata_type_native_collection (previously collection)

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -273,6 +273,9 @@ file that was distributed with this source code.
                 readonly: {{ read_only ? 'true' : 'false' }},
                 minimumInputLength: {{ minimum_input_length }},
                 multiple: {{ multiple ? 'true' : 'false' }},
+                width: "{{ width }}",
+                containerCssClass: "{{ container_css_class  ~ ' form-control' }} ",
+                dropdownCssClass: "{{ dropdown_css_class }}",
                 ajax: {
                     url:  "{{ url ?: url(route.name, route.parameters|default([])) }}",
                     dataType: 'json',
@@ -308,12 +311,11 @@ file that was distributed with this source code.
                     }
                 },
                 formatResult: function (item) {
-                    return {% block sonata_type_model_autocomplete_dropdown_item_format %}'<div class="sonata-autocomplete-dropdown-item">'+item.label+'</div>'{% endblock %};// format of one dropdown item
+                    return {% block sonata_type_model_autocomplete_dropdown_item_format %}'<div class="{{ dropdown_item_css_class }}">'+item.label+'</div>'{% endblock %};// format of one dropdown item
                 },
                 formatSelection: function (item) {
                     return {% block sonata_type_model_autocomplete_selection_format %}item.label{% endblock %};// format selected item '<b>'+item.label+'</b>';
                 },
-                dropdownCssClass: "{{ dropdown_css_class }}",
                 escapeMarkup: function (m) { return m; } // we do not want to escape markup since we are displaying html in results
             });
 

--- a/Tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/Tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -39,6 +39,7 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $this->assertEquals('', $options['placeholder']);
         $this->assertEquals(3, $options['minimum_input_length']);
         $this->assertEquals(10, $options['items_per_page']);
+        $this->assertEquals('', $options['width']);
 
         $this->assertEquals('', $options['url']);
         $this->assertEquals(array('name'=>'sonata_admin_retrieve_autocomplete_items', 'parameters'=>array()), $options['route']);
@@ -46,6 +47,8 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $this->assertEquals('q', $options['req_param_name_search']);
         $this->assertEquals('_page', $options['req_param_name_page_number']);
         $this->assertEquals('_per_page', $options['req_param_name_items_per_page']);
-        $this->assertEquals('sonata-autocomplete-dropdown', $options['dropdown_css_class']);
+        $this->assertEquals('', $options['container_css_class']);
+        $this->assertEquals('', $options['dropdown_css_class']);
+        $this->assertEquals('', $options['dropdown_item_css_class']);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes (just UI) |
| New feature? | yes |
| BC breaks? | yes, but minor (removed some default CSS classes) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

refs #1764
- [x] fixed initial width of input field (with `form-control` class)
- [x] added `width`, `container_css_class`, `dropdown_item_css_class` options
- [x] removed unneeded CSS classes `sonata-autocomplete-dropdown` and `sonata-autocomplete-dropdown-item`
- [ ] test all use cases
