### PR TITLE
Fix/refactor form row for native collections

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -263,8 +263,9 @@ div.sonata-medium-date div {
     vertical-align: middle;
 }
 
-.sonata-collection-delete {
-    float: left;
+.sonata-collection-row > .sonata-collection-delete {
+    position: absolute;
+    z-index: 1;
 }
 
 .sonata-collection-add, .sonata-collection-delete {
@@ -273,10 +274,6 @@ div.sonata-medium-date div {
 
 .no-js .sonata-collection-add, .no-js .sonata-collection-delete {
     display: none;
-}
-
-.form-horizontal .sonata-collection-row-without-label {
-    margin-left: 0;
 }
 
 ul.inputs-list {

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -63,7 +63,7 @@ file that was distributed with this source code.
 {# Labels #}
 {% block form_label %}
 {% spaceless %}
-    {% if label is not sameas(false) and sonata_admin.admin and sonata_admin.admin.getConfigurationPool().getOption('form_type') == 'horizontal' %}
+    {% if label is not sameas(false) and admin_pool.getOption('form_type') == 'horizontal' %}
         {% set label_class = 'col-sm-3' %}
     {% endif %}
 
@@ -129,7 +129,7 @@ file that was distributed with this source code.
     {% if required and empty_value is none and not empty_value_in_choices and not multiple %}
         {% set required = false %}
     {% endif %}
-    {% if sonata_admin.admin and not sonata_admin.admin.getConfigurationPool().getOption('use_select2') %}
+    {% if admin_pool.getOption('use_select2') %}
         {% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
     {% endif %}
     {% if sortable and multiple %}
@@ -160,53 +160,43 @@ file that was distributed with this source code.
 {% endblock choice_widget_collapsed %}
 
 {% block form_row %}
-    {% if sonata_admin.admin and sonata_admin.admin.getConfigurationPool().getOption('form_type') == 'horizontal' %}
-        {% if label is not sameas(false) %}
-            {% set div_class = 'col-sm-9 col-md-9' %}
-        {% else %}
-            {% set div_class = 'col-sm-12' %}
+    <div class="form-group{% if errors|length > 0 %} has-error{% endif %}" id="sonata-ba-field-container-{{ id }}">
+        {% set label = sonata_admin.field_description.options.name|default(label)  %}
+
+        {% set div_class = 'sonata-ba-field' %}
+
+        {% if admin_pool.getOption('form_type') == 'horizontal' %}
+            {% if label is not sameas(false) %}
+                {% set div_class = 'col-sm-9' %}
+            {% else %}
+                {% set div_class = 'col-sm-12' %}
+            {% endif %}
         {% endif %}
-    {% endif %}
 
-    {% if sonata_admin is not defined or not sonata_admin_enabled or not sonata_admin.field_description %}
-        <div class="form-group {% if errors|length > 0%} has-error{% endif %}">
-            {{ form_label(form, label|default(null)) }}
-            <div class="{% if label is sameas(false) %}sonata-collection-row-without-label{% endif %}">
-                {{ form_widget(form, {'horizontal': false, 'horizontal_input_wrapper_class': ''}) }} {# {'horizontal': false, 'horizontal_input_wrapper_class': ''} needed to avoid MopaBootstrapBundle messing with the DOM #}
-                {% if errors|length > 0 %}
-                    <div class="help-block sonata-ba-field-error-messages">
-                        {{ form_errors(form) }}
-                    </div>
-                {% endif %}
-            </div>
+        {{ form_label(form, label|default(null)) }}
+
+        {% if sonata_admin is defined and sonata_admin_enabled %}
+            {% set div_class = div_class ~ ' sonata-ba-field-' ~ sonata_admin.edit ~ '-' ~ sonata_admin.inline %}
+        {% endif %}
+
+        {% if errors|length > 0 %}
+            {% set div_class = div_class ~ ' sonata-ba-field-error' %}
+        {% endif %}
+
+        <div class="{{ div_class }}">
+            {{ form_widget(form, {'horizontal': false, 'horizontal_input_wrapper_class': ''}) }} {# {'horizontal': false, 'horizontal_input_wrapper_class': ''} needed to avoid MopaBootstrapBundle messing with the DOM #}
+
+            {% if errors|length > 0 %}
+                <div class="help-block sonata-ba-field-error-messages">
+                    {{ form_errors(form) }}
+                </div>
+            {% endif %}
+
+            {% if sonata_admin is defined and sonata_admin_enabled and sonata_admin.field_description.help|default(false) %}
+                <span class="help-block sonata-ba-field-help">{{ sonata_admin.admin.trans(sonata_admin.field_description.help, {}, sonata_admin.field_description.translationDomain)|raw }}</span>
+            {% endif %}
         </div>
-    {% else %}
-        <div class="form-group{% if errors|length > 0%} has-error{%endif%}" id="sonata-ba-field-container-{{ id }}">
-            {% block label %}
-                {% if sonata_admin.field_description.options.name is defined %}
-                    {{ form_label(form, sonata_admin.field_description.options.name) }}
-                {% else %}
-                    {{ form_label(form, label|default(null)) }}
-                {% endif %}
-            {% endblock %}
-
-            {% set has_label = sonata_admin.field_description.options.name is defined or label is not sameas(false) %}
-            <div class="{{ div_class|default('') }} sonata-ba-field sonata-ba-field-{{ sonata_admin.edit }}-{{ sonata_admin.inline }} {% if errors|length > 0 %}sonata-ba-field-error{% endif %} {% if not has_label %}sonata-collection-row-without-label{% endif %}">
-
-                {{ form_widget(form, {'horizontal': false, 'horizontal_input_wrapper_class': ''}) }} {# {'horizontal': false, 'horizontal_input_wrapper_class': ''} needed to avoid MopaBootstrapBundle messing with the DOM #}
-
-                {% if errors|length > 0 %}
-                    <div class="help-block sonata-ba-field-error-messages">
-                        {{ form_errors(form) }}
-                    </div>
-                {% endif %}
-
-                {% if sonata_admin.field_description.help %}
-                    <span class="help-block sonata-ba-field-help">{{ sonata_admin.admin.trans(sonata_admin.field_description.help, {}, sonata_admin.field_description.translationDomain)|raw }}</span>
-                {% endif %}
-            </div>
-        </div>
-    {% endif %}
+    </div>
 {% endblock form_row %}
 
 {% block sonata_type_native_collection_widget_row %}
@@ -260,8 +250,8 @@ file that was distributed with this source code.
             {{ form_label(child) }}
 
             {% set div_class = "" %}
-            {% if sonata_admin.admin and sonata_admin.admin.getConfigurationPool().getOption('form_type') == 'horizontal' %}
-                {% set div_class = "col-sm-9 col-md-9" %}
+            {% if admin_pool.getOption('form_type') == 'horizontal' %}
+                {% set div_class = 'col-sm-9' %}
             {% endif%}
 
             <div class="{{ div_class }} sonata-ba-field sonata-ba-field-{{ sonata_admin.edit }}-{{ sonata_admin.inline }} {% if child.vars.errors|length > 0 %}sonata-ba-field-error{% endif %}">


### PR DESCRIPTION
This PR fixes native collections templates. I refactored duplicated ``form_row`` logic to simplify things.

I removed the ``sonata-collection-row-without-label`` class with seems to not be necessary anymore.

**Before**
![before](https://cloud.githubusercontent.com/assets/663607/6524702/d987f138-c3fc-11e4-8f9e-c73a069494ca.JPG)

**After**
![after](https://cloud.githubusercontent.com/assets/663607/6524701/d984bff4-c3fc-11e4-8850-eaaaf12a8c02.JPG)