### PR TITLE
Fix function getFieldValue on BaseFieldDescription for underscore-prefixed attributes

### DIFF
--- a/Admin/BaseFieldDescription.php
+++ b/Admin/BaseFieldDescription.php
@@ -421,9 +421,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
      */
     public static function camelize($property)
     {
-        return preg_replace_callback('/(^|[_. ])+(.)/', function ($match) {
-            return ('.' === $match[1] ? '_' : '') . strtoupper($match[2]);
-        }, $property);
+        return Container::camelize($property);
     }
 
     /**

--- a/Tests/Admin/BaseFieldDescriptionTest.php
+++ b/Tests/Admin/BaseFieldDescriptionTest.php
@@ -132,6 +132,15 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $returnValue2 = $arg1 + $arg2;
         $mock2->expects($this->any())->method('getWithTwoParameters')->with($this->equalTo($arg1),$this->equalTo($arg2))->will($this->returnValue($returnValue2));
         $this->assertEquals(42, $description2->getFieldValue($mock2, 'fake'));
+
+        /**
+         * Test with underscored attribute name
+         */
+        $description3  = new FieldDescription();
+        $mock3         = $this->getMock('stdClass', array('getFake'));
+
+        $mock3->expects($this->once())->method('getFake')->will($this->returnValue(42));
+        $this->assertEquals(42, $description3->getFieldValue($mock3, '_fake'));
     }
 
     /**


### PR DESCRIPTION
fixes #2510
