### PR TITLE
Remove form-control class on select2 init

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -78,6 +78,8 @@ var Admin = {
                 var select = jQuery(this);
                 var allowClearEnabled = false;
 
+                select.removeClass('form-control');
+
                 if (select.find('option[value=""]').length) {
                     allowClearEnabled = true;
                 }

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -127,7 +127,7 @@ file that was distributed with this source code.
                                                 ({{ admin.datagrid.pager.nbresults }})
                                             </label>
 
-                                            <select name="action" style="width: auto; height: auto" {% if admin_pool is defined and not admin_pool.getOption('use_select2') %} class="form-control"{% endif %}>
+                                            <select name="action" style="width: auto; height: auto" class="form-control">
                                                 {% for action, options in batchactions %}
                                                     <option value="{{ action }}">{{ options.label }}</option>
                                                 {% endfor %}

--- a/Resources/views/Form/filter_admin_fields.html.twig
+++ b/Resources/views/Form/filter_admin_fields.html.twig
@@ -16,9 +16,7 @@ file that was distributed with this source code.
 #}
 
 {% block choice_widget_collapsed %}
-    {% if admin_pool is defined and not admin_pool.getOption('use_select2') %}
-        {% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
-    {% endif %}
+    {% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
     {{ parent() }}
 {% endblock choice_widget_collapsed %}
 

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -129,9 +129,7 @@ file that was distributed with this source code.
     {% if required and empty_value is none and not empty_value_in_choices and not multiple %}
         {% set required = false %}
     {% endif %}
-    {% if sonata_admin.admin and not sonata_admin.admin.getConfigurationPool().getOption('use_select2') %}
-        {% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
-    {% endif %}
+    {% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
     {% if sortable and multiple %}
         {{ block('sonata_type_choice_multiple_sortable') }}
     {% else %}

--- a/Resources/views/Pager/base_results.html.twig
+++ b/Resources/views/Pager/base_results.html.twig
@@ -21,7 +21,7 @@ file that was distributed with this source code.
 
 {% block max_per_page %}
     <label class="control-label" for="{{ admin.uniqid }}_per_page">{% trans from 'SonataAdminBundle' %}label_per_page{% endtrans %}</label>
-    <select class="per-page small {% if admin_pool is defined and not admin_pool.getOption('use_select2') %}form-control{% endif %}" id="{{ admin.uniqid }}_per_page" style="width: auto">
+    <select class="per-page small form-control" id="{{ admin.uniqid }}_per_page" style="width: auto">
         {% for per_page in admin.getperpageoptions %}
             <option {% if per_page == admin.datagrid.pager.maxperpage %}selected="selected"{% endif %} value="{{ admin.generateUrl('list', {'filter': admin.datagrid.values | merge({'_page': 1, '_per_page': per_page})}) }}">
                 {{ per_page }}


### PR DESCRIPTION
Remove the ``form-control`` class dynamically instead of doing it in every template.