### PR TITLE
[2.3] Added support for SensioGeneratorBundle 2.5 in GenerateAdminCommand

### DIFF
--- a/Tests/Command/GenerateAdminCommandTest.php
+++ b/Tests/Command/GenerateAdminCommandTest.php
@@ -19,7 +19,9 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Sonata\AdminBundle\Command\GenerateAdminCommand;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\DemoAdminBundle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -194,66 +196,122 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
 
         $command = $this->application->find('sonata:admin:generate');
 
-        $dialog = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper', array('askConfirmation', 'askAndValidate'));
+        // @todo remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping  support for Symfony 2.3
+        // DialogHelper does not exist in SensioGeneratorBundle 2.5+
+        if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
+           $dialog = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper', array('askConfirmation', 'askAndValidate'));
 
-        $dialog->expects($this->any())
-            ->method('askConfirmation')
-            ->will($this->returnCallback(function(OutputInterface $output, $question, $default) {
-                $questionClean = substr($question, 6, strpos($question, '</info>')-6);
+            $dialog->expects($this->any())
+                ->method('askConfirmation')
+                ->will($this->returnCallback(function(OutputInterface $output, $question, $default) {
+                    $questionClean = substr($question, 6, strpos($question, '</info>')-6);
 
-                switch ($questionClean) {
-                    case 'Do you want to generate a controller':
-                        return 'yes';
-                        break;
+                    switch ($questionClean) {
+                        case 'Do you want to generate a controller':
+                            return 'yes';
+                            break;
 
-                    case 'Do you want to update the services YAML configuration file':
-                        return 'yes';
-                        break;
-                }
+                        case 'Do you want to update the services YAML configuration file':
+                            return 'yes';
+                            break;
+                    }
 
-                return $default;
-            }));
+                    return $default;
+                }));
 
-        $dialog->expects($this->any())
-            ->method('askAndValidate')
-            ->will($this->returnCallback(function(OutputInterface $output, $question, $validator, $attempts = false, $default = null) use ($modelEntity) {
+            $dialog->expects($this->any())
+                ->method('askAndValidate')
+                ->will($this->returnCallback(function(OutputInterface $output, $question, $validator, $attempts = false, $default = null) use ($modelEntity) {
 
-                $questionClean = substr($question, 6, strpos($question, '</info>')-6);
+                    $questionClean = substr($question, 6, strpos($question, '</info>')-6);
 
-                switch ($questionClean) {
-                    case 'The fully qualified model class':
-                        return $modelEntity;
-                        break;
+                    switch ($questionClean) {
+                        case 'The fully qualified model class':
+                            return $modelEntity;
+                            break;
 
-                    case 'The bundle name':
-                        return 'AcmeDemoBundle';
-                        break;
+                        case 'The bundle name':
+                            return 'AcmeDemoBundle';
+                            break;
 
-                    case 'The admin class basename':
-                        return 'FooAdmin';
-                        break;
+                        case 'The admin class basename':
+                            return 'FooAdmin';
+                            break;
 
-                    case 'The controller class basename':
-                        return 'FooAdminController';
-                        break;
+                        case 'The controller class basename':
+                            return 'FooAdminController';
+                            break;
 
-                    case 'The services YAML configuration file':
-                        return 'admin.yml';
-                        break;
+                        case 'The services YAML configuration file':
+                            return 'admin.yml';
+                            break;
 
-                    case 'The admin service ID':
-                        return 'acme_demo_admin.admin.foo';
-                        break;
+                        case 'The admin service ID':
+                            return 'acme_demo_admin.admin.foo';
+                            break;
 
-                    case 'The manager type':
-                        return 'foo';
-                        break;
-                }
+                        case 'The manager type':
+                            return 'foo';
+                            break;
+                    }
 
-                return $default;
-            }));
+                    return $default;
+                }));
 
-        $command->getHelperSet()->set($dialog, 'dialog');
+            $command->getHelperSet()->set($dialog, 'dialog');
+        } else {
+            $questionHelper = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper', array('ask'));
+
+            $questionHelper->expects($this->any())
+                ->method('ask')
+                ->will($this->returnCallback(function(InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity) {
+                    $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>')-6);
+
+                    switch ($questionClean) {
+                        // confirmations
+                        case 'Do you want to generate a controller':
+                            return 'yes';
+                            break;
+
+                        case 'Do you want to update the services YAML configuration file':
+                            return 'yes';
+                            break;
+
+                        // inputs
+                        case 'The fully qualified model class':
+                            return $modelEntity;
+                            break;
+
+                        case 'The bundle name':
+                            return 'AcmeDemoBundle';
+                            break;
+
+                        case 'The admin class basename':
+                            return 'FooAdmin';
+                            break;
+
+                        case 'The controller class basename':
+                            return 'FooAdminController';
+                            break;
+
+                        case 'The services YAML configuration file':
+                            return 'admin.yml';
+                            break;
+
+                        case 'The admin service ID':
+                            return 'acme_demo_admin.admin.foo';
+                            break;
+
+                        case 'The manager type':
+                            return 'foo';
+                            break;
+                    }
+
+                    return false;
+                }));
+
+            $command->getHelperSet()->set($questionHelper, 'question');
+        }
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(array(


### PR DESCRIPTION
Kept BC compatibility with SensioGeneratorBundle 2.3 for Symfony 2.3

| Q | A |
| --- | --- |
| Bug fix? | yes (fixing BC break in SensioGeneratorBundle) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #2604, #2626 |
| License | MIT |
