### PR TITLE
Add "custom_button" template to create custom actions in show, edit forms.

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -346,6 +346,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             'outer_list_rows_mosaic'     => 'SonataAdminBundle:CRUD:list_outer_rows_mosaic.html.twig',
             'outer_list_rows_list'       => 'SonataAdminBundle:CRUD:list_outer_rows_list.html.twig',
             'outer_list_rows_tree'       => 'SonataAdminBundle:CRUD:list_outer_rows_tree.html.twig',
+            'custom_action'              => 'SonataAdminBundle:BUTTON:custom_button.html.twig',
         ), $definedTemplates, $overwrittenTemplates['view']);
 
         $definition->addMethodCall('setTemplates', array($definedTemplates));

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -261,6 +261,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('outer_list_rows_mosaic')->defaultValue('SonataAdminBundle:CRUD:list_outer_rows_mosaic.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('outer_list_rows_list')->defaultValue('SonataAdminBundle:CRUD:list_outer_rows_list.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('outer_list_rows_tree')->defaultValue('SonataAdminBundle:CRUD:list_outer_rows_tree.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('custom_action')->defaultValue('SonataAdminBundle:BUTTON:custom_button.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('base_list_field')->defaultValue('SonataAdminBundle:CRUD:base_list_field.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('pager_links')->defaultValue('SonataAdminBundle:Pager:links.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('pager_results')->defaultValue('SonataAdminBundle:Pager:results.html.twig')->cannotBeEmpty()->end()

--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -140,6 +140,7 @@ Full Configuration Options
                 outer_list_rows_mosaic:  'SonataAdminBundle:CRUD:list_outer_rows_mosaic.html.twig'
                 outer_list_rows_list:  'SonataAdminBundle:CRUD:list_outer_rows_list.html.twig'
                 outer_list_rows_tree:  'SonataAdminBundle:CRUD:list_outer_rows_tree.html.twig'
+                custom_action:        'SonataAdminBundle:BUTTON:custom_button.html.twig'
                 base_list_field:      'SonataAdminBundle:CRUD:base_list_field.html.twig'
                 pager_links:          'SonataAdminBundle:Pager:links.html.twig'
                 pager_results:        'SonataAdminBundle:Pager:results.html.twig'

--- a/Resources/views/Button/custom_button.html.twig
+++ b/Resources/views/Button/custom_button.html.twig
@@ -1,0 +1,29 @@
+{#
+
+Example of custom action in show, edit form
+
+#}
+
+{#
+
+    {% if (condition1) %}
+        <li>
+        {% if admin.hasroute('customAction1') and admin.id(object) and admin.isGranted('customAction1', object) %}
+            <a class="sonata-action-element" href="{{ admin.generateObjectUrl('customAction1', object) }}">
+                <i class="fa fa-eye"></i>
+                {{ 'link_custom_action1'|trans({}, 'SonataAdminBundle') }}</a>
+        {% endif %}
+        </li>
+    {% endif %}
+
+    {% if (condition2) %}
+        <li>
+        {% if admin.hasroute('customAction2') and admin.id(object) and admin.isGranted('customAction2', object) %}
+            <a class="sonata-action-element" href="{{ admin.generateObjectUrl('customAction2', object) }}">
+                <i class="fa fa-eye"></i>
+                {{ 'link_custom_action2'|trans({}, 'SonataAdminBundle') }}</a>
+        {% endif %}
+        </li>
+    {% endif %}
+
+#}

--- a/Resources/views/CRUD/base_edit.html.twig
+++ b/Resources/views/CRUD/base_edit.html.twig
@@ -24,6 +24,7 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block actions %}
+    {% include admin.getTemplate('custom_action') %}
     <li>{% include 'SonataAdminBundle:Button:show_button.html.twig' %}</li>
     <li>{% include 'SonataAdminBundle:Button:history_button.html.twig' %}</li>
     <li>{% include 'SonataAdminBundle:Button:acl_button.html.twig' %}</li>

--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -12,6 +12,7 @@ file that was distributed with this source code.
 {% extends base_template %}
 
 {% block actions %}
+    {% include admin.getTemplate('custom_action') %}
     <li>{% include 'SonataAdminBundle:Button:edit_button.html.twig' %}</li>
     <li>{% include 'SonataAdminBundle:Button:history_button.html.twig' %}</li>
     <li>{% include 'SonataAdminBundle:Button:list_button.html.twig' %}</li>


### PR DESCRIPTION
Q | A
------------ | -------------
Bug fix? |	no
New feature? |	yes
BC breaks? |	no
Deprecations? |	no
Tests pass? |	yes
Fixed tickets |	no
License |	MIT
Doc PR |	yes
Add custom_button template to create custom actions in show, edit forms without overriding base show or edit templates. If you want to add some custom actions(like Approve, Disable, Processing and etc.) in form, you can override only this template.