### PR TITLE
Use "request_stack" service instead ```Controller::getRequest()```

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -43,6 +43,23 @@ class CRUDController extends Controller
     protected $admin;
 
     /**
+     * Shortcut to keep BC.
+     *
+     * @return Request The current request
+     *
+     * @return Request
+     */
+    public function getRequest()
+    {
+        // In Symfony 2.4+ use "request_stack" service instead Controller::getRequest()
+        if ($this->container->has('request_stack')) {
+            return $this->container->get('request_stack')->getCurrentRequest();
+        }
+
+        return parent::getRequest();
+    }
+
+    /**
      * Render JSON
      *
      * @param mixed   $data
@@ -325,7 +342,7 @@ class CRUDController extends Controller
             $this->validateCsrfToken('sonata.delete', $request);
 
             $objectName = $this->admin->toString($object);
-            
+
             try {
                 $this->admin->delete($object);
 

--- a/Controller/CoreController.php
+++ b/Controller/CoreController.php
@@ -27,6 +27,23 @@ use Symfony\Component\HttpFoundation\Response;
 class CoreController extends Controller
 {
     /**
+     * Shortcut to keep BC.
+     *
+     * @return Request The current request
+     *
+     * @return Request
+     */
+    public function getRequest()
+    {
+        // In Symfony 2.4+ use "request_stack" service instead Controller::getRequest()
+        if ($this->container->has('request_stack')) {
+            return $this->container->get('request_stack')->getCurrentRequest();
+        }
+
+        return parent::getRequest();
+    }
+
+    /**
      * @return \Sonata\AdminBundle\Admin\Pool
      */
     protected function getAdminPool()


### PR DESCRIPTION
Use "request_stack" service instead ```Controller::getRequest()``` in Symfony 2.4+, which is deprecated

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | n/a