### PR TITLE
Fix InlineValidator missing dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "twig/extensions": "~1.0",
         "sonata-project/exporter": "~1.0",
         "sonata-project/block-bundle": "~2.2,>=2.2.7",
-        "sonata-project/core-bundle": "~2.2,>=2.2.1",
+        "sonata-project/core-bundle": "~2.3",
         "doctrine/common": "~2.4",
         "knplabs/knp-menu-bundle": ">=1.1.0,<3.0.0",
         "knplabs/knp-menu": ">=1.1.0,<3.0.0"


### PR DESCRIPTION
Sonata\CoreBundle\Validator\InlineValidator required by Sonata\AdminBundle\Validator\Constraints\InlineConstraint is only available since sonata-project/core-bundle version 2.3