### PR TITLE
[2.3] Log previous exceptions

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -184,6 +184,15 @@ class CRUDController extends Controller
         return parent::render($view, $parameters, $response);
     }
 
+    private function logModelManagerException($e)
+    {
+        $context = array('exception' => $e);
+        if ($e->getPrevious()) {
+            $context['previous_exception_message'] = $e->getPrevious()->getMessage();
+        }
+        $this->getLogger()->error($e->getMessage(), $context);
+    }
+
     /**
      * List action
      *
@@ -231,7 +240,8 @@ class CRUDController extends Controller
             $modelManager->batchDelete($this->admin->getClass(), $query);
             $this->addFlash('sonata_flash_success', 'flash_batch_delete_success');
         } catch (ModelManagerException $e) {
-            $this->getLogger()->error($e->getMessage());
+
+            $this->logModelManagerException($e);
             $this->addFlash('sonata_flash_error', 'flash_batch_delete_error');
         }
 
@@ -285,7 +295,7 @@ class CRUDController extends Controller
                 );
 
             } catch (ModelManagerException $e) {
-                $this->getLogger()->error($e->getMessage());
+                $this->logModelManagerException($e);
 
                 if ($this->isXmlHttpRequest()) {
                     return $this->renderJson(array('result' => 'error'));
@@ -374,7 +384,7 @@ class CRUDController extends Controller
                     return $this->redirectTo($object);
 
                 } catch (ModelManagerException $e) {
-                    $this->getLogger()->error($e->getMessage());
+                    $this->logModelManagerException($e);
 
                     $isFormValid = false;
                 }
@@ -618,7 +628,7 @@ class CRUDController extends Controller
                     return $this->redirectTo($object);
 
                 } catch (ModelManagerException $e) {
-                    $this->getLogger()->error($e->getMessage());
+                    $this->logModelManagerException($e);
 
                     $isFormValid = false;
                 }


### PR DESCRIPTION
This is #2438 + 1 commit : b931601 . This commit adds two things to the log context array : 
- an `exception` key, that as you can read in [the PSR-3 spec](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#13-context), can be useful to get a nice stack trace (if you are things like ELK or Sentry).
- a `previous_exception_message`, that contains the previous exception message when available. This is very important, because the `ModelManagerException` exception messages are not very helpful. It is something among the lines of

> Failed to create some object

while the previous exception is from the storage layer, describing something like : 

> Unicity constraint for some_column failed

is way more useful. Let's log it.
