### PR TITLE
Cleanup form groups and tabs properly

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1332,7 +1332,40 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
             $extension->configureFormFields($mapper);
         }
 
+        $this->cleanupFormGroupsAndTabs($formBuilder);
         $this->attachInlineValidator();
+    }
+
+    protected function cleanupFormGroupsAndTabs(FormBuilderInterface $formBuilder)
+    {
+        if ($this->formGroups) {
+            foreach ($this->formGroups as $name => &$formGroup) {
+                foreach ($formGroup['fields'] as $field) {
+                    if (!$formBuilder->has($field)) {
+                        unset($formGroup['fields'][$field]);
+                        unset($this->formFieldDescriptions[$field]);
+                    }
+                }
+
+                if (empty($formGroup['fields'])) {
+                    unset($this->formGroups[$name]);
+                }
+            }
+        }
+
+        if ($this->formTabs) {
+            foreach ($this->formTabs as $name => &$formTab) {
+                foreach ($formTab['groups'] as $key => $group) {
+                    if (!isset($this->formGroups[$group])) {
+                        unset($formTab['groups'][$key]);
+                    }
+                }
+
+                if (empty($formTab['groups'])) {
+                    unset($this->formTabs[$name]);
+                }
+            }
+        }
     }
 
     /**
@@ -1625,6 +1658,8 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
      */
     public function removeFieldFromFormGroup($key)
     {
+        trigger_error(__METHOD__.' is deprecated since 2.4 and will be removed in 3.0.', E_USER_DEPRECATED);
+
         foreach ($this->formGroups as $name => $formGroup) {
             unset($this->formGroups[$name]['fields'][$key]);
 

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -820,6 +820,8 @@ interface AdminInterface
      * Remove a form group field.
      *
      * @param string $key
+     *
+     * @deprecated since 2.4, will be removed in 3.0
      */
     public function removeFieldFromFormGroup($key);
 

--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -164,8 +164,6 @@ class FormMapper extends BaseGroupedMapper
      */
     public function remove($key)
     {
-        $this->admin->removeFormFieldDescription($key);
-        $this->admin->removeFieldFromFormGroup($key);
         $this->formBuilder->remove($key);
 
         return $this;

--- a/Resources/translations/SonataAdminBundle.ar.xliff
+++ b/Resources/translations/SonataAdminBundle.ar.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>noscript_warning</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>link_filters</target>

--- a/Resources/translations/SonataAdminBundle.bg.xliff
+++ b/Resources/translations/SonataAdminBundle.bg.xliff
@@ -422,10 +422,6 @@
                 <source>noscript_warning</source>
                 <target>noscript_warning</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>link_filters</target>

--- a/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/Resources/translations/SonataAdminBundle.ca.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>Javascript està desconnectat al seu navegador web. Algunes característiques no funcionaran correctament.</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>No hi ha camps disponibles.</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>link_filters</target>

--- a/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/Resources/translations/SonataAdminBundle.cs.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>Javascript je zakázán ve vašem webovém prohlížeči. Některé funkce nebudou pracovat správně.</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Žádné položky nejsou k dispozici.</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>Filtry</target>

--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -438,10 +438,6 @@
                 <source>noscript_warning</source>
                 <target>Javascript ist in ihrem Brwoser deaktiviert. Einige Funktionen werden nicht korrekt funktionieren.</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Keine Felder verfügbar.</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>Filter</target>

--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -434,10 +434,6 @@
                 <source>noscript_warning</source>
                 <target>Javascript is disabled in your web browser. Some features will not work properly.</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>No fields available.</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>Filters</target>

--- a/Resources/translations/SonataAdminBundle.es.xliff
+++ b/Resources/translations/SonataAdminBundle.es.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>Su navegador no soporta JavaScript o se encuentra deshabilitado  Algunas características no funcionarán correctamente.</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>No hay campos disponibles.</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>Filtros</target>

--- a/Resources/translations/SonataAdminBundle.eu.xliff
+++ b/Resources/translations/SonataAdminBundle.eu.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>noscript_warning</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>link_filters</target>

--- a/Resources/translations/SonataAdminBundle.fa.xliff
+++ b/Resources/translations/SonataAdminBundle.fa.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>اسکریپ فعال نمی باشد</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>گروه نمی تواند خالی باشد</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>فیلترها</target>

--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -438,10 +438,6 @@
                 <source>noscript_warning</source>
                 <target>Certaines fonctionnalités ne fonctionnent sans JavaScript; merci de l'activer sur votre navigateur.</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Pas de champs disponibles.</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>Filtres</target>

--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>noscript_warning</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>link_filters</target>

--- a/Resources/translations/SonataAdminBundle.hu.xliff
+++ b/Resources/translations/SonataAdminBundle.hu.xliff
@@ -434,10 +434,6 @@
                 <source>noscript_warning</source>
                 <target>A böngészőben a Javascript le van tiltva, emiatt néhány funkció nem fog megfelelően működni.</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Nincs elérhető mező.</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>Szűrők</target>

--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>noscript_warning</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>link_filters</target>

--- a/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/Resources/translations/SonataAdminBundle.ja.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>noscript_warning</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>link_filters</target>

--- a/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/Resources/translations/SonataAdminBundle.lb.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>noscript_warning</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>link_filters</target>

--- a/Resources/translations/SonataAdminBundle.lt.xliff
+++ b/Resources/translations/SonataAdminBundle.lt.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>noscript_warning</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>link_filters</target>

--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -434,10 +434,6 @@
                 <source>noscript_warning</source>
                 <target>Javascript is uitgeschakeld in uw browser. Sommige functies zullen niet goed werken.</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Geen velden beschikbaar.</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>Filters</target>

--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -430,10 +430,6 @@
                 <source>noscript_warning</source>
                 <target>Twoja przeglądarka ma wyłączoną obsługę JavaScript. Niektóre funkcje mogą nie działać poprawnie.</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Brak dostępnych pól.</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>Filtry</target>

--- a/Resources/translations/SonataAdminBundle.pt.xliff
+++ b/Resources/translations/SonataAdminBundle.pt.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>noscript_warning</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>link_filters</target>

--- a/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>noscript_warning</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>link_filters</target>

--- a/Resources/translations/SonataAdminBundle.ro.xliff
+++ b/Resources/translations/SonataAdminBundle.ro.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>Javascript este dezactivat în browser-ul dvs. Unele funcții nu vor funcționa corect.</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Nici un câmp nu este disponibil</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>Filtre</target>

--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>В вашем браузере отключен Javascipt. Некоторые функции сайта будут недоступны.</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Нет доступных полей</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>Фильтры</target>

--- a/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/Resources/translations/SonataAdminBundle.sk.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>Javascript je zakázaný vo vašom webovom prehliadači. Niektoré funkcie nebudú pracovať správne.</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Žiadne položky nie sú k dispozícii.</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>Filtre</target>

--- a/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/Resources/translations/SonataAdminBundle.sl.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>noscript_warning</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>link_filters</target>

--- a/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/Resources/translations/SonataAdminBundle.uk.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>Javascript вимкнений у вашому браузері. Деякі функції не будуть працювати належним чином.</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Немає доступних полів</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>Фільтри</target>

--- a/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -426,10 +426,6 @@
                 <source>noscript_warning</source>
                 <target>你的浏览器并不支持Javascript，所以有些功能不能正常使用</target>
             </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>没有可用的列</target>
-            </trans-unit>
             <trans-unit id="link_filters">
                 <source>link_filters</source>
                 <target>link_filters</target>

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1446,6 +1446,9 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         return $tagAdmin;
     }
 
+    /**
+     * @group legacy
+     */
     public function testRemoveFieldFromFormGroup()
     {
         $formGroups = array(
@@ -1471,6 +1474,43 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $admin->removeFieldFromFormGroup('bar');
         $this->assertEquals($admin->getFormGroups(), array());
+    }
+
+    public function testDefineFormBuilderCleanupFormGroupsAndTabs()
+    {
+        $admin = $this->getMockBuilder('Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin')
+            ->disableOriginalConstructor()
+            ->setMethods(array('attachInlineValidator'))
+            ->getMock()
+        ;
+
+        $formContractor = $this->getMock('Sonata\AdminBundle\Builder\FormContractorInterface');
+        $admin->setFormContractor($formContractor);
+
+        $formGroups = array(
+            'foobar' => array(
+                'fields' => array(
+                    'foo' => 'foo',
+                    'bar' => 'bar',
+                ),
+            ),
+        );
+        $admin->setFormGroups($formGroups);
+        $this->assertEquals($admin->getFormGroups(), $formGroups);
+
+        $formTabs = array(
+            'default' => array(
+                'groups' => array('foo', 'bar', 'foobar'),
+            ),
+        );
+        $admin->setFormTabs($formTabs);
+        $this->assertEquals($admin->getFormTabs(), $formTabs);
+
+        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $admin->defineFormBuilder($formBuilder);
+
+        $this->assertEquals($admin->getFormGroups(), array());
+        $this->assertEquals($admin->getFormTabs(), array());
     }
 
     public function testGetFilterParameters()


### PR DESCRIPTION
Currently the ``Admin::$formTabs`` variable is not cleaned up after calling ``$formMapper->remove()``. In this case, empty groups may be visible :

**Before**
![before](https://cloud.githubusercontent.com/assets/663607/6616064/687f37dc-c8aa-11e4-9e2c-f2effc9d8103.JPG)

**After**
![after](https://cloud.githubusercontent.com/assets/663607/6616128/0cffbc6e-c8ab-11e4-807e-8a6124fa9d6e.JPG)

To fix this, instead of adding a new method called after each ``remove()`` call, I moved all the logic into a single one, called when the formBuilder build is over.