### PR TITLE
Support bundles without vendor namespace

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -55,7 +55,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     const CONTEXT_MENU       = 'menu';
     const CONTEXT_DASHBOARD  = 'dashboard';
 
-    const CLASS_REGEX        = '@([A-Za-z0-9]*)\\\(Bundle\\\)?([A-Za-z0-9]+)Bundle\\\(Entity|Document|Model|PHPCR|CouchDocument|Phpcr|Doctrine\\\Orm|Doctrine\\\Phpcr|Doctrine\\\MongoDB|Doctrine\\\CouchDB)\\\(.*)@';
+    const CLASS_REGEX        = '@(?:([A-Za-z0-9]*)\\\(Bundle\\\)?)?([A-Za-z0-9]+)Bundle\\\(Entity|Document|Model|PHPCR|CouchDocument|Phpcr|Doctrine\\\Orm|Doctrine\\\Phpcr|Doctrine\\\MongoDB|Doctrine\\\CouchDB)\\\(.*)@';
 
     /**
      * The class name managed by the admin class
@@ -967,12 +967,21 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
                     $this->urlize($matches[5], '-')
                 );
             } else {
-
-                $this->baseRoutePattern = sprintf('/%s/%s/%s',
-                    $this->urlize($matches[1], '-'),
-                    $this->urlize($matches[3], '-'),
-                    $this->urlize($matches[5], '-')
-                );
+                if ($matches[1]==="")
+                {
+                  $this->baseRoutePattern = sprintf('/%s/%s',
+                      $this->urlize($matches[3], '-'),
+                      $this->urlize($matches[5], '-')
+                  );
+                }
+                else
+                {
+                  $this->baseRoutePattern = sprintf('/%s/%s/%s',
+                      $this->urlize($matches[1], '-'),
+                      $this->urlize($matches[3], '-'),
+                      $this->urlize($matches[5], '-')
+                  );
+                }
             }
         }
 

--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -967,20 +967,17 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
                     $this->urlize($matches[5], '-')
                 );
             } else {
-                if ($matches[1]==="")
-                {
-                  $this->baseRoutePattern = sprintf('/%s/%s',
-                      $this->urlize($matches[3], '-'),
-                      $this->urlize($matches[5], '-')
-                  );
-                }
-                else
-                {
-                  $this->baseRoutePattern = sprintf('/%s/%s/%s',
-                      $this->urlize($matches[1], '-'),
-                      $this->urlize($matches[3], '-'),
-                      $this->urlize($matches[5], '-')
-                  );
+                if ($matches[1] === "") {
+                    $this->baseRoutePattern = sprintf('/%s/%s',
+                        $this->urlize($matches[3], '-'),
+                        $this->urlize($matches[5], '-')
+                    );
+                } else {
+                    $this->baseRoutePattern = sprintf('/%s/%s/%s',
+                        $this->urlize($matches[1], '-'),
+                        $this->urlize($matches[3], '-'),
+                        $this->urlize($matches[5], '-')
+                    );
                 }
             }
         }

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -410,6 +410,22 @@ class AdminTest extends \PHPUnit_Framework_TestCase
                 '/myapplication/my/other-product-category'
             ),
             array(
+                'MyBundle\Entity\Post',
+                '/my/post'
+            ),
+            array(
+                'MyBundle\Entity\Post\Category',
+                '/my/post-category'
+            ),
+            array(
+                'MyBundle\Entity\Product\Category',
+                '/my/product-category'
+            ),
+            array(
+                'MyBundle\Entity\Other\Product\Category',
+                '/my/other-product-category'
+            ),
+            array(
                 'Symfony\Cmf\Bundle\FooBundle\Document\Menu',
                 '/cmf/foo/menu'
             ),
@@ -463,7 +479,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetBaseRoutePatternWithUnreconizedClassname()
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsApp\Entity\Post', 'SonataNewsBundle:PostAdmin');
         $admin->getBaseRoutePattern();
     }
 
@@ -570,7 +586,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetBaseRouteNameWithUnreconizedClassname()
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsApp\Entity\Post', 'SonataNewsBundle:PostAdmin');
         $admin->getBaseRouteName();
     }
 


### PR DESCRIPTION
This pull request is related to issue #2493

i had to change the UnreconizedClassname tests as
```
 $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
```
looks valid and possible to me