### PR TITLE
fix date picker styles inside filter box

### DIFF
--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -451,3 +451,12 @@ div.mosaic-box.sonata-ba-list-row-selected > div.mosaic-inner-text {
 div.form-group div.select2-container {
     width: 80% !important;
 }
+
+div.sonata-filters-box div.form-group div.form-group {
+    margin: 0;    
+}
+
+div.sonata-filters-box div.form-group span.input-group-addon {
+    padding: 3px 10px;
+    font-size: 13px;
+}


### PR DESCRIPTION
tidies up the use of sonata_type_date_picker inside the filter box

before image: http://postimg.org/image/62hpl3vw4/

after image: http://postimg.org/image/4w4h7otbn/