### PR TITLE
Hide empty block groups. Issue #2294.

### DIFF
--- a/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -2,6 +2,7 @@
     <div class="row">
 
     {% for code in groups %}
+        {% if admin.formgroups[code] is defined %}
         {% set form_group = admin.formgroups[code] %}
 
         <div class="{{ form_group.class | default('col-md-12') }}">
@@ -30,6 +31,7 @@
                 {#</div>#}
             </div>
         </div>
+        {% endif %}
     {% endfor %}
     </div>
 {% endmacro %}

--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -26,6 +26,13 @@ file that was distributed with this source code.
         {{ sonata_block_render_event('sonata.admin.show.top', { 'admin': admin, 'object': object }) }}
 
         {% for name, view_group in admin.showgroups %}
+            {% set emptyBlock = null %}
+            {% for field_name in view_group.fields if emptyBlock is null %}
+                {% if elements[field_name] is defined %}
+                    {% set emptyBlock = 1 %}
+                {% endif %}
+            {% endfor %}
+            {% if emptyBlock is not null %}
             <div class="{{ view_group.class | default('col-md-12') }}">
                 <div class="{{ view_group.box_class }}">
                     {% if name %}
@@ -54,6 +61,7 @@ file that was distributed with this source code.
                     </div>
                 </div>
             </div>
+            {% endif %}
         {% endfor %}
 
         {{ sonata_block_render_event('sonata.admin.show.bottom', { 'admin': admin, 'object': object }) }}


### PR DESCRIPTION
Q | A
------------ | -------------
Bug fix? |	no
New feature? |	yes
BC breaks? |	no
Deprecations? |	no
Tests pass? |	yes
Fixed tickets |	#2294 
License |	MIT
Doc PR |	no
Hide empty block groups if it doesn't contain any elements.