### PR TITLE
Reduce Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,21 @@ php:
   - hhvm
 
 env:
-  - SYMFONY_VERSION=2.3.*
-  - SYMFONY_VERSION=2.4.*
-  - SYMFONY_VERSION=2.5.*
   - SYMFONY_VERSION=2.6.*
-  - SYMFONY_VERSION=2.7.*@dev
+
+matrix:
+  include:
+    - php: 5.3.3
+      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: SYMFONY_VERSION=2.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.5.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*@dev
+  allow_failures:
+    - php: hhvm
+    - env: SYMFONY_VERSION=2.7.*@dev
 
 before_script:
   - composer selfupdate
@@ -24,11 +34,3 @@ script: make test
 
 notifications:
     webhooks: http://sonata-project.org/bundles/admin/master/travis
-
-matrix:
-  include:
-    - php: 5.3.3
-      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
-  allow_failures:
-    - php: hhvm
-    - env: SYMFONY_VERSION=2.7.*@dev


### PR DESCRIPTION
Instead of testing each Symfony version on each PHP version, this updated travis file tests only the latest stable Symfony version (2.6.*) against all PHP versions and then only tests other Symfony versions against the latest PHP version (5.6).

This will reduce the amount of jobs, which is a good thing, since Travis does only allow 6 parrallel running jobs per organization.

Btw, I've also removed Symfony 2.4, as it has reached end of life.