### PR TITLE
Fix not needed dropdown table-responsive overflow

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -23,18 +23,18 @@ file that was distributed with this source code.
 
 {% block list_table %}
     <div class="col-xs-12 col-md-12">
-        <div class="box box-primary">
-            <div class="box-body table-responsive no-padding">
-                {{ sonata_block_render_event('sonata.admin.list.table.top', { 'admin': admin }) }}
+        {% if admin.hasRoute('batch') %}
+            <form action="{{ admin.generateUrl('batch', {'filter': admin.filterParameters}) }}" method="POST" >
+                <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
+        {% endif %}
+            <div class="box box-primary">
+                <div class="box-body table-responsive no-padding">
+                    {{ sonata_block_render_event('sonata.admin.list.table.top', { 'admin': admin }) }}
 
-                {% block list_header %}{% endblock %}
+                    {% block list_header %}{% endblock %}
 
-                {% set batchactions = admin.batchactions %}
-                {% if admin.datagrid.results|length > 0 %}
-                    {% if admin.hasRoute('batch') %}
-                    <form action="{{ admin.generateUrl('batch', {'filter': admin.filterParameters}) }}" method="POST" >
-                        <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
-                    {% endif %}
+                    {% set batchactions = admin.batchactions %}
+                    {% if admin.datagrid.results|length > 0 %}
                         <table class="table table-bordered table-striped sonata-ba-list">
                             {% block table_header %}
                                 <thead>
@@ -80,110 +80,106 @@ file that was distributed with this source code.
                             {% endblock %}
 
                             {% block table_footer %}
-                                <tfoot>
-                                    <tr>
-                                        <th colspan="{{ admin.list.elements|length - (app.request.isXmlHttpRequest ? (admin.list.has('_action') + admin.list.has('batch')) : 0) }}">
-                                            <div class="form-inline">
-                                                {% if not app.request.isXmlHttpRequest %}
-                                                    {% if admin.hasRoute('batch') and batchactions|length > 0  %}
-                                                        {% block batch %}
-                                                            <script>
-                                                                {% block batch_javascript %}
-                                                                    jQuery(document).ready(function ($) {
-                                                                        $('#list_batch_checkbox').on('ifChanged', function () {
-                                                                            $(this)
-                                                                                .closest('table')
-                                                                                .find('td.sonata-ba-list-field-batch input[type="checkbox"], div.sonata-ba-list-field-batch input[type="checkbox"]')
-                                                                                .iCheck($(this).is(':checked') ? 'check' : 'uncheck')
-                                                                            ;
-                                                                        });
-
-                                                                        $('td.sonata-ba-list-field-batch input[type="checkbox"], div.sonata-ba-list-field-batch input[type="checkbox"]')
-                                                                            .on('ifChanged', function () {
-                                                                                $(this)
-                                                                                    .closest('tr, div.sonata-ba-list-field-batch')
-                                                                                    .toggleClass('sonata-ba-list-row-selected', $(this).is(':checked'))
-                                                                                ;
-                                                                            })
-                                                                            .trigger('ifChanged')
-                                                                        ;
-                                                                    });
-                                                                {% endblock %}
-                                                            </script>
-
-                                                            {% block batch_actions %}
-                                                                <label class="checkbox" for="{{ admin.uniqid }}_all_elements">
-                                                                    <input type="checkbox" name="all_elements" id="{{ admin.uniqid }}_all_elements">
-                                                                    {{ 'all_elements'|trans({}, 'SonataAdminBundle') }}
-                                                                     ({{ admin.datagrid.pager.nbresults }})
-                                                                </label>
-
-                                                                <select name="action" style="width: auto; height: auto" class="form-control">
-                                                                    {% for action, options in batchactions %}
-                                                                        <option value="{{ action }}">{{ options.label }}</option>
-                                                                    {% endfor %}
-                                                                </select>
-                                                            {% endblock %}
-
-                                                            <input type="submit" class="btn btn-small btn-primary" value="{{ 'btn_batch'|trans({}, 'SonataAdminBundle') }}">
-                                                        {% endblock %}
-                                                    {% endif %}
-
-                                                    <div class="pull-right">
-                                                        {% if admin.hasRoute('export') and admin.isGranted("EXPORT") and admin.getExportFormats()|length %}
-                                                            <div class="btn-group">
-                                                                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-                                                                    <i class="glyphicon glyphicon-export"></i>
-                                                                    {{ "label_export_download"|trans({}, "SonataAdminBundle") }}
-                                                                    <span class="caret"></span>
-                                                                </button>
-                                                                <ul class="dropdown-menu">
-                                                                    {% for format in admin.getExportFormats() %}
-                                                                        <li>
-                                                                            <a href="{{ admin.generateUrl('export', admin.modelmanager.paginationparameters(admin.datagrid, 0) + {'format' : format}) }}">
-                                                                                <i class="glyphicon glyphicon-download"></i>
-                                                                                {{ format|upper }}
-                                                                            </a>
-                                                                        <li>
-                                                                    {% endfor %}
-                                                                </ul>
-                                                            </div>
-
-                                                            &nbsp;-&nbsp;
-                                                        {% endif %}
-
-                                                        {% block pager_results %}
-                                                            {% include admin.getTemplate('pager_results') %}
-                                                        {% endblock %}
-                                                    </div>
-                                                {% endif %}
-                                            </div>
-                                        </th>
-                                    </tr>
-
-                                    {% block pager_links %}
-                                        {% if admin.datagrid.pager.haveToPaginate() %}
-                                            {% include admin.getTemplate('pager_links') %}
-                                        {% endif %}
-                                    {% endblock %}
-
-                                </tfoot>
                             {% endblock %}
                         </table>
-                    {% if admin.hasRoute('batch') %}
-                    </form>
+                    {% else %}
+                        <div class="callout callout-info">
+                            {{ 'no_result'|trans({}, 'SonataAdminBundle') }}
+                        </div>
                     {% endif %}
-                {% else %}
-                    <div class="callout callout-info">
-                        {{ 'no_result'|trans({}, 'SonataAdminBundle') }}
+
+                    {{ sonata_block_render_event('sonata.admin.list.table.bottom', { 'admin': admin }) }}
+                </div>
+                {% block list_footer %}
+                    <div class="box-footer">
+                        <div class="form-inline clearfix">
+                            {% if not app.request.isXmlHttpRequest %}
+                                {% if admin.hasRoute('batch') and batchactions|length > 0  %}
+                                    {% block batch %}
+                                        <script>
+                                            {% block batch_javascript %}
+                                            jQuery(document).ready(function ($) {
+                                                $('#list_batch_checkbox').on('ifChanged', function () {
+                                                    $(this)
+                                                            .closest('table')
+                                                            .find('td.sonata-ba-list-field-batch input[type="checkbox"], div.sonata-ba-list-field-batch input[type="checkbox"]')
+                                                            .iCheck($(this).is(':checked') ? 'check' : 'uncheck')
+                                                    ;
+                                                });
+
+                                                $('td.sonata-ba-list-field-batch input[type="checkbox"], div.sonata-ba-list-field-batch input[type="checkbox"]')
+                                                        .on('ifChanged', function () {
+                                                            $(this)
+                                                                    .closest('tr, div.sonata-ba-list-field-batch')
+                                                                    .toggleClass('sonata-ba-list-row-selected', $(this).is(':checked'))
+                                                            ;
+                                                        })
+                                                        .trigger('ifChanged')
+                                                ;
+                                            });
+                                            {% endblock %}
+                                        </script>
+
+                                        {% block batch_actions %}
+                                            <label class="checkbox" for="{{ admin.uniqid }}_all_elements">
+                                                <input type="checkbox" name="all_elements" id="{{ admin.uniqid }}_all_elements">
+                                                {{ 'all_elements'|trans({}, 'SonataAdminBundle') }}
+                                                ({{ admin.datagrid.pager.nbresults }})
+                                            </label>
+
+                                            <select name="action" style="width: auto; height: auto" class="form-control">
+                                                {% for action, options in batchactions %}
+                                                    <option value="{{ action }}">{{ options.label }}</option>
+                                                {% endfor %}
+                                            </select>
+                                        {% endblock %}
+
+                                        <input type="submit" class="btn btn-small btn-primary" value="{{ 'btn_batch'|trans({}, 'SonataAdminBundle') }}">
+                                    {% endblock %}
+                                {% endif %}
+
+                                <div class="pull-right">
+                                    {% if admin.hasRoute('export') and admin.isGranted("EXPORT") and admin.getExportFormats()|length %}
+                                        <div class="btn-group">
+                                            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                                                <i class="glyphicon glyphicon-export"></i>
+                                                {{ "label_export_download"|trans({}, "SonataAdminBundle") }}
+                                                <span class="caret"></span>
+                                            </button>
+                                            <ul class="dropdown-menu">
+                                                {% for format in admin.getExportFormats() %}
+                                                <li>
+                                                    <a href="{{ admin.generateUrl('export', admin.modelmanager.paginationparameters(admin.datagrid, 0) + {'format' : format}) }}">
+                                                        <i class="glyphicon glyphicon-download"></i>
+                                                        {{ format|upper }}
+                                                    </a>
+                                                <li>
+                                                    {% endfor %}
+                                            </ul>
+                                        </div>
+
+                                        &nbsp;-&nbsp;
+                                    {% endif %}
+
+                                    {% block pager_results %}
+                                        {% include admin.getTemplate('pager_results') %}
+                                    {% endblock %}
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        {% block pager_links %}
+                            {% if admin.datagrid.pager.haveToPaginate() %}
+                                <hr/>
+                                {% include admin.getTemplate('pager_links') %}
+                            {% endif %}
+                        {% endblock %}
                     </div>
-                {% endif %}
-
-                {% block list_footer %}{% endblock %}
-
-                {{ sonata_block_render_event('sonata.admin.list.table.bottom', { 'admin': admin }) }}
+                {% endblock %}
             </div>
-        </div>
+        {% if admin.hasRoute('batch') %}
+            </form>
+        {% endif %}
     </div>
 {% endblock %}
 

--- a/Resources/views/Pager/base_links.html.twig
+++ b/Resources/views/Pager/base_links.html.twig
@@ -9,35 +9,31 @@ file that was distributed with this source code.
 
 #}
 
-<tr>
-    <td colspan="{{ admin.list.elements|length }}">
-        <div class="text-center">
-            <ul class="pagination">
-                {% if admin.datagrid.pager.page > 2  %}
-                    <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, 1)) }}" title="{{ 'link_first_pager'|trans({}, 'SonataAdminBundle') }}">&laquo;</a></li>
-                {% endif %}
+<div class="text-center">
+    <ul class="pagination">
+        {% if admin.datagrid.pager.page > 2  %}
+            <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, 1)) }}" title="{{ 'link_first_pager'|trans({}, 'SonataAdminBundle') }}">&laquo;</a></li>
+        {% endif %}
 
-                {% if admin.datagrid.pager.page != admin.datagrid.pager.previouspage %}
-                    <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.previouspage)) }}" title="{{ 'link_previous_pager'|trans({}, 'SonataAdminBundle') }}">&lsaquo;</a></li>
-                {% endif %}
+        {% if admin.datagrid.pager.page != admin.datagrid.pager.previouspage %}
+            <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.previouspage)) }}" title="{{ 'link_previous_pager'|trans({}, 'SonataAdminBundle') }}">&lsaquo;</a></li>
+        {% endif %}
 
-                {# Set the number of pages to display in the pager #}
-                {% for page in admin.datagrid.pager.getLinks(admin_pool.getOption('pager_links')) %}
-                    {% if page == admin.datagrid.pager.page %}
-                        <li class="active"><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, page)) }}">{{ page }}</a></li>
-                    {% else %}
-                        <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, page)) }}">{{ page }}</a></li>
-                    {% endif %}
-                {% endfor %}
+        {# Set the number of pages to display in the pager #}
+        {% for page in admin.datagrid.pager.getLinks(admin_pool.getOption('pager_links')) %}
+            {% if page == admin.datagrid.pager.page %}
+                <li class="active"><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, page)) }}">{{ page }}</a></li>
+            {% else %}
+                <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, page)) }}">{{ page }}</a></li>
+            {% endif %}
+        {% endfor %}
 
-                {% if admin.datagrid.pager.page != admin.datagrid.pager.nextpage %}
-                    <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.nextpage)) }}" title="{{ 'link_next_pager'|trans({}, 'SonataAdminBundle') }}">&rsaquo;</a></li>
-                {% endif %}
+        {% if admin.datagrid.pager.page != admin.datagrid.pager.nextpage %}
+            <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.nextpage)) }}" title="{{ 'link_next_pager'|trans({}, 'SonataAdminBundle') }}">&rsaquo;</a></li>
+        {% endif %}
 
-                {% if admin.datagrid.pager.page != admin.datagrid.pager.lastpage and admin.datagrid.pager.lastpage != admin.datagrid.pager.nextpage %}
-                    <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.lastpage)) }}" title="{{ 'link_last_pager'|trans({}, 'SonataAdminBundle') }}">&raquo;</a></li>
-                {% endif %}
-            </ul>
-        </div>
-    </td>
-</tr>
+        {% if admin.datagrid.pager.page != admin.datagrid.pager.lastpage and admin.datagrid.pager.lastpage != admin.datagrid.pager.nextpage %}
+            <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.lastpage)) }}" title="{{ 'link_last_pager'|trans({}, 'SonataAdminBundle') }}">&raquo;</a></li>
+        {% endif %}
+    </ul>
+</div>


### PR DESCRIPTION
This PR give a fix for not needed overflow on table-responsive with twitter bootsrap `3.3.*`.

It's related to #2582.

Batch action form, export, pager and page links are now on `list_footer` block instead of `table_block` because this is now outside the table.

Please feel free to review and comment this PR to fix and/or improve it! :+1: 

Thanks.