### PR TITLE
Fix invalid HTML in JS causing test errors

### DIFF
--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -88,7 +88,7 @@ file that was distributed with this source code.
                     }
                 },
                 formatResult: function (item) {
-                    return {% block sonata_type_model_autocomplete_dropdown_item_format %}'<div class="{{ dropdown_item_css_class }}">'+item.label+'</div>'{% endblock %};// format of one dropdown item
+                    return {% block sonata_type_model_autocomplete_dropdown_item_format %}'<div class="{{ dropdown_item_css_class }}">'+item.label+'<\/div>'{% endblock %};// format of one dropdown item
                 },
                 formatSelection: function (item) {
                     return {% block sonata_type_model_autocomplete_selection_format %}item.label{% endblock %};// format selected item '<b>'+item.label+'</b>';


### PR DESCRIPTION
The `sonata_type_model_autocomplete`  form type broke the symfony DomCrawler.

HTML tags are not allowed inside `<script>` tags: http://stackoverflow.com/a/1450633/450789

Where can I add a test that use the DomCrawler ?