### PR TITLE
Fix wrong variable naming enitity in form_types

### DIFF
--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -206,8 +206,8 @@ to_string_callback
     $formMapper
         ->add('category', 'sonata_type_model_autocomplete', array(
             'property'=>'title',
-            'to_string_callback' => function($enitity, $property) {
-                return $enitity->getTitle();
+            'to_string_callback' => function($entity, $property) {
+                return $entity->getTitle();
             },
         )
     );


### PR DESCRIPTION
Wrong variable naming in example of sonata_type_model_autocomplete in form_types page.

$enitity should be $entity.