### PR TITLE
Handle __call method in FieldDescription::getFieldValue

### DIFF
--- a/Admin/BaseFieldDescription.php
+++ b/Admin/BaseFieldDescription.php
@@ -343,6 +343,10 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
             }
         }
 
+        if (method_exists($object, '__call')) {
+            return call_user_func_array(array($object, '__call'), array($fieldName, $parameters));
+        }
+
         if (isset($object->{$fieldName})) {
             return $object->{$fieldName};
         }

--- a/Tests/Admin/BaseFieldDescriptionTest.php
+++ b/Tests/Admin/BaseFieldDescriptionTest.php
@@ -14,6 +14,8 @@ namespace Sonata\AdminBundle\Tests\Admin;
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\FieldDescription;
+use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
+use Sonata\AdminBundle\Tests\Fixtures\Entity\FooCall;
 
 class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
 {
@@ -189,5 +191,42 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('FooBar', BaseFieldDescription::camelize('foo_bar'));
         $this->assertEquals('FooBar', BaseFieldDescription::camelize('foo bar'));
         $this->assertEquals('FOoBar', BaseFieldDescription::camelize('fOo bar'));
+    }
+
+    public function testGetFieldValue()
+    {
+        $foo = new Foo();
+        $foo->setBar('Bar');
+
+        $description = new FieldDescription();
+        $this->assertEquals('Bar', $description->getFieldValue($foo, 'bar'));
+
+        $this->setExpectedException('Sonata\AdminBundle\Exception\NoValueException');
+        $description->getFieldValue($foo, 'inexistantMethod');
+    }
+
+    public function testGetFieldValueWithCodeOption()
+    {
+        $foo = new Foo();
+        $foo->setBaz('Baz');
+
+        $description = new FieldDescription();
+
+        $description->setOption('code', 'getBaz');
+        $this->assertEquals('Baz', $description->getFieldValue($foo, 'inexistantMethod'));
+
+        $description->setOption('code', 'inexistantMethod');
+        $this->setExpectedException('Sonata\AdminBundle\Exception\NoValueException');
+        $description->getFieldValue($foo, 'inexistantMethod');
+    }
+
+    public function testGetFieldValueMagicCall()
+    {
+        $parameters = array('foo', 'bar');
+        $foo = new FooCall();
+
+        $description = new FieldDescription();
+        $description->setOption('parameters', $parameters);
+        $this->assertEquals(array('inexistantMethod', $parameters), $description->getFieldValue($foo, 'inexistantMethod'));
     }
 }

--- a/Tests/Fixtures/Entity/FooCall.php
+++ b/Tests/Fixtures/Entity/FooCall.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Entity;
+
+class FooCall
+{
+    public function __call($method, $arguments)
+    {
+        return array($method, $arguments);
+    }
+}


### PR DESCRIPTION
Related to https://github.com/sonata-project/SonataAdminBundle/pull/2262

With this PR, the ``FieldDescription::getFieldValue`` method can now handle magic ``__call`` methods by passing the ``fieldName`` **and** the ``parameters`` option.