### PR TITLE
Fixed service existence check

### DIFF
--- a/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -64,7 +64,7 @@ class ExtensionCompilerPass implements CompilerPassInterface
             $extensions = $this->getExtensionsForAdmin($id, $admin, $container, $extensionMap);
 
             foreach ($extensions as $extension) {
-                if (!$container->findDefinition($extension)) {
+                if (!$container->has($extension)) {
                     throw new \InvalidArgumentException(sprintf('Unable to find extension service for id %s', $extension));
                 }
                 $admin->addMethodCall('addExtension', array(new Reference($extension)));


### PR DESCRIPTION
I commited some broken code to Sonata recently, this PR fixes it.

`findDefinition` throws an exception when the definition does not exists, which is not what you want.
`hasDefinition` only searches in the definitions, which is not what you want as it doesn't support aliases
`has` searches in both definitions and aliases, which is what you want.