### PR TITLE
[2.3] Fix parent filter showing up when showing child list

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -875,7 +875,8 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         // ok, try to limit to add parent filter
         if ($this->isChild() && $this->getParentAssociationMapping() && !$mapper->has($this->getParentAssociationMapping())) {
             $mapper->add($this->getParentAssociationMapping(), null, array(
-                'field_type' => 'sonata_type_model_reference',
+                'label' => false,
+                'field_type' => 'sonata_type_model_hidden',
                 'field_options' => array(
                     'model_manager' => $this->getModelManager()
                 ),

--- a/Filter/FilterInterface.php
+++ b/Filter/FilterInterface.php
@@ -54,7 +54,7 @@ interface FilterInterface
     /**
      * Returns the label name
      *
-     * @return string
+     * @return string|bool
      */
     public function getLabel();
 

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -206,7 +206,9 @@ file that was distributed with this source code.
                         <div class="filter_container {{ admin.datagrid.hasActiveFilters ? 'active' : 'inactive' }}">
                             {% for filter in admin.datagrid.filters %}
                                 <div class="form-group">
+                                    {% if filter.label is not sameas(false) %}
                                     <label for="{{ form.children[filter.formName].children['value'].vars.id }}">{{ admin.trans(filter.label, {}, filter.translationDomain) }}</label>
+                                    {% endif %}
                                     {% set attr = form.children[filter.formName].children['type'].vars.attr|default({}) %}
                                     {% set attr = attr|merge({'class': (attr.class|default('') ~ ' sonata-filter-option')|trim}) %}
 


### PR DESCRIPTION
Fix created by @fran6co in #2439 ported for branch 2.3.
