### PR TITLE
Only show border on actions buttons

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -103,6 +103,11 @@ div.sonata-actions {
     float: right
 }
 
+.sonata-ba-action.btn:not(:hover) {
+    background: none;
+    color: inherit;
+}
+
 .sonata-ba-list td.sonata-ba-list-field a.sonata-link-identifier {
     font-weight: bold;
 }


### PR DESCRIPTION
@rande Like you asked in https://github.com/sonata-project/SonataAdminBundle/pull/2834#issuecomment-82388376

**Normal**
![button-after](https://cloud.githubusercontent.com/assets/663607/6705810/9237bcd6-cd58-11e4-920f-2fb879774c49.JPG)

**Hovered**
![button-hover](https://cloud.githubusercontent.com/assets/663607/6705811/923c20d2-cd58-11e4-9316-b095a0394366.JPG)

I didn't use the ``btn-outline`` class for 2 reasons : 
- it already exists in AdminLte with a different behavior
- it avoid to add a specific class on these buttons across different bundles