### PR TITLE
fix buildShow bug

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -753,6 +753,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         $this->show = new FieldDescriptionCollection();
         $mapper = new ShowMapper($this->showBuilder, $this->show, $this);
 
+        $this->configureShowField($mapper); // necessary
         $this->configureShowFields($mapper);
 
         foreach ($this->getExtensions() as $extension) {


### PR DESCRIPTION
"$this->configureShowField($mapper)" in buildShow action was removed at the last version because was declared deprecated but this line it's necessary to display the "show screen" with the entity attributes, or the screen will display nothing
