### PR TITLE
Add sonata-ba-list class (fixes regression)

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
 
                 {% set batchactions = admin.batchactions %}
                 {% if admin.datagrid.results|length > 0 %}
-                    <table class="table table-bordered table-striped">
+                    <table class="table table-bordered table-striped sonata-ba-list">
                         {% block table_header %}
                             <thead>
                                 <tr class="sonata-ba-list-field-header">


### PR DESCRIPTION
I suppose the class was accidentally removed here : https://github.com/sonata-project/SonataAdminBundle/commit/4505646a37d975a0fff27865253e9f92d237cd4f