### PR TITLE
Fixed wrong indentation in documentation

### DIFF
--- a/Resources/doc/cookbook/recipe_sortable_listing.rst
+++ b/Resources/doc/cookbook/recipe_sortable_listing.rst
@@ -6,8 +6,8 @@ This is a full working example of how to implement a sortable feature in your So
 Background
 ----------
 
-A sortable behavior is already available for one-to-many relationships (http://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/form_field_definition.html#advanced-usage-one-to-many). 
-However there is no packaged solution to have some up and down arrows to sort 
+A sortable behavior is already available for one-to-many relationships (http://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/form_field_definition.html#advanced-usage-one-to-many).
+However there is no packaged solution to have some up and down arrows to sort
 your records such as showed in the following screen
 
 .. figure:: ../images/admin_sortable_listing.png
@@ -23,7 +23,7 @@ Pre-requisites
 - you already have an Entity class for which you want to implement a sortable feature. For the purpose of the example we are going to call it ``Client``.
 - you already have an Admin set up, in this example we will call it ``ClientAdmin``
 - you already have gedmo/doctrine-extensions bundle in your project (check stof/doctrine-extensions-bundle
-for easier integration in your project) with the sortable feature enabled
+  for easier integration in your project) with the sortable feature enabled
 - you already have pixassociates/sortable-behavior-bundle bundle in your project
 
 The recipe
@@ -39,7 +39,7 @@ First of all we are going to add a position field in our ``Client`` entity.
      */
     private $position;
 
-Then we need to inject the Sortable listener. If you only have the Gedmo bundle enabled, 
+Then we need to inject the Sortable listener. If you only have the Gedmo bundle enabled,
 add the listener to your config.yml
 
 .. code-block:: yaml
@@ -51,8 +51,8 @@ add the listener to your config.yml
                 - { name: doctrine.event_subscriber, connection: default }
             calls:
                 - [ setAnnotationReader, [ @annotation_reader ] ]
-            
-If you have the ``stof/doctrine-extensions-bundle``, you only need to enable the sortable 
+
+If you have the ``stof/doctrine-extensions-bundle``, you only need to enable the sortable
 feature in your config.yml such as
 
 .. code-block:: yaml
@@ -105,10 +105,10 @@ Now you can update your ``services.yml`` to use the handler provider by the pixS
 	            - [ setTranslationDomain, [AcmeDemoBundle]]
 
 
-Last tricky part, in order to get the last position available in our twig template 
-we inject the service container in our admin class, define a public variable ``$last_position`` 
-and retrieve the value from our service in the ``configureListFields`` method. We 
-also define the sort by field to be position 
+Last tricky part, in order to get the last position available in our twig template
+we inject the service container in our admin class, define a public variable ``$last_position``
+and retrieve the value from our service in the ``configureListFields`` method. We
+also define the sort by field to be position
 
 .. code-block:: php
 
@@ -129,7 +129,7 @@ also define the sort by field to be position
     {
         $this->positionService = $positionHandler;
     }
-    
+
     protected $datagridValues = array(
         '_page' => 1,
         '_sort_order' => 'ASC',
@@ -152,7 +152,7 @@ also define the sort by field to be position
 And in  the services.yml add the following call
 
 .. code-block:: yaml
-    
+
 	- [ setContainer, [ @service_container ] ]
 	- [ setPositionService, [@pix_sortable_behavior.position]]
 


### PR DESCRIPTION
Fixes an error:

```
Running Sphinx v1.2.2
loading pickled environment... done
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] cookbook/recipe_sortable_listing                                                                                                                                                                                    

Warning, treated as error:
/.../SonataAdminBundle/Resources/doc/cookbook/recipe_sortable_listing.rst:26: WARNING: Bullet list ends without a blank line; unexpected unindent.

make: *** [test] Error 1
```
