### PR TITLE
Add an ``edit`` button in sonata_type_model form

### DIFF
--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -54,6 +54,7 @@ class ModelType extends AbstractType
     {
         $view->vars['btn_add'] = $options['btn_add'];
         $view->vars['btn_list'] = $options['btn_list'];
+        $view->vars['btn_edit'] = $options['btn_edit'];
         $view->vars['btn_delete'] = $options['btn_delete'];
         $view->vars['btn_catalogue'] = $options['btn_catalogue'];
     }
@@ -93,8 +94,11 @@ class ModelType extends AbstractType
             'query'             => null,
             'choices'           => null,
             'preferred_choices' => array(),
+            'route_generator'   => null,
+            'route_edit_name'   => null,
             'btn_add'           => 'link_add',
             'btn_list'          => 'link_list',
+            'btn_edit'          => 'link_edit',
             'btn_delete'        => 'link_delete',
             'btn_catalogue'     => 'SonataAdminBundle',
             'choice_list'       => function (Options $options, $previousValue) {
@@ -107,7 +111,9 @@ class ModelType extends AbstractType
                     $options['class'],
                     $options['property'],
                     $options['query'],
-                    $options['choices']
+                    $options['choices'],
+                    $options['route_generator'],
+                    $options['route_edit_name']
                 );
             }
         ));

--- a/Form/View/ChoiceView.php
+++ b/Form/View/ChoiceView.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+namespace Sonata\AdminBundle\Form\View;
+
+use Symfony\Component\Form\Extension\Core\View\ChoiceView as BaseView;
+
+/**
+ * Represents a choice in templates with specific attributes
+ */
+class ChoiceView extends BaseView
+{
+    /**
+     * Some attributes, like routes
+     *
+     * @var array
+     */
+    public $attributes = array();
+
+    /**
+     * Creates a new ChoiceView.
+     *
+     * @param mixed  $data  The original choice.
+     * @param string $value The view representation of the choice.
+     * @param string $label The label displayed to humans.
+     * @param array  $attributes Specific attributes of the choice
+     */
+    public function __construct($data, $value, $label, array $attributes = array())
+    {
+        parent::__construct($data, $value, $label);
+        $this->attributes = $attributes;
+    }
+}

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -80,8 +80,8 @@ class
   calculated from the linked Admin class. You usually should not need to set
   this manually.
 
-btn_add, btn_list, btn_delete and btn_catalogue:
-  The labels on the ``add``, ``list`` and ``delete`` buttons can be customized
+btn_add, btn_edit, btn_list, btn_delete and btn_catalogue:
+  The labels on the ``add``, ``edit``, ``list`` and ``delete`` buttons can be customized
   with these parameters. Setting any of them to ``false`` will hide the
   corresponding button. You can also specify a custom translation catalogue
   for these labels, which defaults to ``SonataAdminBundle``.
@@ -344,8 +344,8 @@ delete
   defaults to true and indicates that a 'delete' checkbox should be shown allowing
   the user to delete the linked object.
 
-btn_add, btn_list, btn_delete and btn_catalogue:
-  The labels on the ``add``, ``list`` and ``delete`` buttons can be customized
+btn_add, btn_edit, btn_list, btn_delete and btn_catalogue:
+  The labels on the ``add``, ``edit``, ``list`` and ``delete`` buttons can be customized
   with these parameters. Setting any of them to ``false`` will hide the
   corresponding button. You can also specify a custom translation catalogue
   for these labels, which defaults to ``SonataAdminBundle``.

--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -23,6 +23,7 @@ jQuery(document).ready(function() {
 jQuery(document).on('sonata-admin-append-form-element', function(e) {
     Admin.setup_select2(e.target);
     Admin.setup_icheck(e.target);
+    Admin.setup_select(e.target);
 });
 
 var Admin = {
@@ -45,6 +46,7 @@ var Admin = {
         Admin.setup_form_tabs_for_errors(subject);
         Admin.setup_inline_form_errors(subject);
         Admin.setup_tree_view(subject);
+        Admin.setup_select(subject);
 
 //        Admin.setup_list_modal(subject);
     },
@@ -69,6 +71,45 @@ var Admin = {
             overflow: 'scroll'
         });
     },
+    
+    setup_select: function(subject) {
+       jQuery('select', subject).each(function() {
+            var select = jQuery(this);
+            var fieldContainer = select.closest('div[class="field-container"]');
+            var editBtn = fieldContainer.find('a[class~="sonata_model_edit_btn"]');
+
+            if (editBtn.length) {
+                editBtn.rewriteBtn = function(choice) {
+                    if (choice) {
+                        var href = jQuery(choice).attr('data-sonata-admin-edit-href');
+                        if (href !== undefined && href !== '') {
+                            this.removeClass('disabled');
+                            this.attr('href', href);
+                            return;
+                        }
+                    }
+                    // disable edit link if choice is invalid or removed
+                    this.addClass('disabled');
+                    this.attr('href', null);
+                };
+                
+                // if an entity is already selected
+                var choice = select.find('option:selected:last');
+                editBtn.rewriteBtn(choice);
+                
+                // other cases
+                select.on('change', {btn : editBtn}, function(event) {
+                    Admin.stopEvent(event);
+                    var choice = null;
+                    if (event.added) {
+                        choice = event.added.element[event.added.element.length - 1];
+                    }
+                    editBtn.rewriteBtn(choice);
+                });
+            }
+        });
+    },
+            
     setup_select2: function(subject) {
         if (window.SONATA_CONFIG && window.SONATA_CONFIG.USE_SELECT2 && window.Select2) {
             Admin.log('[core|setup_select2] configure Select2 on', subject);

--- a/Resources/translations/SonataAdminBundle.ar.xliff
+++ b/Resources/translations/SonataAdminBundle.ar.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>إضافة جديدة</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>تعديل</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>قائمة</target>

--- a/Resources/translations/SonataAdminBundle.bg.xliff
+++ b/Resources/translations/SonataAdminBundle.bg.xliff
@@ -66,6 +66,10 @@
                 <source>link_add</source>
                 <target>Добавяне</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Редактиране</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Преглед</target>

--- a/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/Resources/translations/SonataAdminBundle.ca.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Afegeix</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Edita</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Llista</target>

--- a/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/Resources/translations/SonataAdminBundle.cs.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Přidat nový</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Upravit</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Výpis</target>

--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Neu</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Bearbeiten</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Liste</target>

--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Add new</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Edit</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>List</target>

--- a/Resources/translations/SonataAdminBundle.es.xliff
+++ b/Resources/translations/SonataAdminBundle.es.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Agregar nuevo</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Editar</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Listar</target>

--- a/Resources/translations/SonataAdminBundle.eu.xliff
+++ b/Resources/translations/SonataAdminBundle.eu.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Berria gehitu</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Editatu</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Zerrenda ikusi</target>

--- a/Resources/translations/SonataAdminBundle.fa.xliff
+++ b/Resources/translations/SonataAdminBundle.fa.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>اضافه کردن جدید</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>ویرایش</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>لیست</target>

--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Ajouter</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Editer</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Liste</target>

--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Novi unos</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Promijeni</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Lista</target>

--- a/Resources/translations/SonataAdminBundle.hu.xliff
+++ b/Resources/translations/SonataAdminBundle.hu.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Új hozzáadása</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Szerkeszt</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Lista</target>

--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Aggiungi nuovo</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Modifica</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Lista</target>

--- a/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/Resources/translations/SonataAdminBundle.ja.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>追加</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>編集</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>一覧</target>

--- a/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/Resources/translations/SonataAdminBundle.lb.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Nei</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Beaarbechten</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Lëscht</target>

--- a/Resources/translations/SonataAdminBundle.lt.xliff
+++ b/Resources/translations/SonataAdminBundle.lt.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Sukurti naują</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Redaguoti</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Sąrašas</target>

--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Nieuwe toevoegen</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Bijwerken</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Lijst</target>

--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Dodaj</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Edytuj</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Zarządzaj</target>

--- a/Resources/translations/SonataAdminBundle.pt.xliff
+++ b/Resources/translations/SonataAdminBundle.pt.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Novo</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Editar</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Listar</target>

--- a/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Adicionar novo</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Editar</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Listar</target>

--- a/Resources/translations/SonataAdminBundle.ro.xliff
+++ b/Resources/translations/SonataAdminBundle.ro.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Adăugați</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Editați</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Lista</target>

--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Добавить новый</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Редактировать</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Список</target>

--- a/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/Resources/translations/SonataAdminBundle.sk.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Pridať nový</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Upraviť</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Zoznam</target>

--- a/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/Resources/translations/SonataAdminBundle.sl.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Dodaj</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Uredi</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Seznam</target>

--- a/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/Resources/translations/SonataAdminBundle.uk.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>Додати новий</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Редагувати</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Список</target>

--- a/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -70,6 +70,10 @@
                 <source>link_add</source>
                 <target>添加</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>编辑</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>列表</target>

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -154,6 +154,25 @@ file that was distributed with this source code.
 {% endspaceless %}
 {% endblock choice_widget_collapsed %}
 
+{% block choice_widget_options -%}
+    {% for group_label, choice in options %}
+        {%- if choice is iterable -%}
+            <optgroup label="{{ group_label|trans({}, translation_domain) }}">
+                {% set options = choice %}
+                {{- block('choice_widget_options') -}}
+            </optgroup>
+        {%- else -%}
+            <option 
+            {% if choice.attributes is defined and choice.attributes.routes is defined -%}
+                {% for route_name in choice.attributes.routes | keys -%}
+                    data-sonata-admin-{{ route_name }}-href="{{ attribute(choice.attributes.routes, route_name) }}"
+                {%- endfor -%}
+            {% endif %}
+            value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice.label|trans({}, translation_domain) }}</option>
+        {%- endif -%}
+    {% endfor %}
+{%- endblock choice_widget_options %}
+        
 {% block form_row %}
     {% set label_class = "" %}
     {% set div_class = "" %}


### PR DESCRIPTION
Add an `edit` button for sonata-type-model form with `many-to-one` relations.
Button is rewriten and enabled when an option is selected (or already selected)

Edit button uses the traditional modal in create mode.

![edit_hover](https://cloud.githubusercontent.com/assets/5037520/4607866/5dd609ae-5263-11e4-81df-1ed45d612538.png)

I don't know if this approch is not too intrusive (loocking for `select` tags, find an `edit` button to rewrite, change this one at any change on select, ...). Any advice would be appreciated :-)
