### PR TITLE
sonata-project/core-bundle 2.3 is required to get jquery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "twig/extensions": "~1.0",
         "sonata-project/exporter": "~1.0",
         "sonata-project/block-bundle": "~2.2,>=2.2.7",
-        "sonata-project/core-bundle": "~2.2",
+        "sonata-project/core-bundle": "~2.3",
         "doctrine/common": "~2.2",
         "knplabs/knp-menu-bundle": ">=1.1.0,<3.0.0",
         "knplabs/knp-menu": ">=1.1.0,<3.0.0"


### PR DESCRIPTION
This required directory has been introduced in CoreBundle 2.3
https://github.com/sonata-project/SonataCoreBundle/tree/master/Resources/public/vendor
