### PR TITLE
Support for persistent parameters in list editables

### DIFF
--- a/Resources/views/CRUD/base_list_field.html.twig
+++ b/Resources/views/CRUD/base_list_field.html.twig
@@ -28,7 +28,7 @@ file that was distributed with this source code.
         {% set xEditableType = field_description.type|sonata_xeditable_type %}
 
         {% if isEditable and xEditableType %}
-            {% set url = path('sonata_admin_set_object_field_value', { 'context': 'list', 'field': field_description.name, 'objectId': admin.id(object), 'code': admin.code(object)|merge(admin.getPersistentParameters) })  %}
+            {% set url = path('sonata_admin_set_object_field_value', { 'context': 'list', 'field': field_description.name, 'objectId': admin.id(object), 'code': admin.code(object)|merge(admin.getPersistentParameters|default([])) })  %}
             <span {% block field_span_attributes %}class="x-editable" data-type="{{ xEditableType }}" data-value="{{ value }}" data-title="{{ field_description.label|trans({}, field_description.translationDomain) }}" data-pk="{{ admin.id(object) }}" data-url="{{ url }}" {% endblock %}>
                 {{ block('field') }}
             </span>

--- a/Resources/views/CRUD/base_list_field.html.twig
+++ b/Resources/views/CRUD/base_list_field.html.twig
@@ -28,7 +28,7 @@ file that was distributed with this source code.
         {% set xEditableType = field_description.type|sonata_xeditable_type %}
 
         {% if isEditable and xEditableType %}
-            {% set url = path('sonata_admin_set_object_field_value', { 'context': 'list', 'field': field_description.name, 'objectId': admin.id(object), 'code': admin.code(object) })  %}
+            {% set url = path('sonata_admin_set_object_field_value', { 'context': 'list', 'field': field_description.name, 'objectId': admin.id(object), 'code': admin.code(object)|merge(admin.getPersistentParameters) })  %}
             <span {% block field_span_attributes %}class="x-editable" data-type="{{ xEditableType }}" data-value="{{ value }}" data-title="{{ field_description.label|trans({}, field_description.translationDomain) }}" data-pk="{{ admin.id(object) }}" data-url="{{ url }}" {% endblock %}>
                 {{ block('field') }}
             </span>

--- a/Resources/views/CRUD/base_list_field.html.twig
+++ b/Resources/views/CRUD/base_list_field.html.twig
@@ -28,7 +28,7 @@ file that was distributed with this source code.
         {% set xEditableType = field_description.type|sonata_xeditable_type %}
 
         {% if isEditable and xEditableType %}
-            {% set url = path('sonata_admin_set_object_field_value', { 'context': 'list', 'field': field_description.name, 'objectId': admin.id(object), 'code': admin.code(object)|merge(admin.getPersistentParameters|default([])) })  %}
+            {% set url = path('sonata_admin_set_object_field_value', { 'context': 'list', 'field': field_description.name, 'objectId': admin.id(object), 'code': admin.code(object) }|merge(admin.getPersistentParameters|default([])) )  %}
             <span {% block field_span_attributes %}class="x-editable" data-type="{{ xEditableType }}" data-value="{{ value }}" data-title="{{ field_description.label|trans({}, field_description.translationDomain) }}" data-pk="{{ admin.id(object) }}" data-url="{{ url }}" {% endblock %}>
                 {{ block('field') }}
             </span>


### PR DESCRIPTION
The url for inline editables in admin listings was missing support for persistent parameters