### PR TITLE
Use icon class name instead of html in dashboard config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -101,7 +101,7 @@ class Configuration implements ConfigurationInterface
                                 ->children()
                                     ->scalarNode('label')->end()
                                     ->scalarNode('label_catalogue')->end()
-                                    ->scalarNode('icon')->defaultValue('<i class="fa fa-folder"></i>')->end()
+                                    ->scalarNode('icon')->defaultValue('fa fa-folder')->end()
                                     ->arrayNode('items')
                                         ->beforeNormalization()
                                             ->ifArray()

--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -70,6 +70,7 @@ Full Configuration Options
                     id:
                         label:                ~
                         label_catalogue:      ~
+                        icon:                 fa fa-folder
                         items:                []
                         item_adds:            []
                         roles:                []

--- a/Resources/views/Core/add_block.html.twig
+++ b/Resources/views/Core/add_block.html.twig
@@ -41,7 +41,9 @@
                     <li role="presentation" class="divider"></li>
                 {% endif %}
                 <li role="presentation" class="dropdown-header">
-                    {{ group.icon|raw }}
+                    {% if group.icon is not empty %}
+                        <i class="{{ group.icon }}"></i>
+                    {% endif %}
                     {{ group.label|trans({}, group.label_catalogue) }}
                 </li>
 

--- a/Resources/views/Menu/sonata_menu.html.twig
+++ b/Resources/views/Menu/sonata_menu.html.twig
@@ -58,8 +58,9 @@
 
         <a href="#">
             {% set translation_domain = item.attribute('label_catalogue') %}
-            {% set icon = item.attribute('icon')|default ? item.attribute('icon') : '' %}
-            {{ icon|default|raw }}
+            {% if item.attribute('icon')|default is not empty %}
+                <i class="{{ item.attribute('icon') }}"></i>
+            {% endif %}
             {{ parent() }}
             <i class="fa pull-right fa-angle-left"></i>
         </a>


### PR DESCRIPTION
IMHO it's not very clean/useful to use HTML to define icons in the dashboard groups config. This PR automatically adds a ``<i class="..."></i>`` HTML.