### PR TITLE
$ to jQuery

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -12,7 +12,7 @@
 jQuery(document).ready(function() {
     jQuery('html').removeClass('no-js');
     if (window.SONATA_CONFIG && window.SONATA_CONFIG.CONFIRM_EXIT) {
-        jQuery('.sonata-ba-form form').each(function () { $(this).confirmExit(); });
+        jQuery('.sonata-ba-form form').each(function () { jQuery(this).confirmExit(); });
     }
 
     Admin.setup_per_page_switcher(document);
@@ -332,7 +332,7 @@ var Admin = {
             Admin.switch_inline_form_errors(jQuery(this));
         });
 
-        $(subject).on('change', deleteCheckboxSelector, function() {
+        jQuery(subject).on('change', deleteCheckboxSelector, function() {
             Admin.switch_inline_form_errors(jQuery(this));
         });
     },


### PR DESCRIPTION
When you use 2 different jQuery initializations (when you use RequireJS) the $ sign becomes out of scope when select2's are initiated, using jQuery instead of $ will fix this.
