### PR TITLE
Hide automatic parent admin filter

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -885,6 +885,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         // ok, try to limit to add parent filter
         if ($this->isChild() && $this->getParentAssociationMapping() && !$mapper->has($this->getParentAssociationMapping())) {
             $mapper->add($this->getParentAssociationMapping(), null, array(
+                'show_filter' => false,
                 'label' => false,
                 'field_type' => 'sonata_type_model_hidden',
                 'field_options' => array(


### PR DESCRIPTION
This PR adds ``'show_filter' => false`` to the filter automatically added to a child admin.

**Before**
![after](https://cloud.githubusercontent.com/assets/663607/6540666/2aa336dc-c4ab-11e4-8ed2-32425a3e8fef.JPG)

**After**
![before](https://cloud.githubusercontent.com/assets/663607/6540667/2aa48e4c-c4ab-11e4-9267-6a8d6efce41d.JPG)