### PR TITLE
Added warning if javascript is not enabled

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -341,3 +341,13 @@ legend.sonata-ba-fieldset-collapsed-description + .sonata-ba-collapsed-fields {
 .form-horizontal .control-group {
     margin-bottom: 10px;
 }
+
+.noscript-warning {
+    background-color: #C70A0A;
+    color: #FFFFFF;
+    font-size: 14px;
+    font-weight: bold;
+    padding: 4px 0;
+    text-align: center;
+    width: 100%;
+}

--- a/Resources/translations/SonataAdminBundle.ar.xliff
+++ b/Resources/translations/SonataAdminBundle.ar.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>لائحة العمليات</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.bg.xliff
+++ b/Resources/translations/SonataAdminBundle.bg.xliff
@@ -390,6 +390,10 @@
                 <source>link_actions</source>
                 <target>link_actions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/Resources/translations/SonataAdminBundle.ca.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>Accions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/Resources/translations/SonataAdminBundle.cs.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>Akce</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>Javascript je zakázán ve vašem webovém prohlížeči. Některé funkce nebudou pracovat správně.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>Aktionen</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -402,6 +402,10 @@
                 <source>link_actions</source>
                 <target>Actions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>Javascript is disabled in your web browser. Some features will not work properly.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.es.xliff
+++ b/Resources/translations/SonataAdminBundle.es.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>Acciones</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.eu.xliff
+++ b/Resources/translations/SonataAdminBundle.eu.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>link_actions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.fa.xliff
+++ b/Resources/translations/SonataAdminBundle.fa.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>link_actions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>Liste d'actions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>link_actions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.hu.xliff
+++ b/Resources/translations/SonataAdminBundle.hu.xliff
@@ -402,6 +402,10 @@
                 <source>link_actions</source>
                 <target>Műveletek</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>Azioni</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/Resources/translations/SonataAdminBundle.ja.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>link_actions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/Resources/translations/SonataAdminBundle.lb.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>link_actions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.lt.xliff
+++ b/Resources/translations/SonataAdminBundle.lt.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>Veiksmai</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -402,6 +402,10 @@
                 <source>link_actions</source>
                 <target>Acties</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -398,6 +398,10 @@
                 <source>link_actions</source>
                 <target>Akcje</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pt.xliff
+++ b/Resources/translations/SonataAdminBundle.pt.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>link_actions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>Ações</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ro.xliff
+++ b/Resources/translations/SonataAdminBundle.ro.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>link_actions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>Действия</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/Resources/translations/SonataAdminBundle.sk.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>Akcie</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>Javascript je zakázaný vo vašom webovom prehliadači. Niektoré funkcie nebudú pracovať správne.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/Resources/translations/SonataAdminBundle.sl.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>link_actions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/Resources/translations/SonataAdminBundle.uk.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>link_actions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -394,6 +394,10 @@
                 <source>link_actions</source>
                 <target>link_actions</target>
             </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>noscript_warning</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -90,6 +90,13 @@ file that was distributed with this source code.
     <body {% block body_attributes %}class="sonata-bc skin-black fixed"{% endblock %}>
         {% block sonata_header %}
             <header class="header">
+                {% block sonata_header_noscript_warning %}
+                    <noscript>
+                        <div class="noscript-warning">
+                            {{ 'noscript_warning'|trans({}, 'SonataAdminBundle') }}
+                        </div>
+                    </noscript>
+                {% endblock %}
                 {% block logo %}
                     {% spaceless %}
                     <a class="logo" href="{{ url('sonata_admin_dashboard') }}">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

We have a lot of javascript functionality in SonataAdmin. This PR adds a warning for users, that don't have the javascript enabled.

![js_warning](https://cloud.githubusercontent.com/assets/960844/4176626/c2208438-360d-11e4-847b-c769fcfac455.jpg)
