### PR TITLE
Use label_catalogue to translate menu items labels

### DIFF
--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -405,7 +405,7 @@ class SonataAdminExtension extends \Twig_Extension
                 } else {
                     $label             = $item['label'];
                     $route             = $this->router->generate($item['route'], $item['route_params']);
-                    $translationDomain = null;
+                    $translationDomain = $group['label_catalogue'];
                     $admin             = null;
                 }
 


### PR DESCRIPTION
This PR simplify use the group ``label_catalogue`` option to translation the items labels.