### PR TITLE
Symfony 2.7 ValidatorInterface has moved

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -14,7 +14,7 @@ namespace Sonata\AdminBundle\Admin;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\Util\PropertyPath;
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\HttpFoundation\Request;

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -24,7 +24,7 @@ use Sonata\AdminBundle\Route\RouteGeneratorInterface;
 
 use Knp\Menu\FactoryInterface as MenuFactoryInterface;
 
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
The Interface has moved to a new namespace. Projects using 2.7 are unable
to use sonata without this change.