### PR TITLE
Pass options in form templates

### DIFF
--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -147,7 +147,8 @@ BOOM
         );
 
         $container->getDefinition('sonata.admin.form.extension.field')
-            ->replaceArgument(0, $classes);
+            ->replaceArgument(0, $classes)
+            ->replaceArgument(1, $config['options']);
 
         // remove non used service
         if (!isset($bundles['JMSTranslationBundle'])) {

--- a/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -24,13 +24,15 @@ use Sonata\AdminBundle\Exception\NoValueException;
 class FormTypeFieldExtension extends AbstractTypeExtension
 {
     protected $defaultClasses = array();
+    protected $options;
 
     /**
      * @param array $defaultClasses
      */
-    public function __construct(array $defaultClasses = array())
+    public function __construct(array $defaultClasses, array $options)
     {
         $this->defaultClasses = $defaultClasses;
+        $this->options = $options;
     }
 
     /**
@@ -46,7 +48,8 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             'edit'              => 'standard',
             'inline'            => 'natural',
             'field_description' => null,
-            'block_name'        => false
+            'block_name'        => false,
+            'options'           => $this->options,
         );
 
         $builder->setAttribute('sonata_admin_enabled', false);
@@ -134,7 +137,8 @@ class FormTypeFieldExtension extends AbstractTypeExtension
                 'edit'              => 'standard',
                 'inline'            => 'natural',
                 'block_name'        => false,
-                'class'             => false
+                'class'             => false,
+                'options'           => $this->options,
             );
             $view->vars['sonata_admin_code']    = $view->parent->vars['sonata_admin_code'];
 

--- a/Resources/config/form_types.xml
+++ b/Resources/config/form_types.xml
@@ -43,6 +43,7 @@
         <service id="sonata.admin.form.extension.field" class="Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension">
             <tag name="form.type_extension" alias="form" />
             <argument />
+            <argument />
         </service>
 
         <service id="sonata.admin.form.extension.field.mopa" class="Sonata\AdminBundle\Form\Extension\Field\Type\MopaCompatibilityTypeFieldExtension">

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -63,7 +63,7 @@ file that was distributed with this source code.
 {# Labels #}
 {% block form_label %}
 {% spaceless %}
-    {% if label is not sameas(false) and admin_pool is defined and admin_pool.getOption('form_type') == 'horizontal' %}
+    {% if label is not sameas(false) and sonata_admin.options['form_type'] == 'horizontal' %}
         {% set label_class = 'col-sm-3' %}
     {% endif %}
 
@@ -167,7 +167,7 @@ file that was distributed with this source code.
             {% set div_class = div_class ~ ' sonata-collection-row-without-label' %}
         {% endif %}
 
-        {% if admin_pool is defined and admin_pool.getOption('form_type') == 'horizontal' %}
+        {% if sonata_admin.options['form_type'] == 'horizontal' %}
             {% if label is sameas(false) %}
                 {% if 'collection' in form.parent.vars.block_prefixes %}
                     {% set div_class = div_class ~ ' col-sm-12' %}
@@ -266,7 +266,7 @@ file that was distributed with this source code.
             {{ form_label(child) }}
 
             {% set div_class = "" %}
-            {% if admin_pool is defined and admin_pool.getOption('form_type') == 'horizontal' %}
+            {% if sonata_admin.options['form_type'] == 'horizontal' %}
                 {% set div_class = 'col-sm-9' %}
             {% endif%}
 

--- a/Tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
+++ b/Tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
@@ -23,14 +23,14 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function testExtendedType()
     {
-        $extension = new FormTypeFieldExtension();
+        $extension = new FormTypeFieldExtension(array(), array());
 
         $this->assertEquals('field', $extension->getExtendedType());
     }
 
     public function testDefaultOptions()
     {
-        $extension = new FormTypeFieldExtension();
+        $extension = new FormTypeFieldExtension(array(), array());
 
         $resolver = new OptionsResolver();
         $extension->setDefaultOptions($resolver);
@@ -60,7 +60,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
         $config = new FormConfigBuilder('test', 'stdClass', $eventDispatcher, $options);
         $form = new Form($config);
 
-        $extension = new FormTypeFieldExtension();
+        $extension = new FormTypeFieldExtension(array(), array());
         $extension->buildView($formView, $form, array());
 
         $this->assertArrayHasKey('sonata_admin', $formView->vars);
@@ -105,7 +105,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
 
         $formView->vars['block_prefixes'] = array('form', 'field', 'text', '_s50b26aa76cb96_username');
 
-        $extension = new FormTypeFieldExtension();
+        $extension = new FormTypeFieldExtension(array(), array());
         $extension->buildView($formView, $form, array(
             'sonata_help' => 'help text'
         ));
@@ -148,7 +148,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
 
         $formView->vars['block_prefixes'] = array('form', 'field', 'text', '_s50b26aa76cb96_settings_format');
 
-        $extension = new FormTypeFieldExtension();
+        $extension = new FormTypeFieldExtension(array(), array());
         $extension->buildView($formView, $form, array(
             'sonata_help' => 'help text'
         ));
@@ -178,6 +178,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
                  'inline'            => 'natural',
                  'block_name'        => false,
                  'class'             => false,
+                 'options'           => array(),
             ),
             'sonata_admin_code' => 'parent_code',
         );
@@ -194,7 +195,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
         $config = new FormConfigBuilder('test', 'stdClass', $eventDispatcher, $options);
         $form = new Form($config);
 
-        $extension = new FormTypeFieldExtension();
+        $extension = new FormTypeFieldExtension(array(), array());
         $extension->buildView($formView, $form, array(
             'sonata_help' => 'help text'
         ));


### PR DESCRIPTION
See : https://github.com/sonata-project/SonataAdminBundle/commit/e710524a7b7ea58a84924ebef3b1a042259fa531#commitcomment-10090830

To check ``form_type`` in form templates, we can't use : 
- ``admin_pool`` because it's not necessarily available
- ``sonata_admin.admin.getAdminPool()`` because ``sonata_admin.admin`` is not necessarily defined (some forms type do not have a linked admin).

So this PR pass the ``options`` to the templates., this way we don't have to rely on the admin pool anymore.