### PR TITLE
Fixed wrong class in preview documentation

### DIFF
--- a/Resources/doc/reference/preview_mode.rst
+++ b/Resources/doc/reference/preview_mode.rst
@@ -118,7 +118,7 @@ Hiding the fieldset tags with css (display:none) will be enough to only show the
 
 .. code-block:: css
 
-    .sonata-preview-form .row {
+    .sonata-preview-form-container .row {
         display: none;
     };
 
@@ -126,7 +126,7 @@ Or if you prefer less:
 
 .. code-block:: sass
 
-    div.sonata-preview-form {
+    div.sonata-preview-form-container {
       .row {
         display: none;
       };


### PR DESCRIPTION
In https://github.com/sonata-project/SonataAdminBundle/blob/master/Resources/views/CRUD/preview.html.twig

there is ``sonata-preview-form-container`` and not ``sonata-preview-form`` class.