### PR TITLE
Add support for label_format in form_admin_fields.html.twig

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -99,7 +99,14 @@ file that was distributed with this source code.
         {% endif %}
 
         {% if label is empty %}
-            {% set label = name|humanize %}
+            {%- if label_format is not empty -%}
+                {% set label = label_format|replace({
+                    '%name%': name,
+                    '%id%': id,
+                }) %}
+            {%- else -%}
+                {% set label = name|humanize %}
+            {%- endif -%}
         {% endif %}
 
         {% if in_list_checkbox is defined and in_list_checkbox and widget is defined %}


### PR DESCRIPTION
This PR allow the sonata admin form theme to work with form types that use this feature.