### PR TITLE
Make the SensioGeneratorBundle an optional dependency

### DIFF
--- a/Command/GenerateAdminCommand.php
+++ b/Command/GenerateAdminCommand.php
@@ -62,6 +62,14 @@ class GenerateAdminCommand extends ContainerAwareCommand
     /**
      * {@inheritDoc}
      */
+    public function isEnabled()
+    {
+        return class_exists('Sensio\\Bundle\\GeneratorBundle\\SensioGeneratorBundle');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $modelClass = Validators::validateClass($input->getArgument('model'));

--- a/Resources/doc/reference/console.rst
+++ b/Resources/doc/reference/console.rst
@@ -33,6 +33,12 @@ As an argument you need to specify the fully qualified model class.
 All passed arguments and options are used as default values in interactive mode.
 You can disable the interactive mode with ``--no-interaction`` option.
 
+The command require the SensioGeneratorBundle to work. If you don't already have it, you can install it with :
+
+.. code-block:: bash
+
+    composer require --dev sensio/generator-bundle
+
 Options are:
  * ``bundle``: the bundle name (the default value is determined by the given model class, e.g. "YourNSFooBundle")
  * ``admin``: the admin class basename (by default this adds "Admin" to the model class name, e.g. "BarAdmin")

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "symfony/twig-bridge": "~2.3",
         "symfony/class-loader":"~2.3",
         "symfony/expression-language": "~2.4",
-        "sensio/generator-bundle": "~2.3",
         "symfony/translation":"~2.3",
         "symfony/dependency-injection": "~2.3,>=2.3.3",
         "symfony/property-access": "~2.3",
@@ -42,12 +41,14 @@
     },
     "require-dev": {
         "jms/translation-bundle": "~1.1",
+        "sensio/generator-bundle": "~2.3",
         "symfony/yaml": "~2.3",
         "sonata-project/intl-bundle": "~2.1",
         "symfony/phpunit-bridge": "2.7.*@dev"
     },
     "suggest": {
         "jms/translation-bundle": "Extract message keys from Admins",
+        "sensio/generator-bundle": "Add sonata:admin:generate command",
         "sonata-project/intl-bundle": "Add localized date and number into the list"
     },
     "autoload": {


### PR DESCRIPTION
Move sensio/generator-bundle to suggest section section in composer.json and disable command if the bundle is not present.

This allow having the generator bundle installed only in dev environment.