### PR TITLE
remove default value for method argument

### DIFF
--- a/Builder/DatagridBuilderInterface.php
+++ b/Builder/DatagridBuilderInterface.php
@@ -28,7 +28,7 @@ interface DatagridBuilderInterface extends BuilderInterface
      *
      * @return void
      */
-    public function addFilter(DatagridInterface $datagrid, $type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin);
+    public function addFilter(DatagridInterface $datagrid, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin);
 
     /**
      * @param \Sonata\AdminBundle\Admin\AdminInterface $admin

--- a/UPGRADE-2.4.md
+++ b/UPGRADE-2.4.md
@@ -1,0 +1,11 @@
+UPGRADE FROM 2.3 to 2.4
+=======================
+
+### Dependencies
+
+You will need to follow the dependencies upgrade instructions.
+
+## Datagrid builders
+
+If you have implemented a custom datagrid builder, you must adapt the signature
+of its `addFilter` method to match the one in `DatagridBuilderInterface` again.


### PR DESCRIPTION
It makes no sense to have a default value if the arguments after have no
default value.

This P.R. introduces a tiny BC break, which is documented in an upgrade file.
