### PR TITLE
Update SearchHandler.php

### DIFF
--- a/Search/SearchHandler.php
+++ b/Search/SearchHandler.php
@@ -52,7 +52,7 @@ class SearchHandler
             /** @var $filter FilterInterface */
             if ($filter->getOption('global_search', false)) {
                 $filter->setCondition(FilterInterface::CONDITION_OR);
-                $datagrid->setValue($name, null, $term);
+                $datagrid->setValue($filter->getFormName(), null, $term);
                 $found = true;
             }
         }


### PR DESCRIPTION
Fixes case when associated field value beign submitted.
For example, datagrid contains "user.email" field.
The datagrid form expects "user__email" key, but "user.email" given.
As result, the data will not be bound properly, extra_field violation for the form will be raised and the result will be all records