### PR TITLE
Validate admin service id

### DIFF
--- a/Admin/Pool.php
+++ b/Admin/Pool.php
@@ -67,6 +67,7 @@ class Pool
      * Returns whether an admin group exists or not.
      *
      * @param string $group
+     *
      * @return bool
      */
     public function hasGroup($group)
@@ -106,7 +107,9 @@ class Pool
      * Returns all admins related to the given $group
      *
      * @param string $group
+     *
      * @return array
+     *
      * @throws \InvalidArgumentException
      */
     public function getAdminsByGroup($group)
@@ -129,7 +132,7 @@ class Pool
     }
 
     /**
-     * return the admin related to the given $class
+     * Return the admin related to the given $class
      *
      * @param string $class
      *
@@ -191,9 +194,15 @@ class Pool
      * @param string $id
      *
      * @return \Sonata\AdminBundle\Admin\AdminInterface
+     *
+     * @throws \InvalidArgumentException
      */
     public function getInstance($id)
     {
+        if (!in_array($id, $this->adminServiceIds)) {
+            throw new \InvalidArgumentException(sprintf('Admin service "%s" not found in admin pool.', $id));
+        }
+
         return $this->container->get($id);
     }
 

--- a/Tests/Admin/PoolTest.php
+++ b/Tests/Admin/PoolTest.php
@@ -27,6 +27,8 @@ class PoolTest extends \PHPUnit_Framework_TestCase
 
     public function testGetGroups()
     {
+        $this->pool->setAdminServiceIds(array('sonata.user.admin.group1'));
+
         $this->pool->setAdminGroups(array(
             'adminGroup1' => array('sonata.user.admin.group1' => array())
         ));
@@ -52,7 +54,6 @@ class PoolTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDashboardGroups()
     {
-
         $admin_group1 = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin_group1->expects($this->once())->method('showIn')->will($this->returnValue(true));
 
@@ -69,6 +70,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         ));
 
         $pool = new Pool($container, 'Sonata Admin', '/path/to/pic.png');
+        $pool->setAdminServiceIds(array('sonata.user.admin.group1', 'sonata.user.admin.group2', 'sonata.user.admin.group3'));
 
         $pool->setAdminGroups(array(
             'adminGroup1' => array(
@@ -110,6 +112,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAdminsByGroup()
     {
+        $this->pool->setAdminServiceIds(array('sonata.admin1', 'sonata.admin2', 'sonata.admin3'));
         $this->pool->setAdminGroups(array(
             'adminGroup1' => array('items' => array('sonata.admin1', 'sonata.admin2')),
             'adminGroup2' => array('items' => array('sonata.admin3'))
@@ -151,13 +154,24 @@ class PoolTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAdminForClassWhenAdminClassIsSet()
     {
+        $this->pool->setAdminServiceIds(array('sonata.user.admin.group1'));
         $this->pool->setAdminClasses(array('someclass' => array('sonata.user.admin.group1')));
         $this->assertTrue($this->pool->hasAdminByClass('someclass'));
         $this->assertEquals('adminUserClass', $this->pool->getAdminByClass('someclass'));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Admin service "sonata.news.admin.post" not found in admin pool.
+     */
+    public function testGetInstanceWithUndefinedServiceId()
+    {
+        $this->pool->getInstance('sonata.news.admin.post');
+    }
+
     public function testGetAdminByAdminCode()
     {
+        $this->pool->setAdminServiceIds(array('sonata.news.admin.post'));
         $this->assertEquals('adminUserClass', $this->pool->getAdminByAdminCode('sonata.news.admin.post'));
     }
 
@@ -180,6 +194,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($adminMock));
 
         $this->pool = new Pool($containerMock, 'Sonata', '/path/to/logo.png');
+        $this->pool->setAdminServiceIds(array('sonata.news.admin.post'));
 
         $this->assertEquals('commentAdminClass', $this->pool->getAdminByAdminCode('sonata.news.admin.post|sonata.news.admin.comment'));
     }

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -106,6 +106,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->request = new Request();
         $this->pool = new Pool($this->container, 'title', 'logo.png');
+        $this->pool->setAdminServiceIds(array('foo.admin'));
         $this->request->attributes->set('_sonata_admin', 'foo.admin');
         $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
         $this->parameters = array();
@@ -427,6 +428,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('RuntimeException', 'Unable to find the admin class related to the current controller (Sonata\AdminBundle\Controller\CRUDController)');
 
+        $this->pool->setAdminServiceIds(array('nonexistent.admin'));
         $this->request->attributes->set('_sonata_admin', 'nonexistent.admin');
         $this->protectedTestedMethods['configure']->invoke($this->controller);
     }

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -77,13 +77,14 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
     public function testgetShortObjectDescriptionActionInvalidAdmin()
     {
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $twig = new Twig;
+        $twig = new Twig();
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
             'uniqid'   => 'asdasd123'
         ));
         $pool = new Pool($container, 'title', 'logo');
+        $pool->setAdminServiceIds(array('sonata.post.admin'));
         $helper = new AdminHelper($pool);
         $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
         $controller = new HelperController($twig, $pool, $helper, $validator);
@@ -104,7 +105,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
-        $twig = new Twig;
+        $twig = new Twig();
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
@@ -112,6 +113,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $pool = new Pool($container, 'title', 'logo');
+        $pool->setAdminServiceIds(array('sonata.post.admin'));
 
         $helper = new AdminHelper($pool);
 
@@ -130,7 +132,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
-        $twig = new Twig;
+        $twig = new Twig();
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => "",
@@ -139,6 +141,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $pool = new Pool($container, 'title', 'logo');
+        $pool->setAdminServiceIds(array('sonata.post.admin'));
 
         $helper = new AdminHelper($pool);
 
@@ -155,7 +158,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('setUniqid');
         $admin->expects($this->once())->method('getTemplate')->will($this->returnValue($mockTemplate));
-        $admin->expects($this->once())->method('getObject')->will($this->returnValue(new AdminControllerHelper_Foo));
+        $admin->expects($this->once())->method('getObject')->will($this->returnValue(new AdminControllerHelper_Foo()));
         $admin->expects($this->once())->method('toString')->will($this->returnValue('bar'));
         $admin->expects($this->once())->method('generateObjectUrl')->will($this->returnCallback(function($type, $object, $parameters = array()) {
             if ($type != 'edit') {
@@ -172,7 +175,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $twig->expects($this->once())->method('render')
             ->with($mockTemplate)
-            ->will($this->returnCallback(function($templateName, $templateParams) {
+            ->will($this->returnCallback(function ($templateName, $templateParams) {
                 return sprintf('<a href="%s" target="new">%s</a>', $templateParams['admin']->generateObjectUrl('edit', $templateParams['object']), $templateParams['description']);
             }));
 
@@ -184,6 +187,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $pool = new Pool($container, 'title', 'logo');
+        $pool->setAdminServiceIds(array('sonata.post.admin'));
 
         $helper = new AdminHelper($pool);
 
@@ -199,7 +203,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testsetObjectFieldValueAction()
     {
-        $object = new AdminControllerHelper_Foo;
+        $object = new AdminControllerHelper_Foo();
 
         $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getOption')->will($this->returnValue(true));
@@ -216,7 +220,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $adminExtension->expects($this->once())->method('getName')->will($this->returnValue('sonata_admin'));
         $adminExtension->expects($this->once())->method('renderListElement')->will($this->returnValue('<foo />'));
 
-        $twig = new Twig;
+        $twig = new Twig();
         $twig->addExtension($adminExtension);
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
@@ -227,6 +231,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'));
 
         $pool = new Pool($container, 'title', 'logo');
+        $pool->setAdminServiceIds(array('sonata.post.admin'));
 
         $helper = new AdminHelper($pool);
 
@@ -241,7 +246,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testappendFormFieldElementAction()
     {
-        $object = new AdminControllerHelper_Foo;
+        $object = new AdminControllerHelper_Foo();
 
         $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->once())->method('find')->will($this->returnValue($object));
@@ -265,7 +270,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $mockRenderer->expects($this->once())
             ->method('searchAndRenderBlock')
-            ->will($this->returnValue(new Response));
+            ->will($this->returnValue(new Response()));
 
         $formExtension = $this->getMock('Twig_ExtensionInterface', array('renderListElement', 'initRuntime', 'getTokenParsers', 'getNodeVisitors', 'getFilters', 'getTests', 'getFunctions', 'getOperators', 'getGlobals', 'getName'));
 
@@ -274,7 +279,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $formExtension->expects($this->never())->method('setTheme');
         $formExtension->renderer = $mockRenderer;
 
-        $twig = new Twig;
+        $twig = new Twig();
         $twig->addExtension($formExtension);
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
@@ -285,6 +290,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'POST'));
 
         $pool = new Pool($container, 'title', 'logo');
+        $pool->setAdminServiceIds(array('sonata.post.admin'));
 
         $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
 
@@ -314,7 +320,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testretrieveFormFieldElementAction()
     {
-        $object = new AdminControllerHelper_Foo;
+        $object = new AdminControllerHelper_Foo();
 
         $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->once())->method('find')->will($this->returnValue($object));
@@ -348,7 +354,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $mockRenderer->expects($this->once())
             ->method('searchAndRenderBlock')
-            ->will($this->returnValue(new Response));
+            ->will($this->returnValue(new Response()));
 
         $formExtension = $this->getMock('Twig_ExtensionInterface', array('renderListElement', 'initRuntime', 'getTokenParsers', 'getNodeVisitors', 'getFilters', 'getTests', 'getFunctions', 'getOperators', 'getGlobals', 'getName'));
         $formExtension->expects($this->once())->method('getName')->will($this->returnValue('form'));
@@ -356,7 +362,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $formExtension->expects($this->never())->method('setTheme');
         $formExtension->renderer = $mockRenderer;
 
-        $twig = new Twig;
+        $twig = new Twig();
         $twig->addExtension($formExtension);
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
@@ -367,6 +373,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'POST'));
 
         $pool = new Pool($container, 'title', 'logo');
+        $pool->setAdminServiceIds(array('sonata.post.admin'));
 
         $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
 
@@ -385,7 +392,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
     {
         $bar = new AdminControllerHelper_Bar();
 
-        $object = new AdminControllerHelper_Foo;
+        $object = new AdminControllerHelper_Foo();
         $object->setBar($bar);
 
         $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
@@ -399,7 +406,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
-        $twig = new Twig;
+        $twig = new Twig();
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
@@ -409,6 +416,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'));
 
         $pool = new Pool($container, 'title', 'logo');
+        $pool->setAdminServiceIds(array('sonata.post.admin'));
 
         $helper = new AdminHelper($pool);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1337 |
| License | MIT |

As mentioned in ticket #1337, the admin service id should be validated before requesting the service from the container.
