### PR TITLE
Update form_admin_fields.html.twig

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -181,7 +181,7 @@ file that was distributed with this source code.
             </div>
         </div>
     {% else %}
-        <div class="form-group{% if errors|length > 0%} has-error{%endif%}" id="sonata-ba-field-container-{{ id }}">
+        <div class="form-group {% if sonata_admin.field_description.options.form_group_class is defined %} {{ sonata_admin.field_description.options.form_group_class }} {% endif %} {% if errors|length > 0%} has-error{%endif%}" id="sonata-ba-field-container-{{ id }}">
             {% block label %}
                 {% if sonata_admin.field_description.options.name is defined %}
                     {{ form_label(form, sonata_admin.field_description.options.name, { 'attr' : {'class' : label_class} }) }}


### PR DESCRIPTION
I've added the option

```jinja
{% if sonata_admin.field_description.options.form_group_class is defined %} {{ sonata_admin.field_description.options.form_group_class }} {% endif %}
```

to the form-group rendering. This makes it possible to add a custom class to your form groups which can be used to customise the look and feel of a form element (label + field).

In the admin class you can set the class like:

```php
->add('isActive', null, array(), array('form_group_class' => 'my_custom_class'))
```

Check images in attachment.

For the fields I needed a new layout mode, but there are also fields that do not need a horizontal layout and with the class I can choose which one needs to be different than the default layout.

If any questions about this, feel free to ask.

BEFORE: 
![screen shot 2015-02-26 at 11 06 23](https://cloud.githubusercontent.com/assets/3961971/6389822/b3713faa-bda7-11e4-999c-954851f8d81a.png)

AFTER:
![screen shot 2015-02-26 at 11 05 43](https://cloud.githubusercontent.com/assets/3961971/6389830/bbc12742-bda7-11e4-9fe7-5a64d3a4f684.png)
