### PR TITLE
Override money_widget and percent_widget

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -28,6 +28,35 @@ file that was distributed with this source code.
     {{ parent() }}
 {% endblock textarea_widget %}
 
+{% block money_widget -%}
+    {% if money_pattern == '{{ widget }}' %}
+        {{- block('form_widget_simple') -}}
+    {% else %}
+        {% set currencySymbol = money_pattern|replace({'{{ widget }}': ''})|trim %}
+        {% if money_pattern matches '/^{{ widget }}/' %}
+            <div class="input-group">
+                {{- block('form_widget_simple') -}}
+                <span class="input-group-addon">{{ currencySymbol }}</span>
+            </div>
+        {% elseif money_pattern matches '/{{ widget }}$/' %}
+            <div class="input-group">
+                <span class="input-group-addon">{{ currencySymbol }}</span>
+                {{- block('form_widget_simple') -}}
+            </div>
+        {% endif %}
+    {% endif %}
+{%- endblock money_widget %}
+
+{% block percent_widget %}
+    {% spaceless %}
+        {% set type = type|default('text') %}
+        <div class="input-group">
+            {{ block('form_widget_simple') }}
+            <span class="input-group-addon">%</span>
+        </div>
+    {% endspaceless %}
+{% endblock percent_widget %}
+
 {# Labels #}
 {% block form_label %}
 {% spaceless %}


### PR DESCRIPTION
This PR fixes #2214

Input fields are streched to 100% width in the new SonataAdminBundle, but this doesn't take into account any extra text such as percentage signs or currency symbols, causing either the symbol or the input field to be pushed to the next line.

Using Bootstrap's `input-group` we can prevent this, and also render the symbol in a nicer way.

The money widget respects the `money_pattern` variable, so the currency symbol will be rendered before or after the input, depending on the locale or the given `money_pattern`.

**Before:**

![before](https://cloud.githubusercontent.com/assets/1055691/4663294/3a0932d8-553a-11e4-8c59-f9aac49cefc3.png)

**After:**

![after](https://cloud.githubusercontent.com/assets/1055691/4663295/3dcddc0c-553a-11e4-817b-3bbc2f021bbc.png)
