### PR TITLE
Restructure CRUDController::createAction()

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -669,21 +669,21 @@ class CRUDController extends Controller
             );
         }
 
-        $object = $this->admin->getNewInstance();
+        $object = null;
 
         $preResponse = $this->preCreate($request, $object);
         if ($preResponse !== null) {
             return $preResponse;
         }
 
-        $this->admin->setSubject($object);
-
         /** @var $form \Symfony\Component\Form\Form */
         $form = $this->admin->getForm();
-        $form->setData($object);
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
+            $object = $form->getData();
+            $this->admin->setSubject($object);
+
             $isFormValid = $form->isValid();
 
             // persist if the form was valid and if in preview mode the preview was approved


### PR DESCRIPTION
This way the entity can be produced by the form's empty_data closure:

``` php
protected function configureFormFields(FormMapper $formMapper)
{
    $formMapper
        ->add('otherEntity')
    ;

    $formBuilder = $formMapper->getFormBuilder();
    $formBuilder->setEmptyData(function (FormInterface $form) {
        return new Entity($form->get('otherEntity')->getData());
    });
}
```

In turn, that means that entities taking constructor arguments are supported.

However, I'm not sure if this breaks other stuff - it doesn't seem to in my tests...

I've not updated the unit tests yet ... I'm looking for feedback first.