### PR TITLE
Fix collection table cell width on chrome

### DIFF
--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -332,6 +332,11 @@ td.sonata-ba-list-field .editable-empty:not(.editable-open) {
     white-space: normal;
 }
 
+/* bootstrap */
+.input-group-addon {
+    width: auto; /* See https://github.com/sonata-project/SonataAdminBundle/issues/2950 */
+}
+
 /* select2 */
 .select2-choice, .select2-choices, .select2-drop {
     border-radius: 0 !important;

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -259,10 +259,6 @@ file that was distributed with this source code.
 
         {% if sonata_admin is defined and sonata_admin_enabled %}
             {% set div_class = div_class ~ ' sonata-ba-field-' ~ sonata_admin.edit ~ '-' ~ sonata_admin.inline %}
-
-            {% if sonata_admin.edit == 'inline' and sonata_admin.inline == 'table' %}
-                {% set div_class = div_class ~ ' form-inline' %}
-            {% endif %}
         {% endif %}
 
         {% if errors|length > 0 %}


### PR DESCRIPTION
PR https://github.com/sonata-project/SonataAdminBundle/pull/2811 tried to fix a width issue on collection with a table display. But it introduced another display issue on non-inline forms, for example when using sonata_type_admin : 

**With form-inline class**
![before](https://cloud.githubusercontent.com/assets/663607/7317674/8e138df4-ea83-11e4-87ef-38aca5b2407e.JPG)

**Without form-inline class**
![after](https://cloud.githubusercontent.com/assets/663607/7317673/8e12051a-ea83-11e4-9cb8-cf63994e3859.JPG)

The original width issue only occurs when there is an ``.input-group-addon`` element. So I removed the ``form-inline`` class and added a small css fix for this class only.

**Without fix**
![without-fix](https://cloud.githubusercontent.com/assets/663607/7317760/8f641d08-ea84-11e4-983b-5c3643ecc277.JPG)
**With fix**
![with-fix](https://cloud.githubusercontent.com/assets/663607/7317761/8f64d6f8-ea84-11e4-9b7c-c8f8bf02a56b.JPG)

Now, all theses cases display correctly.