### PR TITLE
Log warning if the primary template throws error and the default template is used instead

### DIFF
--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -9,6 +9,7 @@
             <tag name="twig.extension"/>
 
             <argument type="service" id="sonata.admin.pool" />
+            <argument type="service" id="logger" on-invalid="ignore" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1143 |
| License | MIT |
