### PR TITLE
Remove mal-formatted name for autocomplete type

### DIFF
--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -10,7 +10,7 @@ file that was distributed with this source code.
 #}
 {% spaceless %}
 
-    <input type="text" name="{{ full_name }}_autocomplete_input" id="{{ id }}_autocomplete_input" value=""
+    <input type="text" id="{{ id }}_autocomplete_input" value=""
         {%- if read_only %} readonly="readonly"{% endif -%}
         {%- if disabled %} disabled="disabled"{% endif -%}
         {%- if required %} required="required"{% endif %}


### PR DESCRIPTION
Hello,

First of all, thank you for this amazing bundle!

I found an issue with the sonata_type_model_autocomplete with this error:

```text
InvalidArgumentException: Malformed field path "s5527e68f85fe3[contact]_autocomplete_input"

/space/home/vchabot/paprika/vendor/symfony/symfony/src/Symfony/Component/DomCrawler/FormFieldRegistry.php:211
/space/home/vchabot/paprika/vendor/symfony/symfony/src/Symfony/Component/DomCrawler/FormFieldRegistry.php:34
/space/home/vchabot/paprika/vendor/symfony/symfony/src/Symfony/Component/DomCrawler/Form.php:293
/space/home/vchabot/paprika/vendor/symfony/symfony/src/Symfony/Component/DomCrawler/Form.php:483
/space/home/vchabot/paprika/vendor/symfony/symfony/src/Symfony/Component/DomCrawler/Form.php:458
/space/home/vchabot/paprika/vendor/symfony/symfony/src/Symfony/Component/DomCrawler/Form.php:51
/space/home/vchabot/paprika/vendor/symfony/symfony/src/Symfony/Component/DomCrawler/Crawler.php:778
/space/home/vchabot/paprika/src/Crm/CrmBundle/Tests/Admin/CrmAdminTest.php:149
```

Two solutions were possible:
* Rename the name with something like `name="{{ full_name }}[autocomplete_input]"` (will cause a mapping issue with the form)
* Remove the name attribute

As the name is not used, I think it should be better to remove it.