### PR TITLE
We can use the autocomplete with only the LIST role

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -317,7 +317,14 @@ class HelperController
         $admin->setRequest($request);
         $context = $request->get('_context', '');
 
-        if (false === $admin->isGranted('CREATE') && false === $admin->isGranted('EDIT')) {
+        if ($context == 'filter' && false === $admin->isGranted('LIST')) {
+            throw new AccessDeniedException();
+        }
+
+        if ($context != 'filter'
+            && false === $admin->isGranted('CREATE')
+            && false === $admin->isGranted('EDIT')
+        ) {
             throw new AccessDeniedException();
         }
 

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -503,6 +503,30 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Symfony\Component\Security\Core\Exception\AccessDeniedException
+     * @exceptionMessage Invalid format
+     */
+    public function testRetrieveFilterAutocompleteItemsActionNotGranted()
+    {
+        $this->admin->expects($this->exactly(1))
+            ->method('isGranted')
+            ->will($this->returnCallback(function ($operation) {
+                if ($operation == 'LIST') {
+                    return false;
+                }
+
+                return;
+            }));
+
+        $request = new Request(array(
+            'admin_code'     => 'foo.admin',
+            '_context'       => 'filter',
+        ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'));
+
+        $this->controller->retrieveAutocompleteItemsAction($request);
+    }
+
+    /**
+     * @expectedException Symfony\Component\Security\Core\Exception\AccessDeniedException
      * @exceptionMessage Autocomplete list can`t be retrieved because the form element is disabled or read_only.
      */
     public function testRetrieveAutocompleteItemsActionDisabledFormelememt()


### PR DESCRIPTION
My Admin is only granted to display the list of my entities, i should be able to filter the list with the autocomplete filter the same way i can use the doctrine_orm_model filter