### PR TITLE
getValueFromFieldDescription returns null if property is not found

### DIFF
--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -483,15 +483,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
                 throw new NoValueException();
             }));
 
-        $fieldDescription->expects($this->any())
-            ->method('getAssociationAdmin')
-            ->will($this->returnValue($this->admin));
-
-        $this->admin->expects($this->once())
-            ->method('getNewInstance')
-            ->will($this->returnValue('foo'));
-
-        $this->assertEquals('foo', $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
+        $this->assertEquals(null, $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
     }
 
     public function testOutput()

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -157,13 +157,10 @@ class SonataAdminExtension extends \Twig_Extension
             throw new \RuntimeException('remove the loop requirement');
         }
 
-        $value = null;
         try {
             $value = $fieldDescription->getValue($object);
         } catch (NoValueException $e) {
-            if ($fieldDescription->getAssociationAdmin()) {
-                $value = $fieldDescription->getAssociationAdmin()->getNewInstance();
-            }
+            $value = null;
         }
 
         return $value;


### PR DESCRIPTION
Tell me if i'm wrong, but I think it's incorrect to return a new object instance if the property is not found. We should return null instead.

Moreover, it breaks the lists when the property is not found, because it will return a new object instance and then try to generate an link to the object using its empty id, throwing a router "invalid parameter" exception.