### PR TITLE
Do not add form-control class if select2 is used

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -127,7 +127,7 @@ file that was distributed with this source code.
                                                 ({{ admin.datagrid.pager.nbresults }})
                                             </label>
 
-                                            <select name="action" style="width: auto; height: auto" class="form-control">
+                                            <select name="action" style="width: auto; height: auto" {% if admin_pool is defined and not admin_pool.getOption('use_select2') %} class="form-control"{% endif %}>
                                                 {% for action, options in batchactions %}
                                                     <option value="{{ action }}">{{ options.label }}</option>
                                                 {% endfor %}

--- a/Resources/views/Pager/base_results.html.twig
+++ b/Resources/views/Pager/base_results.html.twig
@@ -21,7 +21,7 @@ file that was distributed with this source code.
 
 {% block max_per_page %}
     <label class="control-label" for="{{ admin.uniqid }}_per_page">{% trans from 'SonataAdminBundle' %}label_per_page{% endtrans %}</label>
-    <select class="form-control per-page small" id="{{ admin.uniqid }}_per_page" style="width: auto">
+    <select class="per-page small {% if admin_pool is defined and not admin_pool.getOption('use_select2') %}form-control{% endif %}" id="{{ admin.uniqid }}_per_page" style="width: auto">
         {% for per_page in admin.getperpageoptions %}
             <option {% if per_page == admin.datagrid.pager.maxperpage %}selected="selected"{% endif %} value="{{ admin.generateUrl('list', {'filter': admin.datagrid.values | merge({'_page': 1, '_per_page': per_page})}) }}">
                 {{ per_page }}


### PR DESCRIPTION
Do not add ``form-control`` class to lists bottom selects (batch actions and element per page choices) if select2 is used.