### PR TITLE
Select2 4.0

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -290,8 +290,8 @@ class Configuration implements ConfigurationInterface
 
                                 'bundles/sonataadmin/vendor/jqueryui/themes/base/jquery-ui.css',
 
-                                'bundles/sonatacore/vendor/select2/select2.css',
-                                'bundles/sonatacore/vendor/select2-bootstrap-css/select2-bootstrap.min.css',
+                                'bundles/sonatacore/vendor/select2/dist/css/select2.min.css',
+                                'bundles/sonatacore/vendor/select2-bootstrap-theme/dist/select2-bootstrap.min.css',
 
                                 'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/css/bootstrap-editable.css',
 
@@ -320,7 +320,7 @@ class Configuration implements ConfigurationInterface
 
                                 'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/js/bootstrap-editable.min.js',
 
-                                'bundles/sonatacore/vendor/select2/select2.min.js',
+                                'bundles/sonatacore/vendor/select2/dist/js/select2.min.js',
 
                                 'bundles/sonataadmin/vendor/admin-lte/dist/js/app.min.js',
                                 'bundles/sonataadmin/vendor/iCheck/icheck.min.js',

--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -56,7 +56,7 @@ var Admin = {
         });
     },
     setup_select2: function(subject) {
-        if (window.SONATA_CONFIG && window.SONATA_CONFIG.USE_SELECT2 && window.Select2) {
+        if (window.SONATA_CONFIG && window.SONATA_CONFIG.USE_SELECT2) {
             Admin.log('[core|setup_select2] configure Select2 on', subject);
 
             jQuery('select:not([data-sonata-select2="false"])', subject).each(function() {
@@ -64,7 +64,6 @@ var Admin = {
                 var allowClearEnabled = false;
                 var popover           = select.data('popover');
 
-                select.removeClass('form-control');
 
                 if (select.find('option[value=""]').length || select.attr('data-sonata-select2-allow-clear')==='true') {
                     allowClearEnabled = true;
@@ -74,8 +73,9 @@ var Admin = {
 
                 select.select2({
                     width: function(){
-                        return Admin.get_select2_width(this.element);
+                        return Admin.get_select2_width(jQuery(this));
                     },
+                    placeholder: ' ',
                     dropdownAutoWidth: true,
                     minimumResultsForSearch: 10,
                     allowClear: allowClearEnabled
@@ -446,7 +446,7 @@ var Admin = {
 
         subject.select2({
             width: function(){
-                return Admin.get_select2_width(this.element);
+                return Admin.get_select2_width(jQuery(this));
             },
             dropdownAutoWidth: true,
             data: transformedData,

--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -496,3 +496,12 @@ div.sonata-filters-box div.form-group span.input-group-addon {
     padding: 3px 10px;
     font-size: 13px;
 }
+
+/*
+ * Select2 / AdminLTE css conflict workaround.
+ * Wait for issue resolution and apply patch.
+ * Related issue: https://github.com/almasaeed2010/AdminLTE/issues/668
+ */
+.select2-container .select2-selection--single .select2-selection__rendered {
+    margin-top: 0;
+}

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -72,9 +72,14 @@ file that was distributed with this source code.
 
                 {# omit default EN locale #}
                 {% if locale[:2] != 'en' %}
-                    <script src="{{ asset('bundles/sonatacore/vendor/select2/select2_locale_' ~ locale|replace({'_':'-'}) ~ '.js') }}"></script>
+                    <script src="{{ asset('bundles/sonatacore/vendor/select2/dist/js/i18n/' ~ locale|replace({'_':'-'}) ~ '.js') }}"></script>
                 {% endif %}
             {% endif %}
+
+            {# Select2 Bootstrap theme #}
+            <script type="text/javascript">
+                $.fn.select2.defaults.set('theme', 'bootstrap');
+            </script>
         {% endblock %}
 
         <title>
@@ -255,7 +260,7 @@ file that was distributed with this source code.
                                                         {% endfor %}
                                                     </div>
                                                 {% endif %}
-                                                
+
                                                 {% block sonata_admin_content_actions_wrappers %}
                                                     {% if _actions|replace({ '<li>': '', '</li>': '' })|trim is not empty %}
                                                         <ul class="nav navbar-nav navbar-right">

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "twig/extensions": "~1.0",
         "sonata-project/exporter": "~1.0",
         "sonata-project/block-bundle": "^2.3.9",
-        "sonata-project/core-bundle": "^2.3.10",
+        "sonata-project/core-bundle": "^2.4",
         "doctrine/common": "~2.2",
         "doctrine/inflector": "~1.0",
         "knplabs/knp-menu-bundle": "^2.1.1"


### PR DESCRIPTION
As discussed on #2773, here is a patch fore upgrade Select2 to 4.0 version.

Need this sonata-core PR to works: https://github.com/sonata-project/SonataCoreBundle/pull/147

I'm waiting fix commits on master referred [here](https://github.com/sonata-project/SonataAdminBundle/commit/123d6062ca256a1a05690f444a872b910027bae7#commitcomment-10110377) in order to have stable branch. After this, I will update my demo to show the changes. ;)

Please check this out and give me your review!

I was thinking that Select2 4.0 is full bootstrap compliant. Yeah... not really.
But the new theme is pretty nice to and I think, could be easily tricked.

BTW, select2 4.0 apparently has a theme system to easily integrate bootstrap or another. A discussion about project merging is accessible here: https://github.com/t0m/select2-bootstrap-css/issues/63.

What is your thinking about that?

Thanks.
