### PR TITLE
Change exception message if duplicate field name in show mapper.

### DIFF
--- a/Show/ShowMapper.php
+++ b/Show/ShowMapper.php
@@ -60,12 +60,16 @@ class ShowMapper extends BaseGroupedMapper
         if ($name instanceof FieldDescriptionInterface) {
             $fieldDescription = $name;
             $fieldDescription->mergeOptions($fieldDescriptionOptions);
-        } elseif (is_string($name) && !$this->admin->hasShowFieldDescription($name)) {
-            $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
-                $this->admin->getClass(),
-                $name,
-                $fieldDescriptionOptions
-            );
+        } elseif (is_string($name)) {
+            if (!$this->admin->hasShowFieldDescription($name)) {
+                $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
+                    $this->admin->getClass(),
+                    $name,
+                    $fieldDescriptionOptions
+                );
+            } else {
+                throw new \RuntimeException(sprintf('Duplicate field name "%s" in show mapper. Names should be unique.', $name));
+            }
         } else {
             throw new \RuntimeException('invalid state');
         }


### PR DESCRIPTION
Q | A
------------ | -------------
Bug fix? |	no
New feature? |	yes
BC breaks? |	no
Deprecations? |	no
Tests pass? |	yes
Fixed tickets |	no
License |	MIT
Doc PR |	no
Suggest change exception message from "invalid state" to "Duplicate field name in show mapper." in show mapper when add duplicate field name. Add test case.
What do you think @rande ?
