### PR TITLE
Use Symfony addFlash method

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -1230,12 +1230,18 @@ class CRUDController extends Controller
      *
      * @param string $type
      * @param string $message
+     *
+     * @TODO Remove this method when bumping requirements to Symfony >= 2.6
      */
     protected function addFlash($type, $message)
     {
-        $this->get('session')
-             ->getFlashBag()
-             ->add($type, $message);
+        if (method_exists('Symfony\Bundle\FrameworkBundle\Controller\Controller', 'addFlash')) {
+            parent::addFlash($type, $message);
+        } else {
+            $this->get('session')
+                ->getFlashBag()
+                ->add($type, $message);
+        }
     }
 
     /**

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -295,6 +295,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
                     return true;
                 }
 
+                if ($id == 'session') {
+                    return true;
+                }
+
                 return false;
             }));
 


### PR DESCRIPTION
Symfony has his own `addFlash` method since `2.6` that do globally the same thing with same signature: https://github.com/symfony/symfony/blob/2.6/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php#L107

In this PR, `CRUDController::addFlash` method will use his parent if exists.

I also added a todo note to remove completely this method when bumping requirements to Symfony `>=2.6`.