### PR TITLE
Update form_types.rst

### DIFF
--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -85,6 +85,8 @@ btn_add, btn_list, btn_delete and btn_catalogue:
   with these parameters. Setting any of them to ``false`` will hide the
   corresponding button. You can also specify a custom translation catalogue
   for these labels, which defaults to ``SonataAdminBundle``.
+  
+Note: An admin class for the linked model class needs to be defined to render this form type.  
 
 sonata_type_model_hidden
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
If no admin class for the linked model class is defined no options are rendered in the form. It is really hard to debug this. I only found the solution when I found the following issue: See issue: https://github.com/sonata-project/SonataAdminBundle/issues/2012

Adding this note to the documentation could save people hours of debugging.