### PR TITLE
Add a way to see if a tab group is open

### DIFF
--- a/Mapper/BaseGroupedMapper.php
+++ b/Mapper/BaseGroupedMapper.php
@@ -219,6 +219,16 @@ abstract class BaseGroupedMapper extends BaseMapper
 
         return $this;
     }
+    
+    /**
+     * Returns a boolean indicating if there is an open tab at the moment.
+     * 
+     * @return boolean
+     */
+    public function hasOpenTab()
+    {
+        return null !== $this->currentTab;
+    }
 
     /**
      * Add the fieldname to the current group

--- a/Tests/Mapper/BaseGroupedMapperTest.php
+++ b/Tests/Mapper/BaseGroupedMapperTest.php
@@ -141,7 +141,7 @@ class BaseGroupedMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->baseGroupedMapper->hasOpenTab(), '->hasOpenTab() returns true when there is an open tab');
         
         $this->baseGroupedMapper->end();
-        $this->assertFalse($this->baseGroupedMapper->hasOpenTab(), '->hasOpenTab() returns false when all tabs are closed')
+        $this->assertFalse($this->baseGroupedMapper->hasOpenTab(), '->hasOpenTab() returns false when all tabs are closed');
     }
 
     /**

--- a/Tests/Mapper/BaseGroupedMapperTest.php
+++ b/Tests/Mapper/BaseGroupedMapperTest.php
@@ -132,6 +132,17 @@ class BaseGroupedMapperTest extends \PHPUnit_Framework_TestCase
         $this->baseGroupedMapper->tab('fooTab');
         $this->baseGroupedMapper->tab('barTab');
     }
+    
+    public function testHasOpenTab()
+    {
+        $this->assertFalse($this->baseGroupedMapper->hasOpenTab(), '->hasOpenTab() returns false when there are no tabs');
+        
+        $this->baseGroupedMapper->tab('fooTab');
+        $this->assertTrue($this->baseGroupedMapper->hasOpenTab(), '->hasOpenTab() returns true when there is an open tab');
+        
+        $this->baseGroupedMapper->end();
+        $this->assertFalse($this->baseGroupedMapper->hasOpenTab(), '->hasOpenTab() returns false when all tabs are closed')
+    }
 
     /**
      * @expectedException        RuntimeException


### PR DESCRIPTION
If an Admin didn't use tabs, the `default` tab will never be closed. This causes issues when an admin extension adds a tab to the formmapper (it'll result in the "there is a current open tab" exception).