### PR TITLE
Translate show group using translation_domain

### DIFF
--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -32,7 +32,7 @@ file that was distributed with this source code.
                         <div class="box-header with-border">
                             <h4 class="box-title">
                                 {% block show_title %}
-                                    {{ admin.trans(name) }}
+                                    {{ admin.trans(name, {}, view_group.translation_domain) }}
                                 {% endblock %}
                             </h4>
                         </div>


### PR DESCRIPTION
Now the show group names are translated with the ``translation_domain`` option (with fallback on admin ``translation_domain``)