### PR TITLE
Don't limit mosaic preview

### DIFF
--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -387,7 +387,8 @@ div.mosaic-box-outter {
 }
 
 div.mosaic-inner-box {
-    height: 100px;
+    height: auto;
+    min-height: 50px;
     border-bottom: none;
     overflow: hidden;
 }


### PR DESCRIPTION
For better image rendering as user avatar for example, I propose to remove mosaic box preview height.

Before patch:
![sonata_mosaic_before](https://cloud.githubusercontent.com/assets/1698357/6556481/1c464592-c66e-11e4-9c2b-bd30859c0caa.png)

After patch:
![sonata_mosaic_after](https://cloud.githubusercontent.com/assets/1698357/6556508/392b7baa-c66e-11e4-9d09-3e69090e4390.png)


What do you think?

Thanks.
