### PR TITLE
Update CRUDController.php

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -13,12 +13,12 @@ namespace Sonata\AdminBundle\Controller;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sonata\AdminBundle\Exception\ModelManagerException;
-use Symfony\Component\HttpFoundation\Request;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Util\AdminObjectAclData;
@@ -36,7 +36,7 @@ class CRUDController extends Controller
     /**
      * The current request object
      *
-     * @var \Symfony\Component\HttpFoundation\Request
+     * @var Request
      */
     protected $request;
 
@@ -91,7 +91,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param Request $request
      */
     public function setRequest(Request $request)
     {
@@ -212,7 +212,7 @@ class CRUDController extends Controller
     /**
      * List action
      *
-     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param Request $request
      *
      * @return Response
      *
@@ -283,8 +283,8 @@ class CRUDController extends Controller
     /**
      * Delete action
      *
-     * @param int|string|null                           $id
-     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param int|string|null $id
+     * @param Request         $request
      *
      * @return Response|RedirectResponse
      *
@@ -359,8 +359,8 @@ class CRUDController extends Controller
     /**
      * Edit action
      *
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param int|string|null                           $id
+     * @param Request         $request
+     * @param int|string|null $id
      *
      * @return Response|RedirectResponse
      *
@@ -504,7 +504,7 @@ class CRUDController extends Controller
     /**
      * Batch action
      *
-     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param Request $request
      *
      * @return Response|RedirectResponse
      *
@@ -624,7 +624,7 @@ class CRUDController extends Controller
     /**
      * Create action
      *
-     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param Request $request
      *
      * @return Response
      *
@@ -775,8 +775,8 @@ class CRUDController extends Controller
     /**
      * Show action
      *
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param int|string|null                           $id
+     * @param Request         $request
+     * @param int|string|null $id
      *
      * @return Response
      *
@@ -814,8 +814,8 @@ class CRUDController extends Controller
     /**
      * Show history revisions for object
      *
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param int|string|null                           $id
+     * @param Request         $request
+     * @param int|string|null $id
      *
      * @return Response
      *
@@ -867,9 +867,9 @@ class CRUDController extends Controller
     /**
      * View history revision of object
      *
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param int|string|null                           $id
-     * @param string|null                               $revision
+     * @param Request         $request
+     * @param int|string|null $id
+     * @param string|null     $revision
      *
      * @return Response
      *
@@ -933,10 +933,10 @@ class CRUDController extends Controller
     /**
      * Compare history revisions of object
      *
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param int|string|null                           $id
-     * @param int|string|null                           $base_revision
-     * @param int|string|null                           $compare_revision
+     * @param Request         $request
+     * @param int|string|null $id
+     * @param int|string|null $base_revision
+     * @param int|string|null $compare_revision
      *
      * @return Response
      *
@@ -1019,7 +1019,7 @@ class CRUDController extends Controller
     /**
      * Export data to specified format
      *
-     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param Request $request
      *
      * @return Response
      *
@@ -1087,8 +1087,8 @@ class CRUDController extends Controller
     /**
      * Returns the Response object associated to the acl action
      *
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param int|string|null                           $id
+     * @param Request         $request
+     * @param int|string|null $id
      *
      * @return  \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      *

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Controller;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,6 +19,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Exception\ModelManagerException;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
@@ -29,7 +31,7 @@ class CRUDController extends Controller
     /**
      * The related Admin class
      *
-     * @var \Sonata\AdminBundle\Admin\AdminInterface
+     * @var AdminInterface
      */
     protected $admin;
 
@@ -148,7 +150,7 @@ class CRUDController extends Controller
      * Proxy for the logger service of the container.
      * If no such service is found, a NullLogger is returned.
      *
-     * @return \Psr\Log\LoggerInterface
+     * @return LoggerInterface
      */
     protected function getLogger()
     {

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -11,19 +11,18 @@
 
 namespace Sonata\AdminBundle\Controller;
 
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sonata\AdminBundle\Exception\ModelManagerException;
 use Symfony\Component\HttpFoundation\Request;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Util\AdminObjectAclData;
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Psr\Log\NullLogger;
 
 class CRUDController extends Controller
@@ -31,9 +30,16 @@ class CRUDController extends Controller
     /**
      * The related Admin class
      *
-     * @var AdminInterface
+     * @var \Sonata\AdminBundle\Admin\AdminInterface
      */
     protected $admin;
+
+    /**
+     * The current request object
+     *
+     * @var \Symfony\Component\HttpFoundation\Request
+     */
+    protected $request;
 
     /**
      * Render JSON
@@ -49,8 +55,9 @@ class CRUDController extends Controller
         // fake content-type so browser does not show the download popup when this
         // response is rendered through an iframe (used by the jquery.form.js plugin)
         //  => don't know yet if it is the best solution
-        if ($this->get('request')->get('_xml_http_request')
-            && strpos($this->get('request')->headers->get('Content-Type'), 'multipart/form-data') === 0) {
+        if ($this->request->get('_xml_http_request')
+            && strpos($this->request->headers->get('Content-Type'), 'multipart/form-data') === 0
+        ) {
             $headers['Content-Type'] = 'text/plain';
         } else {
             $headers['Content-Type'] = 'application/json';
@@ -66,7 +73,7 @@ class CRUDController extends Controller
      */
     protected function isXmlHttpRequest()
     {
-        return $this->get('request')->isXmlHttpRequest() || $this->get('request')->get('_xml_http_request');
+        return $this->request->isXmlHttpRequest() || $this->request->get('_xml_http_request');
     }
 
     /**
@@ -77,22 +84,19 @@ class CRUDController extends Controller
      */
     protected function getRestMethod()
     {
-        $request = $this->getRequest();
-        if (Request::getHttpMethodParameterOverride() || !$request->request->has('_method')) {
-            return $request->getMethod();
+        if (Request::getHttpMethodParameterOverride() || !$this->request->request->has('_method')) {
+            return $this->request->getMethod();
         }
 
-        return $request->request->get('_method');
+        return $this->request->request->get('_method');
     }
 
     /**
-     * Sets the Container associated with this Controller.
-     *
-     * @param ContainerInterface $container A ContainerInterface instance
+     * @param \Symfony\Component\HttpFoundation\Request $request
      */
-    public function setContainer(ContainerInterface $container = null)
+    public function setRequest(Request $request)
     {
-        $this->container = $container;
+        $this->request = $request;
 
         $this->configure();
     }
@@ -104,23 +108,27 @@ class CRUDController extends Controller
      */
     protected function configure()
     {
-        $adminCode = $this->container->get('request')->get('_sonata_admin');
+        $adminCode = $this->request->get('_sonata_admin');
 
         if (!$adminCode) {
-            throw new \RuntimeException(sprintf(
-                'There is no `_sonata_admin` defined for the controller `%s` and the current route `%s`',
-                get_class($this),
-                $this->container->get('request')->get('_route')
-            ));
+            throw new \RuntimeException(
+                sprintf(
+                    'There is no `_sonata_admin` defined for the controller `%s` and the current route `%s`',
+                    get_class($this),
+                    $this->request->get('_route')
+                )
+            );
         }
 
-        $this->admin = $this->container->get('sonata.admin.pool')->getAdminByAdminCode($adminCode);
+        $this->admin = $this->get('sonata.admin.pool')->getAdminByAdminCode($adminCode);
 
         if (!$this->admin) {
-            throw new \RuntimeException(sprintf(
-                'Unable to find the admin class related to the current controller (%s)',
-                get_class($this)
-            ));
+            throw new \RuntimeException(
+                sprintf(
+                    'Unable to find the admin class related to the current controller (%s)',
+                    get_class($this)
+                )
+            );
         }
 
         $rootAdmin = $this->admin;
@@ -130,12 +138,10 @@ class CRUDController extends Controller
             $rootAdmin = $rootAdmin->getParent();
         }
 
-        $request = $this->container->get('request');
+        $rootAdmin->setRequest($this->request);
 
-        $rootAdmin->setRequest($request);
-
-        if ($request->get('uniqid')) {
-            $this->admin->setUniqid($request->get('uniqid'));
+        if ($this->request->get('uniqid')) {
+            $this->admin->setUniqid($this->request->get('uniqid'));
         }
     }
 
@@ -143,7 +149,7 @@ class CRUDController extends Controller
      * Proxy for the logger service of the container.
      * If no such service is found, a NullLogger is returned.
      *
-     * @return Psr\Log\LoggerInterface
+     * @return \Psr\Log\LoggerInterface
      */
     protected function getLogger()
     {
@@ -173,7 +179,7 @@ class CRUDController extends Controller
      */
     public function render($view, array $parameters = array(), Response $response = null)
     {
-        $parameters['admin']         = isset($parameters['admin']) ?
+        $parameters['admin'] = isset($parameters['admin']) ?
             $parameters['admin'] :
             $this->admin;
 
@@ -181,11 +187,11 @@ class CRUDController extends Controller
             $parameters['base_template'] :
             $this->getBaseTemplate();
 
-        $parameters['admin_pool']    = $this->get('sonata.admin.pool');
+        $parameters['admin_pool'] = $this->get('sonata.admin.pool');
 
         return parent::render($view, $parameters, $response);
     }
-    
+
     /**
      * @param \Exception $e
      *
@@ -207,17 +213,21 @@ class CRUDController extends Controller
     /**
      * List action
      *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
      * @return Response
      *
      * @throws AccessDeniedException If access is not granted
      */
-    public function listAction()
+    public function listAction(Request $request)
     {
+        $this->setRequest($request);
+
         if (false === $this->admin->isGranted('LIST')) {
             throw new AccessDeniedException();
         }
 
-        if ($listMode = $this->getRequest()->get('_list_mode')) {
+        if ($listMode = $this->request->get('_list_mode')) {
             $this->admin->setListMode($listMode);
         }
 
@@ -227,12 +237,15 @@ class CRUDController extends Controller
         // set the theme for the current Admin Form
         $this->get('twig')->getExtension('form')->renderer->setTheme($formView, $this->admin->getFilterTheme());
 
-        return $this->render($this->admin->getTemplate('list'), array(
-            'action'     => 'list',
-            'form'       => $formView,
-            'datagrid'   => $datagrid,
-            'csrf_token' => $this->getCsrfToken('sonata.batch'),
-        ));
+        return $this->render(
+            $this->admin->getTemplate('list'),
+            array(
+                'action'     => 'list',
+                'form'       => $formView,
+                'datagrid'   => $datagrid,
+                'csrf_token' => $this->getCsrfToken('sonata.batch'),
+            )
+        );
     }
 
     /**
@@ -260,25 +273,30 @@ class CRUDController extends Controller
             $this->addFlash('sonata_flash_error', 'flash_batch_delete_error');
         }
 
-        return new RedirectResponse($this->admin->generateUrl(
-            'list',
-            array('filter' => $this->admin->getFilterParameters())
-        ));
+        return new RedirectResponse(
+            $this->admin->generateUrl(
+                'list',
+                array('filter' => $this->admin->getFilterParameters())
+            )
+        );
     }
 
     /**
      * Delete action
      *
-     * @param int|string|null $id
+     * @param int|string|null                           $id
+     * @param \Symfony\Component\HttpFoundation\Request $request
      *
      * @return Response|RedirectResponse
      *
      * @throws NotFoundHttpException If the object does not exist
      * @throws AccessDeniedException If access is not granted
      */
-    public function deleteAction($id)
+    public function deleteAction($id, Request $request)
     {
-        $id     = $this->get('request')->get($this->admin->getIdParameter());
+        $this->setRequest($request);
+
+        $id = $this->request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
         if (!$object) {
@@ -329,29 +347,35 @@ class CRUDController extends Controller
             return $this->redirectTo($object);
         }
 
-        return $this->render($this->admin->getTemplate('delete'), array(
-            'object'     => $object,
-            'action'     => 'delete',
-            'csrf_token' => $this->getCsrfToken('sonata.delete')
-        ));
+        return $this->render(
+            $this->admin->getTemplate('delete'),
+            array(
+                'object'     => $object,
+                'action'     => 'delete',
+                'csrf_token' => $this->getCsrfToken('sonata.delete')
+            )
+        );
     }
 
     /**
      * Edit action
      *
-     * @param int|string|null $id
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param int|string|null                           $id
      *
      * @return Response|RedirectResponse
      *
      * @throws NotFoundHttpException If the object does not exist
      * @throws AccessDeniedException If access is not granted
      */
-    public function editAction($id = null)
+    public function editAction(Request $request, $id = null)
     {
+        $this->setRequest($request);
+
         // the key used to lookup the template
         $templateKey = 'edit';
 
-        $id = $this->get('request')->get($this->admin->getIdParameter());
+        $id = $this->request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
         if (!$object) {
@@ -369,7 +393,7 @@ class CRUDController extends Controller
         $form->setData($object);
 
         if ($this->getRestMethod() == 'POST') {
-            $form->submit($this->get('request'));
+            $form->submit($this->request);
 
             $isFormValid = $form->isValid();
 
@@ -380,10 +404,12 @@ class CRUDController extends Controller
                     $object = $this->admin->update($object);
 
                     if ($this->isXmlHttpRequest()) {
-                        return $this->renderJson(array(
-                            'result'    => 'ok',
-                            'objectId'  => $this->admin->getNormalizedIdentifier($object)
-                        ));
+                        return $this->renderJson(
+                            array(
+                                'result'   => 'ok',
+                                'objectId' => $this->admin->getNormalizedIdentifier($object)
+                            )
+                        );
                     }
 
                     $this->addFlash(
@@ -429,11 +455,14 @@ class CRUDController extends Controller
         // set the theme for the current Admin Form
         $this->get('twig')->getExtension('form')->renderer->setTheme($view, $this->admin->getFormTheme());
 
-        return $this->render($this->admin->getTemplate($templateKey), array(
-            'action' => 'edit',
-            'form'   => $view,
-            'object' => $object,
-        ));
+        return $this->render(
+            $this->admin->getTemplate($templateKey),
+            array(
+                'action' => 'edit',
+                'form'   => $view,
+                'object' => $object,
+            )
+        );
     }
 
     /**
@@ -447,17 +476,17 @@ class CRUDController extends Controller
     {
         $url = false;
 
-        if (null !== $this->get('request')->get('btn_update_and_list')) {
+        if (null !== $this->request->get('btn_update_and_list')) {
             $url = $this->admin->generateUrl('list');
         }
-        if (null !== $this->get('request')->get('btn_create_and_list')) {
+        if (null !== $this->request->get('btn_create_and_list')) {
             $url = $this->admin->generateUrl('list');
         }
 
-        if (null !== $this->get('request')->get('btn_create_and_create')) {
+        if (null !== $this->request->get('btn_create_and_create')) {
             $params = array();
             if ($this->admin->hasActiveSubClass()) {
-                $params['subclass'] = $this->get('request')->get('subclass');
+                $params['subclass'] = $this->request->get('subclass');
             }
             $url = $this->admin->generateUrl('create', $params);
         }
@@ -476,37 +505,41 @@ class CRUDController extends Controller
     /**
      * Batch action
      *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
      * @return Response|RedirectResponse
      *
      * @throws NotFoundHttpException If the HTTP method is not POST
      * @throws \RuntimeException     If the batch action is not defined
      */
-    public function batchAction()
+    public function batchAction(Request $request)
     {
-        $restMethod = $this->getRestMethod();
+        $this->setRequest($request);
 
-        if ('POST' !== $restMethod) {
-            throw $this->createNotFoundException(sprintf('Invalid request type "%s", POST expected', $restMethod));
+        if ('POST' !== $this->getRestMethod()) {
+            throw $this->createNotFoundException(
+                sprintf('Invalid request type "%s", POST expected', $this->getRestMethod())
+            );
         }
 
         // check the csrf token
         $this->validateCsrfToken('sonata.batch');
 
-        $confirmation = $this->get('request')->get('confirmation', false);
+        $confirmation = $this->request->get('confirmation', false);
 
-        if ($data = json_decode($this->get('request')->get('data'), true)) {
-            $action       = $data['action'];
-            $idx          = $data['idx'];
-            $allElements  = $data['all_elements'];
-            $this->get('request')->request->replace($data);
+        if ($data = json_decode($this->request->get('data'), true)) {
+            $action = $data['action'];
+            $idx = $data['idx'];
+            $allElements = $data['all_elements'];
+            $this->request->request->replace($data);
         } else {
-            $this->get('request')->request->set('idx', $this->get('request')->get('idx', array()));
-            $this->get('request')->request->set('all_elements', $this->get('request')->get('all_elements', false));
+            $this->request->request->set('idx', $this->request->get('idx', array()));
+            $this->request->request->set('all_elements', $this->request->get('all_elements', false));
 
-            $action       = $this->get('request')->get('action');
-            $idx          = $this->get('request')->get('idx');
-            $allElements  = $this->get('request')->get('all_elements');
-            $data         = $this->get('request')->request->all();
+            $action = $this->request->get('action');
+            $idx = $this->request->get('idx');
+            $allElements = $this->request->get('all_elements');
+            $data = $this->request->request->all();
 
             unset($data['_sonata_csrf_token']);
         }
@@ -552,20 +585,25 @@ class CRUDController extends Controller
 
             $formView = $datagrid->getForm()->createView();
 
-            return $this->render($this->admin->getTemplate('batch_confirmation'), array(
-                'action'     => 'list',
-                'action_label' => $actionLabel,
-                'datagrid'   => $datagrid,
-                'form'       => $formView,
-                'data'       => $data,
-                'csrf_token' => $this->getCsrfToken('sonata.batch'),
-            ));
+            return $this->render(
+                $this->admin->getTemplate('batch_confirmation'),
+                array(
+                    'action'       => 'list',
+                    'action_label' => $actionLabel,
+                    'datagrid'     => $datagrid,
+                    'form'         => $formView,
+                    'data'         => $data,
+                    'csrf_token'   => $this->getCsrfToken('sonata.batch'),
+                )
+            );
         }
 
         // execute the action, batchActionXxxxx
         $finalAction = sprintf('batchAction%s', ucfirst($camelizedAction));
         if (!is_callable(array($this, $finalAction))) {
-            throw new \RuntimeException(sprintf('A `%s::%s` method must be callable', get_class($this), $finalAction));
+            throw new \RuntimeException(
+                sprintf('A `%s::%s` method must be callable', get_class($this), $finalAction)
+            );
         }
 
         $query = $datagrid->getQuery();
@@ -587,18 +625,22 @@ class CRUDController extends Controller
     /**
      * Create action
      *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
      * @return Response
      *
      * @throws AccessDeniedException If access is not granted
      */
-    public function createAction()
+    public function createAction(Request $request)
     {
-        // the key used to lookup the template
-        $templateKey = 'edit';
+        $this->setRequest($request);
 
         if (false === $this->admin->isGranted('CREATE')) {
             throw new AccessDeniedException();
         }
+
+        // the key used to lookup the template
+        $templateKey = 'edit';
 
         $object = $this->admin->getNewInstance();
 
@@ -608,8 +650,8 @@ class CRUDController extends Controller
         $form = $this->admin->getForm();
         $form->setData($object);
 
-        if ($this->getRestMethod()== 'POST') {
-            $form->submit($this->get('request'));
+        if ($this->getRestMethod() == 'POST') {
+            $form->submit($this->request);
 
             $isFormValid = $form->isValid();
 
@@ -624,10 +666,12 @@ class CRUDController extends Controller
                     $object = $this->admin->create($object);
 
                     if ($this->isXmlHttpRequest()) {
-                        return $this->renderJson(array(
-                            'result' => 'ok',
-                            'objectId' => $this->admin->getNormalizedIdentifier($object)
-                        ));
+                        return $this->renderJson(
+                            array(
+                                'result'   => 'ok',
+                                'objectId' => $this->admin->getNormalizedIdentifier($object)
+                            )
+                        );
                     }
 
                     $this->addFlash(
@@ -673,11 +717,14 @@ class CRUDController extends Controller
         // set the theme for the current Admin Form
         $this->get('twig')->getExtension('form')->renderer->setTheme($view, $this->admin->getFormTheme());
 
-        return $this->render($this->admin->getTemplate($templateKey), array(
-            'action' => 'create',
-            'form'   => $view,
-            'object' => $object,
-        ));
+        return $this->render(
+            $this->admin->getTemplate($templateKey),
+            array(
+                'action' => 'create',
+                'form'   => $view,
+                'object' => $object,
+            )
+        );
     }
 
     /**
@@ -687,7 +734,7 @@ class CRUDController extends Controller
      */
     protected function isPreviewRequested()
     {
-        return ($this->get('request')->get('btn_preview') !== null);
+        return ($this->request->get('btn_preview') !== null);
     }
 
     /**
@@ -697,7 +744,7 @@ class CRUDController extends Controller
      */
     protected function isPreviewApproved()
     {
-        return ($this->get('request')->get('btn_preview_approve') !== null);
+        return ($this->request->get('btn_preview_approve') !== null);
     }
 
     /**
@@ -711,9 +758,9 @@ class CRUDController extends Controller
     protected function isInPreviewMode()
     {
         return $this->admin->supportsPreviewMode()
-            && ($this->isPreviewRequested()
-                || $this->isPreviewApproved()
-                || $this->isPreviewDeclined());
+        && ($this->isPreviewRequested()
+            || $this->isPreviewApproved()
+            || $this->isPreviewDeclined());
     }
 
     /**
@@ -723,22 +770,25 @@ class CRUDController extends Controller
      */
     protected function isPreviewDeclined()
     {
-        return ($this->get('request')->get('btn_preview_decline') !== null);
+        return ($this->request->get('btn_preview_decline') !== null);
     }
 
     /**
      * Show action
      *
-     * @param int|string|null $id
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param int|string|null                           $id
      *
      * @return Response
      *
      * @throws NotFoundHttpException If the object does not exist
      * @throws AccessDeniedException If access is not granted
      */
-    public function showAction($id = null)
+    public function showAction(Request $request, $id = null)
     {
-        $id = $this->get('request')->get($this->admin->getIdParameter());
+        $this->setRequest($request);
+
+        $id = $this->request->get($this->admin->getIdParameter());
 
         $object = $this->admin->getObject($id);
 
@@ -752,26 +802,32 @@ class CRUDController extends Controller
 
         $this->admin->setSubject($object);
 
-        return $this->render($this->admin->getTemplate('show'), array(
-            'action'   => 'show',
-            'object'   => $object,
-            'elements' => $this->admin->getShow(),
-        ));
+        return $this->render(
+            $this->admin->getTemplate('show'),
+            array(
+                'action'   => 'show',
+                'object'   => $object,
+                'elements' => $this->admin->getShow(),
+            )
+        );
     }
 
     /**
      * Show history revisions for object
      *
-     * @param int|string|null $id
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param int|string|null                           $id
      *
      * @return Response
      *
      * @throws AccessDeniedException If access is not granted
      * @throws NotFoundHttpException If the object does not exist or the audit reader is not available
      */
-    public function historyAction($id = null)
+    public function historyAction(Request $request, $id = null)
     {
-        $id = $this->get('request')->get($this->admin->getIdParameter());
+        $this->setRequest($request);
+
+        $id = $this->request->get($this->admin->getIdParameter());
 
         $object = $this->admin->getObject($id);
 
@@ -798,28 +854,33 @@ class CRUDController extends Controller
 
         $revisions = $reader->findRevisions($this->admin->getClass(), $id);
 
-        return $this->render($this->admin->getTemplate('history'), array(
-            'action'            => 'history',
-            'object'            => $object,
-            'revisions'         => $revisions,
-            'currentRevision'   => $revisions ? current($revisions) : false,
-        ));
+        return $this->render(
+            $this->admin->getTemplate('history'),
+            array(
+                'action'          => 'history',
+                'object'          => $object,
+                'revisions'       => $revisions,
+                'currentRevision' => $revisions ? current($revisions) : false,
+            )
+        );
     }
 
     /**
      * View history revision of object
      *
-     * @param int|string|null $id
-     * @param string|null     $revision
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param int|string|null                           $id
+     * @param string|null                               $revision
      *
      * @return Response
      *
      * @throws AccessDeniedException If access is not granted
      * @throws NotFoundHttpException If the object or revision does not exist or the audit reader is not available
      */
-    public function historyViewRevisionAction($id = null, $revision = null)
+    public function historyViewRevisionAction(Request $request, $id = null, $revision = null)
     {
-        $id = $this->get('request')->get($this->admin->getIdParameter());
+        $this->setRequest($request);
+        $id = $this->request->get($this->admin->getIdParameter());
 
         $object = $this->admin->getObject($id);
 
@@ -860,32 +921,43 @@ class CRUDController extends Controller
 
         $this->admin->setSubject($object);
 
-        return $this->render($this->admin->getTemplate('show'), array(
-            'action'   => 'show',
-            'object'   => $object,
-            'elements' => $this->admin->getShow(),
-        ));
+        return $this->render(
+            $this->admin->getTemplate('show'),
+            array(
+                'action'   => 'show',
+                'object'   => $object,
+                'elements' => $this->admin->getShow(),
+            )
+        );
     }
 
     /**
      * Compare history revisions of object
      *
-     * @param int|string|null $id
-     * @param int|string|null $base_revision
-     * @param int|string|null $compare_revision
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param int|string|null                           $id
+     * @param int|string|null                           $base_revision
+     * @param int|string|null                           $compare_revision
      *
      * @return Response
      *
      * @throws AccessDeniedException If access is not granted
      * @throws NotFoundHttpException If the object or revision does not exist or the audit reader is not available
      */
-    public function historyCompareRevisionsAction($id = null, $base_revision = null, $compare_revision = null)
-    {
+    public function historyCompareRevisionsAction(
+        Request $request,
+        $id = null,
+        $base_revision = null,
+        $compare_revision = null
+    ) {
+
+        $this->setRequest($request);
+
         if (false === $this->admin->isGranted('EDIT')) {
             throw new AccessDeniedException();
         }
 
-        $id = $this->get('request')->get($this->admin->getIdParameter());
+        $id = $this->request->get($this->admin->getIdParameter());
 
         $object = $this->admin->getObject($id);
 
@@ -934,18 +1006,21 @@ class CRUDController extends Controller
 
         $this->admin->setSubject($base_object);
 
-        return $this->render($this->admin->getTemplate('show_compare'), array(
-            'action'            => 'show',
-            'object'            => $base_object,
-            'object_compare'    => $compare_object,
-            'elements'          => $this->admin->getShow()
-        ));
+        return $this->render(
+            $this->admin->getTemplate('show_compare'),
+            array(
+                'action'         => 'show',
+                'object'         => $base_object,
+                'object_compare' => $compare_object,
+                'elements'       => $this->admin->getShow()
+            )
+        );
     }
 
     /**
      * Export data to specified format
      *
-     * @param Request $request
+     * @param \Symfony\Component\HttpFoundation\Request $request
      *
      * @return Response
      *
@@ -954,13 +1029,15 @@ class CRUDController extends Controller
      */
     public function exportAction(Request $request)
     {
+        $this->setRequest($request);
+
         if (false === $this->admin->isGranted('EXPORT')) {
             throw new AccessDeniedException();
         }
 
-        $format = $request->get('format');
+        $format = $this->request->get('format');
 
-        $allowedExportFormats = (array) $this->admin->getExportFormats();
+        $allowedExportFormats = (array)$this->admin->getExportFormats();
 
         if (!in_array($format, $allowedExportFormats)) {
             throw new \RuntimeException(
@@ -1011,20 +1088,23 @@ class CRUDController extends Controller
     /**
      * Returns the Response object associated to the acl action
      *
-     * @param int|string|null $id
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param int|string|null                           $id
      *
-     * @return Response|RedirectResponse
+     * @return  \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      *
      * @throws AccessDeniedException If access is not granted.
      * @throws NotFoundHttpException If the object does not exist or the ACL is not enabled
      */
-    public function aclAction($id = null)
+    public function aclAction(Request $request, $id = null)
     {
+        $this->setRequest($request);
+
         if (!$this->admin->isAclEnabled()) {
             throw new NotFoundHttpException('ACL are not enabled for this admin');
         }
 
-        $id = $this->get('request')->get($this->admin->getIdParameter());
+        $id = $this->request->get($this->admin->getIdParameter());
 
         $object = $this->admin->getObject($id);
 
@@ -1049,26 +1129,28 @@ class CRUDController extends Controller
 
         $form = $adminObjectAclManipulator->createForm($adminObjectAclData);
 
-        $request = $this->getRequest();
-        if ($request->getMethod() === 'POST') {
-            $form->submit($request);
+        if ($this->request->isMethod('POST')) {
+            $form->submit($this->request);
 
             if ($form->isValid()) {
                 $adminObjectAclManipulator->updateAcl($adminObjectAclData);
 
                 $this->addFlash('sonata_flash_success', 'flash_acl_edit_success');
 
-                return new RedirectResponse($this->admin->generateObjectUrl('acl', $object));
+                return $this->redirect($this->admin->generateObjectUrl('acl', $object));
             }
         }
 
-        return $this->render($this->admin->getTemplate('acl'), array(
-            'action'      => 'acl',
-            'permissions' => $adminObjectAclData->getUserPermissions(),
-            'object'      => $object,
-            'users'       => $aclUsers,
-            'form'        => $form->createView()
-        ));
+        return $this->render(
+            $this->admin->getTemplate('acl'),
+            array(
+                'action'      => 'acl',
+                'permissions' => $adminObjectAclData->getUserPermissions(),
+                'object'      => $object,
+                'users'       => $aclUsers,
+                'form'        => $form->createView()
+            )
+        );
     }
 
     /**
@@ -1080,8 +1162,8 @@ class CRUDController extends Controller
     protected function addFlash($type, $message)
     {
         $this->get('session')
-             ->getFlashBag()
-             ->add($type, $message);
+            ->getFlashBag()
+            ->add($type, $message);
     }
 
     /**
@@ -1099,8 +1181,9 @@ class CRUDController extends Controller
 
         if (!$this->container->get('form.csrf_provider')->isCsrfTokenValid(
             $intention,
-            $this->get('request')->request->get('_sonata_csrf_token', false)
-        )) {
+            $this->request->request->get('_sonata_csrf_token', false)
+        )
+        ) {
             throw new HttpException(400, 'The csrf token is not valid, CSRF attack?');
         }
     }

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -1090,7 +1090,7 @@ class CRUDController extends Controller
      * @param Request         $request
      * @param int|string|null $id
      *
-     * @return  \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @return RedirectResponse|Response
      *
      * @throws AccessDeniedException If access is not granted.
      * @throws NotFoundHttpException If the object does not exist or the ACL is not enabled

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\AdminBundle\Controller;
 
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\AdminBundle\Tests\Controller;
 
+use Sonata\AdminBundle\Model\AuditManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Admin\Pool;
@@ -69,7 +69,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
     private $session;
 
     /**
-     * @var Sonata\AdminBundle\Model\AuditManager
+     * @var AuditManager
      */
     private $auditManager;
 
@@ -369,6 +369,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->controller = new CRUDController();
         $this->controller->setContainer($this->container);
+        $this->controller->setRequest($this->request);
 
         // Make some methods public to test them
         $testedMethods = array(
@@ -592,7 +593,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('LIST'))
             ->will($this->returnValue(false));
 
-        $this->controller->listAction();
+        $this->controller->listAction($this->request);
     }
 
     public function testListAction()
@@ -621,7 +622,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($form));
 
         $this->parameters = array();
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->listAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->listAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -743,7 +744,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getObject')
             ->will($this->returnValue(false));
 
-        $this->controller->showAction();
+        $this->controller->showAction($this->request);
     }
 
     public function testShowActionAccessDenied()
@@ -759,7 +760,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('VIEW'))
             ->will($this->returnValue(false));
 
-        $this->controller->showAction();
+        $this->controller->showAction($this->request);
     }
 
     public function testShowAction()
@@ -781,7 +782,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getShow')
             ->will($this->returnValue($show));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->showAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->showAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -840,7 +841,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getObject')
             ->will($this->returnValue(false));
 
-        $this->controller->deleteAction(1);
+        $this->controller->deleteAction(1, $this->request);
     }
 
     public function testDeleteActionAccessDenied()
@@ -856,7 +857,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('DELETE'))
             ->will($this->returnValue(false));
 
-        $this->controller->deleteAction(1);
+        $this->controller->deleteAction(1, $this->request);
     }
 
     public function testDeleteAction()
@@ -872,7 +873,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('DELETE'))
             ->will($this->returnValue(true));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->deleteAction(1));
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->deleteAction(1, $this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -901,7 +902,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('DELETE'))
             ->will($this->returnValue(true));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->deleteAction(1));
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->deleteAction(1, $this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -933,7 +934,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
-        $response = $this->controller->deleteAction(1);
+        $response = $this->controller->deleteAction(1, $this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertEquals(json_encode(array('result'=>'ok')), $response->getContent());
@@ -959,7 +960,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $response = $this->controller->deleteAction(1);
+        $response = $this->controller->deleteAction(1, $this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertEquals(json_encode(array('result'=>'ok')), $response->getContent());
@@ -986,7 +987,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $response = $this->controller->deleteAction(1);
+        $response = $this->controller->deleteAction(1, $this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertEquals(json_encode(array('result'=>'error')), $response->getContent());
@@ -1021,7 +1022,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->setMethod('DELETE');
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
-        $this->controller->deleteAction(1);
+        $this->controller->deleteAction(1, $this->request);
 
     }
 
@@ -1049,7 +1050,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
-        $response = $this->controller->deleteAction(1);
+        $response = $this->controller->deleteAction(1, $this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertSame(array('flash_delete_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -1076,7 +1077,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
-        $response = $this->controller->deleteAction(1);
+        $response = $this->controller->deleteAction(1, $this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertSame(array('flash_delete_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -1103,7 +1104,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->setMethod('POST');
         $this->request->request->set('_method', 'DELETE');
 
-        $response = $this->controller->deleteAction(1);
+        $response = $this->controller->deleteAction(1, $this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertSame(array('flash_delete_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -1126,7 +1127,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         //without POST request parameter "_method" should not be used as real REST method
         $this->request->query->set('_method', 'DELETE');
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->deleteAction(1));
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->deleteAction(1, $this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -1160,7 +1161,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->setMethod('DELETE');
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
-        $response = $this->controller->deleteAction(1);
+        $response = $this->controller->deleteAction(1, $this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertSame(array('flash_delete_error'), $this->session->getFlashBag()->get('sonata_flash_error'));
@@ -1185,7 +1186,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->request->set('_sonata_csrf_token', 'CSRF-INVALID');
 
         try {
-            $this->controller->deleteAction(1);
+            $this->controller->deleteAction(1, $this->request);
         } catch (HttpException $e) {
             $this->assertEquals('The csrf token is not valid, CSRF attack?', $e->getMessage());
             $this->assertEquals(400, $e->getStatusCode());
@@ -1200,7 +1201,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getObject')
             ->will($this->returnValue(false));
 
-        $this->controller->editAction();
+        $this->controller->editAction($this->request);
     }
 
     public function testEditActionAccessDenied()
@@ -1216,7 +1217,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('EDIT'))
             ->will($this->returnValue(false));
 
-        $this->controller->editAction();
+        $this->controller->editAction($this->request);
     }
 
     public function testEditAction()
@@ -1246,7 +1247,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('createView')
             ->will($this->returnValue($formView));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -1292,7 +1293,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->request->setMethod('POST');
 
-        $response = $this->controller->editAction();
+        $response = $this->controller->editAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertSame(array('flash_edit_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -1334,7 +1335,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('createView')
             ->will($this->returnValue($formView));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -1385,7 +1386,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->setMethod('POST');
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $response = $this->controller->editAction();
+        $response = $this->controller->editAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertEquals(json_encode(array('result'=>'ok', 'objectId'  => 'foo_normalized')), $response->getContent());
@@ -1426,7 +1427,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('createView')
             ->will($this->returnValue($formView));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::ajax_layout.html.twig', $this->parameters['base_template']);
@@ -1478,7 +1479,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->setMethod('POST');
         $this->request->request->set('btn_preview', 'Preview');
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -1501,7 +1502,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('CREATE'))
             ->will($this->returnValue(false));
 
-        $this->controller->createAction();
+        $this->controller->createAction($this->request);
     }
 
     public function testCreateAction()
@@ -1531,7 +1532,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('createView')
             ->will($this->returnValue($formView));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -1587,7 +1588,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->request->setMethod('POST');
 
-        $response = $this->controller->createAction();
+        $response = $this->controller->createAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertSame(array('flash_create_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -1631,7 +1632,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->request->setMethod('POST');
 
-        $this->controller->createAction();
+        $this->controller->createAction($this->request);
     }
 
     public function testCreateActionError()
@@ -1669,7 +1670,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('createView')
             ->will($this->returnValue($formView));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -1729,7 +1730,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->setMethod('POST');
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $response = $this->controller->createAction();
+        $response = $this->controller->createAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertEquals(json_encode(array('result'=>'ok', 'objectId'  => 'foo_normalized')), $response->getContent());
@@ -1770,7 +1771,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('createView')
             ->will($this->returnValue($formView));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::ajax_layout.html.twig', $this->parameters['base_template']);
@@ -1822,7 +1823,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->setMethod('POST');
         $this->request->request->set('btn_preview', 'Preview');
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -1908,7 +1909,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('EDIT'))
             ->will($this->returnValue(false));
 
-        $this->controller->historyAction();
+        $this->controller->historyAction($this->request);
     }
 
     public function testHistoryActionNotFoundException()
@@ -1919,7 +1920,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getObject')
             ->will($this->returnValue(false));
 
-        $this->controller->historyAction();
+        $this->controller->historyAction($this->request);
     }
 
     public function testHistoryActionNoReader()
@@ -1948,7 +1949,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(false));
 
-        $this->controller->historyAction();
+        $this->controller->historyAction($this->request);
     }
 
     public function testHistoryAction()
@@ -1987,7 +1988,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Foo'), $this->equalTo(123))
             ->will($this->returnValue(array()));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->historyAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->historyAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -2005,7 +2006,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'ACL are not enabled for this admin');
 
-        $this->controller->aclAction();
+        $this->controller->aclAction($this->request);
     }
 
     public function testAclActionNotFoundException()
@@ -2020,7 +2021,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getObject')
             ->will($this->returnValue(false));
 
-        $this->controller->aclAction();
+        $this->controller->aclAction($this->request);
     }
 
     public function testAclActionAccessDenied()
@@ -2042,7 +2043,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('MASTER'), $this->equalTo($object))
             ->will($this->returnValue(false));
 
-        $this->controller->aclAction();
+        $this->controller->aclAction($this->request);
     }
 
     public function testAclAction()
@@ -2092,7 +2093,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getSecurityHandler')
             ->will($this->returnValue($aclSecurityHandler));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->aclAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->aclAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -2161,7 +2162,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->request->setMethod('POST');
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->aclAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->aclAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -2230,7 +2231,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->request->setMethod('POST');
 
-        $response = $this->controller->aclAction();
+        $response = $this->controller->aclAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
 
@@ -2251,7 +2252,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('EDIT'))
             ->will($this->returnValue(false));
 
-        $this->controller->historyViewRevisionAction();
+        $this->controller->historyViewRevisionAction($this->request);
     }
 
     public function testHistoryViewRevisionActionNotFoundException()
@@ -2264,7 +2265,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getObject')
             ->will($this->returnValue(false));
 
-        $this->controller->historyViewRevisionAction();
+        $this->controller->historyViewRevisionAction($this->request);
     }
 
     public function testHistoryViewRevisionActionNoReader()
@@ -2293,7 +2294,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(false));
 
-        $this->controller->historyViewRevisionAction();
+        $this->controller->historyViewRevisionAction($this->request);
     }
 
     public function testHistoryViewRevisionActionNotFoundRevision()
@@ -2334,7 +2335,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Foo'), $this->equalTo(123), $this->equalTo(456))
             ->will($this->returnValue(null));
 
-        $this->controller->historyViewRevisionAction(123, 456);
+        $this->controller->historyViewRevisionAction($this->request, 123, 456);
     }
 
     public function testHistoryViewRevisionAction()
@@ -2386,7 +2387,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getShow')
             ->will($this->returnValue($fieldDescriptionCollection));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->historyViewRevisionAction(123, 456));
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->historyViewRevisionAction($this->request, 123, 456));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -2409,7 +2410,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('EDIT'))
             ->will($this->returnValue(false));
 
-        $this->controller->historyCompareRevisionsAction();
+        $this->controller->historyCompareRevisionsAction($this->request);
     }
 
     public function testhistoryCompareRevisionsActionNotFoundException()
@@ -2427,7 +2428,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getObject')
             ->will($this->returnValue(false));
 
-        $this->controller->historyCompareRevisionsAction();
+        $this->controller->historyCompareRevisionsAction($this->request);
     }
 
     public function testhistoryCompareRevisionsActionNoReader()
@@ -2456,7 +2457,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(false));
 
-        $this->controller->historyCompareRevisionsAction();
+        $this->controller->historyCompareRevisionsAction($this->request);
     }
 
     public function testhistoryCompareRevisionsActionNotFoundBaseRevision()
@@ -2498,7 +2499,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Foo'), $this->equalTo(123), $this->equalTo(456))
             ->will($this->returnValue(null));
 
-        $this->controller->historyCompareRevisionsAction(123, 456, 789);
+        $this->controller->historyCompareRevisionsAction($this->request, 123, 456, 789);
     }
 
     public function testhistoryCompareRevisionsActionNotFoundCompareRevision()
@@ -2548,7 +2549,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Foo'), $this->equalTo(123), $this->equalTo(789))
             ->will($this->returnValue(null));
 
-        $this->controller->historyCompareRevisionsAction(123, 456, 789);
+        $this->controller->historyCompareRevisionsAction($this->request, 123, 456, 789);
     }
 
     public function testhistoryCompareRevisionsActionAction()
@@ -2608,7 +2609,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getShow')
             ->will($this->returnValue($fieldDescriptionCollection));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->historyCompareRevisionsAction(123, 456, 789));
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->historyCompareRevisionsAction($this->request, 123, 456, 789));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -2627,7 +2628,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid request type "GET", POST expected');
 
-        $this->controller->batchAction();
+        $this->controller->batchAction($this->request);
     }
 
     public function testBatchActionActionNotDefined()
@@ -2644,7 +2645,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->request->set('data', json_encode(array('action'=>'foo', 'idx'=>array('123', '456'), 'all_elements'=>false)));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $this->controller->batchAction();
+        $this->controller->batchAction($this->request);
     }
 
     public function testBatchActionActionInvalidCsrfToken()
@@ -2654,7 +2655,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->request->set('_sonata_csrf_token', 'CSRF-INVALID');
 
         try {
-            $this->controller->batchAction();
+            $this->controller->batchAction($this->request);
         } catch (HttpException $e) {
             $this->assertEquals('The csrf token is not valid, CSRF attack?', $e->getMessage());
             $this->assertEquals(400, $e->getStatusCode());
@@ -2680,7 +2681,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->request->set('data', json_encode(array('action'=>'foo', 'idx'=>array('123', '456'), 'all_elements'=>false)));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $this->controller->batchAction();
+        $this->controller->batchAction($this->request);
     }
 
     public function testBatchActionWithoutConfirmation()
@@ -2726,7 +2727,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->request->set('data', json_encode(array('action'=>'delete', 'idx'=>array('123', '456'), 'all_elements'=>false)));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $result = $this->controller->batchAction();
+        $result = $this->controller->batchAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_delete_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -2777,7 +2778,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->request->set('idx', array('123', '456'));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $result = $this->controller->batchAction();
+        $result = $this->controller->batchAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_delete_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -2821,7 +2822,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getForm')
             ->will($this->returnValue($form));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->batchAction());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->batchAction($this->request));
 
         $this->assertEquals($this->admin, $this->parameters['admin']);
         $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -2859,7 +2860,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->request->set('idx', array('789'));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $result = $controller->batchAction();
+        $result = $controller->batchAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_empty'), $this->session->getFlashBag()->get('sonata_flash_info'));
@@ -2888,7 +2889,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->request->set('idx', array('999'));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $result = $controller->batchAction();
+        $result = $controller->batchAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_foo_error'), $this->session->getFlashBag()->get('sonata_flash_info'));
@@ -2914,7 +2915,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->request->set('idx', array());
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $result = $this->controller->batchAction();
+        $result = $this->controller->batchAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_empty'), $this->session->getFlashBag()->get('sonata_flash_info'));
@@ -2958,7 +2959,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->request->set('idx', array());
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $result = $controller->batchAction();
+        $result = $controller->batchAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $result);
         $this->assertEquals('batchActionBar executed', $result->getContent());

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
         "knplabs/knp-menu": ">=1.1.0,<3.0.0"
     },
     "require-dev": {
-      "phpunit/phpunit": "*",
         "jms/translation-bundle": "~1.1",
         "symfony/yaml": "~2.3",
         "sonata-project/intl-bundle": "~2.1"

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "knplabs/knp-menu": ">=1.1.0,<3.0.0"
     },
     "require-dev": {
+      "phpunit/phpunit": "*",
         "jms/translation-bundle": "~1.1",
         "symfony/yaml": "~2.3",
         "sonata-project/intl-bundle": "~2.1"


### PR DESCRIPTION
CRUDController uses ```$this->getRequest()``` and ```$this->get('request')``` to work with the current request object.

These changes are trying to change (fix?) that. The request object is injected into the action methods by type hinting it in the parameters list (this is a BC break). Also the controller is configured (the ```configure()``` method is called) in the newly introduced ```setRequest()``` method, not when the container is injected (this should not cause any problems and is not a BC break).