### PR TITLE
Backport #2147 to 2.3. Skip child admin when loading route cache

### DIFF
--- a/Route/DefaultRouteGenerator.php
+++ b/Route/DefaultRouteGenerator.php
@@ -142,16 +142,16 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
      */
     private function loadCache(AdminInterface $admin)
     {
-        if (in_array($admin->getCode(), $this->loaded)) {
-            return;
-        }
-
-        $this->caches = array_merge($this->cache->load($admin), $this->caches);
-
-        $this->loaded[] = $admin->getCode();
-
         if ($admin->isChild()) {
             $this->loadCache($admin->getParent());
+        } else {
+            if (in_array($admin->getCode(), $this->loaded)) {
+                return;
+            }
+
+            $this->caches = array_merge($this->cache->load($admin), $this->caches);
+
+            $this->loaded[] = $admin->getCode();
         }
     }
 }

--- a/Tests/Export/ExporterTest.php
+++ b/Tests/Export/ExporterTest.php
@@ -43,7 +43,7 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertEquals($contentType, $response->headers->get('Content-Type'));
-        $this->assertEquals('attachment; filename='.$filename, $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename="'.$filename.'"', $response->headers->get('Content-Disposition'));
     }
 
     public function getGetResponseTests()

--- a/Tests/Route/DefaultRouteGeneratorTest.php
+++ b/Tests/Route/DefaultRouteGeneratorTest.php
@@ -271,4 +271,101 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
             array('/foo/bar?abc=a123&efg=e456&default_param=default_val&uniqid=foo_uniqueid&code=base.Code.Parent&pcode=parent_foo_code&puniqid=parent_foo_uniqueid', 'base.Code.Child.bar', array('default_param'=>'default_val')),
         );
     }
+
+    /**
+     * @dataProvider getGenerateUrlLoadCacheTests
+     */
+    public function testGenerateUrlLoadCache($expected, $name, array $parameters)
+    {
+        $childCollection = new RouteCollection('base.Code.Parent|base.Code.Child', 'admin_acme_child', '/foo', 'BundleName:ControllerName');
+        $childCollection->add('bar');
+
+        $collection = new RouteCollection('base.Code.Parent', 'admin_acme', '/', 'BundleName:ControllerName');
+        $collection->add('foo');
+        $collection->addCollection($childCollection);
+
+        $standaloneCollection = new RouteCollection('base.Code.Child', 'admin_acme_child_standalone', '/', 'BundleName:ControllerName');
+        $standaloneCollection->add('bar');
+
+        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin->expects($this->any())->method('isChild')->will($this->returnValue(true));
+        $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Child'));
+        $admin->expects($this->any())->method('getBaseCodeRoute')->will($this->returnValue('base.Code.Parent|base.Code.Child'));
+        $admin->expects($this->any())->method('getIdParameter')->will($this->returnValue('id'));
+        $admin->expects($this->any())->method('hasParentFieldDescription')->will($this->returnValue(false));
+        $admin->expects($this->any())->method('hasRequest')->will($this->returnValue(true));
+        $admin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
+        $admin->expects($this->any())->method('getPersistentParameters')->will($this->returnValue(array('abc'=>'a123', 'efg'=>'e456')));
+        $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($childCollection));
+        $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
+
+        $parentAdmin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $parentAdmin->expects($this->any())->method('getIdParameter')->will($this->returnValue('childId'));
+        $parentAdmin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
+        $parentAdmin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Parent'));
+        $parentAdmin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
+
+        // no request attached in this test, so this will not be used
+        $parentAdmin->expects($this->never())->method('getPersistentParameters')->will($this->returnValue(array('from'=>'parent')));
+
+        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request->attributes = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $request->attributes->expects($this->any())->method('has')->will($this->returnValue(true));
+        $request->attributes->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function($key) {
+                if ($key == 'childId') {
+                    return '987654';
+                }
+
+                return null;
+            }));
+
+        $admin->expects($this->any())->method('getRequest')->will($this->returnValue($request));
+        $admin->expects($this->any())->method('getParent')->will($this->returnValue($parentAdmin));
+
+        $standaloneAdmin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $standaloneAdmin->expects($this->any())->method('isChild')->will($this->returnValue(false));
+        $standaloneAdmin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Child'));
+        $standaloneAdmin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(false));
+        $standaloneAdmin->expects($this->once())->method('hasRequest')->will($this->returnValue(true));
+        $standaloneAdmin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
+        $standaloneAdmin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array('abc'=>'a123', 'efg'=>'e456')));
+        $standaloneAdmin->expects($this->any())->method('getRoutes')->will($this->returnValue($standaloneCollection));
+        $standaloneAdmin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
+
+        $router = $this->getMock('\Symfony\Component\Routing\RouterInterface');
+        $router->expects($this->exactly(2))
+            ->method('generate')
+            ->will($this->returnCallback(function($name, array $parameters = array()) {
+                $params = '';
+                if (!empty($parameters)) {
+                    $params .= '?'.http_build_query($parameters);
+                }
+
+                switch ($name) {
+                    case 'admin_acme_child_bar':
+                        return '/foo/bar'.$params;
+                    case 'admin_acme_child_standalone_bar':
+                        return '/bar'.$params;
+                }
+
+                return null;
+            }));
+
+        $cache = new RoutesCache($this->cacheTempFolder, true);
+
+        $generator = new DefaultRouteGenerator($router, $cache);
+
+        // Generate once to populate cache
+        $generator->generateUrl($admin, 'bar', $parameters);
+        $this->assertEquals($expected, $generator->generateUrl($standaloneAdmin, $name, $parameters));
+    }
+
+    public function getGenerateUrlLoadCacheTests()
+    {
+        return array(
+            array('/bar?abc=a123&efg=e456&id=123&default_param=default_val', 'bar', array('id'=>123, 'default_param'=>'default_val')),
+        );
+    }
 }


### PR DESCRIPTION
Backport #2147 to 2.3

An admin will include all the routes for child admins when generating
routes. So no need to let a child admin populate any caches.