### PR TITLE
Add missing dependencies to fix tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,13 @@
         "sensio/generator-bundle": "~2.3",
         "symfony/translation":"~2.3",
         "symfony/dependency-injection": "~2.3,>=2.3.3",
+        "symfony/property-access": "~2.3",
         "twig/twig": "~1.15",
         "twig/extensions": "~1.0",
         "sonata-project/exporter": "~1.0",
         "sonata-project/block-bundle": "~2.3",
         "doctrine/common": "~2.2",
+        "doctrine/inflector": "~1.0",
         "knplabs/knp-menu-bundle": ">=2.0,<3.0.0",
         "knplabs/knp-menu": ">=2.0,<3.0"
     },


### PR DESCRIPTION
Since this commit https://github.com/sonata-project/SonataAdminBundle/commit/d25ef67bf925221b2f5f2a1fe03f21ad252a7ad2, tests are broken.

``doctrine/inflector`` is required by ``doctrine/common`` only from version ``2.4``

Moreover, the ``symfony/property-access`` component is missing too (used here https://github.com/sonata-project/SonataAdminBundle/blob/master/Admin/Admin.php#L934)