### PR TITLE
Replace :before with :after

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -147,9 +147,9 @@ th.sonata-ba-list-field-header-order-asc a {
     margin-right: 10px;
 }
 
-th.sonata-ba-list-field-header-order-asc a:hover:before,
-th.sonata-ba-list-field-header-order-asc.sonata-ba-list-field-order-active a:before,
-th.sonata-ba-list-field-header-order-desc.sonata-ba-list-field-order-active a:hover:before {
+th.sonata-ba-list-field-header-order-asc a:hover:after,
+th.sonata-ba-list-field-header-order-asc.sonata-ba-list-field-order-active a:after,
+th.sonata-ba-list-field-header-order-desc.sonata-ba-list-field-order-active a:hover:after {
     content: "";
     display: block;
     border-top: 4px solid black;
@@ -162,9 +162,9 @@ th.sonata-ba-list-field-header-order-desc.sonata-ba-list-field-order-active a:ho
     margin-top: -1px;
 }
 
-th.sonata-ba-list-field-header-order-desc a:hover:before,
-th.sonata-ba-list-field-header-order-desc.sonata-ba-list-field-order-active a:before,
-th.sonata-ba-list-field-header-order-asc.sonata-ba-list-field-order-active a:hover:before {
+th.sonata-ba-list-field-header-order-desc a:hover:after,
+th.sonata-ba-list-field-header-order-desc.sonata-ba-list-field-order-active a:after,
+th.sonata-ba-list-field-header-order-asc.sonata-ba-list-field-order-active a:hover:after {
     content: "";
     display: block;
     border-bottom: 4px solid black;


### PR DESCRIPTION
The sort arrow being right, it makes more sense to use the pseudo-element after.

And if first:letter is used, the pseudo-element before is a problem.
When the :first-letter is apply to an element having content generated using :before, it apply to the first letter of the element including the generated content. 

http://www.w3.org/TR/CSS21/selector.html#before-and-after
