### PR TITLE
Doc: info about different manager_type values to be set depending on storage

### DIFF
--- a/Resources/doc/reference/getting_started.rst
+++ b/Resources/doc/reference/getting_started.rst
@@ -159,6 +159,8 @@ Create either a new ``admin.xml`` or ``admin.yml`` file inside the ``Acme/DemoBu
                calls:
                    - [ setTranslationDomain, [AcmeDemoBundle]]
 
+Example above assumes that you're using SonataDoctrineORMAdminBundle. If you're using SonataDoctrineMongoDBAdminBundle, SonataPropelAdminBundle or SonataDoctrinePhpcrAdminBundle instead, set ``manager_type`` option to ``doctrine_mongodb``, ``propel`` or ``doctrine_phpcr`` respectively.
+
 The basic configuration of an Admin service is quite simple. It creates a service
 instance based on the class you specified before, and accepts three arguments:
 


### PR DESCRIPTION
I was setting up admin panel following the doc and it took me a few minutes to figure out correct value of manager_type for ODM storage. Example in the docs is valid only for ORM, so I added the info so that no one else gets stuck when using other storages.