### PR TITLE
Implement html field type

### DIFF
--- a/DependencyInjection/AbstractSonataAdminExtension.php
+++ b/DependencyInjection/AbstractSonataAdminExtension.php
@@ -54,6 +54,7 @@ abstract class AbstractSonataAdminExtension extends Extension
                         'percent'      => 'SonataAdminBundle:CRUD:list_percent.html.twig',
                         'choice'       => 'SonataAdminBundle:CRUD:list_choice.html.twig',
                         'url'          => 'SonataAdminBundle:CRUD:list_url.html.twig',
+                        'html'         => 'SonataAdminBundle:CRUD:list_html.html.twig',
                     ),
                     'show' => array(
                         'array'        => 'SonataAdminBundle:CRUD:show_array.html.twig',
@@ -72,6 +73,7 @@ abstract class AbstractSonataAdminExtension extends Extension
                         'percent'      => 'SonataAdminBundle:CRUD:base_percent.html.twig',
                         'choice'       => 'SonataAdminBundle:CRUD:show_choice.html.twig',
                         'url'          => 'SonataAdminBundle:CRUD:show_url.html.twig',
+                        'html'          => 'SonataAdminBundle:CRUD:show_html.html.twig',
                     )
                 )
             )

--- a/Resources/doc/reference/field_types.rst
+++ b/Resources/doc/reference/field_types.rst
@@ -19,6 +19,7 @@ There are many field types that can be used in the list action or show action :
 * **percent**: display a percentage
 * **choice**: uses the given value as index for the ``choices`` array and displays (and optionally translates) the matching value
 * **url**: display a link
+* **html**: display (and optionally truncate or strip tags from) raw html
 
 Theses types accept an ``editable`` parameter to edit the value from within the list action.
 This is currently limited to scalar types (text, integer, url...).
@@ -115,3 +116,51 @@ Parameters:
 .. note::
 
     Do not use ``url`` type with ``addIdentifier`` method, because it will create invalid nested urls.
+
+Html
+^^^^
+
+Display (and optionally truncate or strip tags from) raw html.
+
+
+Parameters:
+
+* **strip**: Strip HTML and PHP tags from a string
+* **truncate**: Truncate a string to ``length`` characters beginning from start. Implies strip. Beware of html entities. Make sure to configure your html editor to disable entities if you want to use truncate. For instance, use `config.entities <http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-entities>`_ for ckeditor
+* **truncate.length**: The length to truncate the string to (default ``30``)
+* **truncate.preserve**: Preserve whole words (default ``false``)
+* **truncate.separator**: Separator to be appended to the trimmed string (default ``...``)
+
+.. code-block:: php
+
+    // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
+    // `<p><strong>Creating a Template for the Field</strong> and form</p>` (no escaping is done)
+    $listMapper->add('content', 'html');
+
+    // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
+    // `Creating a Template for the Fi...`
+    $listMapper->add('content', 'html', array('strip' => true));
+
+    // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
+    // `Créer un Template pour...`
+    $listMapper->add('content', 'html', array('truncate' => true));
+
+    // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
+    // `Creating a...`
+    $listMapper->add('content', 'html', array('truncate' => array('length' => 10)));
+
+    // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
+    // `Creating a Template for the Field...`
+    $listMapper->add('content', 'html', array('truncate' => array('preserve' => true)));
+
+    // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
+    // `Creating a Template for the Fi, etc.`
+    $listMapper->add('content', 'html', array('truncate' => array('separator' => ', etc.')));
+
+    // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
+    // `Creating a Template for***`
+    $listMapper->add('content', 'html', array('truncate' => array(
+            'length' => 20,
+            'preserve' => true,
+            'separator' => '***'
+        )));

--- a/Resources/views/CRUD/list_html.html.twig
+++ b/Resources/views/CRUD/list_html.html.twig
@@ -1,0 +1,20 @@
+{% extends admin.getTemplate('base_list_field') %}
+
+{% block field %}
+    {%- if value is empty -%}
+        &nbsp;
+    {% else %}
+        {%- if field_description.options.truncate is defined -%}
+            {% set truncate = field_description.options.truncate %}
+            {% set length = truncate.length|default(30) %}
+            {% set preserve = truncate.preserve|default(false) %}
+            {% set separator = truncate.separator|default('...') %}
+            {{ value|striptags|truncate(length, preserve, separator)|raw }}
+        {%- else -%}
+            {%- if field_description.options.strip is defined -%}
+                {% set value = value|striptags %}
+            {%- endif -%}
+            {{ value|raw }}
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/Resources/views/CRUD/show_html.html.twig
+++ b/Resources/views/CRUD/show_html.html.twig
@@ -1,0 +1,20 @@
+{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+
+{% block field%}
+    {%- if value is empty -%}
+        &nbsp;
+    {% else %}
+        {%- if field_description.options.truncate is defined -%}
+            {% set truncate = field_description.options.truncate %}
+            {% set length = truncate.length|default(30) %}
+            {% set preserve = truncate.preserve|default(false) %}
+            {% set separator = truncate.separator|default('...') %}
+            {{ value|striptags|truncate(length, preserve, separator)|raw }}
+        {%- else -%}
+            {%- if field_description.options.strip is defined -%}
+                {% set value = value|striptags %}
+            {%- endif -%}
+            {{ value|raw }}
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -105,6 +105,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
         $requestContext = new RequestContext();
         $urlGenerator = new UrlGenerator($routeCollection, $requestContext);
         $this->environment->addExtension(new RoutingExtension($urlGenerator));
+        $this->environment->addExtension(new \Twig_Extensions_Extension_Text());
 
         $this->twigExtension->initRuntime($this->environment);
 
@@ -215,6 +216,8 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
                         return 'SonataAdminBundle:CRUD:list_trans.html.twig';
                     case 'url':
                         return 'SonataAdminBundle:CRUD:list_url.html.twig';
+                    case 'html':
+                        return 'SonataAdminBundle:CRUD:list_html.html.twig';
                     case 'nonexistent':
                         // template doesn`t exist
                         return 'SonataAdminBundle:CRUD:list_nonexistent_template.html.twig';
@@ -299,6 +302,54 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
             array('<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345"> <a href="http://localhost/foo/abcd/efgh?param3=ijkl">Foo</a> </td>', 'url', 'Foo', array('route'=>array('name'=>'sonata_admin_foo_param', 'absolute'=>true, 'parameters'=>array('param1'=>'abcd', 'param2'=>'efgh', 'param3'=>'ijkl')))),
             array('<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345"> <a href="/foo/obj/abcd/12345/efgh?param3=ijkl">Foo</a> </td>', 'url', 'Foo', array('route'=>array('name'=>'sonata_admin_foo_object', 'parameters'=>array('param1'=>'abcd', 'param2'=>'efgh', 'param3'=>'ijkl'), 'identifier_parameter_name'=>'barId'))),
             array('<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345"> <a href="http://localhost/foo/obj/abcd/12345/efgh?param3=ijkl">Foo</a> </td>', 'url', 'Foo', array('route'=>array('name'=>'sonata_admin_foo_object', 'absolute'=>true, 'parameters'=>array('param1'=>'abcd', 'param2'=>'efgh', 'param3'=>'ijkl'), 'identifier_parameter_name'=>'barId'))),
+            array(
+                '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345"> <p><strong>Creating a Template for the Field</strong> and form</p> </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array()
+            ),
+            array(
+                '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345"> Creating a Template for the Field and form </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array('strip' => true)
+            ),
+            array(
+                '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345"> Creating a Template for the Fi... </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array('truncate' => true)
+            ),
+            array(
+                '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345"> Creating a... </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array('truncate' => array('length' => 10))
+            ),
+            array(
+                '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345"> Creating a Template for the Field... </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array('truncate' => array('preserve' => true))
+            ),
+            array(
+                '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345"> Creating a Template for the Fi etc. </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array('truncate' => array('separator' => ' etc.'))
+            ),
+            array(
+                '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345"> Creating a Template for[...] </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array(
+                    'truncate' => array(
+                        'length'    => 20,
+                        'preserve'  => true,
+                        'separator' => '[...]'
+                    )
+                )
+            ),
         );
     }
 
@@ -401,6 +452,8 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
                         return 'SonataAdminBundle:CRUD:show_trans.html.twig';
                     case 'url':
                         return 'SonataAdminBundle:CRUD:show_url.html.twig';
+                    case 'html':
+                        return 'SonataAdminBundle:CRUD:show_html.html.twig';
                     default:
                         return false;
                 }
@@ -457,6 +510,54 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
             array('<th>Data</th> <td><a href="http://localhost/foo/abcd/efgh?param3=ijkl">Foo</a></td>', 'url', 'Foo', array('safe'=>false, 'route'=>array('name'=>'sonata_admin_foo_param', 'absolute'=>true, 'parameters'=>array('param1'=>'abcd', 'param2'=>'efgh', 'param3'=>'ijkl')))),
             array('<th>Data</th> <td><a href="/foo/obj/abcd/12345/efgh?param3=ijkl">Foo</a></td>', 'url', 'Foo', array('safe'=>false, 'route'=>array('name'=>'sonata_admin_foo_object', 'parameters'=>array('param1'=>'abcd', 'param2'=>'efgh', 'param3'=>'ijkl'), 'identifier_parameter_name'=>'barId'))),
             array('<th>Data</th> <td><a href="http://localhost/foo/obj/abcd/12345/efgh?param3=ijkl">Foo</a></td>', 'url', 'Foo', array('safe'=>false, 'route'=>array('name'=>'sonata_admin_foo_object', 'absolute'=>true, 'parameters'=>array('param1'=>'abcd', 'param2'=>'efgh', 'param3'=>'ijkl'), 'identifier_parameter_name'=>'barId'))),
+            array(
+                '<th>Data</th> <td><p><strong>Creating a Template for the Field</strong> and form</p> </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array()
+            ),
+            array(
+                '<th>Data</th> <td>Creating a Template for the Field and form </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array('strip' => true)
+            ),
+            array(
+                '<th>Data</th> <td> Creating a Template for the Fi... </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array('truncate' => true)
+            ),
+            array(
+                '<th>Data</th> <td> Creating a... </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array('truncate' => array('length' => 10))
+            ),
+            array(
+                '<th>Data</th> <td> Creating a Template for the Field... </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array('truncate' => array('preserve' => true))
+            ),
+            array(
+                '<th>Data</th> <td> Creating a Template for the Fi etc. </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array('truncate' => array('separator' => ' etc.'))
+            ),
+            array(
+                '<th>Data</th> <td> Creating a Template for[...] </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                array(
+                    'truncate' => array(
+                        'length'    => 20,
+                        'preserve'  => true,
+                        'separator' => '[...]'
+                    )
+                )
+            ),
 
             // NoValueException
             array('<th>Data</th> <td></td>', 'string', new NoValueException(), array('safe' => false)),


### PR DESCRIPTION
Currently, there is no way to display safe html in a sonata list.

![ckeditor](https://cloud.githubusercontent.com/assets/2140469/4921603/7141c64e-650b-11e4-94e3-cbfbcfa33140.png)
![truncate](https://cloud.githubusercontent.com/assets/2140469/4921605/71493a96-650b-11e4-8926-95dbb565985b.png)
![raw](https://cloud.githubusercontent.com/assets/2140469/4921604/7142be28-650b-11e4-9a6b-42cbb0b70340.png)
