### PR TITLE
[FieldDescription] Ensure the object is not used when getting the value of a virtual field (action, batch, etc.)

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -783,9 +783,10 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
 
         if (count($this->getBatchActions()) > 0) {
             $fieldDescription = $this->getModelManager()->getNewFieldDescriptionInstance($this->getClass(), 'batch', array(
-                'label'    => 'batch',
-                'code'     => '_batch',
-                'sortable' => false,
+                'label'         => 'batch',
+                'code'          => '_batch',
+                'sortable'      => false,
+                'virtual_field' => true,
             ));
 
             $fieldDescription->setAdmin($this);
@@ -802,9 +803,10 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
 
         if ($this->hasRequest() && $this->getRequest()->isXmlHttpRequest()) {
             $fieldDescription = $this->getModelManager()->getNewFieldDescriptionInstance($this->getClass(), 'select', array(
-                'label'    => false,
-                'code'     => '_select',
-                'sortable' => false,
+                'label'         => false,
+                'code'          => '_select',
+                'sortable'      => false,
+                'virtual_field' => false,
             ));
 
             $fieldDescription->setAdmin($this);

--- a/Admin/BaseFieldDescription.php
+++ b/Admin/BaseFieldDescription.php
@@ -321,6 +321,10 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
      */
     public function getFieldValue($object, $fieldName)
     {
+        if ($this->isVirtual()) {
+           return null;
+        }
+
         $camelizedFieldName = self::camelize($fieldName);
 
         $getters = array();
@@ -480,5 +484,15 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     public function getTranslationDomain()
     {
         return $this->getOption('translation_domain') ?: $this->getAdmin()->getTranslationDomain();
+    }
+
+    /**
+     * Return true if field is virtual.
+     *
+     * @return boolean
+     */
+    public function isVirtual()
+    {
+        return false !== $this->getOption('virtual_field', false);
     }
 }

--- a/Datagrid/ListMapper.php
+++ b/Datagrid/ListMapper.php
@@ -85,6 +85,11 @@ class ListMapper extends BaseMapper
             }
         }
 
+        // Ensure batch and action pseudo-fields are tagged as virtual
+        if (in_array($type, array('action', 'batch', 'select'))) {
+            $fieldDescriptionOptions['virtual_field'] = true;
+        }
+
         if ($name instanceof FieldDescriptionInterface) {
             $fieldDescription = $name;
             $fieldDescription->mergeOptions($fieldDescriptionOptions);

--- a/Resources/doc/cookbook/recipe_virtual_field.rst
+++ b/Resources/doc/cookbook/recipe_virtual_field.rst
@@ -1,0 +1,12 @@
+Virtual Field Descriptions
+==========================
+
+Some fields including in the various Mappers don't rely on any actual field in
+the Model (e.g., ``_action`` or ``batch``).
+
+In order to prevent any side-effects when trying to retrieve the value of this
+field (which doesn't exist), the option ``virtual_field`` is specified for these
+fields.
+
+When the template is instanciated, or whenever the value of the field is
+required, ``null`` will simply be returned without prying on the Model itself.

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -72,3 +72,4 @@ Cookbook
    cookbook/recipe_customizing_a_mosaic_list
    cookbook/recipe_overwrite_admin_configuration
    cookbook/recipe_improve_performance_large_datasets
+   cookbook/recipe_virtual_field

--- a/Tests/Admin/BaseFieldDescriptionTest.php
+++ b/Tests/Admin/BaseFieldDescriptionTest.php
@@ -157,6 +157,15 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $description->getFieldValue($mock, 'fake');
     }
 
+    public function testGetVirtualValue()
+    {
+        $description = new FieldDescription();
+        $mock = $this->getMock('stdClass', array('getFoo'));
+
+        $description->setOption('virtual_field', true);
+        $description->getFieldValue($mock, 'fake');
+    }
+
     /**
      * @expectedException RuntimeException
      */

--- a/Tests/Datagrid/ListMapperTest.php
+++ b/Tests/Datagrid/ListMapperTest.php
@@ -212,6 +212,17 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
         $this->fail('Failed asserting that exception of type "\RuntimeException" is thrown.');
     }
 
+    public function testAutoAddVirtualOption()
+    {
+        foreach (array('action', 'batch', 'select') as $type) {
+            $this->listMapper->add('_'.$type, $type);
+        }
+
+        foreach ($this->fieldDescriptionCollection as $field) {
+           $this->assertTrue($field->isVirtual(), 'Failed asserting that FieldDescription with type "'.$field->getType().'" is tagged with virtual flag.');
+        }
+    }
+
     public function testReorder()
     {
         $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');


### PR DESCRIPTION
Follow up on #2830

This PR is working and includes tests.

However, this feels more like a path than an actual solution to me. I would need a bit more info/doc before being able to provide a more complete solution.

I currently simply check if the type of the field is a problematic one (action/batch) and added virtual as a generic solution.

--
I think we should refactor `BaseFieldDescription` in order to split it in two:
 - One (`AbstractFieldDescription`?) with only the most basic needs (name, type (?), options, etc.) required for every FieldDescription, but striping away all the mapping information.
 - One (`BaseFieldDescription` or `BaseMappedFieldDescription` ?) extending the first one and including all the properties and methods related to the mapping.

With this, we could create a `VirtualFieldDescription`, not bothering with all the mapping stuff and simply focusing on rendering. If useful, we could even split the `FieldDescriptionInterface` in two to provide a better separation between mapping related method and rendering related ones.

My problem, is mostly knowing which field and which method is used for which part. The PHPDoc doesn't describe the purpose of each concept used in the `FieldDescriptionInterface` (Mapping, Parent, Association, etc.) which makes it a bit hard to know what I can safely remove to build the `VirtualFieldDescription`.

If you think the refactoring would be welcome and I should carry on with it, I shall need the additional information on how to split up the Field Definitions. (Plus there are issues regarding BC and further design details to consider).

If you think the current patch is enough and I shouldn't bother with the rest of the refactoring, feel free to merge and let it go :snowflake:...