### PR TITLE
Fix deprecated SecurityContextInterface usage

### DIFF
--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -16,13 +16,14 @@
     <services>
         <service id="sonata.admin.security.handler.noop" class="%sonata.admin.security.handler.noop.class%" public="false" />
         <service id="sonata.admin.security.handler.role" class="%sonata.admin.security.handler.role.class%" public="false">
-            <argument type="service" id="security.context" on-invalid="null" />
+            <argument /> <!-- security.token_storage or security.context for Symfony <2.6 -->
             <argument type="collection">
                 <argument>ROLE_SUPER_ADMIN</argument>
             </argument>
         </service>
         <service id="sonata.admin.security.handler.acl" class="%sonata.admin.security.handler.acl.class%" public="false">
-            <argument type="service" id="security.context" on-invalid="null" />
+            <argument /> <!-- security.token_storage or security.context for Symfony <2.6 -->
+            <argument /> <!-- security.authorization_checker or security.context for Symfony <2.6 -->
             <argument type="service" id="security.acl.provider" on-invalid="null" />
             <argument>%sonata.admin.security.mask.builder.class%</argument>
             <argument type="collection">

--- a/Security/Handler/AclSecurityHandler.php
+++ b/Security/Handler/AclSecurityHandler.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\AdminBundle\Security\Handler;
 
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Acl\Model\MutableAclProviderInterface;
@@ -31,7 +33,16 @@ use Sonata\AdminBundle\Admin\AdminInterface;
  */
 class AclSecurityHandler implements AclSecurityHandlerInterface
 {
-    protected $securityContext;
+    /**
+     * @var TokenStorageInterface|SecurityContextInterface
+     */
+    protected $tokenStorage;
+
+    /**
+     * @var AuthorizationCheckerInterface|SecurityContextInterface
+     */
+    protected $authorizationChecker;
+
     protected $aclProvider;
     protected $superAdminRoles;
     protected $adminPermissions;
@@ -39,17 +50,28 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
     protected $maskBuilderClass;
 
     /**
-     * @param \Symfony\Component\Security\Core\SecurityContextInterface         $securityContext
-     * @param \Symfony\Component\Security\Acl\Model\MutableAclProviderInterface $aclProvider
-     * @param string                                                            $maskBuilderClass
-     * @param array                                                             $superAdminRoles
+     * @param TokenStorageInterface|SecurityContextInterface $tokenStorage
+     * @param TokenStorageInterface|SecurityContextInterface $authorizationChecker
+     * @param MutableAclProviderInterface                    $aclProvider
+     * @param string                                         $maskBuilderClass
+     * @param array                                          $superAdminRoles
+     *
+     * @todo Go back to signature class check when bumping requirements to SF 2.6+
      */
-    public function __construct(SecurityContextInterface $securityContext, MutableAclProviderInterface $aclProvider, $maskBuilderClass, array $superAdminRoles)
+    public function __construct($tokenStorage, $authorizationChecker, MutableAclProviderInterface $aclProvider, $maskBuilderClass, array $superAdminRoles)
     {
-        $this->securityContext  = $securityContext;
-        $this->aclProvider      = $aclProvider;
-        $this->maskBuilderClass = $maskBuilderClass;
-        $this->superAdminRoles  = $superAdminRoles;
+        if (!$tokenStorage instanceof TokenStorageInterface && !$tokenStorage instanceof SecurityContextInterface) {
+            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        }
+        if (!$authorizationChecker instanceof AuthorizationCheckerInterface && !$authorizationChecker instanceof SecurityContextInterface) {
+            throw new \InvalidArgumentException('Argument 2 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        }
+
+        $this->tokenStorage         = $tokenStorage;
+        $this->authorizationChecker = $authorizationChecker;
+        $this->aclProvider          = $aclProvider;
+        $this->maskBuilderClass     = $maskBuilderClass;
+        $this->superAdminRoles      = $superAdminRoles;
     }
 
     /**
@@ -94,7 +116,7 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
         }
 
         try {
-            return $this->securityContext->isGranted($this->superAdminRoles) || $this->securityContext->isGranted($attributes, $object);
+            return $this->authorizationChecker->isGranted($this->superAdminRoles) || $this->authorizationChecker->isGranted($attributes, $object);
         } catch (AuthenticationCredentialsNotFoundException $e) {
             return false;
         } catch (\Exception $e) {
@@ -138,7 +160,7 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
         }
 
         // retrieving the security identity of the currently logged-in user
-        $user             = $this->securityContext->getToken()->getUser();
+        $user             = $this->tokenStorage->getToken()->getUser();
         $securityIdentity = UserSecurityIdentity::fromAccount($user);
 
         $this->addObjectOwner($acl, $securityIdentity);

--- a/Security/Handler/RoleSecurityHandler.php
+++ b/Security/Handler/RoleSecurityHandler.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Security\Handler;
 
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Sonata\AdminBundle\Admin\AdminInterface;
@@ -23,17 +24,26 @@ use Sonata\AdminBundle\Admin\AdminInterface;
  */
 class RoleSecurityHandler implements SecurityHandlerInterface
 {
-    protected $securityContext;
+    /**
+     * @var TokenStorageInterface|SecurityContextInterface
+     */
+    protected $tokenStorage;
 
     protected $superAdminRoles;
 
     /**
-     * @param \Symfony\Component\Security\Core\SecurityContextInterface $securityContext
-     * @param array                                                     $superAdminRoles
+     * @param TokenStorageInterface|SecurityContextInterface $tokenStorage
+     * @param array                                          $superAdminRoles
+     *
+     * @todo Go back to signature class check when bumping requirements to SF 2.6+
      */
-    public function __construct(SecurityContextInterface $securityContext, array $superAdminRoles)
+    public function __construct($tokenStorage, array $superAdminRoles)
     {
-        $this->securityContext = $securityContext;
+        if (!$tokenStorage instanceof TokenStorageInterface && !$tokenStorage instanceof SecurityContextInterface) {
+            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        }
+
+        $this->tokenStorage = $tokenStorage;
         $this->superAdminRoles = $superAdminRoles;
     }
 
@@ -51,8 +61,8 @@ class RoleSecurityHandler implements SecurityHandlerInterface
         }
 
         try {
-            return $this->securityContext->isGranted($this->superAdminRoles)
-                || $this->securityContext->isGranted($attributes, $object);
+            return $this->tokenStorage->isGranted($this->superAdminRoles)
+                || $this->tokenStorage->isGranted($attributes, $object);
         } catch (AuthenticationCredentialsNotFoundException $e) {
             return false;
         } catch (\Exception $e) {

--- a/UPGRADE-2.4.md
+++ b/UPGRADE-2.4.md
@@ -22,3 +22,7 @@ The inline validation has been migrating to CoreBundle. Just rename ``Sonata\Adm
 ## AdminLTE 2
 
 AdminLTE version 2 has been integrated, this should work out of the box if you havn't change templates. If not you can review the upgrade guide here : [http://almsaeedstudio.com/themes/AdminLTE/documentation/index.html#upgrade](http://almsaeedstudio.com/themes/AdminLTE/documentation/index.html#upgrade)
+
+## AclSecurityHandler
+
+In order to fix deprecated issue by spiting `SecurityContextInterface`, `AclSecurityHandler` constructor got a new argument.


### PR DESCRIPTION
Replaces deprecated `SecurityContextInterface` by `TokenStorageInterface` and `AuthorizationCheckerInterface` for Symfony 2.6+.

Symfony 2.3+ BC kept.

This introduce a little BC break on `AclSecurityHandler` constructor that got a new argument for spitted classes.

I had a note on the `UPGRADE.md` file.