### PR TITLE
Fix parent filter showing up when showing child list

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -887,7 +887,8 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         // ok, try to limit to add parent filter
         if ($this->isChild() && $this->getParentAssociationMapping() && !$mapper->has($this->getParentAssociationMapping())) {
             $mapper->add($this->getParentAssociationMapping(), null, array(
-                'field_type' => 'sonata_type_model_reference',
+                'label' => false,
+                'field_type' => 'sonata_type_model_hidden',
                 'field_options' => array(
                     'model_manager' => $this->getModelManager()
                 ),

--- a/Filter/FilterInterface.php
+++ b/Filter/FilterInterface.php
@@ -54,7 +54,7 @@ interface FilterInterface
     /**
      * Returns the label name
      *
-     * @return string
+     * @return string|bool
      */
     public function getLabel();
 

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -221,7 +221,9 @@ file that was distributed with this source code.
                                 <div class="filter_container">
                                     {% for filter in admin.datagrid.filters %}
                                         <div class="form-group" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ filter.options['show_filter'] ? 'true' : 'false' }}" style="display: {% if filter.isActive() and filter.options['show_filter'] %}block{% else %}none{% endif %}">
+                                            {% if filter.label is not sameas(false) %}
                                             <label for="{{ form.children[filter.formName].children['value'].vars.id }}" class="col-sm-3 control-label">{{ admin.trans(filter.label, {}, filter.translationDomain) }}</label>
+                                            {% endif %}
                                             {% set attr = form.children[filter.formName].children['type'].vars.attr|default({}) %}
                                             {#{% set attr = attr|merge({'class': (attr.class|default('') ~ ' sonata-filter-option')|trim}) %}#}
 


### PR DESCRIPTION
This fixes https://github.com/sonata-project/SonataAdminBundle/issues/2154.

Depends on:

https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/387
https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/122
https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/299
https://github.com/sonata-project/SonataPropelAdminBundle/pull/53
