### PR TITLE
sonata:admin:generate - replace backslashes with forward slashes

### DIFF
--- a/Resources/doc/reference/console.rst
+++ b/Resources/doc/reference/console.rst
@@ -45,7 +45,7 @@ Usage example:
 
 .. code-block:: bash
 
-    php app/console sonata:admin:generate YourNS\FooBundle\Entity\Bar
+    php app/console sonata:admin:generate YourNS/FooBundle/Entity/Bar
 
 
 sonata:admin:list


### PR DESCRIPTION
Within the online documentation, the command to generate a Sonata Admin class is specified as:
php app/console sonata:admin:generate YourNS\FooBundle\Entity\Bar

However, this appears to throw up an error message stating that a fully qualified class model does not exist.
Using forward slashes instead of back slashes works without throwing back this message and ensures that the admin class is successfully generated, e.g.

php app/console sonata:admin:generate YourNS/FooBundle/Entity/Bar