### PR TITLE
Update conditional_validation.rst

### DIFF
--- a/Resources/doc/reference/conditional_validation.rst
+++ b/Resources/doc/reference/conditional_validation.rst
@@ -108,6 +108,8 @@ Example from the ``SonataPageBundle``
 
     use Sonata\PageBundle\Model\PageInterface;
     use Sonata\AdminBundle\Validator\ErrorElement;
+    use Sonata\BlockBundle\Block\BaseBlockService;
+    use Sonata\BlockBundle\Model\BlockInterface;
 
     class RssBlockService extends BaseBlockService
     {


### PR DESCRIPTION
missing namespaces
    use Sonata\BlockBundle\Block\BaseBlockService;
    use Sonata\BlockBundle\Model\BlockInterface;
in sonata.page.cms.page service
