### PR TITLE
Add inline option to show array type

### DIFF
--- a/Resources/views/CRUD/show_array.html.twig
+++ b/Resources/views/CRUD/show_array.html.twig
@@ -18,5 +18,6 @@ file that was distributed with this source code.
         {% else %}
             [{{ key }} => {{ val }}]
         {% endif %}
+        {% if field_description.options.inline is not defined or false == field_description.options.inline %}<br>{% endif %}
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Until now, show ``array`` type was displayed inline, which can be hard to read when there is a lot of data :

![inline](https://cloud.githubusercontent.com/assets/663607/6665273/d180bc76-cbd7-11e4-9635-f62e78905350.JPG)

This PR displays it vertically by default :

![vertical](https://cloud.githubusercontent.com/assets/663607/6665275/d4ebf6c8-cbd7-11e4-896e-c7c1e67789db.JPG)

However, you there is now an ``inline`` option that you can set to ``true`` to get the old behavior.

If you prefer to display it inline by default instead, I can update my PR.


