### PR TITLE
Update form_admin_fields.html.twig

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -235,7 +235,9 @@ file that was distributed with this source code.
 
 {% block form_row %}
     <div class="form-group{% if errors|length > 0 %} has-error{% endif %}" id="sonata-ba-field-container-{{ id }}">
-        {% set label = sonata_admin.field_description.options.name|default(label)  %}
+        {% if sonata_admin.field_description.options is defined %}
+            {% set label = sonata_admin.field_description.options.name|default(label)  %}
+        {% endif %}
 
         {% set div_class = 'sonata-ba-field' %}
 


### PR DESCRIPTION
apparently not all sonata_admin.field_description have options set,
hence it comes to problems.

shouldn't need an else, as default tries to set label to label, so not doing it should keep label.

prevents https://github.com/sonata-project/sandbox/issues/499
prevents https://github.com/sonata-project/sandbox/issues/504