### PR TITLE
sonata-project/block-bundle ~2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "twig/twig": "~1.15",
         "twig/extensions": "~1.0",
         "sonata-project/exporter": "~1.0",
-        "sonata-project/block-bundle": "~2.2,>=2.2.7",
+        "sonata-project/block-bundle": "~2.3",
         "sonata-project/core-bundle": "~2.3,>=2.3.1",
         "doctrine/common": "~2.4",
         "knplabs/knp-menu-bundle": ">=1.1.0,<3.0.0",


### PR DESCRIPTION
Since `ErrorElement` namespace change, sonata-admin must use sonata-block ~2.3.