### PR TITLE
Removed problematic overflow CSS rules for ".box .box-body" in layout.css

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -341,8 +341,3 @@ legend.sonata-ba-fieldset-collapsed-description + .sonata-ba-collapsed-fields {
 .form-horizontal .control-group {
     margin-bottom: 10px;
 }
-
-.box .box-body {
-    overflow-x: auto;
-    overflow-y: hidden;
-}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #2369 |
| License | MIT |
