### PR TITLE
Update ExtensionCompilerPass to support aliases

### DIFF
--- a/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -64,7 +64,7 @@ class ExtensionCompilerPass implements CompilerPassInterface
             $extensions = $this->getExtensionsForAdmin($id, $admin, $container, $extensionMap);
 
             foreach ($extensions as $extension) {
-                if (!$container->hasDefinition($extension)) {
+                if (!$container->findDefinition($extension)) {
                     throw new \InvalidArgumentException(sprintf('Unable to find extension service for id %s', $extension));
                 }
                 $admin->addMethodCall('addExtension', array(new Reference($extension)));


### PR DESCRIPTION
This is a bug fix that exists in all SonataAdminBundle versions. I don't know which version is the oldest still maintained version, so I've targeted 2.3.

`hasDefinition` only searches for real service definitions, `findDefinition` searches through both real service definitions and aliases.

This is usefull as we're going to rename some service IDs for admin extensions and the CMF, but we want to be compatible with older versions (we do that by using aliases). Unfortunately, this wasn't support yet by this bundle.