### PR TITLE
Allow UUID to be used as id parameter

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1743,7 +1743,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     {
         if ($this->subject === null && $this->request) {
             $id = $this->request->get($this->getIdParameter());
-            if (!preg_match('#^[0-9A-Fa-f]+$#', $id)) {
+            if (!preg_match('#^[-0-9A-Fa-f]+$#', $id)) {
                 $this->subject = false;
             } else {
                 $this->subject = $this->getModelManager()->find($this->class, $id);

--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1742,10 +1742,8 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     public function getSubject()
     {
         if ($this->subject === null && $this->request) {
-            if (!$this->subject = $this->getModelManager()->find(
-                $this->class,
-                $this->request->get($this->getIdParameter())
-            )) {
+            $id = $this->request->get($this->getIdParameter());
+            if (!$id || !($this->subject = $this->getModelManager()->find($this->class, $id))) {
                 $this->subject = false;
             }
         }

--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1742,11 +1742,11 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     public function getSubject()
     {
         if ($this->subject === null && $this->request) {
-            $id = $this->request->get($this->getIdParameter());
-            if (!preg_match('#^[-0-9A-Fa-f]+$#', $id)) {
+            if (!$this->subject = $this->getModelManager()->find(
+                $this->class,
+                $this->request->get($this->getIdParameter())
+            )) {
                 $this->subject = false;
-            } else {
-                $this->subject = $this->getModelManager()->find($this->class, $id);
             }
         }
 

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1500,6 +1500,53 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(isset($parameters['post__author']));
         $this->assertEquals(array('value' => $authorId), $parameters['post__author']);
     }
+
+    /**
+     * @covers Sonata\AdminBundle\Admin\Admin::getSubject
+     */
+     public function testGetSubject()
+    {
+        $class = 'Application\Sonata\NewsBundle\Entity\Post';
+        $admin = new PostAdmin('sonata.post.admin.post', $class, 'SonataNewsBundle:PostAdmin');
+
+        $modelManager = $this->getMock(
+            'Sonata\AdminBundle\Model\ModelManagerInterface'
+        );
+        $modelManager->expects($this->once())
+            ->method('find')
+            ->with($class, $this->anything())
+            ->will($this->returnValue(new DummySubject()));
+        $admin->setModelManager($modelManager);
+
+        $admin->setRequest(new Request(array('id' => 'any-arbitrary-string')));
+        $admin->initialize();
+
+        $this->assertNotFalse($admin->getSubject());
+    }
+
+    /**
+     * @covers Sonata\AdminBundle\Admin\Admin::getSubject
+     */
+     public function testGetNonExistSubject()
+    {
+        $class = 'Application\Sonata\NewsBundle\Entity\Post';
+        $admin = new PostAdmin('sonata.post.admin.post', $class, 'SonataNewsBundle:PostAdmin');
+
+        $modelManager = $this->getMock(
+            'Sonata\AdminBundle\Model\ModelManagerInterface'
+        );
+        $modelManager->expects($this->once())
+            ->method('find')
+            ->with($class, $this->anything())
+            ->will($this->returnValue(null));
+        $admin->setModelManager($modelManager);
+
+        $admin->setRequest(new Request(array('id' => 'non-exist-subject')));
+        $admin->initialize();
+
+        $this->assertFalse($admin->getSubject());
+    }
+
 }
 
 class DummySubject


### PR DESCRIPTION
By adding dash as allowed character in the regex.