### PR TITLE
Fixed creation of mock in tests for methods that are necessary.

### DIFF
--- a/Tests/SonataAdminBundleTest.php
+++ b/Tests/SonataAdminBundleTest.php
@@ -28,7 +28,7 @@ class SonataAdminBundleTest extends \PHPUnit_Framework_TestCase
 {
     public function testBuild()
     {
-        $containerBuilder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $containerBuilder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder', array('addCompilerPass'));
 
         $containerBuilder->expects($this->exactly(3))
             ->method('addCompilerPass')


### PR DESCRIPTION
Fixes tests:

```
PHPUnit 4.3.5 by Sebastian Bergmann.

Configuration read from /.../SonataAdminBundle/phpunit.xml.dist

...............................................................  63 / 871 (  7%)
............................................................... 126 / 871 ( 14%)
............................................................... 189 / 871 ( 21%)
............................................................... 252 / 871 ( 28%)
............................................................... 315 / 871 ( 36%)
............................................................... 378 / 871 ( 43%)
............................................................... 441 / 871 ( 50%)
............................................................... 504 / 871 ( 57%)
............................................................... 567 / 871 ( 65%)
............................................................... 630 / 871 ( 72%)
.............................................E................. 693 / 871 ( 79%)
............................................................... 756 / 871 ( 86%)
............................................................... 819 / 871 ( 94%)
....................................................

Time: 16.22 seconds, Memory: 62.50Mb

There was 1 error:

1) Sonata\AdminBundle\Tests\SonataAdminBundleTest::testBuild
PHPUnit_Framework_MockObject_RuntimeException: Cannot mock Symfony\Component\DependencyInjection\ContainerBuilder::addExpressionLanguageProvider() because a class or interface used in the signature is not loaded

/.../SonataAdminBundle/Tests/SonataAdminBundleTest.php:31

Caused by
ReflectionException: Class Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface does not exist

/.../SonataAdminBundle/Tests/SonataAdminBundleTest.php:31
```
