### PR TITLE
Add missing checks to see if admin_pool is defined

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -28,11 +28,11 @@ file that was distributed with this source code.
         {% endblock %}
 
         {% block stylesheets %}
-
-            {% for stylesheet in admin_pool.getOption('stylesheets', []) %}
-                <link rel="stylesheet" href="{{ asset(stylesheet) }}">
-            {% endfor %}
-
+            {% if admin_pool is defined %}
+                {% for stylesheet in admin_pool.getOption('stylesheets', []) %}
+                    <link rel="stylesheet" href="{{ asset(stylesheet) }}">
+                {% endfor %}
+            {% endif %}
         {% endblock %}
 
         {% block javascripts %}
@@ -47,9 +47,11 @@ file that was distributed with this source code.
                };
             </script>
 
-            {% for javascript in admin_pool.getOption('javascripts', []) %}
-                <script src="{{ asset(javascript) }}"></script>
-            {% endfor %}
+            {% if admin_pool is defined %}
+                {% for javascript in admin_pool.getOption('javascripts', []) %}
+                    <script src="{{ asset(javascript) }}"></script>
+                {% endfor %}
+            {% endif %}
 
             {# localize select2 #}
             {% if admin_pool is defined and admin_pool.getOption('use_select2') %}
@@ -100,10 +102,10 @@ file that was distributed with this source code.
                 {% block logo %}
                     {% spaceless %}
                     <a class="logo" href="{{ url('sonata_admin_dashboard') }}">
-                        {% if 'single_image' == admin_pool.getOption('title_mode') or 'both' == admin_pool.getOption('title_mode') %}
+                        {% if admin_pool is defined and ('single_image' == admin_pool.getOption('title_mode') or 'both' == admin_pool.getOption('title_mode')) %}
                             <img src="{{ asset(admin_pool.titlelogo) }}" alt="{{ admin_pool.title }}">
                         {% endif %}
-                        {% if 'single_text' == admin_pool.getOption('title_mode') or 'both' == admin_pool.getOption('title_mode') %}
+                        {% if admin_pool is defined and ('single_text' == admin_pool.getOption('title_mode') or 'both' == admin_pool.getOption('title_mode')) %}
                             <span>{{ admin_pool.title }}</span>
                         {% endif %}
                     </a>
@@ -154,14 +156,14 @@ file that was distributed with this source code.
                                             <a class="dropdown-toggle" data-toggle="dropdown" href="#">
                                                 <i class="fa fa-plus-square fa-fw"></i> <i class="fa fa-caret-down"></i>
                                             </a>
-                                            {% include admin_pool.getTemplate('add_block') %}
+                                            {% if admin_pool is defined %}{% include admin_pool.getTemplate('add_block') %}{% endif %}
                                         </li>
                                         <li class="dropdown user-menu">
                                             <a class="dropdown-toggle" data-toggle="dropdown" href="#">
                                                 <i class="fa fa-user fa-fw"></i> <i class="fa fa-caret-down"></i>
                                             </a>
                                             <ul class="dropdown-menu dropdown-user">
-                                                {% include admin_pool.getTemplate('user_block') %}
+                                                {% if admin_pool is defined %}{% include admin_pool.getTemplate('user_block') %}{% endif %}
                                             </ul>
                                         </li>
                                     </ul>
@@ -198,45 +200,47 @@ file that was distributed with this source code.
                                 {% block side_bar_nav %}
                                     {% if app.security.token and is_granted('ROLE_SONATA_ADMIN') %}
                                         <ul class="sidebar-menu">
-                                            {% for group in admin_pool.dashboardgroups %}
-                                                {% set display = (group.roles is empty or is_granted('ROLE_SUPER_ADMIN') ) %}
-                                                {% for role in group.roles if not display %}
-                                                    {% set display = is_granted(role) %}
+                                            {% if admin_pool is defined %}
+                                                {% for group in admin_pool.dashboardgroups %}
+                                                    {% set display = (group.roles is empty or is_granted('ROLE_SUPER_ADMIN') ) %}
+                                                    {% for role in group.roles if not display %}
+                                                        {% set display = is_granted(role) %}
+                                                    {% endfor %}
+    
+                                                    {# Do not display the group label if no item in group is available #}
+                                                    {% set item_count = 0 %}
+                                                    {% if display %}
+                                                        {% for admin in group.items if item_count == 0 %}
+                                                            {% if admin.hasroute('list') and admin.isGranted('LIST') %}
+                                                                {% set item_count = item_count+1 %}
+                                                            {% endif %}
+                                                        {% endfor %}
+                                                    {% endif %}
+    
+                                                    {% if display and (item_count > 0) %}
+                                                        {% set active = false %}
+                                                        {% for admin in group.items %}
+                                                            {% if admin.hasroute('list') and admin.isGranted('LIST') and app.request.get('_sonata_admin') == admin.code %}
+                                                                {% set active = true %}
+                                                            {% endif %}
+                                                        {% endfor %}
+                                                        <li class="treeview{% if active %} active{% endif %}">
+                                                            <a href="#">
+                                                                {% if group.icon|default() %}{{ group.icon|raw }}{% endif %}
+                                                                <span>{{ group.label|trans({}, group.label_catalogue) }}</span>
+                                                                <i class="fa pull-right fa-angle-left"></i>
+                                                            </a>
+                                                            <ul class="treeview-menu{% if active %} active{% endif %}">
+                                                                {% for admin in group.items %}
+                                                                    {% if admin.hasroute('list') and admin.isGranted('LIST') %}
+                                                                        <li{% if app.request.get('_sonata_admin') == admin.code %} class="active"{% endif %}><a href="{{ admin.generateUrl('list')}}"><i class="fa fa-angle-double-right"></i> {{ admin.label|trans({}, admin.translationdomain) }}</a></li>
+                                                                    {% endif %}
+                                                                {% endfor %}
+                                                            </ul>
+                                                        </li>
+                                                    {% endif %}
                                                 {% endfor %}
-
-                                                {# Do not display the group label if no item in group is available #}
-                                                {% set item_count = 0 %}
-                                                {% if display %}
-                                                    {% for admin in group.items if item_count == 0 %}
-                                                        {% if admin.hasroute('list') and admin.isGranted('LIST') %}
-                                                            {% set item_count = item_count+1 %}
-                                                        {% endif %}
-                                                    {% endfor %}
-                                                {% endif %}
-
-                                                {% if display and (item_count > 0) %}
-                                                    {% set active = false %}
-                                                    {% for admin in group.items %}
-                                                        {% if admin.hasroute('list') and admin.isGranted('LIST') and app.request.get('_sonata_admin') == admin.code %}
-                                                            {% set active = true %}
-                                                        {% endif %}
-                                                    {% endfor %}
-                                                    <li class="treeview{% if active %} active{% endif %}">
-                                                        <a href="#">
-                                                            {% if group.icon|default() %}{{ group.icon|raw }}{% endif %}
-                                                            <span>{{ group.label|trans({}, group.label_catalogue) }}</span>
-                                                            <i class="fa pull-right fa-angle-left"></i>
-                                                        </a>
-                                                        <ul class="treeview-menu{% if active %} active{% endif %}">
-                                                            {% for admin in group.items %}
-                                                                {% if admin.hasroute('list') and admin.isGranted('LIST') %}
-                                                                    <li{% if app.request.get('_sonata_admin') == admin.code %} class="active"{% endif %}><a href="{{ admin.generateUrl('list')}}"><i class="fa fa-angle-double-right"></i> {{ admin.label|trans({}, admin.translationdomain) }}</a></li>
-                                                                {% endif %}
-                                                            {% endfor %}
-                                                        </ul>
-                                                    </li>
-                                                {% endif %}
-                                            {% endfor %}
+                                            {% endif %}
                                         </ul>
                                     {% endif %}
                                 {% endblock side_bar_nav %}


### PR DESCRIPTION
This is similar to #2784 and allows the template to be used globally from outside of the admin bundle.

(there were lots of indentation changes which makes the commit look quite complicated. You can append "?w=0" to see a diff without whitespace changes, like so: https://github.com/sonata-project/SonataAdminBundle/pull/2925/files?w=0 )