### PR TITLE
Add support for entities outside of bundles

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -47,7 +47,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     const CONTEXT_MENU       = 'menu';
     const CONTEXT_DASHBOARD  = 'dashboard';
 
-    const CLASS_REGEX        = '@(?:([A-Za-z0-9]*)\\\)?(Bundle\\\)?([A-Za-z0-9]+)Bundle\\\(Entity|Document|Model|PHPCR|CouchDocument|Phpcr|Doctrine\\\Orm|Doctrine\\\Phpcr|Doctrine\\\MongoDB|Doctrine\\\CouchDB)\\\(.*)@';
+    const CLASS_REGEX        = '@(?:([A-Za-z0-9]*)\\\)?(Bundle\\\)?([A-Za-z0-9]+?)(?:Bundle)?\\\(Entity|Document|Model|PHPCR|CouchDocument|Phpcr|Doctrine\\\Orm|Doctrine\\\Phpcr|Doctrine\\\MongoDB|Doctrine\\\CouchDB)\\\(.*)@';
 
     /**
      * The class name managed by the admin class.

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -437,6 +437,10 @@ class AdminTest extends \PHPUnit_Framework_TestCase
                 'AppBundle\Entity\User',
                 '/app/user',
             ),
+            array(
+                'App\Entity\User',
+                '/app/user',
+            ),
         );
     }
 
@@ -449,13 +453,16 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $admin->getBaseRoutePattern());
     }
 
-    public function testGetBaseRoutePatternWithChildAdmin()
+    /**
+     * @dataProvider provideGetBaseRoutePattern
+     */
+    public function testGetBaseRoutePatternWithChildAdmin($objFqn, $expected)
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $postAdmin = new PostAdmin('sonata.post.admin.post', $objFqn, 'SonataNewsBundle:PostAdmin');
         $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
         $commentAdmin->setParent($postAdmin);
 
-        $this->assertSame('/sonata/news/post/{id}/comment', $commentAdmin->getBaseRoutePattern());
+        $this->assertSame($expected.'/{id}/comment', $commentAdmin->getBaseRoutePattern());
     }
 
     /**
@@ -463,7 +470,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetBaseRoutePatternWithUnreconizedClassname()
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'News\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'News\Thing\Post', 'SonataNewsBundle:PostAdmin');
         $admin->getBaseRoutePattern();
     }
 
@@ -526,6 +533,10 @@ class AdminTest extends \PHPUnit_Framework_TestCase
                 'AppBundle\Entity\User',
                 'admin_app_user',
             ),
+            array(
+                'App\Entity\User',
+                'admin_app_user',
+            ),
         );
     }
 
@@ -539,7 +550,10 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $admin->getBaseRouteName());
     }
 
-    public function testGetBaseRouteNameWithChildAdmin()
+    /**
+     * @dataProvider provideGetBaseRouteName
+     */
+    public function testGetBaseRouteNameWithChildAdmin($objFqn, $expected)
     {
         $routeGenerator = new DefaultRouteGenerator(
             $this->getMock('Symfony\Component\Routing\RouterInterface'),
@@ -547,7 +561,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         );
 
         $pathInfo = new \Sonata\AdminBundle\Route\PathInfoBuilder($this->getMock('Sonata\AdminBundle\Model\AuditManagerInterface'));
-        $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $postAdmin = new PostAdmin('sonata.post.admin.post', $objFqn, 'SonataNewsBundle:PostAdmin');
         $postAdmin->setRouteBuilder($pathInfo);
         $postAdmin->setRouteGenerator($routeGenerator);
         $postAdmin->initialize();
@@ -559,7 +573,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $postAdmin->addChild($commentAdmin);
 
-        $this->assertSame('admin_sonata_news_post_comment', $commentAdmin->getBaseRouteName());
+        $this->assertSame($expected.'_comment', $commentAdmin->getBaseRouteName());
 
         $this->assertTrue($postAdmin->hasRoute('show'));
         $this->assertTrue($postAdmin->hasRoute('sonata.post.admin.post.show'));
@@ -574,7 +588,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetBaseRouteNameWithUnreconizedClassname()
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'News\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'News\Thing\Post', 'SonataNewsBundle:PostAdmin');
         $admin->getBaseRouteName();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2068
| License       | MIT
| Doc PR        | -


Using the Admin class with Entities not in Bundle namespacing currently requires overriding both the `getBaseRoutePattern()` and `getBaseRouteName()` methods for each Admin/Entity pair. There is a slightly less ugly workaround mentioned in #2068 but it breaks child admin functionality and so cannot be used with child entities