### PR TITLE
Fix/refactor form row for native collections

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -263,20 +263,12 @@ div.sonata-medium-date div {
     vertical-align: middle;
 }
 
-.sonata-collection-delete {
-    float: left;
-}
-
 .sonata-collection-add, .sonata-collection-delete {
     box-shadow: none;
 }
 
 .no-js .sonata-collection-add, .no-js .sonata-collection-delete {
     display: none;
-}
-
-.form-horizontal .sonata-collection-row-without-label {
-    margin-left: 0;
 }
 
 ul.inputs-list {

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -63,7 +63,7 @@ file that was distributed with this source code.
 {# Labels #}
 {% block form_label %}
 {% spaceless %}
-    {% if label is not sameas(false) and sonata_admin.admin and sonata_admin.admin.getConfigurationPool().getOption('form_type') == 'horizontal' %}
+    {% if label is not sameas(false) and admin_pool.getOption('form_type') == 'horizontal' %}
         {% set label_class = 'col-sm-3' %}
     {% endif %}
 
@@ -160,62 +160,70 @@ file that was distributed with this source code.
 {% endblock choice_widget_collapsed %}
 
 {% block form_row %}
-    {% if sonata_admin.admin and sonata_admin.admin.getConfigurationPool().getOption('form_type') == 'horizontal' %}
-        {% if label is not sameas(false) %}
-            {% set div_class = 'col-sm-9 col-md-9' %}
-        {% else %}
-            {% set div_class = 'col-sm-12' %}
+    <div class="form-group{% if errors|length > 0 %} has-error{% endif %}" id="sonata-ba-field-container-{{ id }}">
+        {% set label = sonata_admin.field_description.options.name|default(label)  %}
+
+        {% set div_class = 'sonata-ba-field' %}
+
+        {% if label is sameas(false) %}
+            {% set div_class = div_class ~ ' sonata-collection-row-without-label' %}
         {% endif %}
-    {% endif %}
 
-    {% if sonata_admin is not defined or not sonata_admin_enabled or not sonata_admin.field_description %}
-        <div class="form-group {% if errors|length > 0%} has-error{% endif %}">
-            {{ form_label(form, label|default(null)) }}
-            <div class="{% if label is sameas(false) %}sonata-collection-row-without-label{% endif %}">
-                {{ form_widget(form, {'horizontal': false, 'horizontal_input_wrapper_class': ''}) }} {# {'horizontal': false, 'horizontal_input_wrapper_class': ''} needed to avoid MopaBootstrapBundle messing with the DOM #}
-                {% if errors|length > 0 %}
-                    <div class="help-block sonata-ba-field-error-messages">
-                        {{ form_errors(form) }}
-                    </div>
-                {% endif %}
-            </div>
-        </div>
-    {% else %}
-        <div class="form-group{% if errors|length > 0%} has-error{%endif%}" id="sonata-ba-field-container-{{ id }}">
-            {% block label %}
-                {% if sonata_admin.field_description.options.name is defined %}
-                    {{ form_label(form, sonata_admin.field_description.options.name) }}
+        {% if admin_pool.getOption('form_type') == 'horizontal' %}
+            {% if label is sameas(false) %}
+                {% if 'collection' in form.parent.vars.block_prefixes %}
+                    {% set div_class = div_class ~ ' col-sm-12' %}
                 {% else %}
-                    {{ form_label(form, label|default(null)) }}
+                    {% set div_class = div_class ~ ' col-sm-9 col-sm-offset-3' %}
                 {% endif %}
-            {% endblock %}
+            {% else %}
+                {% set div_class = div_class ~ ' col-sm-9' %}
+            {% endif %}
+        {% endif %}
 
-            {% set has_label = sonata_admin.field_description.options.name is defined or label is not sameas(false) %}
-            <div class="{{ div_class|default('') }} sonata-ba-field sonata-ba-field-{{ sonata_admin.edit }}-{{ sonata_admin.inline }} {% if errors|length > 0 %}sonata-ba-field-error{% endif %} {% if not has_label %}sonata-collection-row-without-label{% endif %}">
+        {{ form_label(form, label|default(null)) }}
 
-                {{ form_widget(form, {'horizontal': false, 'horizontal_input_wrapper_class': ''}) }} {# {'horizontal': false, 'horizontal_input_wrapper_class': ''} needed to avoid MopaBootstrapBundle messing with the DOM #}
+        {% if sonata_admin is defined and sonata_admin_enabled %}
+            {% set div_class = div_class ~ ' sonata-ba-field-' ~ sonata_admin.edit ~ '-' ~ sonata_admin.inline %}
+        {% endif %}
 
-                {% if errors|length > 0 %}
-                    <div class="help-block sonata-ba-field-error-messages">
-                        {{ form_errors(form) }}
-                    </div>
-                {% endif %}
+        {% if errors|length > 0 %}
+            {% set div_class = div_class ~ ' sonata-ba-field-error' %}
+        {% endif %}
 
-                {% if sonata_admin.field_description.help %}
-                    <span class="help-block sonata-ba-field-help">{{ sonata_admin.admin.trans(sonata_admin.field_description.help, {}, sonata_admin.field_description.translationDomain)|raw }}</span>
-                {% endif %}
-            </div>
+        <div class="{{ div_class }}">
+            {{ form_widget(form, {'horizontal': false, 'horizontal_input_wrapper_class': ''}) }} {# {'horizontal': false, 'horizontal_input_wrapper_class': ''} needed to avoid MopaBootstrapBundle messing with the DOM #}
+
+            {% if errors|length > 0 %}
+                <div class="help-block sonata-ba-field-error-messages">
+                    {{ form_errors(form) }}
+                </div>
+            {% endif %}
+
+            {% if sonata_admin is defined and sonata_admin_enabled and sonata_admin.field_description.help|default(false) %}
+                <span class="help-block sonata-ba-field-help">{{ sonata_admin.admin.trans(sonata_admin.field_description.help, {}, sonata_admin.field_description.translationDomain)|raw }}</span>
+            {% endif %}
         </div>
-    {% endif %}
+    </div>
 {% endblock form_row %}
 
 {% block sonata_type_native_collection_widget_row %}
 {% spaceless %}
     <div class="sonata-collection-row">
         {% if allow_delete %}
-            <a href="#" class="btn sonata-collection-delete"><i class="fa fa-minus-circle"></i></a>
+            <div class="row">
+                <div class="col-xs-1">
+                    <a href="#" class="btn sonata-collection-delete">
+                        <i class="fa fa-minus-circle"></i>
+                    </a>
+                </div>
+                <div class="col-xs-11">
         {% endif %}
-        {{ form_row(child) }}
+            {{ form_row(child, { label: false }) }}
+        {% if allow_delete %}
+                </div>
+            </div>
+        {% endif %}
     </div>
 {% endspaceless %}
 {% endblock sonata_type_native_collection_widget_row %}
@@ -260,8 +268,8 @@ file that was distributed with this source code.
             {{ form_label(child) }}
 
             {% set div_class = "" %}
-            {% if sonata_admin.admin and sonata_admin.admin.getConfigurationPool().getOption('form_type') == 'horizontal' %}
-                {% set div_class = "col-sm-9 col-md-9" %}
+            {% if admin_pool.getOption('form_type') == 'horizontal' %}
+                {% set div_class = 'col-sm-9' %}
             {% endif%}
 
             <div class="{{ div_class }} sonata-ba-field sonata-ba-field-{{ sonata_admin.edit }}-{{ sonata_admin.inline }} {% if child.vars.errors|length > 0 %}sonata-ba-field-error{% endif %}">


### PR DESCRIPTION
This PR fixes native collections templates. I refactored duplicated ``form_row`` logic to simplify things.

I removed the ``sonata-collection-row-without-label`` class with seems to not be necessary anymore.

**Before**
![before](https://cloud.githubusercontent.com/assets/663607/6524702/d987f138-c3fc-11e4-8f9e-c73a069494ca.JPG)

**After**
![after](https://cloud.githubusercontent.com/assets/663607/6524701/d984bff4-c3fc-11e4-8850-eaaaf12a8c02.JPG)

***Responsive***
![small](https://cloud.githubusercontent.com/assets/663607/6525111/a1765794-c401-11e4-9613-62296e7d3fa7.JPG)
