### PR TITLE
Update date, time and datetime form template

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -195,18 +195,6 @@ textarea.sonata-medium {
     height: 125px;
 }
 
-div.sonata-medium-date {
-    overflow: hidden;
-}
-
-div.sonata-medium-date select {
-    width: 85px;
-}
-
-div.sonata-medium-date div {
-    float: left;
-}
-
 .sonata-ba-field-inline-table select.sonata-medium,
 .sonata-ba-field-inline-table textarea.sonata-medium,
 .sonata-ba-field-inline-table input.sonata-medium {

--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -424,10 +424,6 @@ div.mosaic-box.sonata-ba-list-row-selected > div.mosaic-inner-text {
     border-top: none;
 }
 
-.sonata-ba-form .select2-container {
-    width: 80% !important;
-}
-
 div.sonata-filters-box div.form-group div.form-group {
     margin: 0;
 }

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -157,6 +157,70 @@ file that was distributed with this source code.
 {% endspaceless %}
 {% endblock choice_widget_collapsed %}
 
+{% block date_widget %}
+{% spaceless %}
+    {% if widget == 'single_text' %}
+        {{ block('form_widget_simple') }}
+    {% else %}
+        {% if row is not defined or row == true %}
+            {% set attr = attr|merge({'class': attr.class|default('') ~ ' row' }) %}
+        {% endif %}
+        {% set input_wrapper_class = input_wrapper_class|default('col-sm-4') %}
+        <div {{ block('widget_container_attributes') }}>
+            {{ date_pattern|replace({
+                '{{ year }}':  '<div class="'~ input_wrapper_class ~ '">' ~ form_widget(form.year) ~ '</div>',
+                '{{ month }}': '<div class="'~ input_wrapper_class ~ '">' ~ form_widget(form.month) ~ '</div>',
+                '{{ day }}':   '<div class="'~ input_wrapper_class ~ '">' ~ form_widget(form.day) ~ '</div>',
+            })|raw }}
+        </div>
+    {% endif %}
+{% endspaceless %}
+{% endblock date_widget %}
+
+{% block time_widget %}
+{% spaceless %}
+    {% if widget == 'single_text' %}
+        {{ block('form_widget_simple') }}
+    {% else %}
+        {% if row is not defined or row == true %}
+            {% set attr = attr|merge({'class': attr.class|default('') ~ ' row' }) %}
+        {% endif %}
+        {% set input_wrapper_class = input_wrapper_class|default('col-sm-6') %}
+        <div {{ block('widget_container_attributes') }}>
+            <div class="{{ input_wrapper_class }}">
+                {{ form_widget(form.hour) }}
+            </div>
+            {% if with_minutes %}
+                <div class="{{ input_wrapper_class }}">
+                    {{ form_widget(form.minute) }}
+                </div>
+            {% endif %}
+            {% if with_seconds %}
+                <div class="{{ input_wrapper_class }}">
+                    {{ form_widget(form.second) }}
+                </div>
+            {% endif %}
+        </div>
+    {% endif %}
+{% endspaceless %}
+{% endblock time_widget %}
+
+{% block datetime_widget %}
+{% spaceless %}
+    {% if widget == 'single_text' %}
+        {{ block('form_widget_simple') }}
+    {% else %}
+        {% set attr = attr|merge({'class': attr.class|default('') ~ ' row' }) %}
+        <div {{ block('widget_container_attributes') }}>
+            {{ form_errors(form.date) }}
+            {{ form_errors(form.time) }}
+            {{ form_widget(form.date, {'row': false, 'input_wrapper_class': 'col-sm-2'}) }}
+            {{ form_widget(form.time, {'row': false, 'input_wrapper_class': 'col-sm-2'}) }}
+        </div>
+    {% endif %}
+{% endspaceless %}
+{% endblock datetime_widget %}
+
 {% block form_row %}
     <div class="form-group{% if errors|length > 0 %} has-error{% endif %}" id="sonata-ba-field-container-{{ id }}">
         {% set label = sonata_admin.field_description.options.name|default(label)  %}


### PR DESCRIPTION
**Before**
![before-datetime](https://cloud.githubusercontent.com/assets/663607/6558706/17a68a50-c67e-11e4-9369-c81f0473380e.JPG)

**After**

***Date***
![after-date](https://cloud.githubusercontent.com/assets/663607/6558709/1b33dc72-c67e-11e4-8f28-3e2ab5cfe7e4.JPG)

***Time***
![after-time](https://cloud.githubusercontent.com/assets/663607/6558711/1b5ecb08-c67e-11e4-8cde-a65fd6cd2383.JPG)

***Datetime (without seconds)***
![after-datetime](https://cloud.githubusercontent.com/assets/663607/6558710/1b502b16-c67e-11e4-917e-855369b458c3.JPG)

I had to removed this css because it causes each datetime input to be 80% large only. Is it still usefull ?

```
.sonata-ba-form .select2-container {
    width: 80% !important;
}
```