### PR TITLE
Replace url() with path() for dashboard url

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -104,7 +104,7 @@ file that was distributed with this source code.
                 {% block logo %}
                     {% if admin_pool is defined %}
                         {% spaceless %}
-                        <a class="logo" href="{{ url('sonata_admin_dashboard') }}">
+                        <a class="logo" href="{{ path('sonata_admin_dashboard') }}">
                             {% if 'single_image' == admin_pool.getOption('title_mode') or 'both' == admin_pool.getOption('title_mode') %}
                                 <img src="{{ asset(admin_pool.titlelogo) }}" alt="{{ admin_pool.title }}">
                             {% endif %}


### PR DESCRIPTION
It's not better to use the relative dashboard url generated with the path() twig function instead of the absolute url using the url() function?

I noticed in a project of mine (the hosting server have some special settings regarding the public hostname) that the dashboard url is wrong generated using url(), with path() it is perfect.
