### PR TITLE
Use relative urls for model_autocomplete_widget

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -295,7 +295,7 @@ file that was distributed with this source code.
                 minimumInputLength: {{ minimum_input_length }},
                 multiple: {{ multiple ? 'true' : 'false' }},
                 ajax: {
-                    url:  "{{ url ?: url(route.name, route.parameters|default([])) }}",
+                    url:  "{{ url ?: path(route.name, route.parameters|default([])) }}",
                     dataType: 'json',
                     quietMillis: 100,
                     data: function (term, page) { // page is the one-based page number tracked by Select2


### PR DESCRIPTION
On autocompletion, the url contains the host of the current request.

My issue is when symfony is used behind a reverse proxy the rewrite the domain name, the AJAX request for auto completion is done on the wrong host. 