### PR TITLE
Update base_edit_form_macro.html.twig

### DIFF
--- a/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -1,8 +1,8 @@
-{% macro render_groups(admin, form, groups, has_tab) %}
+{% macro render_groups(admin, form, groups, has_tab, no_padding = false) %}
     {% if has_tab %}<div class="row">{% endif %}
     {% for code in groups %}
         {% set form_group = admin.formgroups[code] %}
-        <div class="{{ form_group.class }}"> {# default class 'col-md-12' removed because it do not work with tabs#}
+        <div class="{{ form_group.class }} {{ no_padding ? "nopadding" }}"> {# default class 'col-md-12' removed because it do not work with tabs#}
             <div class="box box-success">
                 <div class="box-header">
                     <h4 class="box-title">
@@ -18,7 +18,17 @@
 
                         {% for field_name in form_group.fields %}
                             {% if admin.formfielddescriptions[field_name] is defined %}
-                                {{ form_row(form[field_name])}}
+                                {% if form[field_name].vars.sonata_admin.field_description.type == 'sonata_type_admin' %}
+                                    {% set inline_admin = form[field_name].vars.sonata_admin.field_description.associationAdmin %}
+                                    {% set inline_form = form[field_name].vars.form %}
+                                    {% set inline_groups = [] %}
+                                    {% for formtab in inline_admin.formtabs %}
+                                    {% set inline_groups = inline_groups|merge(formtab.groups) %}
+                                    {% endfor %}
+                                    {{ _self.render_groups(inline_admin, inline_form, inline_groups, true, true) }}
+                                {% else %}
+                                    {{ form_row(form[field_name])}}
+                                {% endif %}
                             {% endif %}
                         {% else %}
                             <em>{{ 'message_form_group_empty'|trans({}, 'SonataAdminBundle') }}</em>


### PR DESCRIPTION
Cascade form groups / groups formatting for sonata_type_admin

Before:
![Before](http://jajus.com/sonata_type_admin_before.png)

After:
![After](http://jajus.com/sonata_type_admin_after.png)