### PR TITLE
[2.3] Replaced parent 'text' with 'hidden' in sonata_type_model_list

### DIFF
--- a/Form/Type/ModelTypeList.php
+++ b/Form/Type/ModelTypeList.php
@@ -61,7 +61,6 @@ class ModelTypeList extends AbstractType
         $resolver->setDefaults(array(
             'model_manager'     => null,
             'class'             => null,
-            'parent'            => 'text',
             'btn_add'           => 'link_add',
             'btn_list'          => 'link_list',
             'btn_delete'        => 'link_delete',
@@ -74,7 +73,7 @@ class ModelTypeList extends AbstractType
      */
     public function getParent()
     {
-        return 'text';
+        return 'hidden';
     }
 
     /**


### PR DESCRIPTION
Removed unneeded "parent" option from sonata_type_model_list

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1994, sonata-project/SonataDoctrineORMAdminBundle#257 |
| License | MIT |

PR for branch 2.3
