### PR TITLE
Adapt PHPDoc Block @return value for proper auto-completion.

### DIFF
--- a/Mapper/BaseGroupedMapper.php
+++ b/Mapper/BaseGroupedMapper.php
@@ -33,7 +33,7 @@ abstract class BaseGroupedMapper extends BaseMapper
      * @param string $name
      * @param array  $options
      *
-     * @return BaseGroupedMapper
+     * @return $this
      *
      * @throws \RuntimeException
      */
@@ -142,7 +142,7 @@ abstract class BaseGroupedMapper extends BaseMapper
      *
      * @param boolean $bool
      *
-     * @return BaseGroupedMapper
+     * @return $this
      *
      * @throws \RuntimeException
      */
@@ -162,7 +162,7 @@ abstract class BaseGroupedMapper extends BaseMapper
      *
      * @param boolean $bool
      *
-     * @return BaseGroupedMapper
+     * @return $this
      *
      * @throws \RuntimeException
      */
@@ -193,7 +193,7 @@ abstract class BaseGroupedMapper extends BaseMapper
      * @param string $name
      * @param array  $options
      *
-     * @return BaseGroupedMapper
+     * @return $this
      */
     public function tab($name, array $options = array())
     {
@@ -203,7 +203,7 @@ abstract class BaseGroupedMapper extends BaseMapper
     /**
      * Close the current group or tab
      *
-     * @return BaseGroupedMapper
+     * @return $this
      *
      * @throws \RuntimeException
      */

--- a/Mapper/BaseMapper.php
+++ b/Mapper/BaseMapper.php
@@ -59,14 +59,14 @@ abstract class BaseMapper
     /**
      * @param string $key
      *
-     * @return \Sonata\AdminBundle\Mapper\BaseMapper
+     * @return $this
      */
     abstract public function remove($key);
 
     /**
      * @param array $keys field names
      *
-     * @return \Sonata\AdminBundle\Mapper\BaseMapper
+     * @return $this
      */
     abstract public function reorder(array $keys);
 }


### PR DESCRIPTION
Fixes PhpStorm auto-completion for this kind of code, in a class extending `BaseMapper` : 

```
    protected function configureShowFields(ShowMapper $showMapper)
    {
        $showMapper
            ->with('something')
                ->add('foo', 'text') // <-- add is not recognized without this PR
            ->end();
    }
```