### PR TITLE
Autocomplete improvements & new customization options

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Controller;
 
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -347,6 +348,7 @@ class HelperController
         }
 
         $datagrid = $targetAdmin->getDatagrid();
+        $this->clearDatagridFilters($datagrid);
 
         if ($callback !== null) {
             if (!is_callable($callback)) {
@@ -441,5 +443,15 @@ class HelperController
         }
 
         return $fieldDescription;
+    }
+
+    /**
+     * @param DatagridInterface $datagrid
+     */
+    private function clearDatagridFilters(DatagridInterface $datagrid)
+    {
+        foreach ($datagrid->getFilters() as $filter) {
+            $datagrid->setValue($filter->getName(), null, null);
+        }
     }
 }

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -331,6 +331,7 @@ class HelperController
         $itemsPerPage       = $formAutocomplete->getConfig()->getAttribute('items_per_page');
         $reqParamPageNumber = $formAutocomplete->getConfig()->getAttribute('req_param_name_page_number');
         $toStringCallback   = $formAutocomplete->getConfig()->getAttribute('to_string_callback');
+        $resultItemCallback = $formAutocomplete->getConfig()->getAttribute('response_item_callback');
 
         $searchText = $request->get('q');
 
@@ -396,10 +397,16 @@ class HelperController
                 $label = $resultMetadata->getTitle();
             }
 
-            $items[] = array(
+            $item = array(
                 'id'    => $admin->id($entity),
                 'label' => $label,
             );
+
+            if (is_callable($resultItemCallback)) {
+                $resultItemCallback($admin, $entity, $item);
+            }
+
+            $items[] = $item;
         }
 
         return new JsonResponse(array(

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -436,10 +436,6 @@ class HelperController
             throw new \RuntimeException(sprintf('The field "%s" does not exist.', $field));
         }
 
-        if ($fieldDescription->getType() !== 'sonata_type_model_autocomplete') {
-            throw new \RuntimeException(sprintf('Unsupported form type "%s" for field "%s".', $fieldDescription->getType(), $field));
-        }
-
         if (null === $fieldDescription->getTargetEntity()) {
             throw new \RuntimeException(sprintf('No associated entity with field "%s".', $field));
         }

--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -39,6 +39,7 @@ class ModelAutocompleteType extends AbstractType
 
         $builder->setAttribute('property', $options['property']);
         $builder->setAttribute('callback', $options['callback']);
+        $builder->setAttribute('response_item_callback', $options['response_item_callback']);
         $builder->setAttribute('minimum_input_length', $options['minimum_input_length']);
         $builder->setAttribute('items_per_page', $options['items_per_page']);
         $builder->setAttribute('req_param_name_page_number', $options['req_param_name_page_number']);
@@ -79,6 +80,7 @@ class ModelAutocompleteType extends AbstractType
             'model_manager'                   => null,
             'class'                           => null,
             'callback'                        => null,
+            'response_item_callback'          => null,
             'multiple'                        => false,
 
             'placeholder'                     => '',

--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -77,6 +77,7 @@ class ModelAutocompleteType extends AbstractType
         $resolver->setDefaults(array(
             'attr'                            => array(),
             'compound'                        => true,
+            'error_bubbling'                  => false,
             'model_manager'                   => null,
             'class'                           => null,
             'callback'                        => null,

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -272,57 +272,61 @@ file that was distributed with this source code.
 
     <script>
         (function ($) {
-            var autocompleteInput = $("#{{ form.title.vars.id }}");
-            autocompleteInput.select2({
-                placeholder: "{{ placeholder }}",
-                allowClear: {{ required ? 'false' : 'true' }},
-                enable: {{ disabled ? 'false' : 'true' }},
-                readonly: {{ read_only ? 'true' : 'false' }},
-                minimumInputLength: {{ minimum_input_length }},
-                multiple: {{ multiple ? 'true' : 'false' }},
-                ajax: {
-                    url:  "{{ url ?: url(route.name, route.parameters|default([])) }}",
-                    dataType: 'json',
-                    quietMillis: 100,
-                    data: function (term, page) { // page is the one-based page number tracked by Select2
-                        return {
-                                //search term
-                                "{{ req_param_name_search }}": term,
+            var autocompleteInput = $("#{{ form.title.vars.id }}"),
+                autocompleteOptions = {
+                    placeholder: "{{ placeholder }}",
+                    allowClear: {{ required ? 'false' : 'true' }},
+                    enable: {{ disabled ? 'false' : 'true' }},
+                    readonly: {{ read_only ? 'true' : 'false' }},
+                    minimumInputLength: {{ minimum_input_length }},
+                    multiple: {{ multiple ? 'true' : 'false' }},
+                    ajax: {
+                        url:  "{{ url ?: url(route.name, route.parameters|default([])) }}",
+                        dataType: 'json',
+                        quietMillis: 100,
+                        data: function (term, page) { // page is the one-based page number tracked by Select2
+                            return {
+                                    //search term
+                                    "{{ req_param_name_search }}": term,
 
-                                // page size
-                                "{{ req_param_name_items_per_page }}": {{ items_per_page }},
+                                    // page size
+                                    "{{ req_param_name_items_per_page }}": {{ items_per_page }},
 
-                                // page number
-                                "{{ req_param_name_page_number }}": page,
+                                    // page number
+                                    "{{ req_param_name_page_number }}": page,
 
-                                // admin
-                                'uniqid': "{{ sonata_admin.admin.uniqid }}",
-                                'code':   "{{ sonata_admin.admin.code }}",
-                                'field':  "{{ name }}"
+                                    // admin
+                                    'uniqid': "{{ sonata_admin.admin.uniqid }}",
+                                    'code':   "{{ sonata_admin.admin.code }}",
+                                    'field':  "{{ name }}"
 
-                                // other parameters
-                                {% if req_params is not empty %},
-                                    {%- for key, value in req_params -%}
-                                        "{{- key|e('js') -}}": "{{- value|e('js') -}}"
-                                        {%- if not loop.last -%}, {% endif -%}
-                                    {%- endfor -%}
-                                {% endif %}
-                            };
+                                    // other parameters
+                                    {% if req_params is not empty %},
+                                        {%- for key, value in req_params -%}
+                                            "{{- key|e('js') -}}": "{{- value|e('js') -}}"
+                                            {%- if not loop.last -%}, {% endif -%}
+                                        {%- endfor -%}
+                                    {% endif %}
+                                };
+                        },
+                        results: function (data, page) {
+                            // notice we return the value of more so Select2 knows if more results can be loaded
+                            return {results: data.items, more: data.more};
+                        }
                     },
-                    results: function (data, page) {
-                        // notice we return the value of more so Select2 knows if more results can be loaded
-                        return {results: data.items, more: data.more};
-                    }
-                },
-                formatResult: function (item) {
-                    return {% block sonata_type_model_autocomplete_dropdown_item_format %}'<div class="sonata-autocomplete-dropdown-item">'+item.label+'</div>'{% endblock %};// format of one dropdown item
-                },
-                formatSelection: function (item) {
-                    return {% block sonata_type_model_autocomplete_selection_format %}item.label{% endblock %};// format selected item '<b>'+item.label+'</b>';
-                },
-                dropdownCssClass: "{{ dropdown_css_class }}",
-                escapeMarkup: function (m) { return m; } // we do not want to escape markup since we are displaying html in results
-            });
+                    formatResult: function (item) {
+                        return {% block sonata_type_model_autocomplete_dropdown_item_format %}'<div class="sonata-autocomplete-dropdown-item">'+item.label+'</div>'{% endblock %};// format of one dropdown item
+                    },
+                    formatSelection: function (item) {
+                        return {% block sonata_type_model_autocomplete_selection_format %}item.label{% endblock %};// format selected item '<b>'+item.label+'</b>';
+                    },
+                    dropdownCssClass: "{{ dropdown_css_class }}",
+                    escapeMarkup: function (m) { return m; } // we do not want to escape markup since we are displaying html in results
+                };
+
+            {% block sonata_type_model_autocomplete_select2_options_js %}{% endblock %}
+
+            autocompleteInput.select2(autocompleteOptions);
 
             autocompleteInput.on("change", function(e) {
 


### PR DESCRIPTION
This PR adds extra functionality to  sonata_type_model_autocomplete, fixes few glitches & extends customization options:

1. Added callback with possibility to modify each individual item in response.
2. Removed form type check in HelperController: it made impossible to extend  	sonata_type_model_autocomplete without writing own controller with copying whole retrieveAutocompleteItemsAction method in case of extending it.
3. Added way to customize any autocomplete select2 properties in js via adding sonata_type_model_autocomplete_select2_options_js block before initializing select2 element. Reason to do this is because select2 doesn't allow modification of several options after it has been initialized, you can only destroy it and initialize again from scratch.
4. Make autocomplete item list independent of filters set in corresponding list via removing it's filters. Otherwise, if you set filter in, let's say, product list, and you're using product autocomplete elsewhere, it returns only products that match that filter, which is confusing.
5. Set error bubbling to false - prevent passing error to parent form elements, which occurs by default for compound form types.