### PR TITLE
Fix deprecated SimpleChoiceList usage

### DIFF
--- a/Form/ChoiceList/LegacyModelChoiceList.php
+++ b/Form/ChoiceList/LegacyModelChoiceList.php
@@ -12,20 +12,17 @@
 namespace Sonata\AdminBundle\Form\ChoiceList;
 
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 
 /**
- * Class ModelChoiceList.
+ * Class LegacyModelChoiceList.
  *
- * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ *
+ * @TODO Remove it get back unique ModelChoiceList class when bumping requirements to SF 2.7+
  */
-class ModelChoiceList extends ArrayChoiceList
+class LegacyModelChoiceList extends SimpleChoiceList
 {
-    /**
-     * @var ModelChoiceListAdapter
-     */
-    private $adapter;
-
     /**
      * @param ModelManagerInterface $modelManager
      * @param string                $class

--- a/Form/ChoiceList/ModelChoiceListAdapter.php
+++ b/Form/ChoiceList/ModelChoiceListAdapter.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace Sonata\AdminBundle\Form\ChoiceList;
+
+use Doctrine\Common\Util\ClassUtils;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Component\Form\Exception\InvalidArgumentException;
+use Symfony\Component\Form\Exception\RuntimeException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyPath;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class ModelChoiceListAdapter
+{
+    /**
+     * @param ModelManagerInterface $modelManager
+     * @param string                $class
+     * @param null                  $property
+     * @param null                  $query
+     * @param array                 $choices
+     */
+    public function __construct(ModelManagerInterface $modelManager, $class, $property = null, $query = null, $choices = array())
+    {
+        $this->modelManager   = $modelManager;
+        $this->class          = $class;
+        $this->query          = $query;
+        $this->identifier     = $this->modelManager->getIdentifierFieldNames($this->class);
+        // The property option defines, which property (path) is used for
+        // displaying entities as strings
+        if ($property) {
+            $this->propertyPath = new PropertyPath($property);
+        }
+    }
+
+    /**
+     * @var \Sonata\AdminBundle\Model\ModelManagerInterface
+     */
+    private $modelManager;
+
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * The entities from which the user can choose.
+     *
+     * This array is either indexed by ID (if the ID is a single field)
+     * or by key in the choices array (if the ID consists of multiple fields)
+     *
+     * This property is initialized by initializeChoices(). It should only
+     * be accessed through getEntity() and getEntities().
+     *
+     * @var mixed
+     */
+    private $entities = array();
+
+    /**
+     * Contains the query builder that builds the query for fetching the
+     * entities.
+     *
+     * This property should only be accessed through queryBuilder.
+     *
+     * @var \Doctrine\ORM\QueryBuilder
+     */
+    private $query;
+
+    /**
+     * The fields of which the identifier of the underlying class consists.
+     *
+     * This property should only be accessed through identifier.
+     *
+     * @var array
+     */
+    private $identifier = array();
+
+    /**
+     * A cache for \ReflectionProperty instances for the underlying class.
+     *
+     * This property should only be accessed through getReflProperty().
+     *
+     * @var array
+     */
+    private $reflProperties = array();
+
+    private $propertyPath;
+
+    /**
+     * Initializes the choices and returns them.
+     *
+     * The choices are generated from the entities. If the entities have a
+     * composite identifier, the choices are indexed using ascending integers.
+     * Otherwise the identifiers are used as indices.
+     *
+     * If the entities were passed in the "choices" option, this method
+     * does not have any significant overhead. Otherwise, if a query builder
+     * was passed in the "query" option, this builder is now used to construct
+     * a query which is executed. In the last case, all entities for the
+     * underlying class are fetched from the repository.
+     *
+     * If the option "property" was passed, the property path in that option
+     * is used as option values. Otherwise this method tries to convert
+     * objects to strings using __toString().
+     *
+     * @param $choices
+     *
+     * @return array An array of choices
+     */
+    public function load($choices)
+    {
+        if (is_array($choices)) {
+            $entities = $choices;
+        } elseif ($this->query) {
+            $entities = $this->modelManager->executeQuery($this->query);
+        } else {
+            $entities = $this->modelManager->findBy($this->class);
+        }
+
+        $choices = array();
+        $this->entities = array();
+
+        foreach ($entities as $key => $entity) {
+            if ($this->propertyPath) {
+                // If the property option was given, use it
+                $propertyAccessor = PropertyAccess::createPropertyAccessor();
+                $value = $propertyAccessor->getValue($entity, $this->propertyPath);
+            } else {
+                // Otherwise expect a __toString() method in the entity
+                try {
+                    $value = (string) $entity;
+                } catch (\Exception $e) {
+                    throw new RuntimeException(sprintf("Unable to convert the entity %s to String, entity must have a '__toString()' method defined", ClassUtils::getClass($entity)), 0, $e);
+                }
+            }
+
+            if (count($this->identifier) > 1) {
+                // When the identifier consists of multiple field, use
+                // naturally ordered keys to refer to the choices
+                $choices[$key] = $value;
+                $this->entities[$key] = $entity;
+            } else {
+                // When the identifier is a single field, index choices by
+                // entity ID for performance reasons
+                $id = current($this->getIdentifierValues($entity));
+                $choices[$id] = $value;
+                $this->entities[$id] = $entity;
+            }
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @return array
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Returns the according entities for the choices.
+     *
+     * If the choices were not initialized, they are initialized now. This
+     * is an expensive operation, except if the entities were passed in the
+     * "choices" option.
+     *
+     * @return array An array of entities
+     */
+    public function getEntities()
+    {
+        return $this->entities;
+    }
+
+    /**
+     * Returns the entity for the given key.
+     *
+     * If the underlying entities have composite identifiers, the choices
+     * are initialized. The key is expected to be the index in the choices
+     * array in this case.
+     *
+     * If they have single identifiers, they are either fetched from the
+     * internal entity cache (if filled) or loaded from the database.
+     *
+     * @param string $key The choice key (for entities with composite
+     *                    identifiers) or entity ID (for entities with single
+     *                    identifiers)
+     *
+     * @return object The matching entity
+     */
+    public function getEntity($key)
+    {
+        if (count($this->identifier) > 1) {
+            // $key is a collection index
+            $entities = $this->getEntities();
+
+            return isset($entities[$key]) ? $entities[$key] : null;
+        } elseif ($this->entities) {
+            return isset($this->entities[$key]) ? $this->entities[$key] : null;
+        }
+
+        return $this->modelManager->find($this->class, $key);
+    }
+
+    /**
+     * Returns the \ReflectionProperty instance for a property of the
+     * underlying class.
+     *
+     * @param string $property The name of the property
+     *
+     * @return \ReflectionProperty The reflection instance
+     */
+    private function getReflProperty($property)
+    {
+        if (!isset($this->reflProperties[$property])) {
+            $this->reflProperties[$property] = new \ReflectionProperty($this->class, $property);
+            $this->reflProperties[$property]->setAccessible(true);
+        }
+
+        return $this->reflProperties[$property];
+    }
+
+    /**
+     * Returns the values of the identifier fields of an entity.
+     *
+     * Doctrine must know about this entity, that is, the entity must already
+     * be persisted or added to the identity map before. Otherwise an
+     * exception is thrown.
+     *
+     * @param object $entity The entity for which to get the identifier
+     *
+     * @throws InvalidArgumentException If the entity does not exist in Doctrine's
+     *                                  identity map
+     *
+     * @return array
+     */
+    public function getIdentifierValues($entity)
+    {
+        try {
+            return $this->modelManager->getIdentifierValues($entity);
+        } catch (\Exception $e) {
+            throw new InvalidArgumentException(sprintf('Unable to retrieve the identifier values for entity %s', ClassUtils::getClass($entity)), 0, $e);
+        }
+    }
+
+    /**
+     * @return \Sonata\AdminBundle\Model\ModelManagerInterface
+     */
+    public function getModelManager()
+    {
+        return $this->modelManager;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClass()
+    {
+        return $this->class;
+    }
+}

--- a/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Form\DataTransformer;
 
+use Sonata\AdminBundle\Form\ChoiceList\LegacyModelChoiceList;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
 use Symfony\Component\Form\ChoiceList\LegacyChoiceListAdapter;
 use Symfony\Component\Form\DataTransformerInterface;

--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
+use Sonata\AdminBundle\Form\ChoiceList\LegacyModelChoiceList;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
 use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
@@ -113,7 +114,18 @@ class ModelType extends AbstractType
                     return $choices;
                 }
 
-                return new ModelChoiceList(
+                // @TODO: Remove condition and just return ModelChoiceList when bumping requirements to SF 2.7+
+                if (class_exists('Symfony\Component\Form\ChoiceList\ArrayChoiceList')) {
+                    return new ModelChoiceList(
+                        $options['model_manager'],
+                        $options['class'],
+                        $options['property'],
+                        $options['query'],
+                        $options['choices']
+                    );
+                }
+
+                return new LegacyModelChoiceList(
                     $options['model_manager'],
                     $options['class'],
                     $options['property'],

--- a/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -31,9 +31,16 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->modelChoiceList = $this->getMockBuilder('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList')
-            ->disableOriginalConstructor()
-            ->getMock();
+        // TODO: Remove condition when bumping requirements to SF 2.7+
+        if (class_exists('Symfony\Component\Form\ChoiceList\ArrayChoiceList')) {
+            $this->modelChoiceList = $this->getMockBuilder('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList')
+                ->disableOriginalConstructor()
+                ->getMock();
+        } else {
+            $this->modelChoiceList = $this->getMockBuilder('Sonata\AdminBundle\Form\ChoiceList\LegacyModelChoiceList')
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
 
         // Symfony < 2.7 BC
         if (class_exists('Symfony\Component\Form\ChoiceList\LegacyChoiceListAdapter')) {

--- a/Tests/Form/Type/ModelTypeTest.php
+++ b/Tests/Form/Type/ModelTypeTest.php
@@ -41,7 +41,12 @@ class ModelTypeTest extends TypeTestCase
         $this->assertEquals('link_list', $options['btn_list']);
         $this->assertEquals('link_delete', $options['btn_delete']);
         $this->assertEquals('SonataAdminBundle', $options['btn_catalogue']);
-        $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList', $options['choice_list']);
+        // TODO: Remove condition when bumping requirements to SF 2.7+
+        if (class_exists('Symfony\Component\Form\ChoiceList\ArrayChoiceList')) {
+            $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList', $options['choice_list']);
+        } else {
+            $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\LegacyModelChoiceList', $options['choice_list']);
+        }
     }
 
     /**
@@ -71,7 +76,12 @@ class ModelTypeTest extends TypeTestCase
         $this->assertEquals('link_list', $options['btn_list']);
         $this->assertEquals('link_delete', $options['btn_delete']);
         $this->assertEquals('SonataAdminBundle', $options['btn_catalogue']);
-        $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList', $options['choice_list']);
+        // TODO: Remove condition when bumping requirements to SF 2.7+
+        if (class_exists('Symfony\Component\Form\ChoiceList\ArrayChoiceList')) {
+            $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList', $options['choice_list']);
+        } else {
+            $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\LegacyModelChoiceList', $options['choice_list']);
+        }
     }
 
     public function getCompoundOptionTests()


### PR DESCRIPTION
The only way I found to keep SF 2.3 BC is to split `ModelChoiceList` by making a `LegacyModelChoiceList` for older Symfony versions and use a trait for common code.

Don't hesitate to tell me if you have a better solution.

Please note that `trait` is available since php `5.4` only. I updated the `composer.json` file in consequence.