### PR TITLE
Added function to remove a form group as suggested in Issue #2294

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -226,7 +226,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         if (method_exists($definition, 'setShared')) {
             // Symfony 2.8+
-            $definition->setShared(true);
+            $definition->setShared(false);
         } else {
             // For Symfony <2.8 compatibility
             $definition->setScope(ContainerInterface::SCOPE_PROTOTYPE);

--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -174,6 +174,46 @@ class FormMapper extends BaseGroupedMapper
 
     /**
      * @return FormBuilderInterface
+     * Removes a group.
+     *
+     * @param string $group              The group to delete
+     * @param string $tab                The tab the group belongs to, defaults to 'default'
+     * @param bool   $deleteTabWhenEmpty Wether or not the Tab should be deleted, when the deleted group leaves the tab emmpty after deletion
+     */
+    public function removeGroup($group, $tab = 'default', $deleteTabWhenEmpty = false)
+    {
+        $groups = $this->getGroups();
+
+        // When the default tab is used, the tabname is not prepended to the index in the group array
+        if ($tab !== 'default') {
+            $group = $tab.'.'.$group;
+        }
+
+        if (isset($groups[$group])) {
+            foreach ($groups[$group]['fields'] as $field) {
+                $this->remove($field);
+            }
+        }
+        unset($groups[$group]);
+
+        $tabs = $this->getTabs();
+        $key = array_search($group, $tabs[$tab]['groups']);
+
+        if (false !== $key) {
+            unset($tabs[$tab]['groups'][$key]);
+        }
+        if ($deleteTabWhenEmpty && count($tabs[$tab]['groups']) == 0) {
+            unset($tabs[$tab]);
+        }
+
+        $this->setTabs($tabs);
+        $this->setGroups($groups);
+
+        return $this;
+    }
+
+    /**
+     * @return \Symfony\Component\Form\FormBuilderInterface
      */
     public function getFormBuilder()
     {

--- a/Resources/doc/cookbook/recipe_delete_field_group.rst
+++ b/Resources/doc/cookbook/recipe_delete_field_group.rst
@@ -1,0 +1,45 @@
+Deleting a Group of Fields from an Admin
+========================================
+
+In some cases, when you extend existing Admins, you might want to delete fields from the admin, or make them not show.
+You could delete every field by hand, using the FormMappers ``remove`` method.
+
+    .. code-block:: php
+
+        class UserAdmin extends \Sonata\UserBundle\Admin\Model\UserAdmin {
+
+            protected function configureFormFields(FormMapper $formMapper)
+            {
+                parent::configureFormFields($formMapper);
+
+                $formMapper->remove('facebookName');
+                $formMapper->remove('twitterUid');
+                $formMapper->remove('twitterName');
+                $formMapper->remove('gplusUid');
+                $formMapper->remove('gplusName');
+
+            }
+        }
+
+
+This works, as long as the extended Admin does not use Groups to organize it's field. In the above example, we try to remove all fields from the User Admin, that comes with the SonataUserBundle.
+However, since the fields we deleted, are all part of the 'Social' Group of the form, the fields will be deleted, but the group will stay, even though it is empty.
+For this case, the FormMapper comes with a method, which allows you to get rid of a whole form group: ``removeGroup``
+
+    .. code-block:: php
+
+        class UserAdmin extends \Sonata\UserBundle\Admin\Model\UserAdmin {
+
+            protected function configureFormFields(FormMapper $formMapper)
+            {
+                parent::configureFormFields($formMapper);
+
+                $formMapper->removeGroup('Social', 'User');
+
+            }
+        }
+
+This will remove the whole 'Social' group from the form, which happens to contain all the fields, we deleted manually in the first example. The second argument is the name of the tab, the group belongs to.
+This is optional. However, when not provided, it will be assumed that you mean the 'default' tab. If the group is on another tab, it won't be removed, when this is not provided.
+There is a third optional argument for the method, which let's you choose, whether or not, tabs are also removed, if you happen to remove all groups of a tab. This behaviour is disabled by default, but
+can be enabled, by setting the third argument of ``removeGroup`` to ``true``

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -88,3 +88,4 @@ Cookbook
    cookbook/recipe_bootlint
    cookbook/recipe_lock_protection
    cookbook/recipe_sortable_sonata_type_model
+   cookbook/recipe_delete_field_group

--- a/Tests/Form/FormMapperTest.php
+++ b/Tests/Form/FormMapperTest.php
@@ -360,4 +360,42 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
 
         return $fieldDescription;
     }
+
+    public function testGroupRemovingWithoutTab()
+    {
+        $this->formMapper->with('foobar');
+
+        $this->formMapper->removeGroup('foobar');
+
+        $this->assertEquals(array(), $this->admin->getFormGroups());
+    }
+
+    public function testGroupRemovingWithTab()
+    {
+        $this->formMapper->tab('mytab')->with('foobar');
+
+        $this->formMapper->removeGroup('foobar', 'mytab');
+
+        $this->assertEquals(array(), $this->admin->getFormGroups());
+    }
+
+    public function testGroupRemovingWithoutTabAndWithTabRemoving()
+    {
+        $this->formMapper->with('foobar');
+
+        $this->formMapper->removeGroup('foobar', 'default', true);
+
+        $this->assertEquals(array(), $this->admin->getFormGroups());
+        $this->assertEquals(array(), $this->admin->getFormTabs());
+    }
+
+    public function testGroupRemovingWithTabAndWithTabRemoving()
+    {
+        $this->formMapper->tab('mytab')->with('foobar');
+
+        $this->formMapper->removeGroup('foobar', 'mytab', true);
+
+        $this->assertEquals(array(), $this->admin->getFormGroups());
+        $this->assertEquals(array(), $this->admin->getFormTabs());
+    }
 }


### PR DESCRIPTION
As suggested in Issue #2294, I created a function to remove a form group