### PR TITLE
Sort default Groups and Admins

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Controller;
 
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -98,7 +99,7 @@ class HelperController
 
         $admin->setSubject($subject);
 
-        list(, $form) = $this->helper->appendFormFieldElement($admin, $subject, $elementId);
+        $form = $this->helper->appendFormFieldElement($admin, $subject, $elementId);
 
         /** @var $form \Symfony\Component\Form\Form */
         $view = $this->helper->getChildFormView($form->createView(), $elementId);
@@ -229,7 +230,6 @@ class HelperController
 
         $admin = $this->pool->getInstance($code);
         $admin->setRequest($request);
-
         // alter should be done by using a post method
         if (!$request->isXmlHttpRequest()) {
             return new JsonResponse(array('status' => 'KO', 'message' => 'Expected a XmlHttpRequest request header'));
@@ -270,7 +270,6 @@ class HelperController
         // If property path has more than 1 element, take the last object in order to validate it
         if ($propertyPath->getLength() > 1) {
             $object = $propertyAccessor->getValue($object, $propertyPath->getParent());
-
             $elements     = $propertyPath->getElements();
             $field        = end($elements);
             $propertyPath = new PropertyPath($field);
@@ -282,16 +281,13 @@ class HelperController
 
         if (count($violations)) {
             $messages = array();
-
             foreach ($violations as $violation) {
                 $messages[] = $violation->getMessage();
             }
-
             return new JsonResponse(array('status' => 'KO', 'message' => implode("\n", $messages)));
         }
 
         $admin->update($object);
-
         // render the widget
         // todo : fix this, the twig environment variable is not set inside the extension ...
         $extension = $this->twig->getExtension('sonata_admin');

--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -95,7 +95,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
                 $groupDefaults[$resolvedGroupName]['items'][] = array(
                     'admin'        => $id,
-                    'label'        => '',
+                    'label'        => !empty($attributes['label']) ? $attributes['label'] : '',
                     'route'        => '',
                     'route_params' => array()
                 );
@@ -140,6 +140,26 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     $groups[$resolvedGroupName]['roles'] = $groupDefaults[$resolvedGroupName]['roles'];
                 }
             }
+        } elseif ($container->getParameter('sonata.admin.configuration.admins_sort')) {
+            $groups = $groupDefaults;
+
+            // sort the default group definition
+            ksort($groups);
+            array_walk(
+                $groups,
+                function (&$element) {
+                    usort(
+                        $element['items'],
+                        function ($a, $b) {
+                            if ($a['label'] === $b['label']) {
+                                return 0;
+                            }
+
+                            return $a['label'] < $b['label']?-1:1;
+                        }
+                    );
+                }
+            );
         } else {
             $groups = $groupDefaults;
         }
@@ -304,7 +324,6 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     || $definedTemplates['pager_results'] === 'SonataAdminBundle:Pager:results.html.twig'
                 )
             ) {
-
                 $definedTemplates['pager_results'] = 'SonataAdminBundle:Pager:simple_pager_results.html.twig';
             }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -76,6 +76,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('html5_validate')->defaultValue(true)->end()
+                        ->booleanNode('admins_sort')->defaultFalse()->end()
                         ->booleanNode('confirm_exit')->defaultValue(true)->end()
                         ->booleanNode('use_select2')->defaultValue(true)->end()
                         ->booleanNode('use_icheck')->defaultValue(true)->end()

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -89,6 +89,7 @@ BOOM
         $container->setParameter('sonata.admin.configuration.admin_services', $config['admin_services']);
         $container->setParameter('sonata.admin.configuration.dashboard_groups', $config['dashboard']['groups']);
         $container->setParameter('sonata.admin.configuration.dashboard_blocks', $config['dashboard']['blocks']);
+        $container->setParameter('sonata.admin.configuration.admins_sort', $config['options']['admins_sort']);
 
         if (null === $config['security']['acl_user_manager'] && isset($bundles['FOSUserBundle'])) {
             $container->setParameter('sonata.admin.security.acl_user_manager', 'fos_user.user_manager');

--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -57,6 +57,7 @@ Full Configuration Options
             title_logo:           bundles/sonataadmin/logo_title.png
             options:
                 html5_validate:       true
+                admins_sort:          false
                 confirm_exit:         true
                 use_select2:          true
                 use_icheck:           true

--- a/Resources/doc/reference/dashboard.rst
+++ b/Resources/doc/reference/dashboard.rst
@@ -50,6 +50,8 @@ Configuring the ``Admin`` list
 
 As you probably noticed by now, the ``Admin`` list groups ``Admin`` mappings together.
 There are several ways in which you can configure these groups.
+The order of all admins is when you defined them. To get a natural sorting add the option
+admins_sort: true.
 
 Using the ``Admin`` service declaration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -94,8 +94,11 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
 
         $twig = new Twig();
+
         $helper = new AdminHelper($pool);
+
         $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+
         $this->controller = new HelperController($twig, $pool, $helper, $validator);
 
         // php 5.3 BC
@@ -121,21 +124,25 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
     public function testgetShortObjectDescriptionActionInvalidAdmin()
     {
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
         $twig = new Twig();
+
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
             'uniqid'   => 'asdasd123'
         ));
+
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(array('sonata.post.admin'));
-        $helper = new AdminHelper($pool);
-        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
-        $controller = new HelperController($twig, $pool, $helper, $validator);
 
+        $helper = new AdminHelper($pool);
+
+        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+
+        $controller = new HelperController($twig, $pool, $helper, $validator);
         $controller->getShortObjectDescriptionAction($request);
     }
-
     /**
      * @expectedException \RuntimeException
      * @exceptionMessage Invalid format
@@ -162,8 +169,8 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $helper = new AdminHelper($pool);
 
         $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
-        $controller = new HelperController($twig, $pool, $helper, $validator);
 
+        $controller = new HelperController($twig, $pool, $helper, $validator);
         $controller->getShortObjectDescriptionAction($request);
     }
 
@@ -177,6 +184,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
         $twig = new Twig();
+
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => "",
@@ -190,8 +198,8 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $helper = new AdminHelper($pool);
 
         $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
-        $controller = new HelperController($twig, $pool, $helper, $validator);
 
+        $controller = new HelperController($twig, $pool, $helper, $validator);
         $controller->getShortObjectDescriptionAction($request);
     }
 
@@ -208,7 +216,6 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
             if ($type != 'edit') {
                 return 'invalid name';
             }
-
             return '/ok/url';
         }));
 
@@ -219,7 +226,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $twig->expects($this->once())->method('render')
             ->with($mockTemplate)
-            ->will($this->returnCallback(function ($templateName, $templateParams) {
+            ->will($this->returnCallback(function($templateName, $templateParams) {
                 return sprintf('<a href="%s" target="new">%s</a>', $templateParams['admin']->generateObjectUrl('edit', $templateParams['object']), $templateParams['description']);
             }));
 
@@ -242,6 +249,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $response = $controller->getShortObjectDescriptionAction($request);
 
         $expected = '<a href="/ok/url" target="new">bar</a>';
+
         $this->assertEquals($expected, $response->getContent());
     }
 
@@ -266,6 +274,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $twig = new Twig();
         $twig->addExtension($adminExtension);
+
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
@@ -311,13 +320,11 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $mockRenderer = $this->getMockBuilder('Symfony\Bridge\Twig\Form\TwigRendererInterface')
             ->disableOriginalConstructor()
             ->getMock();
-
         $mockRenderer->expects($this->once())
             ->method('searchAndRenderBlock')
             ->will($this->returnValue(new Response()));
 
         $formExtension = $this->getMock('Twig_ExtensionInterface', array('renderListElement', 'initRuntime', 'getTokenParsers', 'getNodeVisitors', 'getFilters', 'getTests', 'getFunctions', 'getOperators', 'getGlobals', 'getName'));
-
         $formExtension->expects($this->once())->method('getName')->will($this->returnValue('form'));
         $formExtension->expects($this->never())->method('searchAndRenderBlock');
         $formExtension->expects($this->never())->method('setTheme');
@@ -325,6 +332,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $twig = new Twig();
         $twig->addExtension($formExtension);
+
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
@@ -341,7 +349,6 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $mockView = $this->getMockBuilder('Symfony\Component\Form\FormView')
             ->disableOriginalConstructor()
             ->getMock();
-
         $mockForm = $this->getMockBuilder('Symfony\Component\Form\Form')
             ->disableOriginalConstructor()
             ->getMock();
@@ -350,13 +357,11 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($mockView));
 
         $helper = $this->getMock('Sonata\AdminBundle\Admin\AdminHelper', array('appendFormFieldElement', 'getChildFormView'), array($pool));
-        $helper->expects($this->once())->method('appendFormFieldElement')->will($this->returnValue(array(
-            $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface'),
-            $mockForm
-        )));
+        $helper->expects($this->once())->method('appendFormFieldElement')->will($this->returnValue($mockForm));
         $helper->expects($this->once())->method('getChildFormView')->will($this->returnValue($mockView));
 
         $controller = new HelperController($twig, $pool, $helper, $validator);
+
         $response = $controller->appendFormFieldElementAction($request);
 
         $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
@@ -372,7 +377,6 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $mockView = $this->getMockBuilder('Symfony\Component\Form\FormView')
             ->disableOriginalConstructor()
             ->getMock();
-
         $mockForm = $this->getMockBuilder('Symfony\Component\Form\Form')
             ->disableOriginalConstructor()
             ->getMock();
@@ -395,7 +399,6 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $mockRenderer = $this->getMockBuilder('Symfony\Bridge\Twig\Form\TwigRendererInterface')
             ->disableOriginalConstructor()
             ->getMock();
-
         $mockRenderer->expects($this->once())
             ->method('searchAndRenderBlock')
             ->will($this->returnValue(new Response()));
@@ -408,6 +411,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $twig = new Twig();
         $twig->addExtension($formExtension);
+
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
@@ -427,6 +431,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $helper->expects($this->once())->method('getChildFormView')->will($this->returnValue($mockView));
 
         $controller = new HelperController($twig, $pool, $helper, $validator);
+
         $response = $controller->retrieveFormFieldElementAction($request);
 
         $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
@@ -450,7 +455,12 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
+        $adminExtension = $this->getMock('Twig_ExtensionInterface', array('renderListElement', 'initRuntime', 'getTokenParsers', 'getNodeVisitors', 'getFilters', 'getTests', 'getFunctions', 'getOperators', 'getGlobals', 'getName'));
+        $adminExtension->expects($this->once())->method('getName')->will($this->returnValue('sonata_admin'));
+        $adminExtension->expects($this->any())->method('renderListElement')->will($this->returnValue('<foo />'));
+
         $twig = new Twig();
+        $twig->addExtension($adminExtension);;
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,


### PR DESCRIPTION
Sorts all admins and groups regardless of their order in configuration. (https://github.com/sonata-project/SonataAdminBundle/issues/3018)

* ```<tag name="sonata.admin" group="Z-Group" label="A-Admin"/>```
* ```<tag name="sonata.admin" group="Y-Group" label="C-Admin"/>```
* ```<tag name="sonata.admin" group="Y-Group" label="B-Admin"/>```

would result in the following order:

- Y-Group:
 - B-Admin
 - C-Admin
- Z-Group:
 - A-Admin