### PR TITLE
Fix deprecated setAllowedTypes method

### DIFF
--- a/Block/AdminListBlockService.php
+++ b/Block/AdminListBlockService.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\BlockBundle\Block\BaseBlockService;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -81,8 +82,12 @@ class AdminListBlockService extends BaseBlockService
             'groups' => false
         ));
 
-        $resolver->setAllowedTypes(array(
-            'groups' => array('bool', 'array')
-        ));
+        if (version_compare(Kernel::VERSION, '2.6', '<')) {
+            $resolver->setAllowedTypes(array(
+                'groups' => array('bool', 'array')
+            ));
+        } else {
+            $resolver->setAllowedTypes('groups', array('bool', 'array'));
+        }
     }
 }

--- a/Form/Type/AclMatrixType.php
+++ b/Form/Type/AclMatrixType.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -62,10 +63,15 @@ class AclMatrixType extends AbstractType
             'acl_value',
         ));
 
-        $resolver->setAllowedTypes(array(
-            'permissions' => 'array',
-            'acl_value' => array('string', '\Symfony\Component\Security\Core\User\UserInterface'),
-        ));
+        if (version_compare(Kernel::VERSION, '2.6', '<')) {
+            $resolver->setAllowedTypes(array(
+                'permissions' => 'array',
+                'acl_value' => array('string', '\Symfony\Component\Security\Core\User\UserInterface'),
+            ));
+        } else {
+            $resolver->setAllowedTypes('permissions', 'array');
+            $resolver->setAllowedTypes('acl_value', array('string', '\Symfony\Component\Security\Core\User\UserInterface'));
+        }
     }
 
     /**


### PR DESCRIPTION
Fix deprecated `setAllowedTypes` method parameters from SF 2.6.

Symfony 2.3+ BC kept.