### PR TITLE
Fix deprecated ValidatorInterface usage

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -17,7 +17,8 @@ use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\PropertyAccess\PropertyAccess;
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
@@ -403,7 +404,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     protected $securityHandler = null;
 
     /**
-     * @var ValidatorInterface $validator
+     * @var ValidatorInterface|LegacyValidatorInterface $validator
      */
     protected $validator = null;
 
@@ -2586,8 +2587,13 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function setValidator(ValidatorInterface $validator)
+    public function setValidator($validator)
     {
+        // TODO: Remove it when bumping requirements to SF 2.5+
+        if (!$validator instanceof ValidatorInterface && !$validator instanceof LegacyValidatorInterface) {
+            throw new \InvalidArgumentException('Argument 1 must be an instance of Symfony\Component\Validator\Validator\ValidatorInterface or Symfony\Component\Validator\ValidatorInterface');
+        }
+
         $this->validator = $validator;
     }
 

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -24,7 +24,8 @@ use Knp\Menu\FactoryInterface as MenuFactoryInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\CoreBundle\Model\Metadata;
 
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -459,14 +460,14 @@ interface AdminInterface
     public function id($entity);
 
     /**
-     * @param \Symfony\Component\Validator\ValidatorInterface $validator
+     * @param ValidatorInterface|LegacyValidatorInterface $validator
      *
      * @return void
      */
-    public function setValidator(ValidatorInterface $validator);
+    public function setValidator($validator);
 
     /**
-     * @return \Symfony\Component\Validator\ValidatorInterface
+     * @return ValidatorInterface|LegacyValidatorInterface
      */
     public function getValidator();
 


### PR DESCRIPTION
This fixes following deprecation notice:

```php
 * @deprecated since version 2.5, to be removed in 3.0.
 *             Use {@link \Symfony\Component\Validator\ValidatorInterface} instead.
```

I manage `AdminInterface` and `Admin` class to accept both old and new `ValidatorInterface` on `setValidator` to keep Symfony 2.3+ BC.