### PR TITLE
Clear hidden filters on submit

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -287,7 +287,7 @@ var Admin = {
         });
 
         jQuery('.sonata-filter-form', subject).on('submit', function () {
-            jQuery(this).find(':input:hidden:not([type="hidden"])').val('');
+            jQuery(this).find('[sonata-filter="true"]:hidden :input').val('');
         });
     },
 


### PR DESCRIPTION
When the filter form is submitted, all the hidden fields are cleared. This way, not extra fields will be submitted after : 
- removing a whole filter line (by unchecking it from the dropdown)
- hidding the advancers filters