### PR TITLE
Do not add form-control class to file inputs

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -19,7 +19,10 @@ file that was distributed with this source code.
 {%- endblock form_widget %}
 
 {% block form_widget_simple %}
-    {% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
+    {% set type = type|default('text') %}
+    {% if type != 'file' %}
+        {% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
+    {% endif %}
     {{ parent() }}
 {% endblock form_widget_simple %}
 


### PR DESCRIPTION
File inputs should not have a ``form-control`` class (see http://getbootstrap.com/css/#forms)