### PR TITLE
Do not display menu item if no child is displayed

### DIFF
--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -997,17 +997,8 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
         $menu = $this->twigExtension->getKnpMenu($request);
 
         $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
-        $this->assertArrayHasKey('bar', $menu->getChildren());
-
-        foreach ($menu->getChildren() as $key => $child) {
-            $this->assertInstanceOf('Knp\Menu\MenuItem', $child);
-            $this->assertEquals('bar', $child->getName());
-            $this->assertEquals($adminGroups['bar']['label'], $child->getLabel());
-
-            // menu items
-            $children = $child->getChildren();
-            $this->assertCount(0, $children);
-        }
+        $this->assertArrayNotHasKey('bar', $menu->getChildren());
+        $this->assertCount(0, $menu->getChildren());
     }
 
     public function testGetKnpMenuWithNotGrantedList()
@@ -1044,16 +1035,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
         $menu = $this->twigExtension->getKnpMenu($request);
 
         $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
-        $this->assertArrayHasKey('bar', $menu->getChildren());
-
-        foreach ($menu->getChildren() as $key => $child) {
-            $this->assertInstanceOf('Knp\Menu\MenuItem', $child);
-            $this->assertEquals('bar', $child->getName());
-            $this->assertEquals($adminGroups['bar']['label'], $child->getLabel());
-
-            // menu items
-            $children = $child->getChildren();
-            $this->assertCount(0, $children);
-        }
+        $this->assertArrayNotHasKey('bar', $menu->getChildren());
+        $this->assertCount(0, $menu->getChildren());
     }
 }

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -415,6 +415,10 @@ class SonataAdminExtension extends \Twig_Extension
                     ->setExtra('admin', $admin)
                 ;
             }
+
+            if (0 === count($menu[$name]->getChildren())) {
+                $menu->removeChild($name);
+            }
         }
 
         return $menu;


### PR DESCRIPTION
In these screenshots, the ``Affiliation``, ``Media`` and ``Reporting`` items are empty because the user is not allowed access to any of their children. However, they are visible.

This PR fixes it.

Before | After
------------ | -------------
![before](https://cloud.githubusercontent.com/assets/663607/6621427/dd9cd390-c8d6-11e4-92f4-95265943f6c6.JPG) | ![after](https://cloud.githubusercontent.com/assets/663607/6621429/e02b5a32-c8d6-11e4-854c-b7b08de45965.JPG)

