### PR TITLE
Custom Knp menu

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -96,6 +96,21 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('groups')
                             ->useAttributeAsKey('id')
                             ->prototype('array')
+                                ->beforeNormalization()
+                                    ->ifArray()
+                                    ->then(function($items) {
+                                        if (isset($items['provider'])) {
+                                            $disallowedItems = array('items', 'label', 'label_catalogue');
+                                            foreach($disallowedItems as $item) {
+                                                if (isset($items[$item])) {
+                                                    throw new \InvalidArgumentException(sprintf('The config value "%s" cannot be used alongside "provider" config value', $item));
+                                                }
+                                            }
+                                        }
+
+                                        return $items;
+                                    })
+                                ->end()
                                 ->fixXmlConfig('item')
                                 ->fixXmlConfig('item_add')
                                 ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -100,7 +100,7 @@ class Configuration implements ConfigurationInterface
                                     ->ifArray()
                                     ->then(function($items) {
                                         if (isset($items['provider'])) {
-                                            $disallowedItems = array('items', 'label', 'label_catalogue');
+                                            $disallowedItems = array('items', 'label');
                                             foreach($disallowedItems as $item) {
                                                 if (isset($items[$item])) {
                                                     throw new \InvalidArgumentException(sprintf('The config value "%s" cannot be used alongside "provider" config value', $item));

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -102,6 +102,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('label')->end()
                                     ->scalarNode('label_catalogue')->end()
                                     ->scalarNode('icon')->defaultValue('<i class="fa fa-folder"></i>')->end()
+                                    ->scalarNode('provider')->end()
                                     ->arrayNode('items')
                                         ->beforeNormalization()
                                             ->ifArray()

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -10,6 +10,7 @@
 
             <argument type="service" id="sonata.admin.pool" />
             <argument type="service" id="router" />
+            <argument type="service" id="knp_menu.helper" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
     </services>

--- a/Resources/doc/cookbook/recipe_knp_menu.rst
+++ b/Resources/doc/cookbook/recipe_knp_menu.rst
@@ -1,35 +1,39 @@
 KnpMenu
 =======
 
-The admin comes with `KnpMenu <https://github.com/KnpLabs/KnpMenu>`_ integration
-It integrates a menu with the KnpMenu library. This menu can be a SonataAdmin service or a route of a custom controller.
+The admin comes with `KnpMenu <https://github.com/KnpLabs/KnpMenu>`_ integration.
+It integrates a menu with the KnpMenu library. This menu can be a SonataAdmin service, a menu created with a Knp menu provider or a route of a custom controller.
 
 Add a custom controller entry in the menu
 -----------------------------------------
 
 To add a custom controller entry in the admin menu:
 
-Create your controller
+Create your controller:
 
 .. code-block:: php
 
-    /**
-     * @Route("/blog", name="blog_home")
-     */
-    public function blogAction()
+    class BlogController 
     {
-        // ...
+        /**
+         * @Route("/blog", name="blog_home")
+         */
+        public function blogAction()
+        {
+            // ...
+        }
+
+        /**
+         * @Route("/blog/article/{articleId}", name="blog_article")
+         */
+        public function ArticleAction($articleId)
+        {
+            // ...
+        }
     }
 
-    /**
-     * @Route("/blog/article/{articleId}", name="blog_article")
-     */
-    public function ArticleAction($articleId)
-    {
-        // ...
-    }
 
-Add the controller route as an item of the menu
+Add the controller route as an item of the menu:
 
 .. code-block:: yaml
 
@@ -49,7 +53,7 @@ Add the controller route as an item of the menu
                           label:        Article
                     ...
 
-Also you can override the template of knp_menu used by sonata. The default one is `SonataAdminBundle:Menu:sonata_menu.html.twig`:
+You can also override the template of knp_menu used by sonata. The default one is `SonataAdminBundle:Menu:sonata_menu.html.twig`:
 
 .. code-block:: yaml
 
@@ -59,4 +63,34 @@ Also you can override the template of knp_menu used by sonata. The default one i
             knp_menu_template:           ApplicationAdminBundle:Menu:custom_knp_menu.html.twig
         ...
 
-And voilà, now you have a new menu group which contains an entry to sonata_admin_id, to your blog and to a specific article.
+And voilà, now you have a menu group which contains a link to a sonata admin via its id, to your blog and to a specific article.
+
+Using a menu provider
+---------------------
+
+As seen above, the main way to declare your menu is by declaring items in your sonata admin config file. In some case you may have to create a more complexe menu depending on your business logic. This is possible by using a menu provider to populate a whole menu group. This is done with the ``provider`` config value.
+
+Tthe following configuration uses a menu provider to populate the menu group ``my_group``:
+
+.. code-block:: yaml
+
+    sonata_admin:
+        dashboard:
+            groups:
+                my_group:
+                    provider:        'MyBundle:MyMenuProvider:getMyMenu'
+                    icon:            '<i class="fa fa-edit"></i>'
+
+With KnpMenuBundle you can create a custom menu by using a builder class or by declaring it as a service. Please see the `Knp documentation <http://symfony.com/doc/current/bundles/KnpMenuBundle/index.html#create-your-first-menu>`_ for further information. 
+
+In sonata, whatever the implementation you choose, you only have to provide the menu alias to the provider config key:
+
+* If you are using a builder class, your menu alias should be something like ``MyBundle:MyMenuProvider:getMyMenu``.
+* If you are using a service, your menu alias is the alias set in the ``knp_menu.menu`` tag. In the following example this is ``my_menu_alias``:
+    .. code-block:: xml
+
+        <service id="my_menu_provider" class="MyBundle/MyDirectory/MyMenuProvider">
+            <tag name="knp_menu.menu" alias="my_menu_alias" />
+        </service>
+
+Please note that when using the provider option, you can't set the menu label via the configuration. It is done in your custom menu.

--- a/Resources/views/Menu/sonata_menu.html.twig
+++ b/Resources/views/Menu/sonata_menu.html.twig
@@ -31,7 +31,7 @@
             {%- endfor %}
         {%- endif %}
 
-        {%- if item.level == 1%}
+        {%- if item.hasChildren %}
             {%- do item.setAttribute('class', (item.attribute('class')~' treeview')|trim) %}
         {%- endif %}
         {%- if active %}

--- a/Resources/views/Menu/sonata_menu.html.twig
+++ b/Resources/views/Menu/sonata_menu.html.twig
@@ -17,7 +17,9 @@
 
     {%- if item.displayed and display|default %}
         {%- set active = false %}
-        {%- if item.getExtra('admin') is not empty and item.getExtra('admin').hasroute('list') and item.getExtra('admin').isGranted('LIST') and request.get('_sonata_admin') == item.getExtra('admin').code %}
+        {%- if item.getExtra('active') is not empty and item.getExtra('active') %}
+            {%- set active = true %}
+        {%- elseif item.getExtra('admin') is not empty and item.getExtra('admin').hasroute('list') and item.getExtra('admin').isGranted('LIST') and request.get('_sonata_admin') == item.getExtra('admin').code %}
             {%- set active = true %}
         {%- elseif item.route is defined and request.get('_route') == item.route %}
             {%- set active = true %}
@@ -47,7 +49,7 @@
 {% block linkElement %}
     {% spaceless %}
         {% set translation_domain = item.getExtra('translationdomain', 'messages') %}
-        {% set icon = item.level > 1 ? '<i class="fa fa-angle-double-right"></i>' : '' %}
+        {% set icon = item.attribute('icon') ? item.attribute('icon') : (item.level > 1 ? '<i class="fa fa-angle-double-right"></i>' : '') %}
         {% set is_link = true %}
         {{ parent() }}
     {% endspaceless %}

--- a/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -106,6 +106,10 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('articleId' => 3) , $dashboardGroupsSettings['sonata_group_one']['items'][2]['route_params']);
         $this->assertContains('sonata_news_admin', $dashboardGroupsSettings['sonata_group_one']['item_adds']);
         $this->assertContains('ROLE_ONE', $dashboardGroupsSettings['sonata_group_one']['roles']);
+
+        $this->assertArrayHasKey('sonata_group_two', $dashboardGroupsSettings);
+        $this->assertArrayHasKey('provider', $dashboardGroupsSettings['sonata_group_two']);
+        $this->assertContains('my_menu', $dashboardGroupsSettings['sonata_group_two']['provider']);
     }
 
     /**
@@ -147,6 +151,10 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('sonata_news_admin', $adminGroups['sonata_group_one']['item_adds']);
         $this->assertFalse(in_array('sonata_article_admin', $adminGroups['sonata_group_one']['items']));
         $this->assertContains('ROLE_ONE', $adminGroups['sonata_group_one']['roles']);
+
+        $this->assertArrayHasKey('sonata_group_two', $adminGroups);
+        $this->assertArrayHasKey('provider', $adminGroups['sonata_group_two']);
+        $this->assertContains('my_menu', $adminGroups['sonata_group_two']['provider']);
 
         $this->assertArrayHasKey('Sonata\AdminBundle\Tests\DependencyInjection\Post', $adminClasses);
         $this->assertContains('sonata_post_admin', $adminClasses['Sonata\AdminBundle\Tests\DependencyInjection\Post']);
@@ -285,6 +293,9 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
                             'sonata_news_admin'
                         ),
                         'roles' => array('ROLE_ONE'),
+                    ),
+                    'sonata_group_two' => array(
+                        'provider' => 'my_menu',
                     ),
                 )
             ),

--- a/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -383,6 +383,9 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->register('knp_menu.factory')
             ->setClass('Knp\Menu\Silex\RouterAwareFactory');
         $container
+            ->register('knp_menu.helper')
+            ->setClass('Knp\Menu\Twig\Helper');
+        $container
             ->register('event_dispatcher')
             ->setClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
 

--- a/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -308,6 +308,9 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
         $container
             ->register('validator')
             ->setClass('Symfony\Component\Validator\ValidatorInterface');
+        $container
+            ->register('knp_menu.helper')
+            ->setClass('Knp\Menu\Twig\Helper');
 
         // Add admin definition's
         $container

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\AdminBundle\Tests\Twig\Extension;
 
+use Knp\Menu\MenuFactory;
+use Knp\Menu\MenuItem;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
@@ -95,7 +97,13 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->logger = $this->getMock('Psr\Log\LoggerInterface');
 
+        $menu = new MenuItem('bar', new MenuFactory());
+        $menu->addChild('foo');
         $this->helper = $this->getMockBuilder('Knp\Menu\Twig\Helper')->disableOriginalConstructor()->getMock();
+        $this->helper->expects($this->any())
+            ->method('get')
+            ->with('my_menu')
+            ->willReturn($menu);
 
         $this->twigExtension = new SonataAdminExtension($this->pool, $this->router, $this->helper, $this->logger);
 
@@ -1040,5 +1048,37 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
         $this->assertArrayNotHasKey('bar', $menu->getChildren());
         $this->assertCount(0, $menu->getChildren());
+    }
+
+    public function testGetKnpMenuWithProvider()
+    {
+        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+
+        $adminGroups = array(
+            "bar" => array(
+                "provider"        => 'my_menu',
+                "label_catalogue" => '',
+                "icon"            => '<i class="fa fa-edit"></i>',
+                "roles"           => array(),
+            ),
+        );
+        $this->pool->setAdminGroups($adminGroups);
+        $menu = $this->twigExtension->getKnpMenu($request);
+
+        $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
+        $this->assertArrayHasKey('bar', $menu->getChildren());
+
+        foreach ($menu->getChildren() as $key => $child) {
+            $this->assertInstanceOf('Knp\Menu\MenuItem', $child);
+            $this->assertEquals("bar", $child->getName());
+            $this->assertEquals("bar", $child->getLabel());
+
+            // menu items
+            $children = $child->getChildren();
+            $this->assertCount(1, $children);
+            $this->assertArrayHasKey('foo', $children);
+            $this->assertInstanceOf('Knp\Menu\MenuItem', $child['foo']);
+            $this->assertEquals('foo', $child['foo']->getLabel());
+        }
     }
 }

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -95,7 +95,9 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->logger = $this->getMock('Psr\Log\LoggerInterface');
 
-        $this->twigExtension = new SonataAdminExtension($this->pool, $this->router, $this->logger);
+        $this->helper = $this->getMockBuilder('Knp\Menu\Twig\Helper')->disableOriginalConstructor()->getMock();
+
+        $this->twigExtension = new SonataAdminExtension($this->pool, $this->router, $this->helper, $this->logger);
 
         $loader = new StubFilesystemLoader(array(
             __DIR__.'/../../../Resources/views/CRUD',

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Twig\Extension;
 use Doctrine\Common\Util\ClassUtils;
 use Knp\Menu\MenuFactory;
 use Knp\Menu\ItemInterface;
+use Knp\Menu\Twig\Helper;
 use Psr\Log\LoggerInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
@@ -41,6 +42,11 @@ class SonataAdminExtension extends \Twig_Extension
     protected $router;
 
     /**
+     * @var Helper
+     */
+    protected $knpHelper;
+
+    /**
      * @var LoggerInterface
      */
     protected $logger;
@@ -49,11 +55,12 @@ class SonataAdminExtension extends \Twig_Extension
      * @param Pool            $pool
      * @param LoggerInterface $logger
      */
-    public function __construct(Pool $pool, RouterInterface $router, LoggerInterface $logger = null)
+    public function __construct(Pool $pool, RouterInterface $router, Helper $knpHelper, LoggerInterface $logger = null)
     {
-        $this->pool   = $pool;
-        $this->logger = $logger;
-        $this->router = $router;
+        $this->pool      = $pool;
+        $this->logger    = $logger;
+        $this->router    = $router;
+        $this->knpHelper = $knpHelper;
     }
 
     /**
@@ -379,6 +386,22 @@ class SonataAdminExtension extends \Twig_Extension
         ;
 
         foreach ($this->pool->getAdminGroups() as $name => $group) {
+
+            // Check if the menu group is built by a menu provider
+            if (isset($group['provider'])) {
+                $subMenu = $this->knpHelper->get($group['provider']);
+
+                $menu->addChild($subMenu)
+                    ->setAttributes(array(
+                        'icon'            => $group['icon'],
+                        'label_catalogue' => $group['label_catalogue']
+                    ))
+                    ->setExtra('roles', $group['roles']);
+
+                continue;
+            }
+
+            // The menu group is built by config
             $menu
                 ->addChild($name, array('label' => $group['label']))
                 ->setAttributes(


### PR DESCRIPTION
This PR allows usage of a custom Knp menu as a menu group:

    sonata_admin:
        dashboard:
            groups:
                my_group:
                    provider: 'MyBundle:MyMenuProvider:getMyMenu'

- [x] Code
- [x] Documentation
- [x] Tests