### PR TITLE
Update base_list.html.twig

### DIFF
--- a/Resources/public/css/tree.css
+++ b/Resources/public/css/tree.css
@@ -7,6 +7,8 @@
     padding-left: 0;
     margin-left: 15px;
     margin-right: 15px;
+    overflow: hidden;
+    padding-bottom: 10px;
 }
 .sonata-tree ul {
     list-style: none;
@@ -89,10 +91,6 @@
 /**
  * Toggleable tree
  */
-.sonata-tree--toggleable {
-    margin-left: 0;
-}
-
 .sonata-tree--toggleable li > ul {
     display: none;
 }
@@ -118,6 +116,10 @@
 /**
  * Smaller tree
  */
+.sonata-tree--small {
+    margin-left: 0;
+}
+
 .sonata-tree--small .sonata-tree__item__edit {
     font-size: 12px;
 }

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -35,7 +35,7 @@ file that was distributed with this source code.
                     <form action="{{ admin.generateUrl('batch', {'filter': admin.filterParameters}) }}" method="POST" >
                         <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
                     {% endif %}
-                        <table class="table table-bordered table-striped">
+                        <table class="{% block sonata_list_table_class %}table table-bordered table-striped{% endblock %}">
                             {% block table_header %}
                                 <thead>
                                     <tr class="sonata-ba-list-field-header">
@@ -61,10 +61,17 @@ file that was distributed with this source code.
                                                 {% endif %}
 
                                                 {% spaceless %}
-                                                    <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}">
-                                                        {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters) }}">{% endif %}
+                                                    <th class="
+                                                        {%- block sonata_list_table_header_th_class -%}
+                                                            sonata-ba-list-field-header-{{ field_description.type}} 
+                                                            {%- if sortable -%}
+                                                                sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}
+                                                            {%- endif -%}
+                                                        {%- endblock %}" {% block sonata_list_table_header_th_attribute %}{% endblock -%}
+                                                        >
+                                                        {%- if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters) }}">{% endif -%}
                                                         {{ admin.trans(field_description.label, {}, field_description.translationDomain) }}
-                                                        {% if sortable %}</a>{% endif %}
+                                                        {%- if sortable %}</a>{% endif -%}
                                                     </th>
                                                 {% endspaceless %}
                                             {% endif %}


### PR DESCRIPTION
The additional blocks will allow adding attributes and additional classes to <table> and <th> tags without needed to make a copy the whole view. I'm interested in this because I'd like to use the FooTable.js library, which uses data attributes to set the auto-show/hide for each column (for responsive tables).

If it's of interest, I could create a pull request with the templating code that I'm adding into the <th> tags. It allows the attributes on the tag to be set per field by specifying as an option within the Admin class. I.e., 'th_attributes' => array('name' => 'value', ...)

Here's the additional code that could be included within the <th> tag: {% if field_description.options.th_attributes is defined %}{% for th_attribute, th_attribute_value in field_description.options.th_attributes %}{{ th_attribute }}={{th_attribute_value}}{% endfor %}{% endif %}
