### PR TITLE
Add select2-bootstrap css

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -266,7 +266,7 @@ class Configuration implements ConfigurationInterface
                                 'bundles/sonataadmin/vendor/jqueryui/themes/base/jquery-ui.css',
 
                                 'bundles/sonatacore/vendor/select2/select2.css',
-                                'bundles/sonatacore/vendor/select2/select2-bootstrap.css',
+                                'bundles/sonatacore/vendor/select2-bootstrap-css/select2-bootstrap.min.css',
 
                                 'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/css/bootstrap-editable.css',
 

--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -306,22 +306,6 @@ form.sonata-filter-form.form-stacked {
     padding-left: 0;
 }
 
-.filter_container .form-group {
-    margin: 5px 0 5px 0;
-}
-
-.filter_container .control-label {
-    padding-top: 3px;
-}
-
-.filter_container .form-control {
-    max-height: 25px;
-}
-
-.filter_container .select2-container .select2-choice {
-    height: 23px;
-}
-
 body.fixed .sonata-list-table {
     position: relative;
     margin-left: 15px;
@@ -353,12 +337,8 @@ td.sonata-ba-list-field .editable-empty:not(.editable-open) {
 }
 
 /* select2 */
-div.select2-container {
-    margin-left: 0 !important;
-}
-
-div.select2-drop ul {
-    margin: 0 !important;
+.select2-choice, .select2-choices, .select2-drop {
+    border-radius: 0 !important;
 }
 
 /* Used for the mosaic view */

--- a/Resources/views/Form/filter_admin_fields.html.twig
+++ b/Resources/views/Form/filter_admin_fields.html.twig
@@ -16,7 +16,9 @@ file that was distributed with this source code.
 #}
 
 {% block choice_widget_collapsed %}
-    {% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
+    {% if admin_pool is defined and not admin_pool.getOption('use_select2') %}
+        {% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
+    {% endif %}
     {{ parent() }}
 {% endblock choice_widget_collapsed %}
 


### PR DESCRIPTION
Needs https://github.com/sonata-project/SonataCoreBundle/pull/146

This PR updates select2 css for bootstrap : 

**Filters**
![filters](https://cloud.githubusercontent.com/assets/663607/6517002/29294ce8-c397-11e4-807c-52c9163dac46.JPG)

**Forms**
![form](https://cloud.githubusercontent.com/assets/663607/6517003/2929af76-c397-11e4-9e8e-9746b61fda6f.JPG)

**Lists (bottom)**
![list](https://cloud.githubusercontent.com/assets/663607/6517004/292b3648-c397-11e4-9080-1b3a6b50669a.JPG)