### PR TITLE
[RFC] Added support for sonata Hateoas relation provider

### DIFF
--- a/Serializer/Hateoas/SonataRelationProviderResolver.php
+++ b/Serializer/Hateoas/SonataRelationProviderResolver.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+namespace Sonata\AdminBundle\Serializer\Hateoas;
+
+use Hateoas\Configuration\Provider\Resolver\RelationProviderResolverInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Hateoas\Configuration\RelationProvider;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Hateoas\Configuration\Relation;
+use Hateoas\Configuration\Route;
+
+/**
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class SonataRelationProviderResolver implements RelationProviderResolverInterface
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
+    /**
+     * @param Pool $pool
+     * @param UrlGeneratorInterface $urlGenerator
+     */
+    public function __construct(Pool $pool, UrlGeneratorInterface $urlGenerator)
+    {
+        $this->pool = $pool;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getRelationProvider(RelationProvider $relationProvider, $object)
+    {
+        if (false === $this->pool->hasAdminByClass(get_class($object))) {
+            return null;
+        }
+
+        return array($this, 'getRelations');
+    }
+
+    /**
+     * Return the sonata admin relations
+     *
+     * @return array
+     */
+    public function getRelations($object)
+    {
+        $admin = $this->pool->getAdminByClass(get_class($object));
+        $relations = array();
+
+        foreach ($admin->getRoutes() as $routeName => $route) {
+            $relations[] = new Relation(
+                $routeName,
+                new Route(
+                    $routeName,
+                    array(
+                        $admin->getIdParameter(), $admin->getUrlsafeIdentifier($object)
+                    )
+                )
+            );
+        }
+
+        return $relations;
+    }
+}

--- a/Tests/Serializer/Hateoas/SonataRelationProviderResolverTest.php
+++ b/Tests/Serializer/Hateoas/SonataRelationProviderResolverTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Serializer\Hateoas;
+
+use Sonata\AdminBundle\Serializer\Hateoas\SonataRelationProviderResolver;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Route;
+
+
+/**
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class SonataRelationProviderResolverTest extends \PHPUnit_Framework_TestCase
+{
+    private $relationProviderResolver;
+    private $pool;
+    private $generator;
+    private $object;
+    private $admin;
+
+    public function setUp()
+    {
+        $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->generator = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $this->object = new \stdClass;
+        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->relationProvider = $this->getMockBuilder('Hateoas\Configuration\RelationProvider')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->relationProviderResolver = new SonataRelationProviderResolver($this->pool, $this->generator);
+    }
+
+    public function provideGetRelationProvider()
+    {
+        return array(
+            array(true),
+            array(false),
+        );
+    }
+
+    /**
+     * @dataProvider provideGetRelationProvider
+     */
+    public function testGetRelationProvider($hasAdmin)
+    {
+        $expectation = $this->pool->expects($this->once())
+            ->method('hasAdminByClass')
+            ->with('stdClass');
+        $expectation->will($this->returnValue($hasAdmin));
+
+        $res = $this->relationProviderResolver->getRelationProvider($this->relationProvider, $this->object);
+
+        if (false === $hasAdmin) {
+            $this->assertNull($res);
+            return;
+        }
+
+        $this->assertTrue(is_callable($res));
+    }
+
+    public function provideGetRelations()
+    {
+        return array(
+            array(
+                array(
+                    'view_object' => array(
+                        'path' => '/path/to/view',
+                    ),
+                    'edit_object' => array(
+                        'path' => '/path/to/edit',
+                    ),
+                )
+            )
+        );
+    }
+
+    /**
+     * @dataProvider provideGetRelations
+     */
+    public function testGetRelations($routes)
+    {
+        $routeCollection = new RouteCollection();
+        foreach ($routes as $routeName => $routeConfig) {
+            $routeCollection->add($routeName, new Route($routeConfig['path']));
+        }
+
+        $this->pool->expects($this->once())
+            ->method('getAdminByClass')
+            ->with('stdClass')
+            ->will($this->returnValue($this->admin));
+
+        $this->admin->expects($this->once())
+            ->method('getRoutes')
+            ->will($this->returnValue($routeCollection));
+
+        $relations = $this->relationProviderResolver->getRelations($this->object);
+
+        $this->assertCount(count($routes), $relations);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     },
     "require-dev": {
         "jms/translation-bundle": "~1.1",
+        "willdurand/hateoas-bundle": "~1.0@dev",
         "symfony/yaml": "~2.3",
         "sonata-project/intl-bundle": "~2.1"
     },


### PR DESCRIPTION
This PR is an RFC for adding support for providing relations for the [Hateoas](https://github.com/willdurand/hateoas) bundle.

See #2683 

Note this hasn't been tested in a real project and is currently missing the required dependency injection configuration.

As a side-note this will be used by the [CmfRestBundle](https://github.com/symfony-cmf/ResourceRestBundle) which will be the web API for the new tree browser javascript library(ies) we are developing for the [SonataPhpcrAdminBundle](https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle)