### PR TITLE
Fix deprecated getMetadataFactory method usage

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1359,7 +1359,12 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         $admin = $this;
 
         // add the custom inline validation option
-        $metadata = $this->validator->getMetadataFactory()->getMetadataFor($this->getClass());
+        // TODO: Remove conditional method when bumping requirements to SF 2.5+
+        if (method_exists($this->validator, 'getMetadataFor')) {
+            $metadata = $this->validator->getMetadataFor($this->getClass());
+        } else {
+            $metadata = $this->validator->getMetadataFactory()->getMetadataFor($this->getClass());
+        }
 
         $metadata->addConstraint(new InlineConstraint(array(
             'service' => $this,

--- a/Command/ExplainAdminCommand.php
+++ b/Command/ExplainAdminCommand.php
@@ -90,8 +90,13 @@ class ExplainAdminCommand extends ContainerAwareCommand
             $output->writeln(sprintf('  - % -25s  % -15s % -15s', $name, $fieldDescription->getType(), $fieldDescription->getTemplate()));
         }
 
-        $validatorFactory = $this->getContainer()->get('validator')->getMetadataFactory();
-        $metadata = $validatorFactory->getMetadataFor($admin->getClass());
+        $validator = $this->getContainer()->get('validator');
+        // TODO: Remove conditional method when bumping requirements to SF 2.5+
+        if (method_exists($validator, 'getMetadataFor')) {
+            $metadata = $validator->getMetadataFor($admin->getClass());
+        } else {
+            $metadata = $validator->getMetadataFactory()->getMetadataFor($admin->getClass());
+        }
 
         $output->writeln('');
         $output->writeln('<comment>Validation Framework</comment> - http://symfony.com/doc/2.0/book/validation.html');


### PR DESCRIPTION
Fixes the following deprecation notice:

```
The Symfony\Component\Validator\Validator\RecursiveValidator::getMetadataFactory method is deprecated in version 2.5 and will be removed in version 3.0. Use the Symfony\Component\Validator\Validator\ValidatorInterface::getMetadataFor or Symfony\Component\Validator\Validator\ValidatorInterface::hasMetadataFor method instead.
```

Symfony 2.3+ BC kept.