### PR TITLE
Show link should be used if we doesn't have the edit route

### DIFF
--- a/Datagrid/ListMapper.php
+++ b/Datagrid/ListMapper.php
@@ -52,7 +52,7 @@ class ListMapper extends BaseMapper
         $fieldDescriptionOptions['identifier'] = true;
 
         if (!isset($fieldDescriptionOptions['route']['name'])) {
-            $routeName = $this->admin->isGranted('EDIT') ? 'edit' : 'show';
+            $routeName = ($this->admin->isGranted('EDIT') && $this->admin->hasRoute('edit')) ? 'edit' : 'show';
             $fieldDescriptionOptions['route']['name'] = $routeName;
         }
 


### PR DESCRIPTION
If we have the EDIT role but not the edit route, the identifier doesn't contains a link to the show action.

I have an admin which doesn't contains an edit action, but only an editable field form the list.
I've disable the route, but the user still have the right to edit the object (required for the editable column)

