### PR TITLE
Add form-inline class to inline editable fields

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -247,6 +247,10 @@ file that was distributed with this source code.
 
         {% if sonata_admin is defined and sonata_admin_enabled %}
             {% set div_class = div_class ~ ' sonata-ba-field-' ~ sonata_admin.edit ~ '-' ~ sonata_admin.inline %}
+            
+            {% if sonata_admin.edit == 'inline' and sonata_admin.inline == 'table' %}
+                {% set div_class = div_class ~ ' form-inline' %}
+            {% endif %}
         {% endif %}
 
         {% if errors|length > 0 %}


### PR DESCRIPTION
On chrome (at least), ``sonata_type_collection`` type with ``edit => inline`` and ``inline => table`` options are not displayed correctly. Adding the ``form-inline`` class fixes the problem.

**Before**
![inline-before](https://cloud.githubusercontent.com/assets/663607/6604557/726fc9cc-c829-11e4-86ee-272420bbd3b4.JPG)

**After**
![inline-after](https://cloud.githubusercontent.com/assets/663607/6604556/726a1b94-c829-11e4-8129-eed572e247d7.JPG)