### PR TITLE
Update standard_layout.html.twig

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -127,6 +127,7 @@ file that was distributed with this source code.
 
                             <div class="navbar-left">
                                 {% block sonata_breadcrumb %}
+                                    <div class="hidden-xs">
                                     {% if _breadcrumb is not empty or action is defined %}
                                         <ol class="nav navbar-top-links breadcrumb">
                                             {% if _breadcrumb is empty %}
@@ -150,6 +151,7 @@ file that was distributed with this source code.
                                             {% endif %}
                                         </ol>
                                     {% endif %}
+                                    </div>
                                 {% endblock sonata_breadcrumb %}
                             </div>
 


### PR DESCRIPTION
When resizing to xsmall devices in bootstrap the breadcrumb is breaking the mobile responsive layout (all of the actions, etc fall over to the next line and no longer line up with the background). 
Ideally the breadcrumb div would be updated to sit within a variable width container that would allow the user to pan left and right with the mouse/their finger to read the entire breadcrumb on mobile devices. If I get a chance I can look at integrating this, but for the time being I suggest wrapping it up using the hidden-xs bootstrap class so that it doesn't appear broken to the user on xsmall devices.
