### PR TITLE
Improved `show_filter` filter option to always display filter.

### DIFF
--- a/Datagrid/Datagrid.php
+++ b/Datagrid/Datagrid.php
@@ -14,7 +14,6 @@ namespace Sonata\AdminBundle\Datagrid;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
-
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\CallbackTransformer;
@@ -224,7 +223,7 @@ class Datagrid implements DatagridInterface
     {
         $this->values[$name] = array(
             'type'  => $operator,
-            'value' => $value
+            'value' => $value,
         );
     }
 
@@ -248,7 +247,8 @@ class Datagrid implements DatagridInterface
     public function hasDisplayableFilters()
     {
         foreach ($this->filters as $name => $filter) {
-            if ($filter->isActive() && $filter->getOption('show_filter', true)) {
+            $showFilter = $filter->getOption('show_filter', null);
+            if (($filter->isActive() && $showFilter === null) || ($showFilter === true)) {
                 return true;
             }
         }

--- a/Filter/Filter.php
+++ b/Filter/Filter.php
@@ -183,7 +183,7 @@ abstract class Filter implements FilterInterface
     public function setOptions(array $options)
     {
         $this->options = array_merge(
-            array('show_filter' => true),
+            array('show_filter' => null),
             $this->getDefaultOptions(),
             $options
         );

--- a/Resources/doc/reference/action_list.rst
+++ b/Resources/doc/reference/action_list.rst
@@ -221,6 +221,45 @@ To do:
 Filters
 -------
 
+You can add filters to let user control which data will be displayed.
+
+.. code-block:: php
+
+    <?php
+    // src/Acme/DemoBundle/Admin/PostAdmin.php
+
+    use Sonata\AdminBundle\Datagrid\DatagridMapper;;
+
+    class ClientAdmin extends Admin
+    {
+
+        protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+        {
+            $datagridMapper
+                ->add('phone')
+                ->add('email')
+            ;
+        }
+    }
+
+All filters are hidden by defualt for space-saving. User has to check which filter
+he wants to use.
+
+To make the filter always visible (even when it is inactive), set the parameter
+``show_filter`` to ``true``.
+
+.. code-block:: php
+
+    <?php
+
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $datagridMapper
+            ->add('phone')
+            ->add('email', null, array('show_filter'=>true))
+        ;
+    }
+
 To do:
 
 - basic filter configuration and options

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -195,10 +195,10 @@ file that was distributed with this source code.
                 <a href="#" class="dropdown-toggle sonata-ba-action" data-toggle="dropdown">{{ 'link_filters'|trans({}, 'SonataAdminBundle') }} <b class="caret"></b></a>
 
                 <ul class="dropdown-menu" role="menu">
-                    {% for filter in admin.datagrid.filters if filter.options['show_filter']%}
+                    {% for filter in admin.datagrid.filters if (filter.options['show_filter'] is sameas(true) or filter.options['show_filter'] is null) %}
                         <li>
                             <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
-                                <i class="fa {{ filter.isActive() ? 'fa-check-square-o' : 'fa-square-o' }}"></i>{{ admin.trans(filter.label, {}, filter.translationDomain) }}
+                                <i class="fa {{ (filter.isActive() or filter.options['show_filter']) ? 'fa-check-square-o' : 'fa-square-o' }}"></i>{{ admin.trans(filter.label, {}, filter.translationDomain) }}
                             </a>
                         </li>
                     {% endfor %}
@@ -222,7 +222,7 @@ file that was distributed with this source code.
                             <div class="col-md-9">
                                 <div class="filter_container">
                                     {% for filter in admin.datagrid.filters %}
-                                        <div class="form-group" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ filter.options['show_filter'] ? 'true' : 'false' }}" style="display: {% if filter.isActive() and filter.options['show_filter'] %}block{% else %}none{% endif %}">
+                                        <div class="form-group" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ (filter.options['show_filter'] is sameas(true) or filter.options['show_filter'] is null) ? 'true' : 'false' }}" style="display: {% if (filter.isActive() and filter.options['show_filter'] is null) or (filter.options['show_filter'] is sameas(true)) %}block{% else %}none{% endif %}">
                                             {% if filter.label is not sameas(false) %}
                                             <label for="{{ form.children[filter.formName].children['value'].vars.id }}" class="col-sm-3 control-label">{{ admin.trans(filter.label, {}, filter.translationDomain) }}</label>
                                             {% endif %}

--- a/Tests/Datagrid/DatagridMapperTest.php
+++ b/Tests/Datagrid/DatagridMapperTest.php
@@ -57,7 +57,7 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
 
         $filter->expects($this->any())
             ->method('getDefaultOptions')
-            ->will($this->returnValue(array('foo_default_option'=>'bar_default')));
+            ->will($this->returnValue(array('foo_default_option' => 'bar_default')));
 
         $datagridBuilder->expects($this->any())
             ->method('addFilter')
@@ -76,7 +76,7 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
 
         $modelManager->expects($this->any())
             ->method('getNewFieldDescriptionInstance')
-            ->will($this->returnCallback(function($class, $name, array $options = array()) use ($fieldDescription) {
+            ->will($this->returnCallback(function ($class, $name, array $options = array()) use ($fieldDescription) {
                 $fieldDescriptionClone = clone $fieldDescription;
                 $fieldDescriptionClone->setName($name);
                 $fieldDescriptionClone->setOptions($options);
@@ -95,7 +95,7 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
     {
         $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
 
-        $this->assertEquals($this->datagridMapper, $this->datagridMapper->add($fieldDescription, null, array('field_name'=>'fooFilterName')));
+        $this->assertEquals($this->datagridMapper, $this->datagridMapper->add($fieldDescription, null, array('field_name' => 'fooFilterName')));
         $this->assertEquals($this->datagridMapper, $this->datagridMapper->remove('fooName'));
         $this->assertEquals($this->datagridMapper, $this->datagridMapper->reorder(array()));
     }
@@ -106,7 +106,7 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
 
         $fieldDescription = $this->getFieldDescriptionMock('foo.name', 'fooLabel');
 
-        $this->datagridMapper->add($fieldDescription, null, array('field_name'=>'fooFilterName'));
+        $this->datagridMapper->add($fieldDescription, null, array('field_name' => 'fooFilterName'));
 
         $filter = $this->datagridMapper->get('foo.name');
         $this->assertInstanceOf('Sonata\AdminBundle\Filter\FilterInterface', $filter);
@@ -114,14 +114,14 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo__name', $filter->getFormName());
         $this->assertEquals('text', $filter->getFieldType());
         $this->assertEquals('fooLabel', $filter->getLabel());
-        $this->assertEquals(array('required'=>false), $filter->getFieldOptions());
+        $this->assertEquals(array('required' => false), $filter->getFieldOptions());
         $this->assertEquals(array(
             'foo_default_option' => 'bar_default',
             'label' => 'fooLabel',
             'field_name' => 'fooFilterName',
             'placeholder' => 'short_object_description_placeholder',
             'link_parameters' => array(),
-            'show_filter' => true
+            'show_filter' => null,
         ), $filter->getOptions());
     }
 
@@ -131,7 +131,7 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
 
         $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
 
-        $this->datagridMapper->add($fieldDescription, 'foo_type', array('field_name'=>'fooFilterName', 'foo_filter_option'=>'foo_filter_option_value', 'foo_default_option'=>'bar_custom'), 'foo_field_type', array('foo_field_option'=>'baz'));
+        $this->datagridMapper->add($fieldDescription, 'foo_type', array('field_name' => 'fooFilterName', 'foo_filter_option' => 'foo_filter_option_value', 'foo_default_option' => 'bar_custom'), 'foo_field_type', array('foo_field_option' => 'baz'));
 
         $filter = $this->datagridMapper->get('fooName');
         $this->assertInstanceOf('Sonata\AdminBundle\Filter\FilterInterface', $filter);
@@ -139,17 +139,17 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('fooName', $filter->getFormName());
         $this->assertEquals('foo_field_type', $filter->getFieldType());
         $this->assertEquals('fooLabel', $filter->getLabel());
-        $this->assertEquals(array('foo_field_option'=>'baz'), $filter->getFieldOptions());
+        $this->assertEquals(array('foo_field_option' => 'baz'), $filter->getFieldOptions());
         $this->assertEquals(array(
             'foo_default_option' => 'bar_custom',
             'label' => 'fooLabel',
             'field_name' => 'fooFilterName',
-            'field_options' => array ('foo_field_option' => 'baz'),
+            'field_options' => array('foo_field_option' => 'baz'),
             'field_type' => 'foo_field_type',
             'placeholder' => 'short_object_description_placeholder',
             'foo_filter_option' => 'foo_filter_option_value',
             'link_parameters' => array(),
-            'show_filter' => true
+            'show_filter' => null,
         ), $filter->getOptions());
     }
 
@@ -184,7 +184,7 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
 
         $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
 
-        $this->datagridMapper->add($fieldDescription, null, array('field_name'=>'fooFilterName'));
+        $this->datagridMapper->add($fieldDescription, null, array('field_name' => 'fooFilterName'));
         $this->assertTrue($this->datagridMapper->has('fooName'));
 
         $this->datagridMapper->remove('fooName');
@@ -226,8 +226,8 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
         } catch (\RuntimeException $e) {
             $this->assertContains('Duplicate field name "fooName" in datagrid mapper. Names should be unique.', $e->getMessage());
 
-        return;
- }
+            return;
+        }
 
         $this->fail('Failed asserting that exception of type "\RuntimeException" is thrown.');
     }
@@ -239,10 +239,10 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
         $fieldDescription3 = $this->getFieldDescriptionMock('fooName3', 'fooLabel3');
         $fieldDescription4 = $this->getFieldDescriptionMock('fooName4', 'fooLabel4');
 
-        $this->datagridMapper->add($fieldDescription1, null, array('field_name'=>'fooFilterName1'));
-        $this->datagridMapper->add($fieldDescription2, null, array('field_name'=>'fooFilterName2'));
-        $this->datagridMapper->add($fieldDescription3, null, array('field_name'=>'fooFilterName3'));
-        $this->datagridMapper->add($fieldDescription4, null, array('field_name'=>'fooFilterName4'));
+        $this->datagridMapper->add($fieldDescription1, null, array('field_name' => 'fooFilterName1'));
+        $this->datagridMapper->add($fieldDescription2, null, array('field_name' => 'fooFilterName2'));
+        $this->datagridMapper->add($fieldDescription3, null, array('field_name' => 'fooFilterName3'));
+        $this->datagridMapper->add($fieldDescription4, null, array('field_name' => 'fooFilterName4'));
 
         $this->assertEquals(array(
             'fooName1',

--- a/Tests/Datagrid/DatagridTest.php
+++ b/Tests/Datagrid/DatagridTest.php
@@ -71,7 +71,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
                     return $formTypes[$name];
                 }
 
-                return null;
+                return;
             }));
 
         // php 5.3 BC
@@ -83,7 +83,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnCallback(function ($name, $type, $options) use (& $formTypes, $eventDispatcher, $formFactory) {
                 $formTypes[$name] = new FormBuilder($name, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Form\TestEntity', $eventDispatcher, $formFactory, $options);
 
-                return null;
+                return;
             }));
 
         // php 5.3 BC
@@ -151,11 +151,11 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
         $this->datagrid->addFilter($filter2);
         $this->datagrid->addFilter($filter3);
 
-        $this->assertEquals(array('foo'=>$filter1, 'bar'=>$filter2, 'baz'=>$filter3), $this->datagrid->getFilters());
+        $this->assertEquals(array('foo' => $filter1, 'bar' => $filter2, 'baz' => $filter3), $this->datagrid->getFilters());
 
         $this->datagrid->removeFilter('bar');
 
-        $this->assertEquals(array('foo'=>$filter1, 'baz'=>$filter3), $this->datagrid->getFilters());
+        $this->assertEquals(array('foo' => $filter1, 'baz' => $filter3), $this->datagrid->getFilters());
     }
 
     public function testReorderFilters()
@@ -181,12 +181,12 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
         $this->datagrid->addFilter($filter2);
         $this->datagrid->addFilter($filter3);
 
-        $this->assertEquals(array('foo'=>$filter1, 'bar'=>$filter2, 'baz'=>$filter3), $this->datagrid->getFilters());
+        $this->assertEquals(array('foo' => $filter1, 'bar' => $filter2, 'baz' => $filter3), $this->datagrid->getFilters());
         $this->assertEquals(array('foo', 'bar', 'baz'), array_keys($this->datagrid->getFilters()));
 
         $this->datagrid->reorderFilters(array('bar', 'baz', 'foo'));
 
-        $this->assertEquals(array('bar'=>$filter2, 'baz'=>$filter3, 'foo'=>$filter1), $this->datagrid->getFilters());
+        $this->assertEquals(array('bar' => $filter2, 'baz' => $filter3, 'foo' => $filter1), $this->datagrid->getFilters());
         $this->assertEquals(array('bar', 'baz', 'foo'), array_keys($this->datagrid->getFilters()));
     }
 
@@ -196,7 +196,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->datagrid->setValue('foo', 'bar', 'baz');
 
-        $this->assertEquals(array('foo'=>array('type'=>'bar', 'value'=>'baz')), $this->datagrid->getValues());
+        $this->assertEquals(array('foo' => array('type' => 'bar', 'value' => 'baz')), $this->datagrid->getValues());
     }
 
     public function testGetColumns()
@@ -241,34 +241,59 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
     public function testHasDisplayableFilters()
     {
         $this->assertFalse($this->datagrid->hasDisplayableFilters());
+    }
 
-        $filter1 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
-        $filter1->expects($this->once())
+    public function testHasDisplayableFiltersNotActive()
+    {
+        $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
-        $filter1->expects($this->any())
+        $filter->expects($this->any())
             ->method('getOption')
             ->will($this->returnValue(false));
-        $filter1->expects($this->any())
+        $filter->expects($this->any())
             ->method('isActive')
             ->will($this->returnValue(false));
 
-        $this->datagrid->addFilter($filter1);
+        $this->datagrid->addFilter($filter);
 
         $this->assertFalse($this->datagrid->hasDisplayableFilters());
+    }
 
-        $filter2 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
-        $filter2->expects($this->once())
+    public function testHasDisplayableFiltersActive()
+    {
+        $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
-        $filter2->expects($this->any())
+        $filter->expects($this->any())
             ->method('getOption')
             ->will($this->returnValue(true));
-        $filter2->expects($this->any())
+        $filter->expects($this->any())
             ->method('isActive')
             ->will($this->returnValue(true));
 
-        $this->datagrid->addFilter($filter2);
+        $this->datagrid->addFilter($filter);
+
+        $this->assertTrue($this->datagrid->hasDisplayableFilters());
+    }
+
+    public function testHasDisplayableFiltersAlwaysShow()
+    {
+        $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter->expects($this->once())
+            ->method('getName')
+            ->will($this->returnValue('bar'));
+        $filter->expects($this->any())
+            ->method('getOption')
+            ->with($this->equalTo('show_filter'))
+            ->will($this->returnValue(true));
+        $filter->expects($this->any())
+            ->method('isActive')
+            ->will($this->returnValue(false));
+
+        $this->datagrid->addFilter($filter);
 
         $this->assertTrue($this->datagrid->hasDisplayableFilters());
     }
@@ -303,7 +328,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(false));
         $filter1->expects($this->any())
             ->method('getRenderSettings')
-            ->will($this->returnValue(array('foo1', array('bar1'=>'baz1'))));
+            ->will($this->returnValue(array('foo1', array('bar1' => 'baz1'))));
 
         $this->datagrid->addFilter($filter1);
 
@@ -319,13 +344,13 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
         $filter2->expects($this->any())
             ->method('getRenderSettings')
-            ->will($this->returnValue(array('foo2', array('bar2'=>'baz2'))));
+            ->will($this->returnValue(array('foo2', array('bar2' => 'baz2'))));
 
         $this->datagrid->addFilter($filter2);
 
         $this->datagrid->buildPager();
 
-        $this->assertEquals(array('foo'=>null, 'bar'=> null), $this->datagrid->getValues());
+        $this->assertEquals(array('foo' => null, 'bar' => null), $this->datagrid->getValues());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('fooFormName'));
         $this->assertEquals(array('bar1' => 'baz1'), $this->formBuilder->get('fooFormName')->getOptions());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('barFormName'));
@@ -351,7 +376,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(false));
         $filter->expects($this->any())
             ->method('getRenderSettings')
-            ->will($this->returnValue(array('foo', array('bar'=>'baz'))));
+            ->will($this->returnValue(array('foo', array('bar' => 'baz'))));
 
         $this->datagrid->addFilter($filter);
 
@@ -377,7 +402,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('1'))
             ->will($this->returnValue(null));
 
-        $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, array('_sort_by'=>$sortBy));
+        $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, array('_sort_by' => $sortBy));
 
         $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter->expects($this->once())
@@ -391,13 +416,13 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(false));
         $filter->expects($this->any())
             ->method('getRenderSettings')
-            ->will($this->returnValue(array('foo', array('bar'=>'baz'))));
+            ->will($this->returnValue(array('foo', array('bar' => 'baz'))));
 
         $this->datagrid->addFilter($filter);
 
         $this->datagrid->buildPager();
 
-        $this->assertEquals(array('_sort_by'=>$sortBy, 'foo'=>null), $this->datagrid->getValues());
+        $this->assertEquals(array('_sort_by' => $sortBy, 'foo' => null), $this->datagrid->getValues());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('fooFormName'));
         $this->assertEquals(array('bar' => 'baz'), $this->formBuilder->get('fooFormName')->getOptions());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_by'));
@@ -426,7 +451,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('3'))
             ->will($this->returnValue(null));
 
-        $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, array('_sort_by'=>$sortBy, '_page'=>$page, '_per_page'=>$perPage));
+        $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, array('_sort_by' => $sortBy, '_page' => $page, '_per_page' => $perPage));
 
         $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter->expects($this->once())
@@ -440,13 +465,13 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(false));
         $filter->expects($this->any())
             ->method('getRenderSettings')
-            ->will($this->returnValue(array('foo', array('bar'=>'baz'))));
+            ->will($this->returnValue(array('foo', array('bar' => 'baz'))));
 
         $this->datagrid->addFilter($filter);
 
         $this->datagrid->buildPager();
 
-        $this->assertEquals(array('_sort_by'=>$sortBy, 'foo'=>null, '_page' => 3, '_per_page' => 50), $this->datagrid->getValues());
+        $this->assertEquals(array('_sort_by' => $sortBy, 'foo' => null, '_page' => 3, '_per_page' => 50), $this->datagrid->getValues());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('fooFormName'));
         $this->assertEquals(array('bar' => 'baz'), $this->formBuilder->get('fooFormName')->getOptions());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_by'));
@@ -487,7 +512,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->datagrid->buildPager();
 
-        $this->assertEquals(array('_page' => array('type'=>null, 'value'=>3), '_per_page' => array('type'=>null, 'value'=>50)), $this->datagrid->getValues());
+        $this->assertEquals(array('_page' => array('type' => null, 'value' => 3), '_per_page' => array('type' => null, 'value' => 50)), $this->datagrid->getValues());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_by'));
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_order'));
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_page'));

--- a/Tests/Filter/FilterTest.php
+++ b/Tests/Filter/FilterTest.php
@@ -28,7 +28,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
             'label'         => 'foo',
             'field_type'    => 'integer',
             'field_options' => array('required' => true),
-            'field_name'    => 'name'
+            'field_name'    => 'name',
         );
 
         $filter->setOptions($options);
@@ -38,7 +38,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
 
         $expected = $options;
         $expected['foo'] = 'bar';
-        $expected['show_filter'] = true;
+        $expected['show_filter'] = null;
 
         $this->assertEquals($expected, $filter->getOptions());
         $this->assertEquals('name', $filter->getFieldName());
@@ -56,10 +56,10 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FooFilter();
         $filter->initialize('name', array(
-            'field_options' => array('foo'=>'bar', 'baz'=>12345)
+            'field_options' => array('foo' => 'bar', 'baz' => 12345),
         ));
 
-        $this->assertSame(array('foo'=>'bar', 'baz'=>12345), $filter->getFieldOptions());
+        $this->assertSame(array('foo' => 'bar', 'baz' => 12345), $filter->getFieldOptions());
         $this->assertSame('bar', $filter->getFieldOption('foo'));
         $this->assertSame(12345, $filter->getFieldOption('baz'));
     }
@@ -67,12 +67,12 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     public function testSetFieldOption()
     {
         $filter = new FooFilter();
-        $this->assertEquals(array('required'=>false), $filter->getFieldOptions());
+        $this->assertEquals(array('required' => false), $filter->getFieldOptions());
 
         $filter->setFieldOption('foo', 'bar');
         $filter->setFieldOption('baz', 12345);
 
-        $this->assertSame(array('foo'=>'bar', 'baz'=>12345), $filter->getFieldOptions());
+        $this->assertSame(array('foo' => 'bar', 'baz' => 12345), $filter->getFieldOptions());
         $this->assertSame('bar', $filter->getFieldOption('foo'));
         $this->assertSame(12345, $filter->getFieldOption('baz'));
     }
@@ -81,7 +81,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FooFilter();
         $filter->initialize('name', array(
-            'field_name' => 'bar'
+            'field_name' => 'bar',
         ));
 
         $this->assertEquals('name', $filter->getName());
@@ -165,7 +165,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
             'length'     => 200,
             'unique'     => true,
             'nullable'   => false,
-            'declared'   => 'Foo\Bar\User'
+            'declared'   => 'Foo\Bar\User',
         );
 
         $filter = new FooFilter();
@@ -178,17 +178,15 @@ class FilterTest extends \PHPUnit_Framework_TestCase
         $parentAssociationMapping = array(
             0 => array('fieldName'    => 'user',
                 'targetEntity' => 'Foo\Bar\User',
-                'joinColumns'  =>
-                array(
-                    0 =>
-                    array(
+                'joinColumns'  => array(
+                    0 => array(
                         'name'                 => 'user_id',
                         'referencedColumnName' => 'user_id',
-                    )
+                    ),
                 ),
                 'type'         => 2,
                 'mappedBy'     => null,
-            )
+            ),
         );
 
         $filter = new FooFilter();
@@ -217,13 +215,11 @@ class FilterTest extends \PHPUnit_Framework_TestCase
         $associationMapping = array(
             'fieldName'    => 'user',
             'targetEntity' => 'Foo\Bar\User',
-            'joinColumns'  =>
-            array(
-                0 =>
-                array(
+            'joinColumns'  => array(
+                0 => array(
                     'name'                 => 'user_id',
                     'referencedColumnName' => 'user_id',
-                )
+                ),
             ),
             'type'         => 2,
             'mappedBy'     => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2668
| License       | MIT

This PR deprecates #2490.

The current master version of SonataAdmin hides all filters by default which is great UI improvement. But there are some use cases, when we need some filters to be always visible.

Instead of adding another option (which may be confusing) this PR uses alreay available option `show_filter`. The default value of this option is changed from `true` to `null`. `null` in this context means: use the default behaviour of filters (hidden, but usable after check the checkbox).
If it will be set to `true`, the filter will be always visible.