### PR TITLE
Fix deprecated Form::submit usage

### DIFF
--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -106,7 +106,7 @@ class AdminHelper
 
         $form = $formBuilder->getForm();
         $form->setData($subject);
-        $form->submit($admin->getRequest());
+        $form->handleRequest($admin->getRequest());
 
         // get the field element
         $childFormBuilder = $this->getChildFormBuilder($formBuilder, $elementId);

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -415,10 +415,9 @@ class CRUDController extends Controller
         /** @var $form \Symfony\Component\Form\Form */
         $form = $this->admin->getForm();
         $form->setData($object);
+        $form->handleRequest($request);
 
-        if ($this->getRestMethod($request) === 'POST') {
-            $form->submit($request);
-
+        if ($form->isSubmitted()) {
             $isFormValid = $form->isValid();
 
             // persist if the form was valid and if in preview mode the preview was approved
@@ -682,10 +681,9 @@ class CRUDController extends Controller
         /** @var $form \Symfony\Component\Form\Form */
         $form = $this->admin->getForm();
         $form->setData($object);
+        $form->handleRequest($request);
 
-        if ($this->getRestMethod($request) === 'POST') {
-            $form->submit($request);
-
+        if ($form->isSubmitted()) {
             $isFormValid = $form->isValid();
 
             // persist if the form was valid and if in preview mode the preview was approved
@@ -1205,7 +1203,7 @@ class CRUDController extends Controller
             }
 
             if (isset($form)) {
-                $form->submit($request);
+                $form->handleRequest($request);
 
                 if ($form->isValid()) {
                     $adminObjectAclManipulator->$updateMethod($adminObjectAclData);

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -148,7 +148,7 @@ class HelperController
         $formBuilder = $admin->getFormBuilder($subject);
 
         $form = $formBuilder->getForm();
-        $form->submit($request);
+        $form->handleRequest($request);
 
         $view = $this->helper->getChildFormView($form->createView(), $elementId);
 

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -1412,6 +1412,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($form));
 
         $form->expects($this->once())
+            ->method('isSubmitted')
+            ->will($this->returnValue(true));
+
+        $form->expects($this->once())
             ->method('isValid')
             ->will($this->returnValue(true));
 
@@ -1454,6 +1458,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
+
+        $form->expects($this->once())
+            ->method('isSubmitted')
+            ->will($this->returnValue(true));
 
         $form->expects($this->once())
             ->method('isValid')
@@ -1514,6 +1522,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($form));
 
         $form->expects($this->once())
+            ->method('isSubmitted')
+            ->will($this->returnValue(true));
+
+        $form->expects($this->once())
             ->method('isValid')
             ->will($this->returnValue(true));
 
@@ -1552,6 +1564,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
+
+        $form->expects($this->once())
+            ->method('isSubmitted')
+            ->will($this->returnValue(true));
 
         $form->expects($this->once())
             ->method('isValid')
@@ -1668,6 +1684,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->any())
             ->method('createView')
             ->will($this->returnValue($formView));
+
+        $form->expects($this->once())
+            ->method('isSubmitted')
+            ->will($this->returnValue(true));
 
         $form->expects($this->once())
             ->method('isValid')
@@ -1811,6 +1831,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($form));
 
         $form->expects($this->once())
+            ->method('isSubmitted')
+            ->will($this->returnValue(true));
+
+        $form->expects($this->once())
             ->method('isValid')
             ->will($this->returnValue(true));
 
@@ -1866,6 +1890,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($form));
 
         $form->expects($this->once())
+            ->method('isSubmitted')
+            ->will($this->returnValue(true));
+
+        $form->expects($this->once())
             ->method('isValid')
             ->will($this->returnValue(true));
 
@@ -1901,6 +1929,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
+
+        $form->expects($this->once())
+            ->method('isSubmitted')
+            ->will($this->returnValue(true));
 
         $form->expects($this->once())
             ->method('isValid')
@@ -2029,6 +2061,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($form));
 
         $form->expects($this->once())
+            ->method('isSubmitted')
+            ->will($this->returnValue(true));
+
+        $form->expects($this->once())
             ->method('isValid')
             ->will($this->returnValue(true));
 
@@ -2075,6 +2111,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
+
+        $form->expects($this->once())
+            ->method('isSubmitted')
+            ->will($this->returnValue(true));
 
         $form->expects($this->once())
             ->method('isValid')
@@ -2137,6 +2177,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->any())
             ->method('createView')
             ->will($this->returnValue($formView));
+
+        $form->expects($this->once())
+            ->method('isSubmitted')
+            ->will($this->returnValue(true));
 
         $form->expects($this->once())
             ->method('isValid')


### PR DESCRIPTION
Fixes following deprecation notices:

> Passing a Symfony\Component\HttpFoundation\Request object to the Symfony\Component\Form\Form::bind and Symfony\Component\Form\Form::submit methods is deprecated since 2.3 and will be removed in 3.0. Use the Symfony\Component\Form\Form::handleRequest method instead. If you want to test whether the form was submitted separately, you can use the Symfony\Component\Form\Form::isSubmitted method.

> The Symfony\Component\Form\Extension\HttpFoundation\EventListener\BindRequestListener class is deprecated since version 2.3 and will be removed in 3.0. Pass the Request instance to the \Symfony\Component\Form\Form::handleRequest() method instead.