### PR TITLE
Bootlint integration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -79,6 +79,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('confirm_exit')->defaultValue(true)->end()
                         ->booleanNode('use_select2')->defaultValue(true)->end()
                         ->booleanNode('use_icheck')->defaultValue(true)->end()
+                        ->booleanNode('use_bootlint')->defaultValue(false)->end()
                         ->integerNode('pager_links')->defaultValue(null)->end()
                         ->scalarNode('form_type')->defaultValue('standard')->end()
                         ->integerNode('dropdown_number_groups_per_colums')->defaultValue(2)->end()

--- a/Resources/doc/cookbook/recipe_bootlint.rst
+++ b/Resources/doc/cookbook/recipe_bootlint.rst
@@ -1,0 +1,25 @@
+Bootlint
+========
+
+The admin comes with `Bootlint <https://github.com/twbs/bootlint>`_ integration
+since version 2.4.0. Bootlint is an HTML linter for Bootstrap projects.
+
+You should use it when you want add some contributions on Sonata UI to check
+the eventual Twitter Bootstrap conventions' mistakes.
+
+Enable Bootlint
+---------------
+
+To use Bootlint in your admin, you can enable it in ``config.yml``.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        sonata_admin:
+            options:
+                use_bootlint:    true # enable Bootlint
+
+Then open your browser debugger to look after some Bootlint warnings on console.
+
+No warning? Congrats! You page is fully Bootstrap compliant! ;)

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -73,3 +73,4 @@ Cookbook
    cookbook/recipe_overwrite_admin_configuration
    cookbook/recipe_improve_performance_large_datasets
    cookbook/recipe_virtual_field
+   cookbook/recipe_bootlint

--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -60,6 +60,7 @@ Full Configuration Options
                 confirm_exit:         true
                 use_select2:          true
                 use_icheck:           true
+                use_bootlint:         false
                 pager_links:          null
                 form_type:            standard
                 dropdown_number_groups_per_colums:  2

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -46,7 +46,7 @@ file that was distributed with this source code.
                 };
                 window.SONATA_TRANSLATIONS = {
                     CONFIRM_EXIT:  '{{ 'confirm_exit'|trans({}, 'SonataAdminBundle')|escape('js') }}'
-               };
+                };
             </script>
 
             {% if admin_pool is defined %}
@@ -71,6 +71,12 @@ file that was distributed with this source code.
                 {% endif %}
             {% endif %}
 
+            {% if admin_pool is defined and admin_pool.getOption('use_bootlint') %}
+                {# Bootlint - https://github.com/twbs/bootlint#in-the-browser #}
+                <script type="text/javascript">
+                    javascript:(function(){var s=document.createElement("script");s.onload=function(){bootlint.showLintReportForCurrentDocument([], {hasProblems: false, problemFree: false});};s.src="https://maxcdn.bootstrapcdn.com/bootlint/latest/bootlint.min.js";document.body.appendChild(s)})();
+                </script>
+            {% endif %}
         {% endblock %}
 
         <title>


### PR DESCRIPTION
Related to #2878.

 - [x] Bootlint option
 - [x] Bootlint integration
 - [x] Add some documentation

As our Sonata Admin default theme is based on Twitter Bootstrap, it could be useful to have bootlint for dev env in order to fix and optimize bootstrap integration.

 > Bootlint is a tool that checks for several common HTML mistakes in webpages that are using Bootstrap in a fairly "vanilla" way. Vanilla Bootstrap's components/widgets require their parts of the DOM to conform to certain structures. Bootlint checks that instances of Bootstrap components have correctly-structured HTML. Optimal usage of Bootstrap also requires that your pages include certain <meta> tags, an HTML5 doctype declaration, etc.; Bootlint checks that these are present.

Related repository: https://github.com/twbs/bootlint

Note: Bootlint only works included on bottom of the body. So I move all the javascripts block on body bottom.
Is that a problem? Tell me if yes. BTW, I think it's highly recommended to have js files loaded on body, after the rest of the DOM.

Thanks.