### PR TITLE
Fix bad form collection JS counter

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -337,9 +337,17 @@ var Admin = {
         var counters = [];
 
         // Count and save element of each collection
+        var highestCounterRegexp = new RegExp('_([0-9])+$');
         jQuery(subject).find('[data-prototype]').each(function() {
             var collection = jQuery(this);
-            counters[collection.attr('id')] = collection.children().length-1;
+            var counter = 0;
+            collection.children().each(function() {
+                var matches = highestCounterRegexp.exec(jQuery(this).find('.form-control').attr('id'));
+                if (matches && matches[1] && matches[1] > counter) {
+                    counter = matches[1];
+                }
+            });
+            counters[collection.attr('id')] = counter;
         });
 
         jQuery(subject).on('click', '.sonata-collection-add', function(event) {

--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -332,16 +332,21 @@ var Admin = {
     },
 
     setup_collection_buttons: function(subject) {
-        var counter = jQuery(subject).closest('[data-prototype]').children().length;
-
         Admin.log('[core|setup_collection_buttons] setup collection buttons', subject);
+
+        var counters = [];
+
+        // Count and save element of each collection
+        jQuery(subject).find('[data-prototype]').each(function() {
+            var collection = $(this);
+            counters[collection.attr('id')] = collection.children().length-1;
+        });
 
         jQuery(subject).on('click', '.sonata-collection-add', function(event) {
             Admin.stopEvent(event);
 
-            counter++;
-
             var container = jQuery(this).closest('[data-prototype]');
+            var counter = ++counters[container.attr('id')];
             var proto = container.attr('data-prototype');
             var protoName = container.attr('data-prototype-name') || '__name__';
             // Set field id

--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -338,7 +338,7 @@ var Admin = {
 
         // Count and save element of each collection
         jQuery(subject).find('[data-prototype]').each(function() {
-            var collection = $(this);
+            var collection = jQuery(this);
             counters[collection.attr('id')] = collection.children().length-1;
         });
 


### PR DESCRIPTION
This fix issue #2857 that was introduced on PR #2831.

Fixed issue: The counter was not properly initialized (counting nothing) and always started by 0 on page load.

Improvement: Instead of a global `counter` variable, I make a `counters` to count element number collection by collection. I think it's very more proper.

@rande @EmmanuelVella can you please review and merge it? Even if is dev branch, this issue is quite critical.

Thanks.