### PR TITLE
Update block_admin_list.html.twig - translation

### DIFF
--- a/Resources/views/Block/block_admin_list.html.twig
+++ b/Resources/views/Block/block_admin_list.html.twig
@@ -49,7 +49,7 @@ file that was distributed with this source code.
                                             <ul class="dropdown-menu">
                                                 {% for subclass in admin.subclasses|keys %}
                                                     <li>
-                                                        <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">{{ subclass }}</a>
+                                                        <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">{{ subclass|trans({}, admin.translationdomain) }}</a>
                                                     </li>
                                                 {% endfor %}
                                             </ul>


### PR DESCRIPTION
Subclass is not translated like in SonataAdmin:Button:create_button.html.twig