### PR TITLE
Add 'translation_domain' and 'role' option to menu config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -134,6 +134,8 @@ class Configuration implements ConfigurationInterface
                                             ->children()
                                                 ->scalarNode('admin')->end()
                                                 ->scalarNode('label')->end()
+                                                ->scalarNode('translation_domain')->end()
+                                                ->scalarNode('role')->end()
                                                 ->scalarNode('route')->end()
                                                 ->arrayNode('route_params')
                                                     ->prototype('scalar')->end()

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -10,6 +10,7 @@
 
             <argument type="service" id="sonata.admin.pool" />
             <argument type="service" id="router" />
+            <argument type="service" id="security.context" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
     </services>

--- a/Resources/doc/reference/knp_menu.rst
+++ b/Resources/doc/reference/knp_menu.rst
@@ -42,11 +42,15 @@ Add the controller route as an item of the menu
                     label_catalogue:      ~
                     items:
                         - sonata.news.admin.post
-                        - route:        blog_home
-                          label:        Blog
-                        - route:        blog_article
-                          route_params: { articleId: 3 }
-                          label:        Article
+                        - route:              blog_home
+                          label:              Blog
+                          translation_domain: SonataNewsBundle
+                          role:               ROLE_ADMIN
+                        - route:              blog_article
+                          route_params:       { articleId: 3 }
+                          label:              Article
+                          translation_domain: SonataNewsBundle
+                          role:               ROLE_ADMIN
                     ...
 
 Also you can override the template of knp_menu used by sonata. The default one is `SonataAdminBundle:Menu:sonata_menu.html.twig`:

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -22,6 +22,7 @@ use Sonata\AdminBundle\Exception\NoValueException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 
 class SonataAdminExtension extends \Twig_Extension
 {
@@ -41,6 +42,11 @@ class SonataAdminExtension extends \Twig_Extension
     protected $router;
 
     /**
+     * @var SecurityContextInterface
+     */
+    protected $securityContext;
+
+    /**
      * @var LoggerInterface
      */
     protected $logger;
@@ -49,11 +55,12 @@ class SonataAdminExtension extends \Twig_Extension
      * @param Pool            $pool
      * @param LoggerInterface $logger
      */
-    public function __construct(Pool $pool, RouterInterface $router, LoggerInterface $logger = null)
+    public function __construct(Pool $pool, RouterInterface $router, SecurityContextInterface $securityContext, LoggerInterface $logger = null)
     {
         $this->pool   = $pool;
         $this->logger = $logger;
         $this->router = $router;
+        $this->securityContext = $securityContext;
     }
 
     /**
@@ -403,9 +410,13 @@ class SonataAdminExtension extends \Twig_Extension
                     $route             = $admin->generateUrl('list');
                     $translationDomain = $admin->getTranslationDomain();
                 } else {
+                    if (!empty($item['role']) && !$this->securityContext->isGranted($item['role'])) {
+                        continue;
+                    }
+
                     $label             = $item['label'];
                     $route             = $this->router->generate($item['route'], $item['route_params']);
-                    $translationDomain = null;
+                    $translationDomain = $item['translation_domain'];
                     $admin             = null;
                 }
 


### PR DESCRIPTION
This PR allows to set a ``translation_domain`` and a ``role`` in the menu config : 

```
    sonata_admin:
        dashboard:
            groups:
                news:
                    label:                ~
                    label_catalogue:      ~
                    items:
                        - route:              blog_article
                          route_params:       { articleId: 3 }
                          label:              Article
                          translation_domain: SonataNewsBundle
                          role:               ROLE_ADMIN
```