### PR TITLE
Fix deprecated app.security usage

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -199,7 +199,7 @@ file that was distributed with this source code.
                     <section class="sidebar">
                         {% block sonata_side_nav %}
                             {% block sonata_sidebar_search %}
-                                {% if app.security.token and is_granted('ROLE_SONATA_ADMIN') %}
+                                {% if app.user and is_granted('ROLE_SONATA_ADMIN') %}
                                     <form action="{{ path('sonata_admin_search') }}" method="GET" class="sidebar-form" role="search">
                                         <div class="input-group custom-search-form">
                                             <input type="text" name="q" value="{{ app.request.get('q') }}" class="form-control" placeholder="{{ 'search_placeholder'|trans({}, 'SonataAdminBundle') }}">
@@ -215,7 +215,7 @@ file that was distributed with this source code.
 
                             {% block side_bar_before_nav %} {% endblock %}
                             {% block side_bar_nav %}
-                                {% if app.security.token and is_granted('ROLE_SONATA_ADMIN') %}
+                                {% if app.user and is_granted('ROLE_SONATA_ADMIN') %}
                                     {{ knp_menu_render('sonata_admin_sidebar', {template: admin_pool.getTemplate('knp_menu_template')}) }}
                                 {% endif %}
                             {% endblock side_bar_nav %}


### PR DESCRIPTION
Fix the following deprecation notice:

> The "app.security" variable is deprecated since version 2.6 and will be removed in 3.0.

Btw, checking `app.security.token` before `is_granted` is not necessary, isn't it?