### PR TITLE
Replace box-success with box-primary

### DIFF
--- a/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -3,7 +3,7 @@
     {% for code in groups %}
         {% set form_group = admin.formgroups[code] %}
         <div class="{{ form_group.class }}"> {# default class 'col-md-12' removed because it do not work with tabs#}
-            <div class="box box-success">
+            <div class="box box-primary">
                 <div class="box-header">
                     <h4 class="box-title">
                         {{ admin.trans(form_group.name, {}, form_group.translation_domain) }}


### PR DESCRIPTION
I think it's a more apprioriate class name. It's better to override "box-primary" instead of "box-success" to customize this color.

**Before**
![before](https://cloud.githubusercontent.com/assets/663607/6506854/2fdfd23a-c34e-11e4-9cb1-91e0a4b99723.JPG)

**After**
![after](https://cloud.githubusercontent.com/assets/663607/6506853/2fc81c08-c34e-11e4-87dc-a7ee15d59595.JPG)