### PR TITLE
Bootstrap radio-buttons toggle issue

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -216,8 +216,6 @@ class Configuration implements ConfigurationInterface
 
                                 'bundles/sonatacore/vendor/moment/min/moment.min.js',
 
-                                'bundles/sonataadmin/vendor/bootstrap/dist/js/bootstrap.min.js',
-
                                 'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js',
 
                                 'bundles/sonataadmin/vendor/jqueryui/ui/minified/jquery-ui.min.js',
@@ -226,6 +224,7 @@ class Configuration implements ConfigurationInterface
                                 'bundles/sonataadmin/jquery/jquery.form.js',
                                 'bundles/sonataadmin/jquery/jquery.confirmExit.js',
 
+                                'bundles/sonataadmin/vendor/bootstrap/dist/js/bootstrap.min.js',
                                 'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/js/bootstrap-editable.min.js',
 
                                 'bundles/sonataadmin/vendor/select2/select2.min.js',


### PR DESCRIPTION
bootstrap button groups (option) are not working anymore: http://stackoverflow.com/a/13539923/1232436

i know that this is the opposite of this issue: https://github.com/sonata-project/SonataAdminBundle/commit/a9b73cc48dc9bf7a33a2c31143a8a9d68aaa38b3

but i think there can be used the bootstrap dialog instead of the jquery ui dialog. (which would make more sense anyway)
