### PR TITLE
Update list__select.html.twig

### DIFF
--- a/Resources/views/CRUD/list__select.html.twig
+++ b/Resources/views/CRUD/list__select.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    <a class="btn btn-default" href="{{ admin.generateObjectUrl('edit', object) }}">
+    <a class="btn btn-default" href="{{ admin.generateObjectUrl('list', object) }}">
         <i class="glyphicon glyphicon-arrow-right"></i>
         {{ 'list_select'|trans({}, 'SonataAdminBundle') }}
     </a>


### PR DESCRIPTION
when listing we are sure that only the list action is available, all other action could have been removed

You get an error if you remove the 'edit' route and try to use the admin for a sonata_type_model_list