### PR TITLE
List editable choice

### DIFF
--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -4,12 +4,37 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="sonata.admin.twig.extension.x_editable_type_mapping" type="collection">
+            <parameter key="choice">select</parameter>
+            <parameter key="boolean">select</parameter>
+            <parameter key="text">text</parameter>
+            <parameter key="textarea">textarea</parameter>
+            <parameter key="html">textarea</parameter>
+            <parameter key="email">email</parameter>
+            <parameter key="string">text</parameter>
+            <parameter key="smallint">text</parameter>
+            <parameter key="bigint">text</parameter>
+            <parameter key="integer">number</parameter>
+            <parameter key="decimal">number</parameter>
+            <parameter key="currency">number</parameter>
+            <parameter key="percent">number</parameter>
+            <parameter key="url">url</parameter>
+            <parameter key="date">date</parameter>
+        </parameter>
+    </parameters>
+
     <services>
         <service id="sonata.admin.twig.extension" class="Sonata\AdminBundle\Twig\Extension\SonataAdminExtension">
             <tag name="twig.extension"/>
 
             <argument type="service" id="sonata.admin.pool" />
             <argument type="service" id="logger" on-invalid="ignore" />
+
+            <call method="setXEditableTypeMapping">
+                <argument>%sonata.admin.twig.extension.x_editable_type_mapping%</argument>
+            </call>
+
         </service>
     </services>
 </container>

--- a/Resources/views/CRUD/list_choice.html.twig
+++ b/Resources/views/CRUD/list_choice.html.twig
@@ -11,9 +11,25 @@ file that was distributed with this source code.
 
 {% extends admin.getTemplate('base_list_field') %}
 
+{% set is_editable =
+    field_description.options.editable is defined and
+    field_description.options.editable and
+    admin.isGranted('EDIT', object)
+%}
+{% set x_editable_type = field_description.type|sonata_xeditable_type %}
+
+{% if is_editable and x_editable_type %}
+    {% block field_span_attributes %}
+        {% spaceless %}
+            {{ parent() }}
+            data-source="{{ field_description|sonata_xeditable_choices|json_encode }}"
+        {% endspaceless %}
+    {% endblock %}
+{% endif %}
+
 {% block field %}
 {% spaceless %}
-    {% if field_description.options.choices  is defined %}
+    {% if field_description.options.choices is defined %}
         {% if field_description.options.multiple is defined and field_description.options.multiple==true and value is iterable %}
 
             {% set result = '' %}

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -36,6 +36,11 @@ class SonataAdminExtension extends \Twig_Extension
     protected $logger;
 
     /**
+     * @var string[]
+     */
+    private $xEditableTypeMapping = array();
+
+    /**
      * @param Pool            $pool
      * @param LoggerInterface $logger
      */
@@ -391,29 +396,20 @@ EOT;
     }
 
     /**
+     * @param array $xEditableTypeMapping
+     */
+    public function setXEditableTypeMapping($xEditableTypeMapping)
+    {
+        $this->xEditableTypeMapping = $xEditableTypeMapping;
+    }
+
+    /**
      * @param $type
      *
      * @return string|bool
      */
     public function getXEditableType($type)
     {
-        $mapping = array(
-            'boolean'    => 'select',
-            'text'       => 'text',
-            'textarea'   => 'textarea',
-            'html'       => 'textarea',
-            'email'      => 'email',
-            'string'     => 'text',
-            'smallint'   => 'text',
-            'bigint'     => 'text',
-            'integer'    => 'number',
-            'decimal'    => 'number',
-            'currency'   => 'number',
-            'percent'    => 'number',
-            'url'        => 'url',
-            'date'       => 'date',
-        );
-
-        return isset($mapping[$type]) ? $mapping[$type] : false;
+        return isset($this->xEditableTypeMapping[$type]) ? $this->xEditableTypeMapping[$type] : false;
     }
 }

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -92,6 +92,10 @@ class SonataAdminExtension extends \Twig_Extension
                 'sonata_xeditable_type',
                 array($this, 'getXEditableType')
             ),
+            new \Twig_SimpleFilter(
+                'sonata_xeditable_choices',
+                array($this, 'getXEditableChoices')
+            ),
         );
     }
 
@@ -396,7 +400,7 @@ EOT;
     }
 
     /**
-     * @param array $xEditableTypeMapping
+     * @param string[] $xEditableTypeMapping
      */
     public function setXEditableTypeMapping($xEditableTypeMapping)
     {
@@ -411,5 +415,41 @@ EOT;
     public function getXEditableType($type)
     {
         return isset($this->xEditableTypeMapping[$type]) ? $this->xEditableTypeMapping[$type] : false;
+    }
+
+    /**
+     * Return xEditable choices based on the field description choices options & catalogue options.
+     * With the following choice options:
+     *     ['Status1' => 'Alias1', 'Status2' => 'Alias2']
+     * The method will return:
+     *     [['value' => 'Status1', 'text' => 'Alias1'], ['value' => 'Status2', 'text' => 'Alias2']].
+     *
+     * @param FieldDescriptionInterface $fieldDescription
+     *
+     * @return array
+     */
+    public function getXEditableChoices(FieldDescriptionInterface $fieldDescription)
+    {
+        $choices   = $fieldDescription->getOption('choices', array());
+        $catalogue = $fieldDescription->getOption('catalogue');
+        $xEditableChoices = array();
+        if (!empty($choices)) {
+            reset($choices);
+            $first = current($choices);
+            // the choices are already in the right format
+            if (is_array($first) && array_key_exists('value', $first) && array_key_exists('text', $first)) {
+                $xEditableChoices = $choices;
+            } else {
+                foreach ($choices as $value => $text) {
+                    $text = $catalogue ? $fieldDescription->getAdmin()->trans($text, array(), $catalogue) : $text;
+                    $xEditableChoices[] = array(
+                        'value' => $value,
+                        'text'  => $text,
+                    );
+                }
+            }
+        }
+
+        return $xEditableChoices;
     }
 }


### PR DESCRIPTION
Add x-editable support for (non multiple) choice in lists, this feature was once mentioned in #1867 by @EmmanuelVella  and also requested in #2269.
Multiple choice may require more work though.

First thing was to move the `x-editable` types mapping to the **parameters**, *imho* its was pretty annoying to have it hard-coded in the twig extension. Especially if you need to add more editable types in your project.

The behaviour is quite similar to the way `booleans` were handled. 
```php
    protected function configureListFields(ListMapper $list)
    {
        $list
            ->add('status', 'choice',
                [
                    'editable' => true,
                    'choices' => ['Status1' => 'Alias1', 'Status2' => 'Alias2'],
                    'catalogue' =>'admin'
                ]
            );
    }
```

The tricky part is to transform the provided **choices** options into something that can be fed to the `x-editable` widget : 
### Choices
```php
['Status1' => 'Alias1', 'Status2' => 'Alias2']
```
### X-editable choices
```php
[['value' => 'Status1', 'text' => 'Alias1'], ['value' => 'Status2', 'text' => 'Alias2']]
```
This is working pretty well for `enum` like `array`, but It might be interesting to handle more inputs, like `ArrayCollection`. 
How would you guys do to handle such cases?

Any feedbacks welcome.