### PR TITLE
Specify btn classes on sonata-collection buttons

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -347,7 +347,7 @@ file that was distributed with this source code.
 
             {% set div_class = "" %}
             {% if sonata_admin.options['form_type'] == 'horizontal' %}
-                {% set div_class = 'col-bsm-9' %}
+                {% set div_class = 'col-sm-9' %}
             {% endif%}
 
             <div class="{{ div_class }} sonata-ba-field sonata-ba-field-{{ sonata_admin.edit }}-{{ sonata_admin.inline }} {% if child.vars.errors|length > 0 %}sonata-ba-field-error{% endif %}">

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -291,7 +291,7 @@ file that was distributed with this source code.
         {% if allow_delete %}
             <div class="row">
                 <div class="col-xs-1">
-                    <a href="#" class="btn btn-danger sonata-collection-delete">
+                    <a href="#" class="btn btn-link sonata-collection-delete">
                         <i class="fa fa-minus-circle"></i>
                     </a>
                 </div>
@@ -319,7 +319,7 @@ file that was distributed with this source code.
         {% endfor %}
         {{ form_rest(form) }}
         {% if allow_add %}
-            <div><a href="#" class="btn btn-success sonata-collection-add"><i class="fa fa-plus-circle"></i></a></div>
+            <div><a href="#" class="btn btn-link sonata-collection-add"><i class="fa fa-plus-circle"></i></a></div>
         {% endif %}
     </div>
 {% endspaceless %}
@@ -347,7 +347,7 @@ file that was distributed with this source code.
 
             {% set div_class = "" %}
             {% if sonata_admin.options['form_type'] == 'horizontal' %}
-                {% set div_class = 'col-sm-9' %}
+                {% set div_class = 'col-bsm-9' %}
             {% endif%}
 
             <div class="{{ div_class }} sonata-ba-field sonata-ba-field-{{ sonata_admin.edit }}-{{ sonata_admin.inline }} {% if child.vars.errors|length > 0 %}sonata-ba-field-error{% endif %}">

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -259,7 +259,7 @@ file that was distributed with this source code.
 
         {% if sonata_admin is defined and sonata_admin_enabled %}
             {% set div_class = div_class ~ ' sonata-ba-field-' ~ sonata_admin.edit ~ '-' ~ sonata_admin.inline %}
-            
+
             {% if sonata_admin.edit == 'inline' and sonata_admin.inline == 'table' %}
                 {% set div_class = div_class ~ ' form-inline' %}
             {% endif %}
@@ -291,7 +291,7 @@ file that was distributed with this source code.
         {% if allow_delete %}
             <div class="row">
                 <div class="col-xs-1">
-                    <a href="#" class="btn sonata-collection-delete">
+                    <a href="#" class="btn btn-danger sonata-collection-delete">
                         <i class="fa fa-minus-circle"></i>
                     </a>
                 </div>
@@ -319,7 +319,7 @@ file that was distributed with this source code.
         {% endfor %}
         {{ form_rest(form) }}
         {% if allow_add %}
-            <div><a href="#" class="btn sonata-collection-add"><i class="fa fa-plus-circle"></i></a></div>
+            <div><a href="#" class="btn btn-success sonata-collection-add"><i class="fa fa-plus-circle"></i></a></div>
         {% endif %}
     </div>
 {% endspaceless %}


### PR DESCRIPTION
Bootstrap button must have a style class after `.btn`.

I propose 3 solutions.

### Solution 1: Colors on buttons (the chosen one on this PR):

![sonata_collection_btn_01](https://cloud.githubusercontent.com/assets/1698357/6923798/48c6e69a-d7d4-11e4-9bbe-52022d5decdc.png)

### Solution 2: Just default buttons
![sonata_collection_btn_02](https://cloud.githubusercontent.com/assets/1698357/6923797/48c6a45a-d7d4-11e4-999f-48b88e0fa5d5.png)

### Solution 3: The `btn-link` method
Note: This solution is nearly the same as the actual design.

![sonata_collection_btn_03](https://cloud.githubusercontent.com/assets/1698357/6923796/48c5b8ec-d7d4-11e4-813e-3552ef1f7cf2.png)


If you choose solution 1, just merge this PR right now to take modifications effect! :+1: 

If you want another, tell me so I will update my PR.

Thanks.