### PR TITLE
Admin::getSubject() is not valid for UUID as identifier

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1745,7 +1745,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     {
         if ($this->subject === null && $this->request) {
             $id = $this->request->get($this->getIdParameter());
-            if (!preg_match('#^[0-9A-Fa-f]+$#', $id)) {
+            if (!preg_match('#^[0-9A-Fa-f\-]+$#', $id)) {
                 $this->subject = false;
             } else {
                 $this->subject = $this->getModelManager()->find($this->class, $id);

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1571,6 +1571,33 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($barFieldDescription, $modelAdmin->getFilterFieldDescription('bar'));
         $this->assertSame($bazFieldDescription, $modelAdmin->getFilterFieldDescription('baz'));
     }
+
+    public function testGetSubject()
+    {
+        $entity = new Post();
+        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager
+            ->expects($this->any())
+            ->method('find')
+            ->will($this->returnValue($entity));
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin->setModelManager($modelManager);
+
+        $admin->setRequest(new Request(array('id' => 'azerty')));
+        $this->assertFalse($admin->getSubject());
+
+        $admin->setSubject(null);
+        $admin->setRequest(new Request(array('id' => 42)));
+        $this->assertEquals($entity, $admin->getSubject());
+
+        $admin->setSubject(null);
+        $admin->setRequest(new Request(array('id' => '4f69bbb5f14a13347f000092')));
+        $this->assertEquals($entity, $admin->getSubject());
+
+        $admin->setSubject(null);
+        $admin->setRequest(new Request(array('id' => '0779ca8d-e2be-11e4-ac58-0242ac11000b')));
+        $this->assertEquals($entity, $admin->getSubject());
+    }
 }
 
 class DummySubject


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This PR is submitted after bug dicovered when following online doc to create a "clone" action on an entity with UUID as Identifier.