### PR TITLE
Reset advanced filters when manually hidden

### DIFF
--- a/Resources/public/App.js
+++ b/Resources/public/App.js
@@ -99,7 +99,18 @@ $(function() {
     };
 
     $('[data-toggle="advanced-filter"]').click(function() {
-        $('.advanced-filter').toggle();
+        $('.advanced-filter').toggle('fast', function () {
+            $(this)
+                .find(':input:hidden')
+                .filter(function () { return $(this).val() })
+                .each(function () {
+                    $(this)
+                        .val('')
+                        .trigger('change') // Force select2 to refresh
+                    ;
+                })
+            ;
+        });
     });
 
     /* Sidebar tree view */


### PR DESCRIPTION
Sorry for this extra PR. I forgot to reset the advanced filters when they are manually hidden. This will avoid to submit them while they are hidden.

To be forgiven, I also added a cool sliding animation.