### PR TITLE
PHP CS Fixer install and apply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ coverage
 composer.lock
 /vendor
 composer.phar
+.php_cs.cache
 
 # clean up some non bower ready package
 Resources/public/vendor/admin-lte/bootstrap

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,20 @@
+<?php
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in(array(__DIR__))
+    ->exclude(array('Tests/Fixtures'))
+;
+
+return Symfony\CS\Config\Config::create()
+    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
+    ->fixers(array(
+        '-unalign_double_arrow',
+        '-unalign_equals',
+        'align_double_arrow',
+        'newline_after_open_tag',
+        'ordered_use',
+        'long_array_syntax',
+    ))
+    ->setUsingCache(true)
+    ->finder($finder)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ env:
 matrix:
   fast_finish: true
   include:
+    - php: 5.6
+      env: CS_FIXER=run
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
@@ -51,7 +53,9 @@ before_script:
   - export PATH=$HOME/.local/bin:$PATH
   - pip install -r Resources/doc/requirements.txt --user `whoami`
 
-script: make test
+script:
+ - if [ "$CS_FIXER" = "run" ]; then make cs_dry_run ; fi;
+ - make test
 
 notifications:
   webhooks: https://sonata-project.org/bundles/admin/master/travis

--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -11,45 +11,42 @@
 
 namespace Sonata\AdminBundle\Admin;
 
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-use Sonata\CoreBundle\Model\Metadata;
-use Symfony\Component\Form\Form;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\PropertyAccess\PropertyPath;
-use Symfony\Component\PropertyAccess\PropertyAccess;
-use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\Translation\TranslatorInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Datagrid\ListMapper;
-use Sonata\AdminBundle\Datagrid\DatagridMapper;
-use Sonata\AdminBundle\Show\ShowMapper;
-
-use Sonata\CoreBundle\Validator\ErrorElement;
-use Sonata\CoreBundle\Validator\Constraints\InlineConstraint;
-
-use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
-use Sonata\AdminBundle\Builder\FormContractorInterface;
-use Sonata\AdminBundle\Builder\ListBuilderInterface;
-use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
-use Sonata\AdminBundle\Builder\ShowBuilderInterface;
-use Sonata\AdminBundle\Builder\RouteBuilderInterface;
-use Sonata\AdminBundle\Route\RouteGeneratorInterface;
-use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
-use Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface;
-use Sonata\AdminBundle\Route\RouteCollection;
-use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Doctrine\Common\Util\ClassUtils;
 use Knp\Menu\FactoryInterface as MenuFactoryInterface;
 use Knp\Menu\ItemInterface as MenuItemInterface;
-use Doctrine\Common\Util\ClassUtils;
+use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
+use Sonata\AdminBundle\Builder\FormContractorInterface;
+use Sonata\AdminBundle\Builder\ListBuilderInterface;
+use Sonata\AdminBundle\Builder\RouteBuilderInterface;
+use Sonata\AdminBundle\Builder\ShowBuilderInterface;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\Pager;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\AdminBundle\Route\RouteGeneratorInterface;
+use Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface;
+use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
+use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
+use Sonata\CoreBundle\Model\Metadata;
+use Sonata\CoreBundle\Validator\Constraints\InlineConstraint;
+use Sonata\CoreBundle\Validator\ErrorElement;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
 /**
- * Class Admin
+ * Class Admin.
  *
- * @package Sonata\AdminBundle\Admin
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 abstract class Admin implements AdminInterface, DomainObjectInterface
@@ -60,28 +57,28 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     const CLASS_REGEX        = '@(?:([A-Za-z0-9]*)\\\)?(Bundle\\\)?([A-Za-z0-9]+)Bundle\\\(Entity|Document|Model|PHPCR|CouchDocument|Phpcr|Doctrine\\\Orm|Doctrine\\\Phpcr|Doctrine\\\MongoDB|Doctrine\\\CouchDB)\\\(.*)@';
 
     /**
-     * The class name managed by the admin class
+     * The class name managed by the admin class.
      *
      * @var string
      */
     private $class;
 
     /**
-     * The subclasses supported by the admin class
+     * The subclasses supported by the admin class.
      *
      * @var array
      */
     private $subClasses = array();
 
     /**
-     * The list collection
+     * The list collection.
      *
      * @var array
      */
     private $list;
 
     /**
-     * The list FieldDescription constructed from the configureListField method
+     * The list FieldDescription constructed from the configureListField method.
      *
      * @var array
      */
@@ -90,7 +87,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     private $show;
 
     /**
-     * The show FieldDescription constructed from the configureShowFields method
+     * The show FieldDescription constructed from the configureShowFields method.
      *
      * @var array
      */
@@ -102,7 +99,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     private $form;
 
     /**
-     * The list FieldDescription constructed from the configureFormField method
+     * The list FieldDescription constructed from the configureFormField method.
      *
      * @var array
      */
@@ -114,98 +111,98 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     private $filter;
 
     /**
-     * The filter FieldDescription constructed from the configureFilterField method
+     * The filter FieldDescription constructed from the configureFilterField method.
      *
      * @var array
      */
     protected $filterFieldDescriptions = array();
 
     /**
-     * The number of result to display in the list
+     * The number of result to display in the list.
      *
-     * @var integer
+     * @var int
      */
     protected $maxPerPage = 32;
 
     /**
-     * The maximum number of page numbers to display in the list
+     * The maximum number of page numbers to display in the list.
      *
-     * @var integer
+     * @var int
      */
     protected $maxPageLinks = 25;
 
     /**
-     * The base route name used to generate the routing information
+     * The base route name used to generate the routing information.
      *
      * @var string
      */
     protected $baseRouteName;
 
     /**
-     * The base route pattern used to generate the routing information
+     * The base route pattern used to generate the routing information.
      *
      * @var string
      */
     protected $baseRoutePattern;
 
     /**
-     * The base name controller used to generate the routing information
+     * The base name controller used to generate the routing information.
      *
      * @var string
      */
     protected $baseControllerName;
 
     /**
-     * The form group disposition
+     * The form group disposition.
      *
-     * @var array|boolean
+     * @var array|bool
      */
     private $formGroups = false;
 
     /**
-     * The form tabs disposition
+     * The form tabs disposition.
      *
-     * @var array|boolean
+     * @var array|bool
      */
     private $formTabs = false;
 
     /**
-     * The view group disposition
+     * The view group disposition.
      *
-     * @var array|boolean
+     * @var array|bool
      */
     private $showGroups = false;
 
     /**
-     * The view tab disposition
+     * The view tab disposition.
      *
-     * @var array|boolean
+     * @var array|bool
      */
     private $showTabs = false;
 
     /**
-     * The label class name  (used in the title/breadcrumb ...)
+     * The label class name  (used in the title/breadcrumb ...).
      *
      * @var string
      */
     protected $classnameLabel;
 
     /**
-     * The translation domain to be used to translate messages
+     * The translation domain to be used to translate messages.
      *
      * @var string
      */
     protected $translationDomain = 'messages';
 
     /**
-     * Options to set to the form (ie, validation_groups)
+     * Options to set to the form (ie, validation_groups).
      *
      * @var array
      */
     protected $formOptions = array();
 
     /**
-     * Default values to the datagrid
+     * Default values to the datagrid.
      *
      * @var array
      */
@@ -215,70 +212,70 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     );
 
     /**
-     * Predefined per page options
+     * Predefined per page options.
      *
      * @var array
      */
     protected $perPageOptions = array(16, 32, 64, 128, 192);
 
     /**
-     * Pager type
+     * Pager type.
      *
      * @var string
      */
     protected $pagerType = Pager::TYPE_DEFAULT;
 
     /**
-     * The code related to the admin
+     * The code related to the admin.
      *
      * @var string
      */
     protected $code;
 
     /**
-     * The label
+     * The label.
      *
      * @var string
      */
     protected $label;
 
     /**
-     * Whether or not to persist the filters in the session
+     * Whether or not to persist the filters in the session.
      *
-     * @var boolean
+     * @var bool
      */
     protected $persistFilters = false;
 
     /**
-     * Array of routes related to this admin
+     * Array of routes related to this admin.
      *
      * @var \Sonata\AdminBundle\Route\RouteCollection
      */
     protected $routes;
 
     /**
-     * The subject only set in edit/update/create mode
+     * The subject only set in edit/update/create mode.
      *
      * @var object
      */
     protected $subject;
 
     /**
-     * Define a Collection of child admin, ie /admin/order/{id}/order-element/{childId}
+     * Define a Collection of child admin, ie /admin/order/{id}/order-element/{childId}.
      *
      * @var array
      */
     protected $children = array();
 
     /**
-     * Reference the parent collection
+     * Reference the parent collection.
      *
      * @var AdminInterface|null
      */
     protected $parent = null;
 
     /**
-     * The base code route refer to the prefix used to generate the route name
+     * The base code route refer to the prefix used to generate the route name.
      *
      * @var string
      */
@@ -287,86 +284,86 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     /**
      * The related field reflection, ie if OrderElement is linked to Order,
      * then the $parentReflectionProperty must be the ReflectionProperty of
-     * the order (OrderElement::$order)
+     * the order (OrderElement::$order).
      *
-     * @var \ReflectionProperty $parentReflectionProperty
+     * @var \ReflectionProperty
      */
     protected $parentAssociationMapping = null;
 
     /**
      * Reference the parent FieldDescription related to this admin
-     * only set for FieldDescription which is associated to an Sub Admin instance
+     * only set for FieldDescription which is associated to an Sub Admin instance.
      *
      * @var FieldDescriptionInterface
      */
     protected $parentFieldDescription;
 
     /**
-     * If true then the current admin is part of the nested admin set (from the url)
+     * If true then the current admin is part of the nested admin set (from the url).
      *
-     * @var boolean
+     * @var bool
      */
     protected $currentChild = false;
 
     /**
      * The uniqid is used to avoid clashing with 2 admin related to the code
-     * ie: a Block linked to a Block
+     * ie: a Block linked to a Block.
      *
      * @var string
      */
     protected $uniqid;
 
     /**
-     * The Entity or Document manager
+     * The Entity or Document manager.
      *
      * @var \Sonata\AdminBundle\Model\ModelManagerInterface
      */
     protected $modelManager;
 
     /**
-     * The manager type to use for the admin
+     * The manager type to use for the admin.
      *
      * @var string
      */
     private $managerType;
 
     /**
-     * The current request object
+     * The current request object.
      *
      * @var \Symfony\Component\HttpFoundation\Request
      */
     protected $request;
 
     /**
-     * The translator component
+     * The translator component.
      *
      * @var \Symfony\Component\Translation\TranslatorInterface
      */
     protected $translator;
 
     /**
-     * The related form contractor
+     * The related form contractor.
      *
      * @var \Sonata\AdminBundle\Builder\FormContractorInterface
      */
     protected $formContractor;
 
     /**
-     * The related list builder
+     * The related list builder.
      *
      * @var \Sonata\AdminBundle\Builder\ListBuilderInterface
      */
     protected $listBuilder;
 
     /**
-     * The related view builder
+     * The related view builder.
      *
      * @var ShowBuilderInterface
      */
     protected $showBuilder;
 
     /**
-     * The related datagrid builder
+     * The related datagrid builder.
      *
      * @var \Sonata\AdminBundle\Builder\DatagridBuilderInterface
      */
@@ -378,21 +375,21 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     protected $routeBuilder;
 
     /**
-     * The datagrid instance
+     * The datagrid instance.
      *
      * @var \Sonata\AdminBundle\Datagrid\DatagridInterface
      */
     protected $datagrid;
 
     /**
-     * The router instance
+     * The router instance.
      *
      * @var RouteGeneratorInterface
      */
     protected $routeGenerator;
 
     /**
-     * The generated breadcrumbs
+     * The generated breadcrumbs.
      *
      * @var array
      */
@@ -404,12 +401,12 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     protected $securityHandler = null;
 
     /**
-     * @var ValidatorInterface|LegacyValidatorInterface $validator
+     * @var ValidatorInterface|LegacyValidatorInterface
      */
     protected $validator = null;
 
     /**
-     * The configuration pool
+     * The configuration pool.
      *
      * @var Pool
      */
@@ -463,14 +460,14 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     /**
      * Setting to true will enable preview mode for
      * the entity and show a preview button in the
-     * edit/create forms
+     * edit/create forms.
      *
-     * @var boolean
+     * @var bool
      */
     protected $supportsPreviewMode = false;
 
     /**
-     * Roles and permissions per role
+     * Roles and permissions per role.
      *
      * @var array [role] => array([permission], [permission])
      */
@@ -526,7 +523,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * DEPRECATED: Use configureTabMenu instead
+     * DEPRECATED: Use configureTabMenu instead.
      *
      * @param MenuItemInterface $menu
      * @param                   $action
@@ -541,7 +538,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Configures the tab menu in your admin
+     * Configures the tab menu in your admin.
      *
      * @param MenuItemInterface $menu
      * @param string            $action
@@ -608,7 +605,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * define custom variable
+     * define custom variable.
      */
     public function initialize()
     {
@@ -742,14 +739,12 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function preBatchAction($actionName, ProxyQueryInterface $query, array & $idx, $allElements)
+    public function preBatchAction($actionName, ProxyQueryInterface $query, array &$idx, $allElements)
     {
     }
 
     /**
-     * build the view FieldDescription array
-     *
-     * @return void
+     * build the view FieldDescription array.
      */
     protected function buildShow()
     {
@@ -768,9 +763,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * build the list FieldDescription array
-     *
-     * @return void
+     * build the list FieldDescription array.
      */
     protected function buildList()
     {
@@ -896,15 +889,15 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         // ok, try to limit to add parent filter
         if ($this->isChild() && $this->getParentAssociationMapping() && !$mapper->has($this->getParentAssociationMapping())) {
             $mapper->add($this->getParentAssociationMapping(), null, array(
-                'show_filter' => false,
-                'label' => false,
-                'field_type' => 'sonata_type_model_hidden',
+                'show_filter'   => false,
+                'label'         => false,
+                'field_type'    => 'sonata_type_model_hidden',
                 'field_options' => array(
                     'model_manager' => $this->getModelManager(),
                 ),
                 'operator_type' => 'hidden',
             ), null, null, array(
-                'admin_code' => $this->getParent()->getCode()
+                'admin_code' => $this->getParent()->getCode(),
             ));
         }
 
@@ -915,7 +908,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
 
     /**
      * Returns the name of the parent related field, so the field can be use to set the default
-     * value (ie the parent object) or to filter the object
+     * value (ie the parent object) or to filter the object.
      *
      * @return string the name of the parent related field
      */
@@ -925,9 +918,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Build the form FieldDescription collection
-     *
-     * @return void
+     * Build the form FieldDescription collection.
      */
     protected function buildForm()
     {
@@ -959,7 +950,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns the baseRoutePattern used to generate the routing information
+     * Returns the baseRoutePattern used to generate the routing information.
      *
      * @throws \RuntimeException
      *
@@ -992,7 +983,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns the baseRouteName used to generate the routing information
+     * Returns the baseRouteName used to generate the routing information.
      *
      * @throws \RuntimeException
      *
@@ -1025,7 +1016,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * urlize the given word
+     * urlize the given word.
      *
      * @param string $word
      * @param string $sep  the separator
@@ -1085,7 +1076,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Gets the subclass corresponding to the given name
+     * Gets the subclass corresponding to the given name.
      *
      * @param string $name The name of the sub class
      *
@@ -1194,9 +1185,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Build all the related urls to the current admin
-     *
-     * @return void
+     * Build all the related urls to the current admin.
      */
     private function buildRoutes()
     {
@@ -1262,8 +1251,6 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
 
     /**
      * @param array $templates
-     *
-     * @return void
      */
     public function setTemplates(array $templates)
     {
@@ -1273,8 +1260,6 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     /**
      * @param string $name
      * @param string $template
-     *
-     * @return void
      */
     public function setTemplate($name, $template)
     {
@@ -1333,11 +1318,9 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
 
     /**
      * This method is being called by the main admin class and the child class,
-     * the getFormBuilder is only call by the main admin class
+     * the getFormBuilder is only call by the main admin class.
      *
      * @param \Symfony\Component\Form\FormBuilderInterface $formBuilder
-     *
-     * @return void
      */
     public function defineFormBuilder(FormBuilderInterface $formBuilder)
     {
@@ -1353,7 +1336,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Attach the inline validator to the model metadata, this must be done once per admin
+     * Attach the inline validator to the model metadata, this must be done once per admin.
      */
     protected function attachInlineValidator()
     {
@@ -1485,7 +1468,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         $menu->setChildrenAttribute('class', 'nav navbar-nav');
 
         // Prevents BC break with KnpMenuBundle v1.x
-        if (method_exists($menu, "setCurrentUri")) {
+        if (method_exists($menu, 'setCurrentUri')) {
             $menu->setCurrentUri($this->getRequest()->getBaseUrl().$this->getRequest()->getPathInfo());
         }
 
@@ -1524,7 +1507,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns the root code
+     * Returns the root code.
      *
      * @return string the root code
      */
@@ -1534,7 +1517,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns the master admin
+     * Returns the master admin.
      *
      * @return \Sonata\AdminBundle\Admin\Admin the root admin class
      */
@@ -1582,7 +1565,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @param boolean $persist
+     * @param bool $persist
      */
     public function setPersistFilters($persist)
     {
@@ -1796,7 +1779,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns true if the admin has a FieldDescription with the given $name
+     * Returns true if the admin has a FieldDescription with the given $name.
      *
      * @param string $name
      *
@@ -1816,11 +1799,9 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * remove a FieldDescription
+     * remove a FieldDescription.
      *
      * @param string $name
-     *
-     * @return void
      */
     public function removeFormFieldDescription($name)
     {
@@ -1828,7 +1809,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * build and return the collection of form FieldDescription
+     * build and return the collection of form FieldDescription.
      *
      * @return array collection of form FieldDescription
      */
@@ -1840,7 +1821,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns the form FieldDescription with the given $name
+     * Returns the form FieldDescription with the given $name.
      *
      * @param string $name
      *
@@ -2023,7 +2004,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns true if the admin has children, false otherwise
+     * Returns true if the admin has children, false otherwise.
      *
      * @return bool if the admin has children
      */
@@ -2046,14 +2027,14 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     public function getUniqid()
     {
         if (!$this->uniqid) {
-            $this->uniqid = "s".uniqid();
+            $this->uniqid = 's'.uniqid();
         }
 
         return $this->uniqid;
     }
 
     /**
-     * Returns the classname label
+     * Returns the classname label.
      *
      * @return string the classname label
      */
@@ -2116,7 +2097,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Generates the breadcrumbs array
+     * Generates the breadcrumbs array.
      *
      * Note: the method will be called by the top admin instance (parent => child)
      *
@@ -2194,7 +2175,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns the current child admin instance
+     * Returns the current child admin instance.
      *
      * @return \Sonata\AdminBundle\Admin\AdminInterface|null the current child admin instance
      */
@@ -2224,10 +2205,10 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Translate a message id
+     * Translate a message id.
      *
      * @param string      $id
-     * @param integer     $count
+     * @param int         $count
      * @param array       $parameters
      * @param string|null $domain
      * @param string|null $locale
@@ -2367,8 +2348,6 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
 
     /**
      * @param \Sonata\AdminBundle\Builder\ShowBuilderInterface $showBuilder
-     *
-     * @return void
      */
     public function setShowBuilder(ShowBuilderInterface $showBuilder)
     {
@@ -2480,7 +2459,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Set the roles and permissions per role
+     * Set the roles and permissions per role.
      *
      * @param array $information
      */
@@ -2498,7 +2477,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Return the list of permissions the user should have in order to display the admin
+     * Return the list of permissions the user should have in order to display the admin.
      *
      * @param string $context
      *
@@ -2713,7 +2692,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
             return (string) $object;
         }
 
-        return sprintf("%s:%s", ClassUtils::getClass($object), spl_object_hash($object));
+        return sprintf('%s:%s', ClassUtils::getClass($object), spl_object_hash($object));
     }
 
     /**
@@ -2741,7 +2720,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Set custom per page options
+     * Set custom per page options.
      *
      * @param array $options
      */
@@ -2751,7 +2730,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns predefined per page options
+     * Returns predefined per page options.
      *
      * @return array
      */
@@ -2761,7 +2740,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Set pager type
+     * Set pager type.
      *
      * @param string $pagerType
      */
@@ -2771,7 +2750,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Get pager type
+     * Get pager type.
      *
      * @return string
      */
@@ -2781,7 +2760,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns true if the per page value is allowed, false otherwise
+     * Returns true if the per page value is allowed, false otherwise.
      *
      * @param int $perPage
      *
@@ -2793,7 +2772,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Predefine per page options
+     * Predefine per page options.
      */
     protected function predefinePerPageOptions()
     {
@@ -2835,7 +2814,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
             throw new \RuntimeException(sprintf('No request attached to the current admin: %s', $this->getCode()));
         }
 
-        $this->getRequest()->getSession()->set(sprintf("%s.list_mode", $this->getCode()), $mode);
+        $this->getRequest()->getSession()->set(sprintf('%s.list_mode', $this->getCode()), $mode);
     }
 
     /**
@@ -2847,6 +2826,6 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
             return 'list';
         }
 
-        return $this->getRequest()->getSession()->get(sprintf("%s.list_mode", $this->getCode()), 'list');
+        return $this->getRequest()->getSession()->get(sprintf('%s.list_mode', $this->getCode()), 'list');
     }
 }

--- a/Admin/AdminExtension.php
+++ b/Admin/AdminExtension.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sonata package.
  *
@@ -10,20 +11,18 @@
 
 namespace Sonata\AdminBundle\Admin;
 
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Datagrid\ListMapper;
-use Sonata\AdminBundle\Datagrid\DatagridMapper;
-use Sonata\AdminBundle\Show\ShowMapper;
-use Sonata\AdminBundle\Route\RouteCollection;
-use Sonata\CoreBundle\Validator\ErrorElement;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-
 use Knp\Menu\ItemInterface as MenuItemInterface;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\CoreBundle\Validator\ErrorElement;
 
 /**
- * Class AdminExtension
+ * Class AdminExtension.
  *
- * @package Sonata\AdminBundle\Admin
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 abstract class AdminExtension implements AdminExtensionInterface
@@ -32,37 +31,43 @@ abstract class AdminExtension implements AdminExtensionInterface
      * {@inheritdoc}
      */
     public function configureFormFields(FormMapper $form)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
     public function configureListFields(ListMapper $list)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
     public function configureDatagridFilters(DatagridMapper $filter)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
     public function configureShowFields(ShowMapper $show)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
     public function configureRoutes(AdminInterface $admin, RouteCollection $collection)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
     public function configureSideMenu(AdminInterface $admin, MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
@@ -78,25 +83,29 @@ abstract class AdminExtension implements AdminExtensionInterface
      * {@inheritdoc}
      */
     public function validate(AdminInterface $admin, ErrorElement $errorElement, $object)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
     public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list')
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
     public function alterNewInstance(AdminInterface $admin, $object)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
     public function alterObject(AdminInterface $admin, $object)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
@@ -110,35 +119,41 @@ abstract class AdminExtension implements AdminExtensionInterface
      * {@inheritdoc}
      */
     public function preUpdate(AdminInterface $admin, $object)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
     public function postUpdate(AdminInterface $admin, $object)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
     public function prePersist(AdminInterface $admin, $object)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
     public function postPersist(AdminInterface $admin, $object)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
     public function preRemove(AdminInterface $admin, $object)
-    {}
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
     public function postRemove(AdminInterface $admin, $object)
-    {}
+    {
+    }
 }

--- a/Admin/AdminExtensionInterface.php
+++ b/Admin/AdminExtensionInterface.php
@@ -11,20 +11,18 @@
 
 namespace Sonata\AdminBundle\Admin;
 
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Datagrid\ListMapper;
-use Sonata\AdminBundle\Datagrid\DatagridMapper;
-use Sonata\AdminBundle\Show\ShowMapper;
-use Sonata\AdminBundle\Route\RouteCollection;
-use Sonata\CoreBundle\Validator\ErrorElement;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-
 use Knp\Menu\ItemInterface as MenuItemInterface;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\CoreBundle\Validator\ErrorElement;
 
 /**
- * Interface AdminExtensionInterface
+ * Interface AdminExtensionInterface.
  *
- * @package Sonata\AdminBundle\Admin
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface AdminExtensionInterface
@@ -56,7 +54,7 @@ interface AdminExtensionInterface
     public function configureRoutes(AdminInterface $admin, RouteCollection $collection);
 
     /**
-     * DEPRECATED: Use configureTabMenu instead
+     * DEPRECATED: Use configureTabMenu instead.
      *
      * @param AdminInterface    $admin
      * @param MenuItemInterface $menu
@@ -70,7 +68,7 @@ interface AdminExtensionInterface
     public function configureSideMenu(AdminInterface $admin, MenuItemInterface $menu, $action, AdminInterface $childAdmin = null);
 
     /**
-     * Builds the tab menu
+     * Builds the tab menu.
      *
      * @param AdminInterface    $admin
      * @param MenuItemInterface $menu
@@ -106,18 +104,20 @@ interface AdminExtensionInterface
     public function alterNewInstance(AdminInterface $admin, $object);
 
     /**
-     * Get a chance to modify object instance
+     * Get a chance to modify object instance.
      *
-     * @param  AdminInterface $admin
+     * @param AdminInterface $admin
      * @param  $object
+     *
      * @return mixed
      */
     public function alterObject(AdminInterface $admin, $object);
 
     /**
-     * Get a chance to add persistent parameters
+     * Get a chance to add persistent parameters.
      *
-     * @param  AdminInterface $admin
+     * @param AdminInterface $admin
+     *
      * @return array
      */
     public function getPersistentParameters(AdminInterface $admin);

--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -13,16 +13,15 @@ namespace Sonata\AdminBundle\Admin;
 
 use Doctrine\Common\Inflector\Inflector;
 use Doctrine\Common\Util\ClassUtils;
+use Sonata\AdminBundle\Exception\NoValueException;
+use Sonata\AdminBundle\Util\FormBuilderIterator;
+use Sonata\AdminBundle\Util\FormViewIterator;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
-use Sonata\AdminBundle\Exception\NoValueException;
-use Sonata\AdminBundle\Util\FormViewIterator;
-use Sonata\AdminBundle\Util\FormBuilderIterator;
 
 /**
- * Class AdminHelper
+ * Class AdminHelper.
  *
- * @package Sonata\AdminBundle\Admin
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AdminHelper
@@ -53,7 +52,7 @@ class AdminHelper
             }
         }
 
-        return null;
+        return;
     }
 
     /**
@@ -70,7 +69,7 @@ class AdminHelper
             }
         }
 
-        return null;
+        return;
     }
 
     /**
@@ -89,7 +88,7 @@ class AdminHelper
      * Note:
      *   This code is ugly, but there is no better way of doing it.
      *   For now the append form element action used to add a new row works
-     *   only for direct FieldDescription (not nested one)
+     *   only for direct FieldDescription (not nested one).
      *
      * @throws \RuntimeException
      *
@@ -142,7 +141,7 @@ class AdminHelper
         while ($objectCount < $postCount) {
             // append a new instance into the object
             $this->addNewInstance($form->getData(), $fieldDescription);
-            $objectCount++;
+            ++$objectCount;
         }
 
         $this->addNewInstance($form->getData(), $fieldDescription);
@@ -157,7 +156,7 @@ class AdminHelper
     }
 
     /**
-     * Add a new instance to the related FieldDescriptionInterface value
+     * Add a new instance to the related FieldDescriptionInterface value.
      *
      * @param object                                              $object
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $fieldDescription
@@ -187,7 +186,7 @@ class AdminHelper
     }
 
     /**
-     * Camelize a string
+     * Camelize a string.
      *
      * @static
      *

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -11,82 +11,71 @@
 
 namespace Sonata\AdminBundle\Admin;
 
+use Knp\Menu\FactoryInterface as MenuFactoryInterface;
+use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
-use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 use Sonata\AdminBundle\Builder\RouteBuilderInterface;
-use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Route\RouteGeneratorInterface;
-use Knp\Menu\FactoryInterface as MenuFactoryInterface;
-
-use Sonata\CoreBundle\Validator\ErrorElement;
+use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
+use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Sonata\CoreBundle\Model\Metadata;
-
-use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
 /**
- * Interface AdminInterface
+ * Interface AdminInterface.
  *
- * @package Sonata\AdminBundle\Admin
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface AdminInterface
 {
     /**
      * @param \Sonata\AdminBundle\Builder\FormContractorInterface $formContractor
-     *
-     * @return void
      */
     public function setFormContractor(FormContractorInterface $formContractor);
 
     /**
-     * Set ListBuilder
+     * Set ListBuilder.
      *
      * @param ListBuilderInterface $listBuilder
-     *
-     * @return void
      */
     public function setListBuilder(ListBuilderInterface $listBuilder);
 
     /**
-     * Get ListBuilder
+     * Get ListBuilder.
      *
      * @return \Sonata\AdminBundle\Builder\ListBuilderInterface
      */
     public function getListBuilder();
 
     /**
-     * Set DatagridBuilder
+     * Set DatagridBuilder.
      *
      * @param \Sonata\AdminBundle\Builder\DatagridBuilderInterface $datagridBuilder
-     *
-     * @return void
      */
     public function setDatagridBuilder(DatagridBuilderInterface $datagridBuilder);
 
     /**
-     * Get DatagridBuilder
+     * Get DatagridBuilder.
      *
      * @return \Sonata\AdminBundle\Builder\DatagridBuilderInterface
      */
     public function getDatagridBuilder();
 
     /**
-     * Set translator
+     * Set translator.
      *
      * @param \Symfony\Component\Translation\TranslatorInterface $translator
-     *
-     * @return void
      */
     public function setTranslator(TranslatorInterface $translator);
 
     /**
-     * Get translator
+     * Get translator.
      *
      * @return \Symfony\Component\Translation\TranslatorInterface
      */
@@ -94,22 +83,16 @@ interface AdminInterface
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     *
-     * @return void
      */
     public function setRequest(Request $request);
 
     /**
      * @param Pool $pool
-     *
-     * @return void
      */
     public function setConfigurationPool(Pool $pool);
 
     /**
      * @param \Sonata\AdminBundle\Route\RouteGeneratorInterface $routeGenerator
-     *
-     * @return void
      */
     public function setRouteGenerator(RouteGeneratorInterface $routeGenerator);
 
@@ -117,7 +100,7 @@ interface AdminInterface
      * Returns subjectClass/class/subclass name managed
      * - subclass name if subclass parameter is defined
      * - subject class name if subject is defined
-     * - class name if not
+     * - class name if not.
      *
      * @return string
      */
@@ -125,8 +108,6 @@ interface AdminInterface
 
     /**
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $fieldDescription
-     *
-     * @return void
      */
     public function attachAdminClass(FieldDescriptionInterface $fieldDescription);
 
@@ -136,33 +117,33 @@ interface AdminInterface
     public function getDatagrid();
 
     /**
-     * Set base controller name
+     * Set base controller name.
      *
      * @param string $baseControllerName
      */
     public function setBaseControllerName($baseControllerName);
 
     /**
-     * Get base controller name
+     * Get base controller name.
      *
      * @return string
      */
     public function getBaseControllerName();
 
     /**
-     * Generates the object url with the given $name
+     * Generates the object url with the given $name.
      *
-     * @param string  $name
-     * @param mixed   $object
-     * @param array   $parameters
-     * @param boolean $absolute
+     * @param string $name
+     * @param mixed  $object
+     * @param array  $parameters
+     * @param bool   $absolute
      *
      * @return string return a complete url
      */
     public function generateObjectUrl($name, $object, array $parameters = array(), $absolute = false);
 
     /**
-     * Generates an url for the given parameters
+     * Generates an url for the given parameters.
      *
      * @param string $name
      * @param array  $parameters
@@ -173,7 +154,7 @@ interface AdminInterface
     public function generateUrl($name, array $parameters = array(), $absolute = false);
 
     /**
-     * Generates an url for the given parameters
+     * Generates an url for the given parameters.
      *
      * @param string $name
      * @param array  $parameters
@@ -206,7 +187,7 @@ interface AdminInterface
     public function getFormBuilder();
 
     /**
-     * Return FormFieldDescription
+     * Return FormFieldDescription.
      *
      * @param string $name
      *
@@ -215,14 +196,14 @@ interface AdminInterface
     public function getFormFieldDescription($name);
 
     /**
-     * Build and return the collection of form FieldDescription
+     * Build and return the collection of form FieldDescription.
      *
      * @return array collection of form FieldDescription
      */
     public function getFormFieldDescriptions();
 
     /**
-     * Returns a form depend on the given $object
+     * Returns a form depend on the given $object.
      *
      * @return \Symfony\Component\Form\Form
      */
@@ -236,19 +217,17 @@ interface AdminInterface
     public function getRequest();
 
     /**
-     * @return boolean true if a request object is linked to this Admin, false
-     *                 otherwise.
+     * @return bool true if a request object is linked to this Admin, false
+     *              otherwise.
      */
     public function hasRequest();
 
     /**
-     *
      * @return string
      */
     public function getCode();
 
     /**
-     *
      * @return string
      */
     public function getBaseCodeRoute();
@@ -257,7 +236,7 @@ interface AdminInterface
      * Return the roles and permissions per role
      * - different permissions per role for the acl handler
      * - one permission that has the same name as the role for the role handler
-     * This should be used by experimented users
+     * This should be used by experimented users.
      *
      * @return array [role] => array([permission], [permission])
      */
@@ -265,27 +244,25 @@ interface AdminInterface
 
     /**
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $parentFieldDescription
-     *
-     * @return void
      */
     public function setParentFieldDescription(FieldDescriptionInterface $parentFieldDescription);
 
     /**
-     * Get parent field description
+     * Get parent field description.
      *
      * @return \Sonata\AdminBundle\Admin\FieldDescriptionInterface The parent field description
      */
     public function getParentFieldDescription();
 
     /**
-     * Returns true if the Admin is linked to a parent FieldDescription
+     * Returns true if the Admin is linked to a parent FieldDescription.
      *
      * @return bool
      */
     public function hasParentFieldDescription();
 
     /**
-     * translate a message id
+     * translate a message id.
      *
      * @param string $id
      * @param array  $parameters
@@ -297,28 +274,28 @@ interface AdminInterface
     public function trans($id, array $parameters = array(), $domain = null, $locale = null);
 
     /**
-     * Returns the list of available urls
+     * Returns the list of available urls.
      *
      * @return \Sonata\AdminBundle\Route\RouteCollection the list of available urls
      */
     public function getRoutes();
 
     /**
-     * Return the parameter name used to represent the id in the url
+     * Return the parameter name used to represent the id in the url.
      *
      * @return string
      */
     public function getRouterIdParameter();
 
     /**
-     * Returns the parameter representing request id, ie: id or childId
+     * Returns the parameter representing request id, ie: id or childId.
      *
      * @return string
      */
     public function getIdParameter();
 
     /**
-     * Returns true if the route $name is available
+     * Returns true if the route $name is available.
      *
      * @param string $name
      *
@@ -327,7 +304,7 @@ interface AdminInterface
     public function hasRoute($name);
 
     /**
-     * Returns true if the admin has a FieldDescription with the given $name
+     * Returns true if the admin has a FieldDescription with the given $name.
      *
      * @param string $name
      *
@@ -336,43 +313,37 @@ interface AdminInterface
     public function hasShowFieldDescription($name);
 
     /**
-     * add a FieldDescription
+     * add a FieldDescription.
      *
      * @param string                                              $name
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $fieldDescription
-     *
-     * @return void
      */
     public function addShowFieldDescription($name, FieldDescriptionInterface $fieldDescription);
 
     /**
-     * Remove a ShowFieldDescription
+     * Remove a ShowFieldDescription.
      *
      * @param string $name
      */
     public function removeShowFieldDescription($name);
 
     /**
-     * add a list FieldDescription
+     * add a list FieldDescription.
      *
      * @param string                                              $name
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $fieldDescription
-     *
-     * @return void
      */
     public function addListFieldDescription($name, FieldDescriptionInterface $fieldDescription);
 
     /**
-     * Remove a list FieldDescription
+     * Remove a list FieldDescription.
      *
      * @param string $name
-     *
-     * @return void
      */
     public function removeListFieldDescription($name);
 
     /**
-     * Returns true if the filter FieldDescription exists
+     * Returns true if the filter FieldDescription exists.
      *
      * @param string $name
      *
@@ -381,31 +352,29 @@ interface AdminInterface
     public function hasFilterFieldDescription($name);
 
     /**
-     * add a filter FieldDescription
+     * add a filter FieldDescription.
      *
      * @param string                                              $name
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $fieldDescription
-     *
-     * @return void
      */
     public function addFilterFieldDescription($name, FieldDescriptionInterface $fieldDescription);
 
     /**
-     * Remove a filter FieldDescription
+     * Remove a filter FieldDescription.
      *
      * @param string $name
      */
     public function removeFilterFieldDescription($name);
 
     /**
-     * Returns the filter FieldDescription collection
+     * Returns the filter FieldDescription collection.
      *
      * @return FieldDescriptionInterface[]
      */
     public function getFilterFieldDescriptions();
 
     /**
-     * Returns a filter FieldDescription
+     * Returns a filter FieldDescription.
      *
      * @param string $name
      *
@@ -414,7 +383,7 @@ interface AdminInterface
     public function getFilterFieldDescription($name);
 
     /**
-     * Returns a list depend on the given $object
+     * Returns a list depend on the given $object.
      *
      * @return \Sonata\AdminBundle\Admin\FieldDescriptionCollection
      */
@@ -422,8 +391,6 @@ interface AdminInterface
 
     /**
      * @param \Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface $securityHandler
-     *
-     * @return void
      */
     public function setSecurityHandler(SecurityHandlerInterface $securityHandler);
 
@@ -436,7 +403,7 @@ interface AdminInterface
      * @param string      $name
      * @param object|null $object
      *
-     * @return boolean
+     * @return bool
      */
     public function isGranted($name, $object = null);
 
@@ -451,7 +418,7 @@ interface AdminInterface
     public function getNormalizedIdentifier($entity);
 
     /**
-     * Shorthand method for templating
+     * Shorthand method for templating.
      *
      * @param object $entity
      *
@@ -461,8 +428,6 @@ interface AdminInterface
 
     /**
      * @param ValidatorInterface|LegacyValidatorInterface $validator
-     *
-     * @return void
      */
     public function setValidator($validator);
 
@@ -478,8 +443,6 @@ interface AdminInterface
 
     /**
      * @param array $formTheme
-     *
-     * @return void
      */
     public function setFormTheme(array $formTheme);
 
@@ -490,8 +453,6 @@ interface AdminInterface
 
     /**
      * @param array $filterTheme
-     *
-     * @return void
      */
     public function setFilterTheme(array $filterTheme);
 
@@ -502,13 +463,11 @@ interface AdminInterface
 
     /**
      * @param AdminExtensionInterface $extension
-     *
-     * @return void
      */
     public function addExtension(AdminExtensionInterface $extension);
 
     /**
-     * Returns an array of extension related to the current Admin
+     * Returns an array of extension related to the current Admin.
      *
      * @return AdminExtensionInterface[]
      */
@@ -516,8 +475,6 @@ interface AdminInterface
 
     /**
      * @param \Knp\Menu\FactoryInterface $menuFactory
-     *
-     * @return void
      */
     public function setMenuFactory(MenuFactoryInterface $menuFactory);
 
@@ -556,23 +513,21 @@ interface AdminInterface
     /**
      * Returning true will enable preview mode for
      * the target entity and show a preview button
-     * when editing/creating an entity
+     * when editing/creating an entity.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsPreviewMode();
 
     /**
-     * add an Admin child to the current one
+     * add an Admin child to the current one.
      *
      * @param \Sonata\AdminBundle\Admin\AdminInterface $child
-     *
-     * @return void
      */
     public function addChild(AdminInterface $child);
 
     /**
-     * Returns true or false if an Admin child exists for the given $code
+     * Returns true or false if an Admin child exists for the given $code.
      *
      * @param string $code Admin code
      *
@@ -581,14 +536,14 @@ interface AdminInterface
     public function hasChild($code);
 
     /**
-     * Returns an collection of admin children
+     * Returns an collection of admin children.
      *
      * @return array list of Admin children
      */
     public function getChildren();
 
     /**
-     * Returns an admin child with the given $code
+     * Returns an admin child with the given $code.
      *
      * @param string $code
      *
@@ -609,9 +564,9 @@ interface AdminInterface
     public function setUniqid($uniqId);
 
     /**
-     * Returns the uniqid
+     * Returns the uniqid.
      *
-     * @return integer
+     * @return int
      */
     public function getUniqid();
 
@@ -635,7 +590,7 @@ interface AdminInterface
     public function getSubject();
 
     /**
-     * Returns a list FieldDescription
+     * Returns a list FieldDescription.
      *
      * @param string $name
      *
@@ -644,7 +599,7 @@ interface AdminInterface
     public function getListFieldDescription($name);
 
     /**
-     * Returns true if the list FieldDescription exists
+     * Returns true if the list FieldDescription exists.
      *
      * @param string $name
      *
@@ -653,28 +608,27 @@ interface AdminInterface
     public function hasListFieldDescription($name);
 
     /**
-     * Returns the collection of list FieldDescriptions
+     * Returns the collection of list FieldDescriptions.
      *
      * @return array
      */
     public function getListFieldDescriptions();
 
     /**
-     * Returns the array of allowed export formats
+     * Returns the array of allowed export formats.
      *
      * @return array
      */
     public function getExportFormats();
 
     /**
-     * Returns SourceIterator
+     * Returns SourceIterator.
      *
      * @return \Exporter\Source\SourceIteratorInterface
      */
     public function getDataSourceIterator();
 
     /**
-     * @return void
      */
     public function configure();
 
@@ -742,14 +696,14 @@ interface AdminInterface
     public function postRemove($object);
 
     /**
-     * Call before the batch action, allow you to alter the query and the idx
+     * Call before the batch action, allow you to alter the query and the idx.
      *
      * @param string              $actionName
      * @param ProxyQueryInterface $query
      * @param array               $idx
      * @param bool                $allElements
      */
-    public function preBatchAction($actionName, ProxyQueryInterface $query, array & $idx, $allElements);
+    public function preBatchAction($actionName, ProxyQueryInterface $query, array &$idx, $allElements);
 
     /**
      * Return array of filter parameters.
@@ -759,18 +713,15 @@ interface AdminInterface
     public function getFilterParameters();
 
     /**
-     * Return true if the Admin is related to a subject
+     * Return true if the Admin is related to a subject.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasSubject();
 
     /**
-     *
      * @param \Sonata\CoreBundle\Validator\ErrorElement $errorElement
-     * @param mixed                                      $object
-     *
-     * @return void
+     * @param mixed                                     $object
      *
      * @deprecated this feature cannot be stable, use a custom validator,
      *             the feature will be removed with Symfony 2.2
@@ -780,12 +731,12 @@ interface AdminInterface
     /**
      * @param string $context
      *
-     * @return boolean
+     * @return bool
      */
     public function showIn($context);
 
     /**
-     * Add object security, fe. make the current user owner of the object
+     * Add object security, fe. make the current user owner of the object.
      *
      * @param mixed $object
      */
@@ -798,20 +749,18 @@ interface AdminInterface
 
     /**
      * @param AdminInterface $admin
-     *
-     * @return void
      */
     public function setParent(AdminInterface $admin);
 
     /**
-     * Returns true if the Admin class has an Parent Admin defined
+     * Returns true if the Admin class has an Parent Admin defined.
      *
-     * @return boolean
+     * @return bool
      */
     public function isChild();
 
     /**
-     * Returns template
+     * Returns template.
      *
      * @param string $name
      *
@@ -820,30 +769,28 @@ interface AdminInterface
     public function getTemplate($name);
 
     /**
-     * Set the translation domain
+     * Set the translation domain.
      *
      * @param string $translationDomain the translation domain
-     *
-     * @return void
      */
     public function setTranslationDomain($translationDomain);
 
     /**
-     * Returns the translation domain
+     * Returns the translation domain.
      *
      * @return string the translation domain
      */
     public function getTranslationDomain();
 
     /**
-     * Return the form groups
+     * Return the form groups.
      *
      * @return array
      */
     public function getFormGroups();
 
     /**
-     * Set the form groups
+     * Set the form groups.
      *
      * @param array $formGroups
      */
@@ -870,30 +817,28 @@ interface AdminInterface
     public function setShowTabs(array $showTabs);
 
     /**
-     * Remove a form group field
+     * Remove a form group field.
      *
      * @param string $key
-     *
-     * @return void
      */
     public function removeFieldFromFormGroup($key);
 
     /**
-     * Returns the show groups
+     * Returns the show groups.
      *
      * @return array
      */
     public function getShowGroups();
 
     /**
-     * Set the show groups
+     * Set the show groups.
      *
      * @param array $showGroups
      */
     public function setShowGroups(array $showGroups);
 
     /**
-     * Reorder items in showGroup
+     * Reorder items in showGroup.
      *
      * @param string $group
      * @param array  $keys
@@ -901,40 +846,36 @@ interface AdminInterface
     public function reorderShowGroup($group, array $keys);
 
     /**
-     * add a FieldDescription
+     * add a FieldDescription.
      *
      * @param string                                              $name
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $fieldDescription
-     *
-     * @return void
      */
     public function addFormFieldDescription($name, FieldDescriptionInterface $fieldDescription);
 
     /**
-     * Remove a FieldDescription
+     * Remove a FieldDescription.
      *
      * @param string $name
-     *
-     * @return void
      */
     public function removeFormFieldDescription($name);
 
     /**
-     * Returns true if this admin uses ACL
+     * Returns true if this admin uses ACL.
      *
-     * @return boolean
+     * @return bool
      */
     public function isAclEnabled();
 
     /**
-     * Sets the list of supported sub classes
+     * Sets the list of supported sub classes.
      *
      * @param array $subClasses the list of sub classes
      */
     public function setSubClasses(array $subClasses);
 
     /**
-     * Returns true if the admin has the sub classes
+     * Returns true if the admin has the sub classes.
      *
      * @param string $name The name of the sub class
      *
@@ -943,49 +884,49 @@ interface AdminInterface
     public function hasSubClass($name);
 
     /**
-     * Returns true if a subclass is currently active
+     * Returns true if a subclass is currently active.
      *
      * @return bool
      */
     public function hasActiveSubClass();
 
     /**
-     * Returns the currently active sub class
+     * Returns the currently active sub class.
      *
      * @return string the active sub class
      */
     public function getActiveSubClass();
 
     /**
-     * Returns the currently active sub class code
+     * Returns the currently active sub class code.
      *
      * @return string the code for active sub class
      */
     public function getActiveSubclassCode();
 
     /**
-     * Returns the list of batchs actions
+     * Returns the list of batchs actions.
      *
      * @return array the list of batchs actions
      */
     public function getBatchActions();
 
     /**
-     * Returns Admin`s label
+     * Returns Admin`s label.
      *
      * @return string
      */
     public function getLabel();
 
     /**
-     * Returns an array of persistent parameters
+     * Returns an array of persistent parameters.
      *
      * @return array
      */
     public function getPersistentParameters();
 
     /**
-     * Get breadcrumbs for $action
+     * Get breadcrumbs for $action.
      *
      * @param string $action
      *
@@ -994,14 +935,14 @@ interface AdminInterface
     public function getBreadcrumbs($action);
 
     /**
-     * Set the current child status
+     * Set the current child status.
      *
-     * @param boolean $currentChild
+     * @param bool $currentChild
      */
     public function setCurrentChild($currentChild);
 
     /**
-     * Returns the current child status
+     * Returns the current child status.
      *
      * @return bool
      */
@@ -1019,24 +960,24 @@ interface AdminInterface
     public function getTranslationLabel($label, $context = '', $type = '');
 
     /**
-     * DEPRECATED: Use buildTabMenu instead
+     * DEPRECATED: Use buildTabMenu instead.
      *
      * @param string                                   $action
      * @param \Sonata\AdminBundle\Admin\AdminInterface $childAdmin
      *
-     * @return \Knp\Menu\ItemInterface|boolean
+     * @return \Knp\Menu\ItemInterface|bool
      *
      * @deprecated Use buildTabMenu instead
      */
     public function buildSideMenu($action, AdminInterface $childAdmin = null);
 
     /**
-     * Build the tab menu related to the current action
+     * Build the tab menu related to the current action.
      *
      * @param string                                   $action
      * @param \Sonata\AdminBundle\Admin\AdminInterface $childAdmin
      *
-     * @return \Knp\Menu\ItemInterface|boolean
+     * @return \Knp\Menu\ItemInterface|bool
      */
     public function buildTabMenu($action, AdminInterface $childAdmin = null);
 
@@ -1058,7 +999,7 @@ interface AdminInterface
     public function setListMode($mode);
 
     /**
-     * return the list mode
+     * return the list mode.
      *
      * @return string
      */

--- a/Admin/BaseFieldDescription.php
+++ b/Admin/BaseFieldDescription.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Container;
 
 /**
  * A FieldDescription hold the information about a field. A typical
- * admin instance contains different collections of fields
+ * admin instance contains different collections of fields.
  *
  * - form: used by the form
  * - list: used by the list
@@ -65,12 +65,12 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     protected $name;
 
     /**
-     * @var string|integer the type
+     * @var string|int the type
      */
     protected $type;
 
     /**
-     * @var string|integer the original mapping type
+     * @var string|int the original mapping type
      */
     protected $mappingType;
 
@@ -148,7 +148,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         $this->name = $name;
 
         if (!$this->getFieldName()) {
-            $this->setFieldName(substr(strrchr('.' . $name, '.'), 1));
+            $this->setFieldName(substr(strrchr('.'.$name, '.'), 1));
         }
     }
 
@@ -322,7 +322,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     public function getFieldValue($object, $fieldName)
     {
         if ($this->isVirtual()) {
-           return null;
+            return;
         }
 
         $camelizedFieldName = self::camelize($fieldName);
@@ -338,8 +338,8 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         if ($this->getOption('parameters')) {
             $parameters = $this->getOption('parameters');
         }
-        $getters[] = 'get' . $camelizedFieldName;
-        $getters[] = 'is' . $camelizedFieldName;
+        $getters[] = 'get'.$camelizedFieldName;
+        $getters[] = 'is'.$camelizedFieldName;
 
         foreach ($getters as $getter) {
             if (method_exists($object, $getter)) {
@@ -415,7 +415,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     }
 
     /**
-     * Camelize a string
+     * Camelize a string.
      *
      * @static
      *
@@ -429,7 +429,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     }
 
     /**
-     * Defines the help message
+     * Defines the help message.
      *
      * @param string $help
      */
@@ -489,7 +489,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     /**
      * Return true if field is virtual.
      *
-     * @return boolean
+     * @return bool
      */
     public function isVirtual()
     {

--- a/Admin/FieldDescriptionCollection.php
+++ b/Admin/FieldDescriptionCollection.php
@@ -13,9 +13,8 @@
 namespace Sonata\AdminBundle\Admin;
 
 /**
- * Class FieldDescriptionCollection
+ * Class FieldDescriptionCollection.
  *
- * @package Sonata\AdminBundle\Admin
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class FieldDescriptionCollection implements \ArrayAccess, \Countable
@@ -24,8 +23,6 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
 
     /**
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $fieldDescription
-     *
-     * @return void
      */
     public function add(FieldDescriptionInterface $fieldDescription)
     {
@@ -68,8 +65,6 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
 
     /**
      * @param string $name
-     *
-     * @return void
      */
     public function remove($name)
     {

--- a/Admin/FieldDescriptionInterface.php
+++ b/Admin/FieldDescriptionInterface.php
@@ -12,47 +12,42 @@
 namespace Sonata\AdminBundle\Admin;
 
 /**
- * Interface FieldDescriptionInterface
+ * Interface FieldDescriptionInterface.
  *
- * @package Sonata\AdminBundle\Admin
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface FieldDescriptionInterface
 {
     /**
-     * set the field name
+     * set the field name.
      *
      * @param string $fieldName
-     *
-     * @return void
      */
     public function setFieldName($fieldName);
 
     /**
-     * return the field name
+     * return the field name.
      *
      * @return string the field name
      */
     public function getFieldName();
 
     /**
-     * Set the name
+     * Set the name.
      *
      * @param string $name
-     *
-     * @return void
      */
     public function setName($name);
 
     /**
-     * Return the name, the name can be used as a form label or table header
+     * Return the name, the name can be used as a form label or table header.
      *
      * @return string the name
      */
     public function getName();
 
     /**
-     * Return the value represented by the provided name
+     * Return the value represented by the provided name.
      *
      * @param string $name
      * @param null   $default
@@ -62,46 +57,40 @@ interface FieldDescriptionInterface
     public function getOption($name, $default = null);
 
     /**
-     * Define an option, an option is has a name and a value
+     * Define an option, an option is has a name and a value.
      *
      * @param string $name
      * @param mixed  $value
-     *
-     * @return void set the option value
      */
     public function setOption($name, $value);
 
     /**
      * Define the options value, if the options array contains the reserved keywords
      *   - type
-     *   - template
+     *   - template.
      *
      * Then the value are copied across to the related property value
      *
      * @param array $options
-     *
-     * @return void
      */
     public function setOptions(array $options);
 
     /**
-     * return options
+     * return options.
      *
      * @return array options
      */
     public function getOptions();
 
     /**
-     * return the template used to render the field
+     * return the template used to render the field.
      *
      * @param string $template
-     *
-     * @return void
      */
     public function setTemplate($template);
 
     /**
-     * return the template name
+     * return the template name.
      *
      * @return string the template name
      */
@@ -109,114 +98,105 @@ interface FieldDescriptionInterface
 
     /**
      * return the field type, the type is a mandatory field as it used to select the correct template
-     * or the logic associated to the current FieldDescription object
+     * or the logic associated to the current FieldDescription object.
      *
      * @param string $type
-     *
-     * @return void the field type
      */
     public function setType($type);
 
     /**
-     * return the type
+     * return the type.
      *
      * @return int|string
      */
     public function getType();
 
     /**
-     * set the parent Admin (only used in nested admin)
+     * set the parent Admin (only used in nested admin).
      *
      * @param \Sonata\AdminBundle\Admin\AdminInterface $parent
-     *
-     * @return void
      */
     public function setParent(AdminInterface $parent);
 
     /**
-     * return the parent Admin (only used in nested admin)
+     * return the parent Admin (only used in nested admin).
      *
      * @return \Sonata\AdminBundle\Admin\AdminInterface
      */
     public function getParent();
 
     /**
-     * Define the association mapping definition
+     * Define the association mapping definition.
      *
      * @param array $associationMapping
-     *
-     * @return void
      */
     public function setAssociationMapping($associationMapping);
 
     /**
-     * return the association mapping definition
+     * return the association mapping definition.
      *
      * @return array
      */
     public function getAssociationMapping();
 
     /**
-     * return the related Target Entity
+     * return the related Target Entity.
      *
      * @return string|null
      */
     public function getTargetEntity();
 
     /**
-     * set the field mapping information
+     * set the field mapping information.
      *
      * @param array $fieldMapping
-     *
-     * @return void
      */
     public function setFieldMapping($fieldMapping);
 
     /**
-     * return the field mapping definition
+     * return the field mapping definition.
      *
      * @return array the field mapping definition
      */
     public function getFieldMapping();
 
     /**
-     * set the parent association mappings information
+     * set the parent association mappings information.
      *
      * @param array $parentAssociationMappings
-     *
-     * @return void
      */
     public function setParentAssociationMappings(array $parentAssociationMappings);
 
     /**
-     * return the parent association mapping definitions
+     * return the parent association mapping definitions.
      *
      * @return array the parent association mapping definitions
      */
     public function getParentAssociationMappings();
 
     /**
-     * set the association admin instance (only used if the field is linked to an Admin)
+     * set the association admin instance (only used if the field is linked to an Admin).
      *
      * @param \Sonata\AdminBundle\Admin\AdminInterface $associationAdmin the associated admin
      */
     public function setAssociationAdmin(AdminInterface $associationAdmin);
 
     /**
-     * return the associated Admin instance (only used if the field is linked to an Admin)
+     * return the associated Admin instance (only used if the field is linked to an Admin).
+     *
      * @return \Sonata\AdminBundle\Admin\AdminInterface
      */
     public function getAssociationAdmin();
 
     /**
-     * return true if the FieldDescription is linked to an identifier field
+     * return true if the FieldDescription is linked to an identifier field.
      *
      * @return bool
      */
     public function isIdentifier();
 
     /**
-     * return the value linked to the description
+     * return the value linked to the description.
      *
      * @param mixed $object
      *
@@ -225,11 +205,9 @@ interface FieldDescriptionInterface
     public function getValue($object);
 
     /**
-     * set the admin class linked to this FieldDescription
+     * set the admin class linked to this FieldDescription.
      *
      * @param \Sonata\AdminBundle\Admin\AdminInterface $admin
-     *
-     * @return void
      */
     public function setAdmin(AdminInterface $admin);
 
@@ -239,44 +217,38 @@ interface FieldDescriptionInterface
     public function getAdmin();
 
     /**
-     * merge option values related to the provided option name
+     * merge option values related to the provided option name.
      *
      * @throws \RuntimeException
      *
      * @param string $name
      * @param array  $options
-     *
-     * @return void
      */
     public function mergeOption($name, array $options = array());
 
     /**
-     * merge options values
+     * merge options values.
      *
      * @param array $options
-     *
-     * @return void
      */
     public function mergeOptions(array $options = array());
 
     /**
-     * set the original mapping type (only used if the field is linked to an entity)
+     * set the original mapping type (only used if the field is linked to an entity).
      *
      * @param string|int $mappingType
-     *
-     * @return void
      */
     public function setMappingType($mappingType);
 
     /**
-     * return the mapping type
+     * return the mapping type.
      *
      * @return int|string
      */
     public function getMappingType();
 
     /**
-     * return the label to use for the current field
+     * return the label to use for the current field.
      *
      * @return string
      */
@@ -292,26 +264,25 @@ interface FieldDescriptionInterface
     /**
      * Return true if field is sortable.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSortable();
 
     /**
-     * return the field mapping definition used when sorting
+     * return the field mapping definition used when sorting.
      *
      * @return array the field mapping definition
      */
     public function getSortFieldMapping();
 
     /**
-     * return the parent association mapping definitions used when sorting
+     * return the parent association mapping definitions used when sorting.
      *
      * @return array the parent association mapping definitions
      */
     public function getSortParentAssociationMapping();
 
     /**
-     *
      * @param object $object
      * @param string $fieldName
      *

--- a/Admin/Pool.php
+++ b/Admin/Pool.php
@@ -14,9 +14,8 @@ namespace Sonata\AdminBundle\Admin;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class Pool
+ * Class Pool.
  *
- * @package Sonata\AdminBundle\Admin
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class Pool
@@ -115,7 +114,7 @@ class Pool
     }
 
     /**
-     * Returns all admins related to the given $group
+     * Returns all admins related to the given $group.
      *
      * @param string $group
      *
@@ -143,7 +142,7 @@ class Pool
     }
 
     /**
-     * Return the admin related to the given $class
+     * Return the admin related to the given $class.
      *
      * @param string $class
      *
@@ -152,15 +151,15 @@ class Pool
     public function getAdminByClass($class)
     {
         if (!$this->hasAdminByClass($class)) {
-            return null;
+            return;
         }
 
         if (!is_array($this->adminClasses[$class])) {
-            throw new \RuntimeException("Invalid format for the Pool::adminClass property");
+            throw new \RuntimeException('Invalid format for the Pool::adminClass property');
         }
 
         if (count($this->adminClasses[$class]) > 1) {
-            throw new \RuntimeException(sprintf('Unable to find a valid admin for the class: %s, there are too many registered: %s', $class, implode(",", $this->adminClasses[$class])));
+            throw new \RuntimeException(sprintf('Unable to find a valid admin for the class: %s, there are too many registered: %s', $class, implode(',', $this->adminClasses[$class])));
         }
 
         return $this->getInstance($this->adminClasses[$class][0]);
@@ -178,7 +177,7 @@ class Pool
 
     /**
      * Returns an admin class by its Admin code
-     * ie : sonata.news.admin.post|sonata.news.admin.comment => return the child class of post
+     * ie : sonata.news.admin.post|sonata.news.admin.comment => return the child class of post.
      *
      * @param string $adminCode
      *
@@ -200,7 +199,7 @@ class Pool
     }
 
     /**
-     * Returns a new admin instance depends on the given code
+     * Returns a new admin instance depends on the given code.
      *
      * @param string $id
      *
@@ -227,8 +226,6 @@ class Pool
 
     /**
      * @param array $adminGroups
-     *
-     * @return void
      */
     public function setAdminGroups(array $adminGroups)
     {
@@ -245,8 +242,6 @@ class Pool
 
     /**
      * @param array $adminServiceIds
-     *
-     * @return void
      */
     public function setAdminServiceIds(array $adminServiceIds)
     {
@@ -263,8 +258,6 @@ class Pool
 
     /**
      * @param array $adminClasses
-     *
-     * @return void
      */
     public function setAdminClasses(array $adminClasses)
     {
@@ -281,8 +274,6 @@ class Pool
 
     /**
      * @param array $templates
-     *
-     * @return void
      */
     public function setTemplates(array $templates)
     {
@@ -308,7 +299,7 @@ class Pool
             return $this->templates[$name];
         }
 
-        return null;
+        return;
     }
 
     /**

--- a/Block/AdminListBlockService.php
+++ b/Block/AdminListBlockService.php
@@ -11,18 +11,17 @@
 
 namespace Sonata\AdminBundle\Block;
 
-use Sonata\BlockBundle\Block\BlockContextInterface;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\BlockBundle\Block\BaseBlockService;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
- * Class AdminListBlockService
+ * Class AdminListBlockService.
  *
- * @package Sonata\AdminBundle\Block
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AdminListBlockService extends BaseBlockService
@@ -61,7 +60,7 @@ class AdminListBlockService extends BaseBlockService
             'block'         => $blockContext->getBlock(),
             'settings'      => $settings,
             'admin_pool'    => $this->pool,
-            'groups'        => $visibleGroups
+            'groups'        => $visibleGroups,
         ), $response);
     }
 
@@ -79,12 +78,12 @@ class AdminListBlockService extends BaseBlockService
     public function setDefaultSettings(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'groups' => false
+            'groups' => false,
         ));
 
         if (version_compare(Kernel::VERSION, '2.6', '<')) {
             $resolver->setAllowedTypes(array(
-                'groups' => array('bool', 'array')
+                'groups' => array('bool', 'array'),
             ));
         } else {
             $resolver->setAllowedTypes('groups', array('bool', 'array'));

--- a/Block/AdminSearchBlockService.php
+++ b/Block/AdminSearchBlockService.php
@@ -12,21 +12,19 @@
 namespace Sonata\AdminBundle\Block;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Search\SearchHandler;
+use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
-
-use Sonata\AdminBundle\Admin\Pool;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
- * Class AdminSearchBlockService
+ * Class AdminSearchBlockService.
  *
- * @package Sonata\AdminBundle\Block
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AdminSearchBlockService extends BaseBlockService

--- a/Block/AdminStatsBlockService.php
+++ b/Block/AdminStatsBlockService.php
@@ -11,17 +11,16 @@
 
 namespace Sonata\AdminBundle\Block;
 
-use Sonata\BlockBundle\Block\BlockContextInterface;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\BlockBundle\Block\BaseBlockService;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
- * Class AdminStatsBlockService
+ * Class AdminStatsBlockService.
  *
- * @package Sonata\AdminBundle\Block
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AdminStatsBlockService extends BaseBlockService
@@ -55,7 +54,7 @@ class AdminStatsBlockService extends BaseBlockService
             $filters['_per_page'] = array('value' => $blockContext->getSetting('limit'));
         }
 
-        foreach($filters as $name => $data) {
+        foreach ($filters as $name => $data) {
             $datagrid->setValue($name, isset($data['type']) ? $data['type'] : null, $data['value']);
         }
 
@@ -67,7 +66,7 @@ class AdminStatsBlockService extends BaseBlockService
             'admin_pool' => $this->pool,
             'admin'      => $admin,
             'pager'      => $datagrid->getPager(),
-            'datagrid'   => $datagrid
+            'datagrid'   => $datagrid,
         ), $response);
     }
 
@@ -85,12 +84,12 @@ class AdminStatsBlockService extends BaseBlockService
     public function setDefaultSettings(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'icon'    => 'fa-line-chart',
-            'text'    => 'Statistics',
-            'color'   => 'bg-aqua',
-            'code'    => false,
-            'filters' => array(),
-            'limit'   => 1000,
+            'icon'     => 'fa-line-chart',
+            'text'     => 'Statistics',
+            'color'    => 'bg-aqua',
+            'code'     => false,
+            'filters'  => array(),
+            'limit'    => 1000,
             'template' => 'SonataAdminBundle:Block:block_stats.html.twig',
         ));
     }

--- a/Builder/BuilderInterface.php
+++ b/Builder/BuilderInterface.php
@@ -11,23 +11,19 @@
 
 namespace Sonata\AdminBundle\Builder;
 
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 
 /**
- * Interface BuilderInterface
+ * Interface BuilderInterface.
  *
- * @package Sonata\AdminBundle\Builder
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface BuilderInterface
 {
     /**
-     *
      * @param \Sonata\AdminBundle\Admin\AdminInterface            $admin
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $fieldDescription
-     *
-     * @return void
      */
     public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription);
 }

--- a/Builder/DatagridBuilderInterface.php
+++ b/Builder/DatagridBuilderInterface.php
@@ -11,14 +11,13 @@
 
 namespace Sonata\AdminBundle\Builder;
 
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 
 /**
- * Interface DatagridBuilderInterface
+ * Interface DatagridBuilderInterface.
  *
- * @package Sonata\AdminBundle\Builder
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface DatagridBuilderInterface extends BuilderInterface
@@ -30,8 +29,6 @@ interface DatagridBuilderInterface extends BuilderInterface
      * @param string                                              $type
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $fieldDescription
      * @param \Sonata\AdminBundle\Admin\AdminInterface            $admin
-     *
-     * @return void
      */
     public function addFilter(DatagridInterface $datagrid, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin);
 

--- a/Builder/FormContractorInterface.php
+++ b/Builder/FormContractorInterface.php
@@ -16,9 +16,8 @@ use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormFactoryInterface;
 
 /**
- * Interface FormContractorInterface
+ * Interface FormContractorInterface.
  *
- * @package Sonata\AdminBundle\Builder
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface FormContractorInterface extends BuilderInterface

--- a/Builder/ListBuilderInterface.php
+++ b/Builder/ListBuilderInterface.php
@@ -11,14 +11,13 @@
 
 namespace Sonata\AdminBundle\Builder;
 
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 
 /**
- * Interface ListBuilderInterface
+ * Interface ListBuilderInterface.
  *
- * @package Sonata\AdminBundle\Builder
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface ListBuilderInterface extends BuilderInterface

--- a/Builder/RouteBuilderInterface.php
+++ b/Builder/RouteBuilderInterface.php
@@ -15,9 +15,8 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Route\RouteCollection;
 
 /**
- * Interface RouteBuilderInterface
+ * Interface RouteBuilderInterface.
  *
- * @package Sonata\AdminBundle\Builder
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface RouteBuilderInterface

--- a/Builder/ShowBuilderInterface.php
+++ b/Builder/ShowBuilderInterface.php
@@ -11,14 +11,13 @@
 
 namespace Sonata\AdminBundle\Builder;
 
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 
 /**
- * Interface ShowBuilderInterface
+ * Interface ShowBuilderInterface.
  *
- * @package Sonata\AdminBundle\Builder
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface ShowBuilderInterface extends BuilderInterface
@@ -27,8 +26,6 @@ interface ShowBuilderInterface extends BuilderInterface
      * @abstract
      *
      * @param array $options
-     *
-     * @return void
      */
     public function getBaseList(array $options = array());
 
@@ -39,8 +36,6 @@ interface ShowBuilderInterface extends BuilderInterface
      * @param null                                                 $type
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface  $fieldDescription
      * @param \Sonata\AdminBundle\Admin\AdminInterface             $admin
-     *
-     * @return void
      */
     public function addField(FieldDescriptionCollection $list, $type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin);
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,17 @@ desperately need to see some commits get merged on the older branches (`2.0`,
 are no longer supported and your changes will probably not get merged in more
 recent branches.
 
+### Matching coding standards
+
+Before each commit, be sure to match sonata coding standards by running the following command for fix:
+
+```bash
+make cs
+```
+
+And then, add fixed file to your commit before push.
+
+Be sure to add only **your modified files**. If another files are fixed by cs tools, just revert it before commit.
 
 ### Sending a Pull Request
 

--- a/Command/CreateClassCacheCommand.php
+++ b/Command/CreateClassCacheCommand.php
@@ -12,14 +12,13 @@
 namespace Sonata\AdminBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\ClassLoader\ClassCollectionLoader;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\ClassLoader\ClassCollectionLoader;
 
 /**
- * Class CreateClassCacheCommand
+ * Class CreateClassCacheCommand.
  *
- * @package Sonata\AdminBundle\Command
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class CreateClassCacheCommand extends ContainerAwareCommand
@@ -49,7 +48,7 @@ class CreateClassCacheCommand extends ContainerAwareCommand
         $name = 'classes';
         $extension = '.php';
 
-        $output->write("<info>Writing cache file ...</info>");
+        $output->write('<info>Writing cache file ...</info>');
         ClassCollectionLoader::load(
             include($classmap),
             $kernel->getCacheDir(),
@@ -59,6 +58,6 @@ class CreateClassCacheCommand extends ContainerAwareCommand
             $extension
         );
 
-        $output->writeln(" done!");
+        $output->writeln(' done!');
     }
 }

--- a/Command/ExplainAdminCommand.php
+++ b/Command/ExplainAdminCommand.php
@@ -17,9 +17,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class ExplainAdminCommand
+ * Class ExplainAdminCommand.
  *
- * @package Sonata\AdminBundle\Command
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ExplainAdminCommand extends ContainerAwareCommand

--- a/Command/GenerateAdminCommand.php
+++ b/Command/GenerateAdminCommand.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\AdminBundle\Command;
 
-use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 use Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper;
+use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 use Sonata\AdminBundle\Generator\AdminGenerator;
 use Sonata\AdminBundle\Generator\ControllerGenerator;
 use Sonata\AdminBundle\Manipulator\ServicesManipulator;
@@ -23,16 +23,15 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
- * Class GenerateAdminCommand
+ * Class GenerateAdminCommand.
  *
- * @package Sonata\AdminBundle\Command
  * @author  Marek Stipek <mario.dweller@seznam.cz>
  * @author  Simon Cosandey <simon.cosandey@simseo.ch>
  */
@@ -75,11 +74,11 @@ class GenerateAdminCommand extends ContainerAwareCommand
         $modelClass = Validators::validateClass($input->getArgument('model'));
         $modelClassBasename = current(array_slice(explode('\\', $modelClass), -1));
         $bundle = $this->getBundle($input->getOption('bundle') ?: $this->getBundleNameFromClass($modelClass));
-        $adminClassBasename = $input->getOption('admin') ?: $modelClassBasename . 'Admin';
+        $adminClassBasename = $input->getOption('admin') ?: $modelClassBasename.'Admin';
         $adminClassBasename = Validators::validateAdminClassBasename($adminClassBasename);
         $managerType = $input->getOption('manager') ?: $this->getDefaultManagerType();
         $modelManager = $this->getModelManager($managerType);
-        $skeletonDirectory = __DIR__ . '/../Resources/skeleton';
+        $skeletonDirectory = __DIR__.'/../Resources/skeleton';
         $adminGenerator = new AdminGenerator($modelManager, $skeletonDirectory);
 
         try {
@@ -163,7 +162,7 @@ class GenerateAdminCommand extends ContainerAwareCommand
             $input,
             $output,
             'The admin class basename',
-            $input->getOption('admin') ?: $modelClassBasename . 'Admin',
+            $input->getOption('admin') ?: $modelClassBasename.'Admin',
             'Sonata\AdminBundle\Command\Validators::validateAdminClassBasename'
         );
 
@@ -183,19 +182,19 @@ class GenerateAdminCommand extends ContainerAwareCommand
                 $input,
                 $output,
                 'The controller class basename',
-                $input->getOption('controller') ?: $modelClassBasename . 'AdminController',
+                $input->getOption('controller') ?: $modelClassBasename.'AdminController',
                 'Sonata\AdminBundle\Command\Validators::validateControllerClassBasename'
             );
             $input->setOption('controller', $controllerClassBasename);
         }
 
         if ($this->askConfirmation($input, $output, 'Do you want to update the services YAML configuration file', 'yes', '?')) {
-            $path = $this->getBundle($bundleName)->getPath() . '/Resources/config/';
+            $path = $this->getBundle($bundleName)->getPath().'/Resources/config/';
             $servicesFile = $this->askAndValidate(
                 $input,
                 $output,
                 'The services YAML configuration file',
-                is_file($path . 'admin.yml') ? 'admin.yml' : 'services.yml',
+                is_file($path.'admin.yml') ? 'admin.yml' : 'services.yml',
                 'Sonata\AdminBundle\Command\Validators::validateServicesFile'
             );
             $id = $this->askAndValidate(
@@ -249,12 +248,12 @@ class GenerateAdminCommand extends ContainerAwareCommand
         /* @var $application Application */
 
         foreach ($application->getKernel()->getBundles() as $bundle) {
-            if (strpos($class, $bundle->getNamespace() . '\\') === 0) {
+            if (strpos($class, $bundle->getNamespace().'\\') === 0) {
                 return $bundle->getName();
             };
         }
 
-        return null;
+        return;
     }
 
     /**
@@ -309,7 +308,7 @@ class GenerateAdminCommand extends ContainerAwareCommand
             // @todo remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping  support for Symfony 2.3
              $question = $questionHelper->getQuestion($questionText, $default, $separator);
 
-             return $questionHelper->askConfirmation($output, $question, ($default === 'no' ? false : true));
+            return $questionHelper->askConfirmation($output, $question, ($default === 'no' ? false : true));
         }
 
         $question = new ConfirmationQuestion($questionHelper->getQuestion(
@@ -342,7 +341,7 @@ class GenerateAdminCommand extends ContainerAwareCommand
      */
     private function getModelManager($managerType)
     {
-        return $this->getContainer()->get('sonata.admin.manager.' . $managerType);
+        return $this->getContainer()->get('sonata.admin.manager.'.$managerType);
     }
 
     /**
@@ -420,7 +419,6 @@ class GenerateAdminCommand extends ContainerAwareCommand
                 $questionHelper = new QuestionHelper();
                 $this->getHelperSet()->set($questionHelper);
             }
-
         }
 
         return $questionHelper;

--- a/Command/GenerateObjectAclCommand.php
+++ b/Command/GenerateObjectAclCommand.php
@@ -11,17 +11,16 @@
 
 namespace Sonata\AdminBundle\Command;
 
-use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Sonata\AdminBundle\Util\ObjectAclManipulatorInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 
 /**
- * Class GenerateObjectAclCommand
+ * Class GenerateObjectAclCommand.
  *
- * @package Sonata\AdminBundle\Command
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class GenerateObjectAclCommand extends ContainerAwareCommand
@@ -60,7 +59,7 @@ class GenerateObjectAclCommand extends ContainerAwareCommand
                 '',
                 'If the step option is used, you will be asked if you want to generate the object ACL entities for each Admin.',
                 'You must use the shortcut notation like <comment>AcmeDemoBundle:User</comment> if you want to set an object owner.',
-                ''
+                '',
         ));
 
         if ($input->getOption('user_entity')) {
@@ -74,7 +73,6 @@ class GenerateObjectAclCommand extends ContainerAwareCommand
         }
 
         foreach ($this->getContainer()->get('sonata.admin.pool')->getAdminServiceIds() as $id) {
-
             try {
                 $admin = $this->getContainer()->get($id);
             } catch (\Exception $e) {
@@ -88,7 +86,7 @@ class GenerateObjectAclCommand extends ContainerAwareCommand
             }
 
             $securityIdentity = null;
-            if ($input->getOption('step') && $dialog->askConfirmation($output,"<question>Set an object owner?</question>\n", false)) {
+            if ($input->getOption('step') && $dialog->askConfirmation($output, "<question>Set an object owner?</question>\n", false)) {
                 $username = $dialog->askAndValidate($output, 'Please enter the username: ', 'Sonata\AdminBundle\Command\Validators::validateUsername');
 
                 $securityIdentity = new UserSecurityIdentity($username, $this->getUserEntityClass($input, $output));

--- a/Command/ListAdminCommand.php
+++ b/Command/ListAdminCommand.php
@@ -16,9 +16,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class ListAdminCommand
+ * Class ListAdminCommand.
  *
- * @package Sonata\AdminBundle\Command
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ListAdminCommand extends ContainerAwareCommand
@@ -39,10 +38,10 @@ class ListAdminCommand extends ContainerAwareCommand
     {
         $pool = $this->getContainer()->get('sonata.admin.pool');
 
-        $output->writeln("<info>Admin services:</info>");
+        $output->writeln('<info>Admin services:</info>');
         foreach ($pool->getAdminServiceIds() as $id) {
             $instance = $this->getContainer()->get($id);
-            $output->writeln(sprintf("  <info>%-40s</info> %-60s",
+            $output->writeln(sprintf('  <info>%-40s</info> %-60s',
                 $id,
                 $instance->getClass()
             ));

--- a/Command/SetupAclCommand.php
+++ b/Command/SetupAclCommand.php
@@ -11,15 +11,14 @@
 
 namespace Sonata\AdminBundle\Command;
 
+use Sonata\AdminBundle\Util\AdminAclManipulatorInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Sonata\AdminBundle\Util\AdminAclManipulatorInterface;
 
 /**
- * Class SetupAclCommand
+ * Class SetupAclCommand.
  *
- * @package Sonata\AdminBundle\Command
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class SetupAclCommand extends ContainerAwareCommand
@@ -41,7 +40,6 @@ class SetupAclCommand extends ContainerAwareCommand
         $output->writeln('Starting ACL AdminBundle configuration');
 
         foreach ($this->getContainer()->get('sonata.admin.pool')->getAdminServiceIds() as $id) {
-
             try {
                 $admin = $this->getContainer()->get($id);
             } catch (\Exception $e) {

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -12,9 +12,8 @@
 namespace Sonata\AdminBundle\Command;
 
 /**
- * Class Validators
+ * Class Validators.
  *
- * @package Sonata\AdminBundle\Command
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class Validators
@@ -25,6 +24,7 @@ class Validators
      * @param string $username
      *
      * @return mixed
+     *
      * @throws \InvalidArgumentException
      */
     public static function validateUsername($username)
@@ -42,6 +42,7 @@ class Validators
      * @param string $shortcut
      *
      * @return array
+     *
      * @throws \InvalidArgumentException
      */
     public static function validateEntityName($shortcut)
@@ -61,6 +62,7 @@ class Validators
      * @param string $class
      *
      * @return string
+     *
      * @throws \InvalidArgumentException
      */
     public static function validateClass($class)
@@ -80,6 +82,7 @@ class Validators
      * @param string $adminClassBasename
      *
      * @return string
+     *
      * @throws \InvalidArgumentException
      */
     public static function validateAdminClassBasename($adminClassBasename)
@@ -99,6 +102,7 @@ class Validators
      * @param string $controllerClassBasename
      *
      * @return string
+     *
      * @throws \InvalidArgumentException
      */
     public static function validateControllerClassBasename($controllerClassBasename)
@@ -134,6 +138,7 @@ class Validators
      * @param string $serviceId
      *
      * @return string
+     *
      * @throws \InvalidArgumentException
      */
     public static function validateServiceId($serviceId)

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -11,43 +11,42 @@
 
 namespace Sonata\AdminBundle\Controller;
 
+use Psr\Log\NullLogger;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\BaseFieldDescription;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Exception\ModelManagerException;
+use Sonata\AdminBundle\Util\AdminObjectAclData;
 use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sonata\AdminBundle\Exception\ModelManagerException;
-use Symfony\Component\HttpFoundation\Request;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-use Sonata\AdminBundle\Admin\BaseFieldDescription;
-use Sonata\AdminBundle\Util\AdminObjectAclData;
-use Sonata\AdminBundle\Admin\AdminInterface;
-use Psr\Log\NullLogger;
 
 /**
- * Class CRUDController
+ * Class CRUDController.
  *
- * @package Sonata\AdminBundle\Controller
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class CRUDController extends Controller
 {
     /**
-     * The related Admin class
+     * The related Admin class.
      *
      * @var AdminInterface
      */
     protected $admin;
 
     /**
-     * Render JSON
+     * Render JSON.
      *
      * @param mixed   $data
-     * @param integer $status
+     * @param int     $status
      * @param array   $headers
      * @param Request $request
      *
@@ -104,7 +103,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Contextualize the admin class depends on the current request
+     * Contextualize the admin class depends on the current request.
      *
      * @throws \RuntimeException
      */
@@ -161,7 +160,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Returns the base template name
+     * Returns the base template name.
      *
      * @param Request $request
      *
@@ -219,7 +218,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * List action
+     * List action.
      *
      * @param Request $request
      *
@@ -259,7 +258,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Execute a batch delete
+     * Execute a batch delete.
      *
      * @param ProxyQueryInterface $query
      *
@@ -289,7 +288,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Delete action
+     * Delete action.
      *
      * @param int|string|null $id
      * @param Request         $request
@@ -367,7 +366,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Edit action
+     * Edit action.
      *
      * @param int|string|null $id
      * @param Request         $request
@@ -471,7 +470,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Redirect the user depend on this choice
+     * Redirect the user depend on this choice.
      *
      * @param object  $object
      * @param Request $request
@@ -511,7 +510,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Batch action
+     * Batch action.
      *
      * @param Request $request
      *
@@ -593,12 +592,12 @@ class CRUDController extends Controller
             $formView = $datagrid->getForm()->createView();
 
             return $this->render($this->admin->getTemplate('batch_confirmation'), array(
-                'action'     => 'list',
+                'action'       => 'list',
                 'action_label' => $actionLabel,
-                'datagrid'   => $datagrid,
-                'form'       => $formView,
-                'data'       => $data,
-                'csrf_token' => $this->getCsrfToken('sonata.batch'),
+                'datagrid'     => $datagrid,
+                'form'         => $formView,
+                'data'         => $data,
+                'csrf_token'   => $this->getCsrfToken('sonata.batch'),
             ), null, $request);
         }
 
@@ -625,7 +624,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Create action
+     * Create action.
      *
      * @param Request $request
      *
@@ -741,7 +740,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Returns true if the preview is requested to be shown
+     * Returns true if the preview is requested to be shown.
      *
      * @param Request $request
      *
@@ -755,7 +754,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Returns true if the preview has been approved
+     * Returns true if the preview has been approved.
      *
      * @param Request $request
      *
@@ -769,7 +768,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Returns true if the request is in the preview workflow
+     * Returns true if the request is in the preview workflow.
      *
      * That means either a preview is requested or the preview has already been shown
      * and it got approved/declined.
@@ -789,7 +788,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Returns true if the preview has been declined
+     * Returns true if the preview has been declined.
      *
      * @param Request $request
      *
@@ -803,7 +802,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Show action
+     * Show action.
      *
      * @param int|string|null $id
      * @param Request         $request
@@ -843,7 +842,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Show history revisions for object
+     * Show history revisions for object.
      *
      * @param int|string|null $id
      * @param Request         $request
@@ -892,7 +891,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * View history revision of object
+     * View history revision of object.
      *
      * @param int|string|null $id
      * @param string|null     $revision
@@ -955,7 +954,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Compare history revisions of object
+     * Compare history revisions of object.
      *
      * @param int|string|null $id
      * @param int|string|null $base_revision
@@ -1033,7 +1032,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Export data to specified format
+     * Export data to specified format.
      *
      * @param Request $request
      *
@@ -1080,7 +1079,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Gets ACL users
+     * Gets ACL users.
      *
      * @return \Traversable
      */
@@ -1101,7 +1100,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Gets ACL roles
+     * Gets ACL roles.
      *
      * @return \Traversable
      */
@@ -1136,7 +1135,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Returns the Response object associated to the acl action
+     * Returns the Response object associated to the acl action.
      *
      * @param int|string|null $id
      * @param Request         $request
@@ -1234,7 +1233,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Validate CSRF token for action without form
+     * Validate CSRF token for action without form.
      *
      * @param string  $intention
      * @param Request $request
@@ -1258,7 +1257,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Escape string for html output
+     * Escape string for html output.
      *
      * @param string $s
      *
@@ -1270,7 +1269,7 @@ class CRUDController extends Controller
     }
 
     /**
-     * Get CSRF token
+     * Get CSRF token.
      *
      * @param string $intention
      *

--- a/Controller/CoreController.php
+++ b/Controller/CoreController.php
@@ -19,9 +19,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Class CoreController
+ * Class CoreController.
  *
- * @package Sonata\AdminBundle\Controller
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class CoreController extends Controller
@@ -73,7 +72,7 @@ class CoreController extends Controller
             'left'   => array(),
             'center' => array(),
             'right'  => array(),
-            'bottom' => array()
+            'bottom' => array(),
         );
 
         foreach ($this->container->getParameter('sonata.admin.configuration.dashboard_blocks') as $block) {
@@ -83,7 +82,7 @@ class CoreController extends Controller
         return $this->render($this->getAdminPool()->getTemplate('dashboard'), array(
             'base_template'   => $this->getBaseTemplate($request),
             'admin_pool'      => $this->container->get('sonata.admin.pool'),
-            'blocks'          => $blocks
+            'blocks'          => $blocks,
         ));
     }
 
@@ -100,7 +99,6 @@ class CoreController extends Controller
     public function searchAction(Request $request)
     {
         if ($request->get('admin') && $request->isXmlHttpRequest()) {
-
             try {
                 $admin = $this->getAdminPool()->getAdminByAdminCode($request->get('admin'));
             } catch (ServiceNotFoundException $e) {
@@ -120,7 +118,7 @@ class CoreController extends Controller
                     $results[] = array(
                         'label' => $admin->toString($result),
                         'link'  => $admin->generateObjectUrl('edit', $result),
-                        'id'    => $admin->id($result)
+                        'id'    => $admin->id($result),
                     );
                 }
             }
@@ -128,7 +126,7 @@ class CoreController extends Controller
             $response = new JsonResponse(array(
                 'results' => $results,
                 'page'    => $pager ? (int) $pager->getPage() : false,
-                'total'   => $pager ? (int) $pager->getNbResults() : false
+                'total'   => $pager ? (int) $pager->getNbResults() : false,
             ));
             $response->setPrivate();
 
@@ -139,7 +137,7 @@ class CoreController extends Controller
             'base_template' => $this->getBaseTemplate($request),
             'admin_pool'    => $this->container->get('sonata.admin.pool'),
             'query'         => $request->get('q'),
-            'groups'        => $this->getAdminPool()->getDashboardGroups()
+            'groups'        => $this->getAdminPool()->getDashboardGroups(),
         ));
     }
 }

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -11,23 +11,22 @@
 
 namespace Sonata\AdminBundle\Controller;
 
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\PropertyAccess\PropertyAccess;
-use Symfony\Component\PropertyAccess\PropertyPath;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Validator\ValidatorInterface;
-use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Filter\FilterInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Validator\ValidatorInterface;
 
 /**
- * Class HelperController
+ * Class HelperController.
  *
- * @package Sonata\AdminBundle\Controller
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class HelperController
@@ -100,7 +99,7 @@ class HelperController
 
         list(, $form) = $this->helper->appendFormFieldElement($admin, $subject, $elementId);
 
-        /** @var $form \Symfony\Component\Form\Form */
+        /* @var $form \Symfony\Component\Form\Form */
         $view = $this->helper->getChildFormView($form->createView(), $elementId);
 
         // render the widget
@@ -200,14 +199,14 @@ class HelperController
         if ('json' == $request->get('_format')) {
             return new JsonResponse(array('result' => array(
                 'id'    => $admin->id($object),
-                'label' => $admin->toString($object)
+                'label' => $admin->toString($object),
             )));
         } elseif ('html' == $request->get('_format')) {
             return new Response($this->twig->render($admin->getTemplate('short_object_description'), array(
                 'admin'           => $admin,
                 'description'     => $admin->toString($object),
                 'object'          => $object,
-                'link_parameters' => $linkParameters
+                'link_parameters' => $linkParameters,
             )));
         } else {
             throw new \RuntimeException('Invalid format');
@@ -303,7 +302,7 @@ class HelperController
     }
 
     /**
-     * Retrieve list of items for autocomplete form field
+     * Retrieve list of items for autocomplete form field.
      *
      * @param Request $request
      *
@@ -426,7 +425,7 @@ class HelperController
         return new JsonResponse(array(
             'status' => 'OK',
             'more'   => !$pager->isLastPage(),
-            'items'  => $items
+            'items'  => $items,
         ));
     }
 

--- a/Datagrid/Datagrid.php
+++ b/Datagrid/Datagrid.php
@@ -11,24 +11,23 @@
 
 namespace Sonata\AdminBundle\Datagrid;
 
-use Sonata\AdminBundle\Filter\FilterInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
-use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Class Datagrid
+ * Class Datagrid.
  *
- * @package Sonata\AdminBundle\Datagrid
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class Datagrid implements DatagridInterface
 {
     /**
+     * The filter instances.
      *
-     * The filter instances
      * @var array
      */
     protected $filters = array();

--- a/Datagrid/DatagridInterface.php
+++ b/Datagrid/DatagridInterface.php
@@ -15,9 +15,8 @@ namespace Sonata\AdminBundle\Datagrid;
 use Sonata\AdminBundle\Filter\FilterInterface;
 
 /**
- * Interface DatagridInterface
+ * Interface DatagridInterface.
  *
- * @package Sonata\AdminBundle\Datagrid
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface DatagridInterface
@@ -38,7 +37,6 @@ interface DatagridInterface
     public function getResults();
 
     /**
-     * @return void
      */
     public function buildPager();
 
@@ -55,7 +53,7 @@ interface DatagridInterface
     public function getFilters();
 
     /**
-     * Reorder filters
+     * Reorder filters.
      *
      * @param array $keys
      */
@@ -103,12 +101,12 @@ interface DatagridInterface
     public function removeFilter($name);
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function hasActiveFilters();
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function hasDisplayableFilters();
 }

--- a/Datagrid/DatagridMapper.php
+++ b/Datagrid/DatagridMapper.php
@@ -19,9 +19,8 @@ use Sonata\AdminBundle\Mapper\BaseMapper;
 
 /**
  * Class DatagridMapper
- * This class is use to simulate the Form API
+ * This class is use to simulate the Form API.
  *
- * @package Sonata\AdminBundle\Datagrid
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class DatagridMapper extends BaseMapper
@@ -70,7 +69,7 @@ class DatagridMapper extends BaseMapper
             }
 
             if (!isset($filterOptions['field_name'])) {
-                 $filterOptions['field_name'] = substr(strrchr('.'.$name, '.'), 1);
+                $filterOptions['field_name'] = substr(strrchr('.'.$name, '.'), 1);
             }
 
             $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
@@ -101,7 +100,7 @@ class DatagridMapper extends BaseMapper
     /**
      * @param string $key
      *
-     * @return boolean
+     * @return bool
      */
     public function has($key)
     {

--- a/Datagrid/ListMapper.php
+++ b/Datagrid/ListMapper.php
@@ -13,16 +13,15 @@
 namespace Sonata\AdminBundle\Datagrid;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
 use Sonata\AdminBundle\Mapper\BaseMapper;
 
 /**
  * Class ListMapper
- * This class is used to simulate the Form API
+ * This class is used to simulate the Form API.
  *
- * @package Sonata\AdminBundle\Datagrid
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ListMapper extends BaseMapper

--- a/Datagrid/Pager.php
+++ b/Datagrid/Pager.php
@@ -11,9 +11,8 @@
 namespace Sonata\AdminBundle\Datagrid;
 
 /**
- * Class Pager
+ * Class Pager.
  *
- * @package Sonata\AdminBundle\Datagrid
  * @author  Fabien Potencier <fabien.potencier@symfony-project.com>
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
@@ -41,7 +40,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Constructor.
      *
-     * @param integer $maxPerPage Number of records to display per page
+     * @param int $maxPerPage Number of records to display per page
      */
     public function __construct($maxPerPage = 10)
     {
@@ -51,7 +50,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns the current pager's max link.
      *
-     * @return integer
+     * @return int
      */
     public function getCurrentMaxLink()
     {
@@ -61,7 +60,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns the current pager's max record limit.
      *
-     * @return integer
+     * @return int
      */
     public function getMaxRecordLimit()
     {
@@ -71,7 +70,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Sets the current pager's max record limit.
      *
-     * @param integer $limit
+     * @param int $limit
      */
     public function setMaxRecordLimit($limit)
     {
@@ -81,7 +80,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns an array of page numbers to use in pagination links.
      *
-     * @param integer $nbLinks The maximum number of page numbers to return
+     * @param int $nbLinks The maximum number of page numbers to return
      *
      * @return array
      */
@@ -109,7 +108,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns true if the current query requires pagination.
      *
-     * @return boolean
+     * @return bool
      */
     public function haveToPaginate()
     {
@@ -119,7 +118,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns the current cursor.
      *
-     * @return integer
+     * @return int
      */
     public function getCursor()
     {
@@ -129,7 +128,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Sets the current cursor.
      *
-     * @param integer $pos
+     * @param int $pos
      */
     public function setCursor($pos)
     {
@@ -147,7 +146,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns an object by cursor position.
      *
-     * @param integer $pos
+     * @param int $pos
      *
      * @return mixed
      */
@@ -176,7 +175,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function getNext()
     {
         if ($this->cursor + 1 > $this->nbResults) {
-            return null;
+            return;
         } else {
             return $this->retrieveObject($this->cursor + 1);
         }
@@ -190,7 +189,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function getPrevious()
     {
         if ($this->cursor - 1 < 1) {
-            return null;
+            return;
         } else {
             return $this->retrieveObject($this->cursor - 1);
         }
@@ -199,7 +198,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns the first index on the current page.
      *
-     * @return integer
+     * @return int
      */
     public function getFirstIndice()
     {
@@ -213,7 +212,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns the last index on the current page.
      *
-     * @return integer
+     * @return int
      */
     public function getLastIndice()
     {
@@ -231,7 +230,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns the number of results.
      *
-     * @return integer
+     * @return int
      */
     public function getNbResults()
     {
@@ -241,7 +240,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Sets the number of results.
      *
-     * @param integer $nb
+     * @param int $nb
      */
     protected function setNbResults($nb)
     {
@@ -251,7 +250,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns the first page number.
      *
-     * @return integer
+     * @return int
      */
     public function getFirstPage()
     {
@@ -261,7 +260,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns the last page number.
      *
-     * @return integer
+     * @return int
      */
     public function getLastPage()
     {
@@ -271,7 +270,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Sets the last page number.
      *
-     * @param integer $page
+     * @param int $page
      */
     protected function setLastPage($page)
     {
@@ -285,7 +284,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns the current page.
      *
-     * @return integer
+     * @return int
      */
     public function getPage()
     {
@@ -295,7 +294,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns the next page.
      *
-     * @return integer
+     * @return int
      */
     public function getNextPage()
     {
@@ -305,7 +304,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns the previous page.
      *
-     * @return integer
+     * @return int
      */
     public function getPreviousPage()
     {
@@ -375,7 +374,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns true if on the first page.
      *
-     * @return boolean
+     * @return bool
      */
     public function isFirstPage()
     {
@@ -385,7 +384,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns true if on the last page.
      *
-     * @return boolean
+     * @return bool
      */
     public function isLastPage()
     {
@@ -420,7 +419,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      *
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function hasParameter($name)
     {
@@ -441,7 +440,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * Returns true if the properties used for iteration have been initialized.
      *
-     * @return boolean
+     * @return bool
      */
     protected function isIteratorInitialized()
     {
@@ -580,9 +579,9 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
-     * Retrieve the object for a certain offset
+     * Retrieve the object for a certain offset.
      *
-     * @param integer $offset
+     * @param int $offset
      *
      * @return object
      */

--- a/Datagrid/PagerInterface.php
+++ b/Datagrid/PagerInterface.php
@@ -13,43 +13,40 @@
 namespace Sonata\AdminBundle\Datagrid;
 
 /**
- * Interface PagerInterface
+ * Interface PagerInterface.
  *
- * @package Sonata\AdminBundle\Datagrid
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface PagerInterface
 {
     /**
      * Initialize the Pager.
-     *
-     * @return void
      */
     public function init();
 
     /**
      * Returns the maximum number of results per page.
      *
-     * @return integer
+     * @return int
      */
     public function getMaxPerPage();
 
     /**
      * Sets the maximum number of results per page.
      *
-     * @param integer $max
+     * @param int $max
      */
     public function setMaxPerPage($max);
 
     /**
      * Sets the current page.
      *
-     * @param integer $page
+     * @param int $page
      */
     public function setPage($page);
 
     /**
-     * Set query
+     * Set query.
      *
      * @param mixed $query
      */

--- a/Datagrid/ProxyQueryInterface.php
+++ b/Datagrid/ProxyQueryInterface.php
@@ -13,9 +13,8 @@ namespace Sonata\AdminBundle\Datagrid;
 
 /**
  * Interface ProxyQueryInterface
- * Used by the Datagrid to build the query
+ * Used by the Datagrid to build the query.
  *
- * @package Sonata\AdminBundle\Datagrid
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface ProxyQueryInterface

--- a/Datagrid/SimplePager.php
+++ b/Datagrid/SimplePager.php
@@ -14,16 +14,15 @@ namespace Sonata\AdminBundle\Datagrid;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * Class SimplePager
+ * Class SimplePager.
  *
- * @package Sonata\AdminBundle\Datagrid
  * @author  Lukas Kahwe Smith <smith@pooteeweet.org>
  * @author  Sjoerd Peters <sjoerd.peters@gmail.com>
  */
 class SimplePager extends Pager
 {
     /**
-     * @var  boolean
+     * @var bool
      */
     protected $haveToPaginate;
 
@@ -48,8 +47,8 @@ class SimplePager extends Pager
      * If set to 3 the pager will generate links to the next three pages
      * etc.
      *
-     * @param integer $maxPerPage Number of records to display per page
-     * @param int     $threshold
+     * @param int $maxPerPage Number of records to display per page
+     * @param int $threshold
      */
     public function __construct($maxPerPage = 10, $threshold = 1)
     {
@@ -63,11 +62,11 @@ class SimplePager extends Pager
      *
      * In all other cases an estimate of the total count is returned.
      *
-     * @return integer
+     * @return int
      */
     public function getNbResults()
     {
-        $n = ceil(($this->getLastPage() -1) * $this->getMaxPerPage());
+        $n = ceil(($this->getLastPage() - 1) * $this->getMaxPerPage());
         if ($this->getLastPage() == $this->getPage()) {
             return $n + $this->thresholdCount;
         }
@@ -76,7 +75,7 @@ class SimplePager extends Pager
     }
 
     /**
-     * Get all the results for the pager instance
+     * Get all the results for the pager instance.
      *
      * @param mixed $hydrationMode A hydration mode identifier
      *
@@ -98,7 +97,6 @@ class SimplePager extends Pager
             } else {
                 $this->results = new ArrayCollection(array_slice($this->results, 0, $this->getMaxPerPage()));
             }
-
         } else {
             $this->haveToPaginate = false;
         }

--- a/DependencyInjection/AbstractSonataAdminExtension.php
+++ b/DependencyInjection/AbstractSonataAdminExtension.php
@@ -15,15 +15,14 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * Class AbstractSonataAdminExtension
+ * Class AbstractSonataAdminExtension.
  *
- * @package Sonata\AdminBundle\DependencyInjection
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 abstract class AbstractSonataAdminExtension extends Extension
 {
     /**
-     * Fix template configuration
+     * Fix template configuration.
      *
      * @param array            $configs
      * @param ContainerBuilder $container
@@ -59,26 +58,26 @@ abstract class AbstractSonataAdminExtension extends Extension
                         'html'         => 'SonataAdminBundle:CRUD:list_html.html.twig',
                     ),
                     'show' => array(
-                        'array'        => 'SonataAdminBundle:CRUD:show_array.html.twig',
-                        'boolean'      => 'SonataAdminBundle:CRUD:show_boolean.html.twig',
-                        'date'         => 'SonataAdminBundle:CRUD:show_date.html.twig',
-                        'time'         => 'SonataAdminBundle:CRUD:show_time.html.twig',
-                        'datetime'     => 'SonataAdminBundle:CRUD:show_datetime.html.twig',
-                        'text'         => 'SonataAdminBundle:CRUD:base_show_field.html.twig',
-                        'trans'        => 'SonataAdminBundle:CRUD:show_trans.html.twig',
-                        'string'       => 'SonataAdminBundle:CRUD:base_show_field.html.twig',
-                        'smallint'     => 'SonataAdminBundle:CRUD:base_show_field.html.twig',
-                        'bigint'       => 'SonataAdminBundle:CRUD:base_show_field.html.twig',
-                        'integer'      => 'SonataAdminBundle:CRUD:base_show_field.html.twig',
-                        'decimal'      => 'SonataAdminBundle:CRUD:base_show_field.html.twig',
-                        'currency'     => 'SonataAdminBundle:CRUD:show_currency.html.twig',
-                        'percent'      => 'SonataAdminBundle:CRUD:show_percent.html.twig',
-                        'choice'       => 'SonataAdminBundle:CRUD:show_choice.html.twig',
-                        'url'          => 'SonataAdminBundle:CRUD:show_url.html.twig',
+                        'array'         => 'SonataAdminBundle:CRUD:show_array.html.twig',
+                        'boolean'       => 'SonataAdminBundle:CRUD:show_boolean.html.twig',
+                        'date'          => 'SonataAdminBundle:CRUD:show_date.html.twig',
+                        'time'          => 'SonataAdminBundle:CRUD:show_time.html.twig',
+                        'datetime'      => 'SonataAdminBundle:CRUD:show_datetime.html.twig',
+                        'text'          => 'SonataAdminBundle:CRUD:base_show_field.html.twig',
+                        'trans'         => 'SonataAdminBundle:CRUD:show_trans.html.twig',
+                        'string'        => 'SonataAdminBundle:CRUD:base_show_field.html.twig',
+                        'smallint'      => 'SonataAdminBundle:CRUD:base_show_field.html.twig',
+                        'bigint'        => 'SonataAdminBundle:CRUD:base_show_field.html.twig',
+                        'integer'       => 'SonataAdminBundle:CRUD:base_show_field.html.twig',
+                        'decimal'       => 'SonataAdminBundle:CRUD:base_show_field.html.twig',
+                        'currency'      => 'SonataAdminBundle:CRUD:show_currency.html.twig',
+                        'percent'       => 'SonataAdminBundle:CRUD:show_percent.html.twig',
+                        'choice'        => 'SonataAdminBundle:CRUD:show_choice.html.twig',
+                        'url'           => 'SonataAdminBundle:CRUD:show_url.html.twig',
                         'html'          => 'SonataAdminBundle:CRUD:show_html.html.twig',
-                    )
-                )
-            )
+                    ),
+                ),
+            ),
         );
 
         // let's add some magic, only overwrite template if the SonataIntlBundle is enabled

--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -11,19 +11,18 @@
 
 namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Datagrid\Pager;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Add all dependencies to the Admin class, this avoid to write too many lines
  * in the configuration files.
  *
- * @package Sonata\AdminBundle\DependencyInjection\Compiler
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AddDependencyCallsCompilerPass implements CompilerPassInterface
@@ -88,8 +87,8 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     $groupDefaults[$resolvedGroupName] = array(
                         'label'           => $resolvedGroupName,
                         'label_catalogue' => $labelCatalogue,
-                        'icon' => $icon,
-                        'roles' => array()
+                        'icon'            => $icon,
+                        'roles'           => array(),
                     );
                 }
 
@@ -97,7 +96,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     'admin'        => $id,
                     'label'        => '',
                     'route'        => '',
-                    'route_params' => array()
+                    'route_params' => array(),
                 );
             }
         }
@@ -112,7 +111,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     $groupDefaults[$resolvedGroupName] = array(
                         'items' => array(),
                         'label' => $resolvedGroupName,
-                        'roles' => array()
+                        'roles' => array(),
                     );
                 }
 
@@ -153,7 +152,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
     }
 
     /**
-     * This method read the attribute keys and configure admin class to use the related dependency
+     * This method read the attribute keys and configure admin class to use the related dependency.
      *
      * @param Definition $definition
      * @param array      $attributes
@@ -177,7 +176,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         );
 
         foreach ($keys as $key) {
-            $method = 'set' . BaseFieldDescription::camelize($key);
+            $method = 'set'.BaseFieldDescription::camelize($key);
             if (!isset($attributes[$key]) || $definition->hasMethodCall($method)) {
                 continue;
             }
@@ -187,7 +186,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
     }
 
     /**
-     * Apply the default values required by the AdminInterface to the Admin service definition
+     * Apply the default values required by the AdminInterface to the Admin service definition.
      *
      * @param ContainerBuilder $container
      * @param string           $serviceId
@@ -218,15 +217,15 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             'validator'                 => 'validator',
             'security_handler'          => 'sonata.admin.security.handler',
             'menu_factory'              => 'knp_menu.factory',
-            'route_builder'             => 'sonata.admin.route.path_info' .
+            'route_builder'             => 'sonata.admin.route.path_info'.
                 (($manager_type == 'doctrine_phpcr') ? '_slashes' : ''),
-            'label_translator_strategy' => 'sonata.admin.label.strategy.native'
+            'label_translator_strategy' => 'sonata.admin.label.strategy.native',
         );
 
         $definition->addMethodCall('setManagerType', array($manager_type));
 
         foreach ($defaultAddServices as $attr => $addServiceId) {
-            $method = 'set' . BaseFieldDescription::camelize($attr);
+            $method = 'set'.BaseFieldDescription::camelize($attr);
 
             if (isset($overwriteAdminConfiguration[$attr]) || !$definition->hasMethodCall($method)) {
                 $definition->addMethodCall($method, array(new Reference(isset($overwriteAdminConfiguration[$attr]) ? $overwriteAdminConfiguration[$attr] : $addServiceId)));
@@ -276,8 +275,6 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
      * @param ContainerBuilder $container
      * @param Definition       $definition
      * @param array            $overwrittenTemplates
-     *
-     * @return void
      */
     public function fixTemplates(ContainerBuilder $container, Definition $definition, array $overwrittenTemplates = array())
     {
@@ -304,12 +301,11 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     || $definedTemplates['pager_results'] === 'SonataAdminBundle:Pager:results.html.twig'
                 )
             ) {
-
                 $definedTemplates['pager_results'] = 'SonataAdminBundle:Pager:simple_pager_results.html.twig';
             }
 
             $methods[$pos] = $method;
-            $pos++;
+            ++$pos;
         }
 
         $definition->setMethodCalls($methods);

--- a/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
+++ b/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
@@ -11,14 +11,13 @@
 
 namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class AddFilterTypeCompilerPass
+ * Class AddFilterTypeCompilerPass.
  *
- * @package Sonata\AdminBundle\DependencyInjection\Compiler
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AddFilterTypeCompilerPass implements CompilerPassInterface

--- a/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -11,15 +11,14 @@
 
 namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Class ExtensionCompilerPass
+ * Class ExtensionCompilerPass.
  *
- * @package Sonata\AdminBundle\DependencyInjection\Compiler
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ExtensionCompilerPass implements CompilerPassInterface
@@ -93,7 +92,6 @@ class ExtensionCompilerPass implements CompilerPassInterface
 
         foreach ($extensionMap as $type => $subjects) {
             foreach ($subjects as $subject => $extensionList) {
-
                 if ('admins' == $type) {
                     if ($id == $subject) {
                         $extensions = array_merge($extensions, $extensionList);
@@ -141,7 +139,7 @@ class ExtensionCompilerPass implements CompilerPassInterface
     }
 
     /**
-     * Resolves the class argument of the admin to an actual class (in case of %parameter%)
+     * Resolves the class argument of the admin to an actual class (in case of %parameter%).
      *
      * @param Definition       $admin
      * @param ContainerBuilder $container

--- a/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
+++ b/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sonata package.
  *
@@ -15,9 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Class GlobalVariablesCompilerPass
+ * Class GlobalVariablesCompilerPass.
  *
- * @package Sonata\AdminBundle\DependencyInjection\Compiler
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class GlobalVariablesCompilerPass implements CompilerPassInterface

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,12 +15,11 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This class contains the configuration information for the bundle
+ * This class contains the configuration information for the bundle.
  *
  * This information is solely responsible for how the different configuration
  * sections are normalized, and merged.
  *
- * @package Sonata\AdminBundle\DependencyInjection
  * @author  Michael Williams <mtotheikle@gmail.com>
  */
 class Configuration implements ConfigurationInterface
@@ -100,10 +99,10 @@ class Configuration implements ConfigurationInterface
                             ->prototype('array')
                                 ->beforeNormalization()
                                     ->ifArray()
-                                    ->then(function($items) {
+                                    ->then(function ($items) {
                                         if (isset($items['provider'])) {
                                             $disallowedItems = array('items', 'label');
-                                            foreach($disallowedItems as $item) {
+                                            foreach ($disallowedItems as $item) {
                                                 if (isset($items[$item])) {
                                                     throw new \InvalidArgumentException(sprintf('The config value "%s" cannot be used alongside "provider" config value', $item));
                                                 }
@@ -123,14 +122,14 @@ class Configuration implements ConfigurationInterface
                                     ->arrayNode('items')
                                         ->beforeNormalization()
                                             ->ifArray()
-                                            ->then(function($items) {
+                                            ->then(function ($items) {
                                                 foreach ($items as $key => $item) {
                                                     if (is_array($item)) {
                                                         if (!array_key_exists('label', $item) || !array_key_exists('route', $item)) {
                                                             throw new \InvalidArgumentException('Expected either parameters "route" and "label" for array items');
                                                         }
 
-                                                        if (!array_key_exists('route_params', $item)){
+                                                        if (!array_key_exists('route_params', $item)) {
                                                             $items[$key]['route_params'] = array();
                                                         }
 
@@ -140,7 +139,7 @@ class Configuration implements ConfigurationInterface
                                                             'admin'        => $item,
                                                             'label'        => '',
                                                             'route'        => '',
-                                                            'route_params' => array()
+                                                            'route_params' => array(),
                                                         );
                                                     }
                                                 }
@@ -173,7 +172,7 @@ class Configuration implements ConfigurationInterface
                                 'position' => 'left',
                                 'settings' => array(),
                                 'type'     => 'sonata.admin.block.admin_list',
-                                'roles'    => array()
+                                'roles'    => array(),
                             )))
                             ->prototype('array')
                                 ->fixXmlConfig('setting')

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -11,24 +11,22 @@
 
 namespace Sonata\AdminBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\Config\FileLocator;
-use Symfony\Component\Config\Definition\Processor;
 
 /**
- * Class SonataAdminExtension
+ * Class SonataAdminExtension.
  *
- * @package Sonata\AdminBundle\DependencyInjection
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  * @author  Michael Williams <michael.williams@funsational.com>
  */
 class SonataAdminExtension extends Extension
 {
     /**
-     *
      * @param array            $configs   An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      *
@@ -50,8 +48,8 @@ BOOM
             // integrate the SonataUserBundle / FOSUserBundle if the bundle exists
             array_unshift($configs, array(
                 'templates' => array(
-                    'user_block' => 'SonataUserBundle:Admin/Core:user_block.html.twig'
-                )
+                    'user_block' => 'SonataUserBundle:Admin/Core:user_block.html.twig',
+                ),
             ));
         }
 
@@ -59,8 +57,8 @@ BOOM
             // integrate the SonataUserBundle if the bundle exists
             array_unshift($configs, array(
                 'templates' => array(
-                    'history_revision_timestamp' => 'SonataIntlBundle:CRUD:history_revision_timestamp.html.twig'
-                )
+                    'history_revision_timestamp' => 'SonataIntlBundle:CRUD:history_revision_timestamp.html.twig',
+                ),
             ));
         }
 
@@ -162,7 +160,7 @@ BOOM
 
         $container->setParameter('sonata.admin.extension.map', $config['extensions']);
 
-        /**
+        /*
          * This is a work in progress, so for now it is hardcoded
          */
         $classes = array(
@@ -172,7 +170,7 @@ BOOM
             'choice'   => '',
             'integer'  => '',
             'datetime' => 'sonata-medium-date',
-            'date'     => 'sonata-medium-date'
+            'date'     => 'sonata-medium-date',
         );
 
         $container->getDefinition('sonata.admin.form.extension.field')
@@ -198,86 +196,86 @@ BOOM
     public function configureClassesToCompile()
     {
         $this->addClassesToCompile(array(
-            "Sonata\\AdminBundle\\Admin\\Admin",
-            "Sonata\\AdminBundle\\Admin\\AdminExtension",
-            "Sonata\\AdminBundle\\Admin\\AdminExtensionInterface",
-            "Sonata\\AdminBundle\\Admin\\AdminHelper",
-            "Sonata\\AdminBundle\\Admin\\AdminInterface",
-            "Sonata\\AdminBundle\\Admin\\BaseFieldDescription",
-            "Sonata\\AdminBundle\\Admin\\FieldDescriptionCollection",
-            "Sonata\\AdminBundle\\Admin\\FieldDescriptionInterface",
-            "Sonata\\AdminBundle\\Admin\\Pool",
-            "Sonata\\AdminBundle\\Block\\AdminListBlockService",
-            "Sonata\\AdminBundle\\Builder\\DatagridBuilderInterface",
-            "Sonata\\AdminBundle\\Builder\\FormContractorInterface",
-            "Sonata\\AdminBundle\\Builder\\ListBuilderInterface",
-            "Sonata\\AdminBundle\\Builder\\RouteBuilderInterface",
-            "Sonata\\AdminBundle\\Builder\\ShowBuilderInterface",
-            "Sonata\\AdminBundle\\Datagrid\\Datagrid",
-            "Sonata\\AdminBundle\\Datagrid\\DatagridInterface",
-            "Sonata\\AdminBundle\\Datagrid\\DatagridMapper",
-            "Sonata\\AdminBundle\\Datagrid\\ListMapper",
-            "Sonata\\AdminBundle\\Datagrid\\Pager",
-            "Sonata\\AdminBundle\\Datagrid\\PagerInterface",
-            "Sonata\\AdminBundle\\Datagrid\\ProxyQueryInterface",
-            "Sonata\\AdminBundle\\Exception\\ModelManagerException",
-            "Sonata\\AdminBundle\\Exception\\NoValueException",
-            "Sonata\\AdminBundle\\Export\\Exporter",
-            "Sonata\\AdminBundle\\Filter\\Filter",
-            "Sonata\\AdminBundle\\Filter\\FilterFactory",
-            "Sonata\\AdminBundle\\Filter\\FilterFactoryInterface",
-            "Sonata\\AdminBundle\\Filter\\FilterInterface",
-            "Sonata\\AdminBundle\\Form\\ChoiceList\\ModelChoiceList",
-            "Sonata\\AdminBundle\\Form\\DataTransformer\\ArrayToModelTransformer",
-            "Sonata\\AdminBundle\\Form\\DataTransformer\\ModelsToArrayTransformer",
-            "Sonata\\AdminBundle\\Form\\DataTransformer\\ModelToIdTransformer",
-            "Sonata\\AdminBundle\\Form\\EventListener\\MergeCollectionListener",
-            "Sonata\\AdminBundle\\Form\\Extension\\Field\\Type\\FormTypeFieldExtension",
-            "Sonata\\AdminBundle\\Form\\FormMapper",
-            "Sonata\\AdminBundle\\Form\\Type\\AdminType",
-            "Sonata\\AdminBundle\\Form\\Type\\Filter\\ChoiceType",
-            "Sonata\\AdminBundle\\Form\\Type\\Filter\\DateRangeType",
-            "Sonata\\AdminBundle\\Form\\Type\\Filter\\DateTimeRangeType",
-            "Sonata\\AdminBundle\\Form\\Type\\Filter\\DateTimeType",
-            "Sonata\\AdminBundle\\Form\\Type\\Filter\\DateType",
-            "Sonata\\AdminBundle\\Form\\Type\\Filter\\DefaultType",
-            "Sonata\\AdminBundle\\Form\\Type\\Filter\\NumberType",
-            "Sonata\\AdminBundle\\Form\\Type\\ModelReferenceType",
-            "Sonata\\AdminBundle\\Form\\Type\\ModelType",
-            "Sonata\\AdminBundle\\Form\\Type\\ModelTypeList",
-            "Sonata\\AdminBundle\\Guesser\\TypeGuesserChain",
-            "Sonata\\AdminBundle\\Guesser\\TypeGuesserInterface",
-            "Sonata\\AdminBundle\\Model\\AuditManager",
-            "Sonata\\AdminBundle\\Model\\AuditManagerInterface",
-            "Sonata\\AdminBundle\\Model\\AuditReaderInterface",
-            "Sonata\\AdminBundle\\Model\\ModelManagerInterface",
-            "Sonata\\AdminBundle\\Route\\AdminPoolLoader",
-            "Sonata\\AdminBundle\\Route\\DefaultRouteGenerator",
-            "Sonata\\AdminBundle\\Route\\PathInfoBuilder",
-            "Sonata\\AdminBundle\\Route\\QueryStringBuilder",
-            "Sonata\\AdminBundle\\Route\\RouteCollection",
-            "Sonata\\AdminBundle\\Route\\RouteGeneratorInterface",
-            "Sonata\\AdminBundle\\Security\\Acl\\Permission\\AdminPermissionMap",
-            "Sonata\\AdminBundle\\Security\\Acl\\Permission\\MaskBuilder",
-            "Sonata\\AdminBundle\\Security\\Handler\\AclSecurityHandler",
-            "Sonata\\AdminBundle\\Security\\Handler\\AclSecurityHandlerInterface",
-            "Sonata\\AdminBundle\\Security\\Handler\\NoopSecurityHandler",
-            "Sonata\\AdminBundle\\Security\\Handler\\RoleSecurityHandler",
-            "Sonata\\AdminBundle\\Security\\Handler\\SecurityHandlerInterface",
-            "Sonata\\AdminBundle\\Show\\ShowMapper",
-            "Sonata\\AdminBundle\\Translator\\BCLabelTranslatorStrategy",
-            "Sonata\\AdminBundle\\Translator\\FormLabelTranslatorStrategy",
-            "Sonata\\AdminBundle\\Translator\\LabelTranslatorStrategyInterface",
-            "Sonata\\AdminBundle\\Translator\\NativeLabelTranslatorStrategy",
-            "Sonata\\AdminBundle\\Translator\\NoopLabelTranslatorStrategy",
-            "Sonata\\AdminBundle\\Translator\\UnderscoreLabelTranslatorStrategy",
-            "Sonata\\AdminBundle\\Twig\\Extension\\SonataAdminExtension",
-            "Sonata\\AdminBundle\\Util\\AdminAclManipulator",
-            "Sonata\\AdminBundle\\Util\\AdminAclManipulatorInterface",
-            "Sonata\\AdminBundle\\Util\\FormBuilderIterator",
-            "Sonata\\AdminBundle\\Util\\FormViewIterator",
-            "Sonata\\AdminBundle\\Util\\ObjectAclManipulator",
-            "Sonata\\AdminBundle\\Util\\ObjectAclManipulatorInterface",
+            'Sonata\\AdminBundle\\Admin\\Admin',
+            'Sonata\\AdminBundle\\Admin\\AdminExtension',
+            'Sonata\\AdminBundle\\Admin\\AdminExtensionInterface',
+            'Sonata\\AdminBundle\\Admin\\AdminHelper',
+            'Sonata\\AdminBundle\\Admin\\AdminInterface',
+            'Sonata\\AdminBundle\\Admin\\BaseFieldDescription',
+            'Sonata\\AdminBundle\\Admin\\FieldDescriptionCollection',
+            'Sonata\\AdminBundle\\Admin\\FieldDescriptionInterface',
+            'Sonata\\AdminBundle\\Admin\\Pool',
+            'Sonata\\AdminBundle\\Block\\AdminListBlockService',
+            'Sonata\\AdminBundle\\Builder\\DatagridBuilderInterface',
+            'Sonata\\AdminBundle\\Builder\\FormContractorInterface',
+            'Sonata\\AdminBundle\\Builder\\ListBuilderInterface',
+            'Sonata\\AdminBundle\\Builder\\RouteBuilderInterface',
+            'Sonata\\AdminBundle\\Builder\\ShowBuilderInterface',
+            'Sonata\\AdminBundle\\Datagrid\\Datagrid',
+            'Sonata\\AdminBundle\\Datagrid\\DatagridInterface',
+            'Sonata\\AdminBundle\\Datagrid\\DatagridMapper',
+            'Sonata\\AdminBundle\\Datagrid\\ListMapper',
+            'Sonata\\AdminBundle\\Datagrid\\Pager',
+            'Sonata\\AdminBundle\\Datagrid\\PagerInterface',
+            'Sonata\\AdminBundle\\Datagrid\\ProxyQueryInterface',
+            'Sonata\\AdminBundle\\Exception\\ModelManagerException',
+            'Sonata\\AdminBundle\\Exception\\NoValueException',
+            'Sonata\\AdminBundle\\Export\\Exporter',
+            'Sonata\\AdminBundle\\Filter\\Filter',
+            'Sonata\\AdminBundle\\Filter\\FilterFactory',
+            'Sonata\\AdminBundle\\Filter\\FilterFactoryInterface',
+            'Sonata\\AdminBundle\\Filter\\FilterInterface',
+            'Sonata\\AdminBundle\\Form\\ChoiceList\\ModelChoiceList',
+            'Sonata\\AdminBundle\\Form\\DataTransformer\\ArrayToModelTransformer',
+            'Sonata\\AdminBundle\\Form\\DataTransformer\\ModelsToArrayTransformer',
+            'Sonata\\AdminBundle\\Form\\DataTransformer\\ModelToIdTransformer',
+            'Sonata\\AdminBundle\\Form\\EventListener\\MergeCollectionListener',
+            'Sonata\\AdminBundle\\Form\\Extension\\Field\\Type\\FormTypeFieldExtension',
+            'Sonata\\AdminBundle\\Form\\FormMapper',
+            'Sonata\\AdminBundle\\Form\\Type\\AdminType',
+            'Sonata\\AdminBundle\\Form\\Type\\Filter\\ChoiceType',
+            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DateRangeType',
+            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DateTimeRangeType',
+            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DateTimeType',
+            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DateType',
+            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DefaultType',
+            'Sonata\\AdminBundle\\Form\\Type\\Filter\\NumberType',
+            'Sonata\\AdminBundle\\Form\\Type\\ModelReferenceType',
+            'Sonata\\AdminBundle\\Form\\Type\\ModelType',
+            'Sonata\\AdminBundle\\Form\\Type\\ModelTypeList',
+            'Sonata\\AdminBundle\\Guesser\\TypeGuesserChain',
+            'Sonata\\AdminBundle\\Guesser\\TypeGuesserInterface',
+            'Sonata\\AdminBundle\\Model\\AuditManager',
+            'Sonata\\AdminBundle\\Model\\AuditManagerInterface',
+            'Sonata\\AdminBundle\\Model\\AuditReaderInterface',
+            'Sonata\\AdminBundle\\Model\\ModelManagerInterface',
+            'Sonata\\AdminBundle\\Route\\AdminPoolLoader',
+            'Sonata\\AdminBundle\\Route\\DefaultRouteGenerator',
+            'Sonata\\AdminBundle\\Route\\PathInfoBuilder',
+            'Sonata\\AdminBundle\\Route\\QueryStringBuilder',
+            'Sonata\\AdminBundle\\Route\\RouteCollection',
+            'Sonata\\AdminBundle\\Route\\RouteGeneratorInterface',
+            'Sonata\\AdminBundle\\Security\\Acl\\Permission\\AdminPermissionMap',
+            'Sonata\\AdminBundle\\Security\\Acl\\Permission\\MaskBuilder',
+            'Sonata\\AdminBundle\\Security\\Handler\\AclSecurityHandler',
+            'Sonata\\AdminBundle\\Security\\Handler\\AclSecurityHandlerInterface',
+            'Sonata\\AdminBundle\\Security\\Handler\\NoopSecurityHandler',
+            'Sonata\\AdminBundle\\Security\\Handler\\RoleSecurityHandler',
+            'Sonata\\AdminBundle\\Security\\Handler\\SecurityHandlerInterface',
+            'Sonata\\AdminBundle\\Show\\ShowMapper',
+            'Sonata\\AdminBundle\\Translator\\BCLabelTranslatorStrategy',
+            'Sonata\\AdminBundle\\Translator\\FormLabelTranslatorStrategy',
+            'Sonata\\AdminBundle\\Translator\\LabelTranslatorStrategyInterface',
+            'Sonata\\AdminBundle\\Translator\\NativeLabelTranslatorStrategy',
+            'Sonata\\AdminBundle\\Translator\\NoopLabelTranslatorStrategy',
+            'Sonata\\AdminBundle\\Translator\\UnderscoreLabelTranslatorStrategy',
+            'Sonata\\AdminBundle\\Twig\\Extension\\SonataAdminExtension',
+            'Sonata\\AdminBundle\\Util\\AdminAclManipulator',
+            'Sonata\\AdminBundle\\Util\\AdminAclManipulatorInterface',
+            'Sonata\\AdminBundle\\Util\\FormBuilderIterator',
+            'Sonata\\AdminBundle\\Util\\FormViewIterator',
+            'Sonata\\AdminBundle\\Util\\ObjectAclManipulator',
+            'Sonata\\AdminBundle\\Util\\ObjectAclManipulatorInterface',
         ));
     }
 

--- a/Event/AdminEventExtension.php
+++ b/Event/AdminEventExtension.php
@@ -12,18 +12,17 @@
 namespace Sonata\AdminBundle\Event;
 
 use Sonata\AdminBundle\Admin\AdminExtension;
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Datagrid\ListMapper;
-use Sonata\AdminBundle\Datagrid\DatagridMapper;
-use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Show\ShowMapper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
- * Class AdminEventExtension
+ * Class AdminEventExtension.
  *
- * @package Sonata\AdminBundle\Event
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AdminEventExtension extends AdminExtension

--- a/Event/ConfigureEvent.php
+++ b/Event/ConfigureEvent.php
@@ -20,13 +20,12 @@ use Symfony\Component\EventDispatcher\Event;
  *   - configureFormFields
  *   - configureListFields
  *   - configureDatagridFilters
- *   - configureShowFields
+ *   - configureShowFields.
  *
  * You can register the listener to the event dispatcher by using:
  *   - sonata.admin.event.configure.[form|list|datagrid|show]
  *   - sonata.admin.event.configure.[admin_code].[form|list|datagrid|show] (not implemented yet)
  *
- * @package Sonata\AdminBundle\Event
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ConfigureEvent extends Event

--- a/Event/ConfigureQueryEvent.php
+++ b/Event/ConfigureQueryEvent.php
@@ -17,13 +17,12 @@ use Symfony\Component\EventDispatcher\Event;
 
 /**
  * This event is sent by hook:
- *   - configureQuery
+ *   - configureQuery.
  *
  * You can register the listener to the event dispatcher by using:
  *   - sonata.admin.event.configure.query
  *   - sonata.admin.event.configure.[admin_code].query  (not implemented yet)
  *
- * @package Sonata\AdminBundle\Event
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ConfigureQueryEvent extends Event

--- a/Event/PersistenceEvent.php
+++ b/Event/PersistenceEvent.php
@@ -18,13 +18,12 @@ use Symfony\Component\EventDispatcher\Event;
  * This event is sent by hook:
  *   - preUpdate | postUpdate
  *   - prePersist | postPersist
- *   - preRemove | postRemove
+ *   - preRemove | postRemove.
  *
  * You can register the listener to the event dispatcher by using:
  *   - sonata.admin.event.persistence.[pre|post]_[persist|update|remove)
  *   - sonata.admin.event.persistence.[admin_code].[pre|post]_[persist|update|remove)  (not implemented yet)
  *
- * @package Sonata\AdminBundle\Event
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class PersistenceEvent extends Event

--- a/Exception/ModelManagerException.php
+++ b/Exception/ModelManagerException.php
@@ -12,12 +12,10 @@
 namespace Sonata\AdminBundle\Exception;
 
 /**
- * Class ModelManagerException
+ * Class ModelManagerException.
  *
- * @package Sonata\AdminBundle\Exception
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ModelManagerException extends \Exception
 {
-
 }

--- a/Exception/NoValueException.php
+++ b/Exception/NoValueException.php
@@ -12,12 +12,10 @@
 namespace Sonata\AdminBundle\Exception;
 
 /**
- * Class NoValueException
+ * Class NoValueException.
  *
- * @package Sonata\AdminBundle\Exception
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class NoValueException extends \Exception
 {
-
 }

--- a/Filter/Filter.php
+++ b/Filter/Filter.php
@@ -12,9 +12,8 @@
 namespace Sonata\AdminBundle\Filter;
 
 /**
- * Class Filter
+ * Class Filter.
  *
- * @package Sonata\AdminBundle\Filter
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 abstract class Filter implements FilterInterface
@@ -182,7 +181,7 @@ abstract class Filter implements FilterInterface
     }
 
     /**
-     * Set options
+     * Set options.
      *
      * @param array $options
      */
@@ -196,7 +195,7 @@ abstract class Filter implements FilterInterface
     }
 
     /**
-     * Get options
+     * Get options.
      *
      * @return array
      */
@@ -206,7 +205,7 @@ abstract class Filter implements FilterInterface
     }
 
     /**
-     * Set value
+     * Set value.
      *
      * @param mixed $value
      */
@@ -216,7 +215,7 @@ abstract class Filter implements FilterInterface
     }
 
     /**
-     * Get value
+     * Get value.
      *
      * @return mixed
      */
@@ -234,7 +233,7 @@ abstract class Filter implements FilterInterface
 
         return isset($values['value'])
             && false !== $values['value']
-            && "" !== $values['value'];
+            && '' !== $values['value'];
     }
 
     /**

--- a/Filter/FilterFactory.php
+++ b/Filter/FilterFactory.php
@@ -14,9 +14,8 @@ namespace Sonata\AdminBundle\Filter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class FilterFactory
+ * Class FilterFactory.
  *
- * @package Sonata\AdminBundle\Filter
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class FilterFactory implements FilterFactoryInterface

--- a/Filter/FilterFactoryInterface.php
+++ b/Filter/FilterFactoryInterface.php
@@ -12,9 +12,8 @@
 namespace Sonata\AdminBundle\Filter;
 
 /**
- * Interface FilterFactoryInterface
+ * Interface FilterFactoryInterface.
  *
- * @package Sonata\AdminBundle\Filter
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface FilterFactoryInterface

--- a/Filter/FilterInterface.php
+++ b/Filter/FilterInterface.php
@@ -14,9 +14,8 @@ namespace Sonata\AdminBundle\Filter;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 
 /**
- * Interface FilterInterface
+ * Interface FilterInterface.
  *
- * @package Sonata\AdminBundle\Filter
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface FilterInterface
@@ -26,14 +25,12 @@ interface FilterInterface
     const CONDITION_AND = 'AND';
 
     /**
-     * Apply the filter to the QueryBuilder instance
+     * Apply the filter to the QueryBuilder instance.
      *
      * @param ProxyQueryInterface $queryBuilder
      * @param string              $alias
      * @param string              $field
      * @param string              $value
-     *
-     * @return void
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value);
 
@@ -44,21 +41,21 @@ interface FilterInterface
     public function apply($query, $value);
 
     /**
-     * Returns the filter name
+     * Returns the filter name.
      *
      * @return string
      */
     public function getName();
 
     /**
-     * Returns the filter form name
+     * Returns the filter form name.
      *
      * @return string
      */
     public function getFormName();
 
     /**
-     * Returns the label name
+     * Returns the label name.
      *
      * @return string|bool
      */
@@ -91,8 +88,6 @@ interface FilterInterface
     /**
      * @param string $name
      * @param array  $options
-     *
-     * @return void
      */
     public function initialize($name, array $options = array());
 
@@ -122,7 +117,7 @@ interface FilterInterface
     public function getFieldOptions();
 
     /**
-     * Get field option
+     * Get field option.
      *
      * @param string $name
      * @param null   $default
@@ -132,7 +127,7 @@ interface FilterInterface
     public function getFieldOption($name, $default = null);
 
     /**
-     * Set field option
+     * Set field option.
      *
      * @param string $name
      * @param mixed  $value
@@ -145,21 +140,21 @@ interface FilterInterface
     public function getFieldType();
 
     /**
-     * Returns the main widget used to render the filter
+     * Returns the main widget used to render the filter.
      *
      * @return array
      */
     public function getRenderSettings();
 
     /**
-     * Returns true if filter is active
+     * Returns true if filter is active.
      *
-     * @return boolean
+     * @return bool
      */
     public function isActive();
 
     /**
-     * Set the condition to use with the left side of the query : OR or AND
+     * Set the condition to use with the left side of the query : OR or AND.
      *
      * @param string $condition
      */

--- a/Form/ChoiceList/ModelChoiceList.php
+++ b/Form/ChoiceList/ModelChoiceList.php
@@ -12,17 +12,16 @@
 namespace Sonata\AdminBundle\Form\ChoiceList;
 
 use Doctrine\Common\Util\ClassUtils;
-use Symfony\Component\PropertyAccess\PropertyAccess;
-use Symfony\Component\PropertyAccess\PropertyPath;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\Exception\RuntimeException;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
-use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyPath;
 
 /**
- * Class ModelChoiceList
+ * Class ModelChoiceList.
  *
- * @package Sonata\AdminBundle\Form\ChoiceList
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ModelChoiceList extends SimpleChoiceList
@@ -38,7 +37,7 @@ class ModelChoiceList extends SimpleChoiceList
     private $class;
 
     /**
-     * The entities from which the user can choose
+     * The entities from which the user can choose.
      *
      * This array is either indexed by ID (if the ID is a single field)
      * or by key in the choices array (if the ID consists of multiple fields)
@@ -52,7 +51,7 @@ class ModelChoiceList extends SimpleChoiceList
 
     /**
      * Contains the query builder that builds the query for fetching the
-     * entities
+     * entities.
      *
      * This property should only be accessed through queryBuilder.
      *
@@ -61,7 +60,7 @@ class ModelChoiceList extends SimpleChoiceList
     private $query;
 
     /**
-     * The fields of which the identifier of the underlying class consists
+     * The fields of which the identifier of the underlying class consists.
      *
      * This property should only be accessed through identifier.
      *
@@ -70,7 +69,7 @@ class ModelChoiceList extends SimpleChoiceList
     private $identifier = array();
 
     /**
-     * A cache for \ReflectionProperty instances for the underlying class
+     * A cache for \ReflectionProperty instances for the underlying class.
      *
      * This property should only be accessed through getReflProperty().
      *
@@ -104,7 +103,7 @@ class ModelChoiceList extends SimpleChoiceList
     }
 
     /**
-     * Initializes the choices and returns them
+     * Initializes the choices and returns them.
      *
      * The choices are generated from the entities. If the entities have a
      * composite identifier, the choices are indexed using ascending integers.
@@ -143,7 +142,7 @@ class ModelChoiceList extends SimpleChoiceList
                 $propertyAccessor = PropertyAccess::createPropertyAccessor();
                 $value = $propertyAccessor->getValue($entity, $this->propertyPath);
             } else {
-                 // Otherwise expect a __toString() method in the entity
+                // Otherwise expect a __toString() method in the entity
                 try {
                     $value = (string) $entity;
                 } catch (\Exception $e) {
@@ -177,7 +176,7 @@ class ModelChoiceList extends SimpleChoiceList
     }
 
     /**
-     * Returns the according entities for the choices
+     * Returns the according entities for the choices.
      *
      * If the choices were not initialized, they are initialized now. This
      * is an expensive operation, except if the entities were passed in the
@@ -191,7 +190,7 @@ class ModelChoiceList extends SimpleChoiceList
     }
 
     /**
-     * Returns the entity for the given key
+     * Returns the entity for the given key.
      *
      * If the underlying entities have composite identifiers, the choices
      * are initialized. The key is expected to be the index in the choices
@@ -200,14 +199,14 @@ class ModelChoiceList extends SimpleChoiceList
      * If they have single identifiers, they are either fetched from the
      * internal entity cache (if filled) or loaded from the database.
      *
-     * @param  string $key The choice key (for entities with composite
-     *                     identifiers) or entity ID (for entities with single
-     *                     identifiers)
+     * @param string $key The choice key (for entities with composite
+     *                    identifiers) or entity ID (for entities with single
+     *                    identifiers)
+     *
      * @return object The matching entity
      */
     public function getEntity($key)
     {
-
         if (count($this->identifier) > 1) {
             // $key is a collection index
             $entities = $this->getEntities();
@@ -222,7 +221,7 @@ class ModelChoiceList extends SimpleChoiceList
 
     /**
      * Returns the \ReflectionProperty instance for a property of the
-     * underlying class
+     * underlying class.
      *
      * @param string $property The name of the property
      *
@@ -239,15 +238,17 @@ class ModelChoiceList extends SimpleChoiceList
     }
 
     /**
-     * Returns the values of the identifier fields of an entity
+     * Returns the values of the identifier fields of an entity.
      *
      * Doctrine must know about this entity, that is, the entity must already
      * be persisted or added to the identity map before. Otherwise an
      * exception is thrown.
      *
-     * @param  object                   $entity The entity for which to get the identifier
+     * @param object $entity The entity for which to get the identifier
+     *
      * @throws InvalidArgumentException If the entity does not exist in Doctrine's
-     *                                         identity map
+     *                                  identity map
+     *
      * @return array
      */
     public function getIdentifierValues($entity)
@@ -255,7 +256,7 @@ class ModelChoiceList extends SimpleChoiceList
         try {
             return $this->modelManager->getIdentifierValues($entity);
         } catch (\Exception $e) {
-            throw new InvalidArgumentException(sprintf("Unable to retrieve the identifier values for entity %s", ClassUtils::getClass($entity)), 0, $e);
+            throw new InvalidArgumentException(sprintf('Unable to retrieve the identifier values for entity %s', ClassUtils::getClass($entity)), 0, $e);
         }
     }
 

--- a/Form/DataTransformer/ArrayToModelTransformer.php
+++ b/Form/DataTransformer/ArrayToModelTransformer.php
@@ -11,14 +11,12 @@
 
 namespace Sonata\AdminBundle\Form\DataTransformer;
 
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 
-use Sonata\AdminBundle\Model\ModelManagerInterface;
-
 /**
- * Class ArrayToModelTransformer
+ * Class ArrayToModelTransformer.
  *
- * @package Sonata\AdminBundle\Form\DataTransformer
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ArrayToModelTransformer implements DataTransformerInterface
@@ -48,7 +46,7 @@ class ArrayToModelTransformer implements DataTransformerInterface
             return $array;
         }
 
-        $instance = new $this->className;
+        $instance = new $this->className();
 
         if (!is_array($array)) {
             return $instance;

--- a/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -12,14 +12,13 @@
 
 namespace Sonata\AdminBundle\Form\DataTransformer;
 
-use Symfony\Component\Form\DataTransformerInterface;
-use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Doctrine\Common\Util\ClassUtils;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Component\Form\DataTransformerInterface;
 
 /**
- * Transform object to ID and property label
+ * Transform object to ID and property label.
  *
- * @package Sonata\AdminBundle\Form\DataTransformer
  * @author  Andrej Hudec <pulzarraider@gmail.com>
  */
 class ModelToIdPropertyTransformer implements DataTransformerInterface
@@ -41,7 +40,7 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
      * @param bool                  $multiple
      * @param null                  $toStringCallback
      */
-    public function __construct(ModelManagerInterface $modelManager, $className, $property, $multiple=false, $toStringCallback=null)
+    public function __construct(ModelManagerInterface $modelManager, $className, $property, $multiple = false, $toStringCallback = null)
     {
         $this->modelManager     = $modelManager;
         $this->className        = $className;
@@ -62,11 +61,11 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
                 return $collection;
             }
 
-            return null;
+            return;
         }
 
         if (!$this->multiple) {
-             return $this->modelManager->find($this->className, $value);
+            return $this->modelManager->find($this->className, $value);
         }
 
         if (!is_array($value)) {

--- a/Form/DataTransformer/ModelToIdTransformer.php
+++ b/Form/DataTransformer/ModelToIdTransformer.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sonata package.
  *
@@ -11,14 +12,12 @@
 
 namespace Sonata\AdminBundle\Form\DataTransformer;
 
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 
-use Sonata\AdminBundle\Model\ModelManagerInterface;
-
 /**
- * Class ModelToIdTransformer
+ * Class ModelToIdTransformer.
  *
- * @package Sonata\AdminBundle\Form\DataTransformer
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ModelToIdTransformer implements DataTransformerInterface
@@ -42,8 +41,8 @@ class ModelToIdTransformer implements DataTransformerInterface
      */
     public function reverseTransform($newId)
     {
-        if (empty($newId) && !in_array($newId, array("0", 0), true)) {
-            return null;
+        if (empty($newId) && !in_array($newId, array('0', 0), true)) {
+            return;
         }
 
         return $this->modelManager->find($this->className, $newId);
@@ -55,7 +54,7 @@ class ModelToIdTransformer implements DataTransformerInterface
     public function transform($entity)
     {
         if (empty($entity)) {
-            return null;
+            return;
         }
 
         return $this->modelManager->getNormalizedIdentifier($entity);

--- a/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -11,16 +11,14 @@
 
 namespace Sonata\AdminBundle\Form\DataTransformer;
 
-use Symfony\Component\Form\Exception\UnexpectedTypeException;
-use Symfony\Component\Form\Exception\TransformationFailedException;
-use Symfony\Component\Form\DataTransformerInterface;
-
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 /**
- * Class ModelsToArrayTransformer
+ * Class ModelsToArrayTransformer.
  *
- * @package Sonata\AdminBundle\Form\DataTransformer
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ModelsToArrayTransformer implements DataTransformerInterface

--- a/Form/EventListener/MergeCollectionListener.php
+++ b/Form/EventListener/MergeCollectionListener.php
@@ -12,16 +12,14 @@
 
 namespace Sonata\AdminBundle\Form\EventListener;
 
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-
-use Sonata\AdminBundle\Model\ModelManagerInterface;
 
 /**
- * Class MergeCollectionListener
+ * Class MergeCollectionListener.
  *
- * @package Sonata\AdminBundle\Form\EventListener
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class MergeCollectionListener implements EventSubscriberInterface

--- a/Form/Extension/ChoiceTypeExtension.php
+++ b/Form/Extension/ChoiceTypeExtension.php
@@ -12,15 +12,14 @@
 namespace Sonata\AdminBundle\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
- * Class ChoiceTypeExtension
+ * Class ChoiceTypeExtension.
  *
- * @package Sonata\AdminBundle\Form\Extension
  * @author  Amine Zaghdoudi <amine.zaghdoudi@ekino.com>
  */
 class ChoiceTypeExtension extends AbstractTypeExtension

--- a/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -11,21 +11,18 @@
 
 namespace Sonata\AdminBundle\Form\Extension\Field\Type;
 
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Exception\NoValueException;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
-use Sonata\AdminBundle\Exception\NoValueException;
-
 /**
- * Class FormTypeFieldExtension
+ * Class FormTypeFieldExtension.
  *
- * @package Sonata\AdminBundle\Form\Extension\Field\Type
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class FormTypeFieldExtension extends AbstractTypeExtension
@@ -120,7 +117,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
     {
         $sonataAdmin = $form->getConfig()->getAttribute('sonata_admin');
 
-        /**
+        /*
          * We have a child, so we need to upgrade block prefix
          */
         if ($view->parent && $view->parent->vars['sonata_admin_enabled'] && !$sonataAdmin['admin']) {
@@ -129,7 +126,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             $baseName = str_replace('.', '_', $view->parent->vars['sonata_admin_code']);
 
             $baseType = $blockPrefixes[count($blockPrefixes) - 2];
-            $blockSuffix = preg_replace("#^_([a-z0-9]{14})_(.++)$#", "\$2", array_pop($blockPrefixes));
+            $blockSuffix = preg_replace('#^_([a-z0-9]{14})_(.++)$#', "\$2", array_pop($blockPrefixes));
 
             $blockPrefixes[] = sprintf('%s_%s', $baseName, $baseType);
             $blockPrefixes[] = sprintf('%s_%s_%s_%s', $baseName, $baseType, $view->parent->vars['name'], $view->vars['name']);
@@ -162,7 +159,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             $blockPrefixes    = $view->vars['block_prefixes'];
             $baseName = str_replace('.', '_', $sonataAdmin['admin']->getCode());
             $baseType = $blockPrefixes[count($blockPrefixes) - 2];
-            $blockSuffix = preg_replace("#^_([a-z0-9]{14})_(.++)$#", "\$2", array_pop($blockPrefixes));
+            $blockSuffix = preg_replace('#^_([a-z0-9]{14})_(.++)$#', "\$2", array_pop($blockPrefixes));
 
             $blockPrefixes[] = sprintf('%s_%s', $baseName, $baseType);
             $blockPrefixes[] = sprintf('%s_%s_%s', $baseName, $sonataAdmin['name'], $baseType);
@@ -193,7 +190,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
     }
 
     /**
-     * Returns the name of the type being extended
+     * Returns the name of the type being extended.
      *
      * @return string The name of the type being extended
      */
@@ -223,13 +220,13 @@ class FormTypeFieldExtension extends AbstractTypeExtension
 
             // be compatible with mopa if not installed, avoid generating an exception for invalid option
             'label_render'             => true,
-            'sonata_help'        => null
+            'sonata_help'              => null,
         ));
     }
 
     /**
      * return the value related to FieldDescription, if the associated object does no
-     * exists => a temporary one is created
+     * exists => a temporary one is created.
      *
      * @param object                                              $object
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $fieldDescription

--- a/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
@@ -19,11 +19,10 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * This class is built to allow AdminInterface to work properly
- * if the MopaBootstrapBundle is not installed
+ * if the MopaBootstrapBundle is not installed.
  *
  * Class MopaCompatibilityTypeFieldExtension
  *
- * @package Sonata\AdminBundle\Form\Extension\Field\Type
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class MopaCompatibilityTypeFieldExtension extends AbstractTypeExtension

--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -12,16 +12,15 @@
 
 namespace Sonata\AdminBundle\Form;
 
-use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * Class FormMapper
- * This class is use to simulate the Form API
+ * This class is use to simulate the Form API.
  *
- * @package Sonata\AdminBundle\Form
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class FormMapper extends BaseGroupedMapper
@@ -73,8 +72,8 @@ class FormMapper extends BaseGroupedMapper
         }
 
         // "Dot" notation is not allowed as form name, but can be used as property path to access nested data.
-        if (!$name instanceof FormBuilderInterface && strpos($fieldName, '.')!==false && !isset($options['property_path'])) {
-             $options['property_path'] = $fieldName;
+        if (!$name instanceof FormBuilderInterface && strpos($fieldName, '.') !== false && !isset($options['property_path'])) {
+            $options['property_path'] = $fieldName;
 
              // fix the form name
              $fieldName = str_replace('.', '__', $fieldName);

--- a/Form/Type/AclMatrixType.php
+++ b/Form/Type/AclMatrixType.php
@@ -20,9 +20,8 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
- * This type define an ACL matrix
+ * This type define an ACL matrix.
  *
- * @package Sonata\AdminBundle\Form\Type
  * @author  Samuel Roze <samuel@sroze.io>
  * @author  Baptiste Meyer <baptiste@les-tilleuls.coop>
  */
@@ -66,7 +65,7 @@ class AclMatrixType extends AbstractType
         if (version_compare(Kernel::VERSION, '2.6', '<')) {
             $resolver->setAllowedTypes(array(
                 'permissions' => 'array',
-                'acl_value' => array('string', '\Symfony\Component\Security\Core\User\UserInterface'),
+                'acl_value'   => array('string', '\Symfony\Component\Security\Core\User\UserInterface'),
             ));
         } else {
             $resolver->setAllowedTypes('permissions', 'array');

--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -12,23 +12,20 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
+use Sonata\AdminBundle\Form\DataTransformer\ArrayToModelTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-
-use Sonata\AdminBundle\Form\DataTransformer\ArrayToModelTransformer;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 /**
- * Class AdminType
+ * Class AdminType.
  *
- * @package Sonata\AdminBundle\Form\Type
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AdminType extends AbstractType
@@ -115,7 +112,7 @@ class AdminType extends AbstractType
             'btn_add'         => 'link_add',
             'btn_list'        => 'link_list',
             'btn_delete'      => 'link_delete',
-            'btn_catalogue'   => 'SonataAdminBundle'
+            'btn_catalogue'   => 'SonataAdminBundle',
         ));
     }
 

--- a/Form/Type/ChoiceFieldMaskType.php
+++ b/Form/Type/ChoiceFieldMaskType.php
@@ -13,15 +13,14 @@
 namespace Sonata\AdminBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
- * Class ChoiceFieldMaskType
+ * Class ChoiceFieldMaskType.
  *
- * @package Sonata\AdminBundle\Form\Type
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ChoiceFieldMaskType extends AbstractType

--- a/Form/Type/Filter/ChoiceType.php
+++ b/Form/Type/Filter/ChoiceType.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sonata package.
  *
@@ -14,14 +15,12 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-
 /**
- * Class ChoiceType
+ * Class ChoiceType.
  *
- * @package Sonata\AdminBundle\Form\Type\Filter
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ChoiceType extends AbstractType

--- a/Form/Type/Filter/DateRangeType.php
+++ b/Form/Type/Filter/DateRangeType.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sonata package.
  *
@@ -14,14 +15,12 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-
 /**
- * Class DateRangeType
+ * Class DateRangeType.
  *
- * @package Sonata\AdminBundle\Form\Type\Filter
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class DateRangeType extends AbstractType
@@ -80,7 +79,7 @@ class DateRangeType extends AbstractType
     {
         $resolver->setDefaults(array(
             'field_type'    => 'sonata_type_date_range',
-            'field_options' => array('format' => 'yyyy-MM-dd')
+            'field_options' => array('format' => 'yyyy-MM-dd'),
         ));
     }
 }

--- a/Form/Type/Filter/DateTimeRangeType.php
+++ b/Form/Type/Filter/DateTimeRangeType.php
@@ -15,14 +15,12 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-
 /**
- * Class DateTimeRangeType
+ * Class DateTimeRangeType.
  *
- * @package Sonata\AdminBundle\Form\Type\Filter
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class DateTimeRangeType extends AbstractType
@@ -81,7 +79,7 @@ class DateTimeRangeType extends AbstractType
     {
         $resolver->setDefaults(array(
             'field_type'    => 'sonata_type_datetime_range',
-            'field_options' => array('date_format' => 'yyyy-MM-dd')
+            'field_options' => array('date_format' => 'yyyy-MM-dd'),
         ));
     }
 }

--- a/Form/Type/Filter/DateTimeType.php
+++ b/Form/Type/Filter/DateTimeType.php
@@ -15,14 +15,12 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-
 /**
- * Class DateTimeType
+ * Class DateTimeType.
  *
- * @package Sonata\AdminBundle\Form\Type\Filter
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class DateTimeType extends AbstractType
@@ -97,7 +95,7 @@ class DateTimeType extends AbstractType
     {
         $resolver->setDefaults(array(
             'field_type'    => 'datetime',
-            'field_options' => array('date_format' => 'yyyy-MM-dd')
+            'field_options' => array('date_format' => 'yyyy-MM-dd'),
         ));
     }
 }

--- a/Form/Type/Filter/DateType.php
+++ b/Form/Type/Filter/DateType.php
@@ -15,14 +15,12 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Optionsresolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-use Symfony\Component\Optionsresolver\OptionsResolverInterface;
-
 /**
- * Class DateType
+ * Class DateType.
  *
- * @package Sonata\AdminBundle\Form\Type\Filter
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class DateType extends AbstractType
@@ -97,7 +95,7 @@ class DateType extends AbstractType
     {
         $resolver->setDefaults(array(
             'field_type'    => 'date',
-            'field_options' => array('date_format' => 'yyyy-MM-dd')
+            'field_options' => array('date_format' => 'yyyy-MM-dd'),
         ));
     }
 }

--- a/Form/Type/Filter/DefaultType.php
+++ b/Form/Type/Filter/DefaultType.php
@@ -14,14 +14,12 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
- * Class DefaultType
+ * Class DefaultType.
  *
- * @package Sonata\AdminBundle\Form\Type\Filter
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class DefaultType extends AbstractType
@@ -64,7 +62,7 @@ class DefaultType extends AbstractType
             'operator_type'    => 'hidden',
             'operator_options' => array(),
             'field_type'       => 'text',
-            'field_options'    => array()
+            'field_options'    => array(),
         ));
     }
 }

--- a/Form/Type/Filter/NumberType.php
+++ b/Form/Type/Filter/NumberType.php
@@ -15,14 +15,12 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-
 /**
- * Class NumberType
+ * Class NumberType.
  *
- * @package Sonata\AdminBundle\Form\Type\Filter
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class NumberType extends AbstractType

--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -12,15 +12,15 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
-use Symfony\Component\Form\FormBuilderInterface;
+use Sonata\AdminBundle\Form\DataTransformer\ModelToIdPropertyTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\Form\FormView;
-use Symfony\Component\Form\FormInterface;
-use Sonata\AdminBundle\Form\DataTransformer\ModelToIdPropertyTransformer;
-use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener;
 
 /**
  * This type defines a standard text field with autocomplete feature.
@@ -126,7 +126,7 @@ class ModelAutocompleteType extends AbstractType
 
             // ajax parameters
             'url'                           => '',
-            'route'                         => array('name'=>'sonata_admin_retrieve_autocomplete_items', 'parameters'=>array()),
+            'route'                         => array('name' => 'sonata_admin_retrieve_autocomplete_items', 'parameters' => array()),
             'req_params'                    => array(),
             'req_param_name_search'         => 'q',
             'req_param_name_page_number'    => '_page',
@@ -139,7 +139,7 @@ class ModelAutocompleteType extends AbstractType
 
             'dropdown_auto_width'           => false,
 
-            'template'                      => 'SonataAdminBundle:Form/Type:sonata_type_model_autocomplete.html.twig'
+            'template'                      => 'SonataAdminBundle:Form/Type:sonata_type_model_autocomplete.html.twig',
         ));
 
         $resolver->setRequired(array('property'));

--- a/Form/Type/ModelHiddenType.php
+++ b/Form/Type/ModelHiddenType.php
@@ -12,17 +12,15 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
-use Symfony\Component\Form\FormBuilderInterface;
+use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
-use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
-
 /**
- * This type define a standard hidden field, that stored id to a object
+ * This type define a standard hidden field, that stored id to a object.
  *
- * @package Sonata\AdminBundle\Form\Type
  * @author  Andrej Hudec <pulzarraider@gmail.com>
  */
 class ModelHiddenType extends AbstractType

--- a/Form/Type/ModelReferenceType.php
+++ b/Form/Type/ModelReferenceType.php
@@ -12,17 +12,15 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
-use Symfony\Component\Form\FormBuilderInterface;
+use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
-use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
-
 /**
- * Class ModelReferenceType
+ * Class ModelReferenceType.
  *
- * @package Sonata\AdminBundle\Form\Type
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ModelReferenceType extends AbstractType

--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -12,25 +12,23 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
+use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
+use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
+use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
+use Sonata\AdminBundle\Form\EventListener\MergeCollectionListener;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
-use Sonata\AdminBundle\Form\EventListener\MergeCollectionListener;
-use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
-use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
-use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
-
 /**
  * Class ModelType
- * This type define a standard select input with a + sign to add new associated object
+ * This type define a standard select input with a + sign to add new associated object.
  *
- * @package Sonata\AdminBundle\Form\Type
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ModelType extends AbstractType
@@ -123,7 +121,7 @@ class ModelType extends AbstractType
                     $options['query'],
                     $options['choices']
                 );
-            }
+            },
         ));
     }
 

--- a/Form/Type/ModelTypeList.php
+++ b/Form/Type/ModelTypeList.php
@@ -12,20 +12,19 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
-use Symfony\Component\Form\FormBuilderInterface;
+use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
-use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
-
 /**
  * This type is used to render an hidden input text and 3 links
  *   - an add form modal
  *   - a list modal to select the targeted entities
- *   - a clear selection link
+ *   - a clear selection link.
  */
 class ModelTypeList extends AbstractType
 {
@@ -75,7 +74,7 @@ class ModelTypeList extends AbstractType
             'btn_add'       => 'link_add',
             'btn_list'      => 'link_list',
             'btn_delete'    => 'link_delete',
-            'btn_catalogue' => 'SonataAdminBundle'
+            'btn_catalogue' => 'SonataAdminBundle',
         ));
     }
 

--- a/Generator/AdminGenerator.php
+++ b/Generator/AdminGenerator.php
@@ -17,9 +17,8 @@ use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 /**
- * Class AdminGenerator
+ * Class AdminGenerator.
  *
- * @package Sonata\AdminBundle\Generator
  * @author  Marek Stipek <mario.dweller@seznam.cz>
  * @author  Simon Cosandey <simon.cosandey@simseo.ch>
  */
@@ -45,9 +44,10 @@ class AdminGenerator extends Generator
     }
 
     /**
-     * @param  BundleInterface   $bundle
-     * @param  string            $adminClassBasename
-     * @param  string            $modelClass
+     * @param BundleInterface $bundle
+     * @param string          $adminClassBasename
+     * @param string          $modelClass
+     *
      * @throws \RuntimeException
      */
     public function generate(BundleInterface $bundle, $adminClassBasename, $modelClass)
@@ -66,8 +66,8 @@ class AdminGenerator extends Generator
 
         $this->renderFile('Admin.php.twig', $this->file, array(
             'classBasename' => array_pop($parts),
-            'namespace' => implode('\\', $parts),
-            'fields' => $this->modelManager->getExportFields($modelClass)
+            'namespace'     => implode('\\', $parts),
+            'fields'        => $this->modelManager->getExportFields($modelClass),
         ));
     }
 

--- a/Generator/ControllerGenerator.php
+++ b/Generator/ControllerGenerator.php
@@ -16,9 +16,8 @@ use Sensio\Bundle\GeneratorBundle\Generator\Generator;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 /**
- * Class ControllerGenerator
+ * Class ControllerGenerator.
  *
- * @package Sonata\AdminBundle\Generator
  * @author  Marek Stipek <mario.dweller@seznam.cz>
  * @author  Simon Cosandey <simon.cosandey@simseo.ch>
  */
@@ -39,8 +38,9 @@ class ControllerGenerator extends Generator
     }
 
     /**
-     * @param  BundleInterface   $bundle
-     * @param  string            $controllerClassBasename
+     * @param BundleInterface $bundle
+     * @param string          $controllerClassBasename
+     *
      * @throws \RuntimeException
      */
     public function generate(BundleInterface $bundle, $controllerClassBasename)
@@ -63,7 +63,7 @@ class ControllerGenerator extends Generator
 
         $this->renderFile('AdminController.php.twig', $this->file, array(
             'classBasename' => array_pop($parts),
-            'namespace' => implode('\\', $parts)
+            'namespace'     => implode('\\', $parts),
         ));
     }
 

--- a/Guesser/TypeGuesserChain.php
+++ b/Guesser/TypeGuesserChain.php
@@ -12,12 +12,12 @@
 
 namespace Sonata\AdminBundle\Guesser;
 
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Guess\Guess;
-use Sonata\AdminBundle\Model\ModelManagerInterface;
 
 /**
- * The code is based on Symfony2 Form Components
+ * The code is based on Symfony2 Form Components.
  *
  * @author Bernhard Schussek <bernhard.schussek@symfony.com>
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -56,7 +56,7 @@ class TypeGuesserChain implements TypeGuesserInterface
 
     /**
      * Executes a closure for each guesser and returns the best guess from the
-     * return values
+     * return values.
      *
      * @param \Closure $closure The closure to execute. Accepts a guesser
      *                          as argument and should return a Guess instance

--- a/Guesser/TypeGuesserInterface.php
+++ b/Guesser/TypeGuesserInterface.php
@@ -15,9 +15,8 @@ namespace Sonata\AdminBundle\Guesser;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 
 /**
- * Interface TypeGuesserInterface
+ * Interface TypeGuesserInterface.
  *
- * @package Sonata\AdminBundle\Guesser
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface TypeGuesserInterface

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+cs:
+	./vendor/bin/php-cs-fixer fix --verbose
+
+cs_dry_run:
+	./vendor/bin/php-cs-fixer fix --verbose --dry-run
+
 test:
 	phpunit
 	cd Resources/doc && sphinx-build -W -b html -d _build/doctrees . _build/html

--- a/Manipulator/ServicesManipulator.php
+++ b/Manipulator/ServicesManipulator.php
@@ -15,9 +15,8 @@ namespace Sonata\AdminBundle\Manipulator;
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * Class ServicesManipulator
+ * Class ServicesManipulator.
  *
- * @package Sonata\AdminBundle\Manipulator
  * @author  Marek Stipek <mario.dweller@seznam.cz>
  * @author  Simon Cosandey <simon.cosandey@simseo.ch>
  */
@@ -43,11 +42,12 @@ class ServicesManipulator
     }
 
     /**
-     * @param  string            $serviceId
-     * @param  string            $modelClass
-     * @param  string            $adminClass
-     * @param  string            $controllerName
-     * @param  string            $managerType
+     * @param string $serviceId
+     * @param string $modelClass
+     * @param string $adminClass
+     * @param string $controllerName
+     * @param string $managerType
+     *
      * @throws \RuntimeException
      */
     public function addResource($serviceId, $modelClass, $adminClass, $controllerName, $managerType)
@@ -75,7 +75,7 @@ class ServicesManipulator
                     $code .= "\n";
                 }
             } else {
-                $code .= $code === '' ? '' : "\n" . "services:\n";
+                $code .= $code === '' ? '' : "\n"."services:\n";
             }
         }
 

--- a/Mapper/BaseGroupedMapper.php
+++ b/Mapper/BaseGroupedMapper.php
@@ -14,9 +14,8 @@ namespace Sonata\AdminBundle\Mapper;
 
 /**
  * Class BaseGroupedMapper
- * This class is used to simulate the Form API
+ * This class is used to simulate the Form API.
  *
- * @package Sonata\AdminBundle\Mapper
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 abstract class BaseGroupedMapper extends BaseMapper
@@ -33,7 +32,7 @@ abstract class BaseGroupedMapper extends BaseMapper
     abstract protected function setTabs(array $tabs);
 
     /**
-     * Add new group or tab (if parameter "tab=true" is available in options)
+     * Add new group or tab (if parameter "tab=true" is available in options).
      *
      * @param string $name
      * @param array  $options
@@ -44,7 +43,7 @@ abstract class BaseGroupedMapper extends BaseMapper
      */
     public function with($name, array $options = array())
     {
-        /**
+        /*
          * The current implementation should work with the following workflow:
          *
          *     $formMapper
@@ -99,9 +98,7 @@ abstract class BaseGroupedMapper extends BaseMapper
             ), $tabs[$code], $options);
 
             $this->currentTab = $code;
-
         } else {
-
             if ($this->currentGroup) {
                 throw new \RuntimeException(sprintf('You should close previous group "%s" with end() before adding new tab "%s".', $this->currentGroup, $name));
             }
@@ -111,7 +108,7 @@ abstract class BaseGroupedMapper extends BaseMapper
                 $this->with('default', array(
                     'tab'                => true,
                     'auto_created'       => true,
-                    'translation_domain' => isset($options['translation_domain']) ? $options['translation_domain'] : null
+                    'translation_domain' => isset($options['translation_domain']) ? $options['translation_domain'] : null,
                 )); // add new tab automatically
             }
 
@@ -144,9 +141,9 @@ abstract class BaseGroupedMapper extends BaseMapper
     }
 
     /**
-     * Only nested add if the condition match true
+     * Only nested add if the condition match true.
      *
-     * @param boolean $bool
+     * @param bool $bool
      *
      * @return $this
      *
@@ -164,9 +161,9 @@ abstract class BaseGroupedMapper extends BaseMapper
     }
 
     /**
-     * Only nested add if the condition match false
+     * Only nested add if the condition match false.
      *
-     * @param boolean $bool
+     * @param bool $bool
      *
      * @return $this
      *
@@ -194,7 +191,7 @@ abstract class BaseGroupedMapper extends BaseMapper
     }
 
     /**
-     * Add new tab
+     * Add new tab.
      *
      * @param string $name
      * @param array  $options
@@ -207,7 +204,7 @@ abstract class BaseGroupedMapper extends BaseMapper
     }
 
     /**
-     * Close the current group or tab
+     * Close the current group or tab.
      *
      * @return $this
      *
@@ -225,11 +222,11 @@ abstract class BaseGroupedMapper extends BaseMapper
 
         return $this;
     }
-    
+
     /**
      * Returns a boolean indicating if there is an open tab at the moment.
-     * 
-     * @return boolean
+     *
+     * @return bool
      */
     public function hasOpenTab()
     {
@@ -237,7 +234,7 @@ abstract class BaseGroupedMapper extends BaseMapper
     }
 
     /**
-     * Add the field name to the current group
+     * Add the field name to the current group.
      *
      * @param string $fieldName
      */
@@ -255,7 +252,7 @@ abstract class BaseGroupedMapper extends BaseMapper
 
     /**
      * Return the name of the currently selected group. The method also makes
-     * sure a valid group name is currently selected
+     * sure a valid group name is currently selected.
      *
      * Note that this can have the side effect to change the 'group' value
      * returned by the getGroup function

--- a/Mapper/BaseMapper.php
+++ b/Mapper/BaseMapper.php
@@ -17,9 +17,8 @@ use Sonata\AdminBundle\Builder\BuilderInterface;
 
 /**
  * Class BaseMapper
- * This class is used to simulate the Form API
+ * This class is used to simulate the Form API.
  *
- * @package Sonata\AdminBundle\Mapper
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 abstract class BaseMapper
@@ -29,8 +28,8 @@ abstract class BaseMapper
     protected $builder;
 
     /**
-     * @param BuilderInterface   $builder
-     * @param AdminInterface     $admin
+     * @param BuilderInterface $builder
+     * @param AdminInterface   $admin
      */
     public function __construct(BuilderInterface $builder, AdminInterface $admin)
     {
@@ -56,7 +55,7 @@ abstract class BaseMapper
     /**
      * @param string $key
      *
-     * @return boolean
+     * @return bool
      */
     abstract public function has($key);
 

--- a/Menu/MenuBuilder.php
+++ b/Menu/MenuBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sonata package.
  *
@@ -65,9 +66,9 @@ class MenuBuilder
             $attributes = array();
 
             $extras = array(
-                'icon' => $group['icon'],
+                'icon'            => $group['icon'],
                 'label_catalogue' => $group['label_catalogue'],
-                'roles' => $group['roles'],
+                'roles'           => $group['roles'],
             );
 
             // Check if the menu group is built by a menu provider
@@ -85,9 +86,9 @@ class MenuBuilder
 
             // The menu group is built by config
             $menu->addChild($name, array(
-                'label' => $group['label'],
+                'label'      => $group['label'],
                 'attributes' => $attributes,
-                'extras' => $extras,
+                'extras'     => $extras,
             ));
 
             foreach ($group['items'] as $item) {
@@ -102,17 +103,17 @@ class MenuBuilder
                     $label = $admin->getLabel();
                     $options = $admin->generateMenuUrl('list');
                     $options['extras'] = array(
-                        'translation_domain' =>$admin->getTranslationDomain(),
-                        'admin' => $admin,
+                        'translation_domain' => $admin->getTranslationDomain(),
+                        'admin'              => $admin,
                     );
                 } else {
                     $label = $item['label'];
                     $options = array(
-                        'route' => $item['route'],
+                        'route'           => $item['route'],
                         'routeParameters' => $item['route_params'],
-                        'extras' => array(
+                        'extras'          => array(
                             'translation_domain' => $group['label_catalogue'],
-                        )
+                        ),
                     );
                 }
 
@@ -131,7 +132,7 @@ class MenuBuilder
     }
 
     /**
-     * Sets the request the service
+     * Sets the request the service.
      *
      * @param Request $request
      */

--- a/Model/AuditManager.php
+++ b/Model/AuditManager.php
@@ -14,9 +14,8 @@ namespace Sonata\AdminBundle\Model;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class AuditManager
+ * Class AuditManager.
  *
- * @package Sonata\AdminBundle\Model
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AuditManager implements AuditManagerInterface

--- a/Model/AuditManagerInterface.php
+++ b/Model/AuditManagerInterface.php
@@ -12,9 +12,8 @@
 namespace Sonata\AdminBundle\Model;
 
 /**
- * Interface AuditManagerInterface
+ * Interface AuditManagerInterface.
  *
- * @package Sonata\AdminBundle\Model
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface AuditManagerInterface

--- a/Model/AuditReaderInterface.php
+++ b/Model/AuditReaderInterface.php
@@ -12,9 +12,8 @@
 namespace Sonata\AdminBundle\Model;
 
 /**
- * Interface AuditReaderInterface
+ * Interface AuditReaderInterface.
  *
- * @package Sonata\AdminBundle\Model
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface AuditReaderInterface

--- a/Model/ModelManagerInterface.php
+++ b/Model/ModelManagerInterface.php
@@ -22,7 +22,7 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 interface ModelManagerInterface
 {
     /**
-     * Returns a new FieldDescription
+     * Returns a new FieldDescription.
      *
      * @param string $class
      * @param string $name
@@ -48,8 +48,6 @@ interface ModelManagerInterface
 
     /**
      * @param object $object
-     *
-     * @return void
      */
     public function delete($object);
 
@@ -80,16 +78,12 @@ interface ModelManagerInterface
     /**
      * @param string              $class
      * @param ProxyQueryInterface $queryProxy
-     *
-     * @return void
      */
     public function batchDelete($class, ProxyQueryInterface $queryProxy);
 
     /**
      * @param array  $parentAssociationMapping
      * @param string $class
-     *
-     * @return void
      */
     public function getParentFieldDescription($parentAssociationMapping, $class);
 
@@ -172,17 +166,15 @@ interface ModelManagerInterface
     public function getModelCollectionInstance($class);
 
     /**
-     * Removes an element from the collection
+     * Removes an element from the collection.
      *
      * @param mixed $collection
      * @param mixed $element
-     *
-     * @return void
      */
     public function collectionRemoveElement(&$collection, &$element);
 
     /**
-     * Add an element from the collection
+     * Add an element from the collection.
      *
      * @param mixed $collection
      * @param mixed $element
@@ -192,17 +184,17 @@ interface ModelManagerInterface
     public function collectionAddElement(&$collection, &$element);
 
     /**
-     * Check if the element exists in the collection
+     * Check if the element exists in the collection.
      *
      * @param mixed $collection
      * @param mixed $element
      *
-     * @return boolean
+     * @return bool
      */
     public function collectionHasElement(&$collection, &$element);
 
     /**
-     * Clear the collection
+     * Clear the collection.
      *
      * @param mixed $collection
      *
@@ -211,7 +203,7 @@ interface ModelManagerInterface
     public function collectionClear(&$collection);
 
     /**
-     * Returns the parameters used in the columns header
+     * Returns the parameters used in the columns header.
      *
      * @param FieldDescriptionInterface $fieldDescription
      * @param DatagridInterface         $datagrid
@@ -236,8 +228,6 @@ interface ModelManagerInterface
     /**
      * @param string $class
      * @param object $instance
-     *
-     * @return void
      */
     public function modelTransform($class, $instance);
 
@@ -275,8 +265,6 @@ interface ModelManagerInterface
      * @param string              $class
      * @param ProxyQueryInterface $query
      * @param array               $idx
-     *
-     * @return void
      */
     public function addIdentifiersToQuery($class, ProxyQueryInterface $query, array $idx);
 }

--- a/Resources/views/Core/dashboard.html.twig
+++ b/Resources/views/Core/dashboard.html.twig
@@ -79,7 +79,7 @@ file that was distributed with this source code.
         {% if not has_left and not has_right %}
             {% set width_center = 12 %}
         {% endif %}
-        
+
         {# don't show left column if only center one is present #}
         {% if has_left or has_right %}
         <div class="col-md-{{ width_left }}">

--- a/Route/AdminPoolLoader.php
+++ b/Route/AdminPoolLoader.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sonata project.
  *
@@ -10,17 +11,15 @@
 
 namespace Sonata\AdminBundle\Route;
 
-use Symfony\Component\Routing\RouteCollection as SymfonyRouteCollection;
+use Sonata\AdminBundle\Admin\Pool;
 use Symfony\Component\Config\Loader\FileLoader;
 use Symfony\Component\Config\Resource\FileResource;
-
-use Sonata\AdminBundle\Admin\Pool;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\RouteCollection as SymfonyRouteCollection;
 
 /**
- * Class AdminPoolLoader
+ * Class AdminPoolLoader.
  *
- * @package Sonata\AdminBundle\Route
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AdminPoolLoader extends FileLoader
@@ -66,7 +65,6 @@ class AdminPoolLoader extends FileLoader
     {
         $collection = new SymfonyRouteCollection();
         foreach ($this->adminServiceIds as $id) {
-
             $admin = $this->pool->getInstance($id);
 
             foreach ($admin->getRoutes()->getElements() as $code => $route) {

--- a/Route/DefaultRouteGenerator.php
+++ b/Route/DefaultRouteGenerator.php
@@ -16,9 +16,8 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
- * Class DefaultRouteGenerator
+ * Class DefaultRouteGenerator.
  *
- * @package Sonata\AdminBundle\Route
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class DefaultRouteGenerator implements RouteGeneratorInterface
@@ -106,7 +105,7 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
         return array(
             'route'           => $this->caches[$code],
             'routeParameters' => $parameters,
-            'routeAbsolute'   => $absolute
+            'routeAbsolute'   => $absolute,
         );
     }
 

--- a/Route/PathInfoBuilder.php
+++ b/Route/PathInfoBuilder.php
@@ -12,14 +12,13 @@
 
 namespace Sonata\AdminBundle\Route;
 
-use Sonata\AdminBundle\Builder\RouteBuilderInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Builder\RouteBuilderInterface;
 use Sonata\AdminBundle\Model\AuditManagerInterface;
 
 /**
- * Class PathInfoBuilder
+ * Class PathInfoBuilder.
  *
- * @package Sonata\AdminBundle\Route
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class PathInfoBuilder implements RouteBuilderInterface

--- a/Route/QueryStringBuilder.php
+++ b/Route/QueryStringBuilder.php
@@ -12,14 +12,13 @@
 
 namespace Sonata\AdminBundle\Route;
 
-use Sonata\AdminBundle\Builder\RouteBuilderInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Builder\RouteBuilderInterface;
 use Sonata\AdminBundle\Model\AuditManagerInterface;
 
 /**
- * Class QueryStringBuilder
+ * Class QueryStringBuilder.
  *
- * @package Sonata\AdminBundle\Route
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class QueryStringBuilder implements RouteBuilderInterface

--- a/Route/RouteCollection.php
+++ b/Route/RouteCollection.php
@@ -15,9 +15,8 @@ namespace Sonata\AdminBundle\Route;
 use Symfony\Component\Routing\Route;
 
 /**
- * Class RouteCollection
+ * Class RouteCollection.
  *
- * @package Sonata\AdminBundle\Route
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class RouteCollection
@@ -57,12 +56,12 @@ class RouteCollection
      */
     public function add($name, $pattern = null, array $defaults = array(), array $requirements = array(), array $options = array())
     {
-        $pattern    = $this->baseRoutePattern . '/'. ($pattern ?: $name);
+        $pattern    = $this->baseRoutePattern.'/'.($pattern ?: $name);
         $code       = $this->getCode($name);
-        $routeName  = $this->baseRouteName . '_' . $name;
+        $routeName  = $this->baseRouteName.'_'.$name;
 
         if (!isset($defaults['_controller'])) {
-            $defaults['_controller'] = $this->baseControllerName . ':' . $this->actionify($code);
+            $defaults['_controller'] = $this->baseControllerName.':'.$this->actionify($code);
         }
 
         if (!isset($defaults['_sonata_admin'])) {
@@ -89,7 +88,7 @@ class RouteCollection
             return $name;
         }
 
-        return $this->baseCodeRoute . '.' . $name;
+        return $this->baseCodeRoute.'.'.$name;
     }
 
     /**
@@ -175,7 +174,7 @@ class RouteCollection
     }
 
     /**
-     * Remove all routes except routes in $routeList
+     * Remove all routes except routes in $routeList.
      *
      * @param array $routeList
      *
@@ -199,7 +198,7 @@ class RouteCollection
     }
 
     /**
-     * Remove all routes
+     * Remove all routes.
      *
      * @return \Sonata\AdminBundle\Route\RouteCollection
      */
@@ -211,7 +210,7 @@ class RouteCollection
     }
 
     /**
-     * Convert a word in to the format for a symfony action action_name => actionName
+     * Convert a word in to the format for a symfony action action_name => actionName.
      *
      * @param string $action Word to actionify
      *

--- a/Route/RouteGeneratorInterface.php
+++ b/Route/RouteGeneratorInterface.php
@@ -15,9 +15,8 @@ namespace Sonata\AdminBundle\Route;
 use Sonata\AdminBundle\Admin\AdminInterface;
 
 /**
- * Interface RouteGeneratorInterface
+ * Interface RouteGeneratorInterface.
  *
- * @package Sonata\AdminBundle\Route
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface RouteGeneratorInterface

--- a/Route/RoutesCache.php
+++ b/Route/RoutesCache.php
@@ -16,9 +16,8 @@ use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Resource\FileResource;
 
 /**
- * Class RoutesCache
+ * Class RoutesCache.
  *
- * @package Sonata\AdminBundle\Route
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class RoutesCache
@@ -29,7 +28,7 @@ class RoutesCache
     protected $cacheFolder;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $debug;
 
@@ -47,6 +46,7 @@ class RoutesCache
      * @param AdminInterface $admin
      *
      * @return mixed
+     *
      * @throws \RuntimeException
      */
     public function load(AdminInterface $admin)

--- a/Route/RoutesCacheWarmUp.php
+++ b/Route/RoutesCacheWarmUp.php
@@ -15,9 +15,8 @@ use Sonata\AdminBundle\Admin\Pool;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
 /**
- * Class RoutesCacheWarmUp
+ * Class RoutesCacheWarmUp.
  *
- * @package Sonata\AdminBundle\Route
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class RoutesCacheWarmUp implements CacheWarmerInterface

--- a/Search/SearchHandler.php
+++ b/Search/SearchHandler.php
@@ -16,9 +16,8 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Filter\FilterInterface;
 
 /**
- * Class SearchHandler
+ * Class SearchHandler.
  *
- * @package Sonata\AdminBundle\Search
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class SearchHandler

--- a/Security/Acl/Permission/AdminPermissionMap.php
+++ b/Security/Acl/Permission/AdminPermissionMap.php
@@ -35,7 +35,7 @@ class AdminPermissionMap implements PermissionMapInterface
 
     /**
      * Map each permission to the permissions it should grant access for
-     * fe. grant access for the view permission if the user has the edit permission
+     * fe. grant access for the view permission if the user has the edit permission.
      *
      * @var array
      */
@@ -47,55 +47,55 @@ class AdminPermissionMap implements PermissionMapInterface
             MaskBuilder::MASK_EDIT,
             MaskBuilder::MASK_OPERATOR,
             MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER
+            MaskBuilder::MASK_OWNER,
         ),
 
         self::PERMISSION_EDIT => array(
             MaskBuilder::MASK_EDIT,
             MaskBuilder::MASK_OPERATOR,
             MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER
+            MaskBuilder::MASK_OWNER,
         ),
 
         self::PERMISSION_CREATE => array(
             MaskBuilder::MASK_CREATE,
             MaskBuilder::MASK_OPERATOR,
             MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER
+            MaskBuilder::MASK_OWNER,
         ),
 
         self::PERMISSION_DELETE => array(
             MaskBuilder::MASK_DELETE,
             MaskBuilder::MASK_OPERATOR,
             MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER
+            MaskBuilder::MASK_OWNER,
         ),
 
         self::PERMISSION_UNDELETE => array(
             MaskBuilder::MASK_UNDELETE,
             MaskBuilder::MASK_OPERATOR,
             MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER
+            MaskBuilder::MASK_OWNER,
         ),
 
         self::PERMISSION_LIST => array(
             MaskBuilder::MASK_LIST,
             MaskBuilder::MASK_OPERATOR,
             MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER
+            MaskBuilder::MASK_OWNER,
         ),
 
         self::PERMISSION_EXPORT => array(
             MaskBuilder::MASK_EXPORT,
             MaskBuilder::MASK_OPERATOR,
             MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER
+            MaskBuilder::MASK_OWNER,
         ),
 
         self::PERMISSION_OPERATOR => array(
             MaskBuilder::MASK_OPERATOR,
             MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER
+            MaskBuilder::MASK_OWNER,
         ),
 
         self::PERMISSION_MASTER => array(
@@ -114,7 +114,7 @@ class AdminPermissionMap implements PermissionMapInterface
     public function getMasks($permission, $object)
     {
         if (!isset($this->map[$permission])) {
-            return null;
+            return;
         }
 
         return $this->map[$permission];

--- a/Security/Acl/Permission/MaskBuilder.php
+++ b/Security/Acl/Permission/MaskBuilder.php
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Acl\Permission\MaskBuilder as BaseMaskBuilder;
 
 /**
  * {@inheritDoc}
- * - LIST: the SID is allowed to view a list of the domain objects / fields
+ * - LIST: the SID is allowed to view a list of the domain objects / fields.
  */
 class MaskBuilder extends BaseMaskBuilder
 {

--- a/Security/Handler/AclSecurityHandler.php
+++ b/Security/Handler/AclSecurityHandler.php
@@ -11,24 +11,23 @@
 
 namespace Sonata\AdminBundle\Security\Handler;
 
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
-use Symfony\Component\Security\Acl\Model\MutableAclProviderInterface;
-use Symfony\Component\Security\Acl\Model\AclInterface;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
-use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
-use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
+use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
 use Symfony\Component\Security\Acl\Exception\NotAllAclsFoundException;
-use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Component\Security\Acl\Model\AclInterface;
+use Symfony\Component\Security\Acl\Model\MutableAclProviderInterface;
+use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
- * Class AclSecurityHandler
+ * Class AclSecurityHandler.
  *
- * @package Sonata\AdminBundle\Security\Handler
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AclSecurityHandler implements AclSecurityHandlerInterface
@@ -129,7 +128,7 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
      */
     public function getBaseRole(AdminInterface $admin)
     {
-        return 'ROLE_' . str_replace('.', '_', strtoupper($admin->getCode())) . '_%s';
+        return 'ROLE_'.str_replace('.', '_', strtoupper($admin->getCode())).'_%s';
     }
 
     /**
@@ -185,7 +184,7 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
         try {
             $acl = $this->aclProvider->findAcl($objectIdentity);
         } catch (AclNotFoundException $e) {
-            return null;
+            return;
         }
 
         return $acl;

--- a/Security/Handler/AclSecurityHandlerInterface.php
+++ b/Security/Handler/AclSecurityHandlerInterface.php
@@ -16,15 +16,14 @@ use Symfony\Component\Security\Acl\Model\AclInterface;
 use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
 
 /**
- * Interface AclSecurityHandlerInterface
+ * Interface AclSecurityHandlerInterface.
  *
- * @package Sonata\AdminBundle\Security\Handler
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface AclSecurityHandlerInterface extends SecurityHandlerInterface
 {
     /**
-     * Set the permissions not related to an object instance and also to be available when objects do not exist
+     * Set the permissions not related to an object instance and also to be available when objects do not exist.
      *
      * @abstract
      *
@@ -33,15 +32,16 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
     public function setAdminPermissions(array $permissions);
 
     /**
-     * Return the permissions not related to an object instance and also to be available when objects do not exist
+     * Return the permissions not related to an object instance and also to be available when objects do not exist.
      *
      * @abstract
+     *
      * @return array
      */
     public function getAdminPermissions();
 
     /**
-     * Set the permissions related to an object instance
+     * Set the permissions related to an object instance.
      *
      * @abstract
      *
@@ -50,15 +50,16 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
     public function setObjectPermissions(array $permissions);
 
     /**
-     * Return the permissions related to an object instance
+     * Return the permissions related to an object instance.
      *
      * @abstract
+     *
      * @return array
      */
     public function getObjectPermissions();
 
     /**
-     * Get the ACL for the passed object identity
+     * Get the ACL for the passed object identity.
      *
      * @abstract
      *
@@ -69,7 +70,7 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
     public function getObjectAcl(ObjectIdentityInterface $objectIdentity);
 
     /**
-     * Find the ACLs for the passed object identities
+     * Find the ACLs for the passed object identities.
      *
      * @abstract
      *
@@ -77,12 +78,13 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
      * @param array        $sids an array of SecurityIdentityInterface implementations
      *
      * @throws \Exception
+     *
      * @return \SplObjectStorage mapping the passed object identities to ACLs
      */
     public function findObjectAcls(\Traversable $oids, array $sids = array());
 
     /**
-     * Add an object owner ACE to the object ACL
+     * Add an object owner ACE to the object ACL.
      *
      * @abstract
      *
@@ -92,17 +94,15 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
     public function addObjectOwner(AclInterface $acl, UserSecurityIdentity $securityIdentity = null);
 
     /**
-     * Add the object class ACE's to the object ACL
+     * Add the object class ACE's to the object ACL.
      *
      * @param AclInterface $acl
      * @param array        $roleInformation
-     *
-     * @return void
      */
     public function addObjectClassAces(AclInterface $acl, array $roleInformation = array());
 
     /**
-     * Create an object ACL
+     * Create an object ACL.
      *
      * @abstract
      *
@@ -113,29 +113,25 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
     public function createAcl(ObjectIdentityInterface $objectIdentity);
 
     /**
-     * Update the ACL
+     * Update the ACL.
      *
      * @abstract
      *
      * @param AclInterface $acl
-     *
-     * @return void
      */
     public function updateAcl(AclInterface $acl);
 
     /**
-     * Delete the ACL
+     * Delete the ACL.
      *
      * @abstract
      *
      * @param ObjectIdentityInterface $objectIdentity
-     *
-     * @return void
      */
     public function deleteAcl(ObjectIdentityInterface $objectIdentity);
 
     /**
-     * Helper method to find the index of a class ACE for a role
+     * Helper method to find the index of a class ACE for a role.
      *
      * @param AclInterface $acl
      * @param string       $role
@@ -145,7 +141,7 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
     public function findClassAceIndexByRole(AclInterface $acl, $role);
 
     /**
-     * Helper method to find the index of a class ACE for a username
+     * Helper method to find the index of a class ACE for a username.
      *
      * @param AclInterface $acl
      * @param string       $username

--- a/Security/Handler/NoopSecurityHandler.php
+++ b/Security/Handler/NoopSecurityHandler.php
@@ -14,9 +14,8 @@ namespace Sonata\AdminBundle\Security\Handler;
 use Sonata\AdminBundle\Admin\AdminInterface;
 
 /**
- * Class NoopSecurityHandler
+ * Class NoopSecurityHandler.
  *
- * @package Sonata\AdminBundle\Security\Handler
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class NoopSecurityHandler implements SecurityHandlerInterface

--- a/Security/Handler/RoleSecurityHandler.php
+++ b/Security/Handler/RoleSecurityHandler.php
@@ -11,15 +11,14 @@
 
 namespace Sonata\AdminBundle\Security\Handler;
 
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
- * Class RoleSecurityHandler
+ * Class RoleSecurityHandler.
  *
- * @package Sonata\AdminBundle\Security\Handler
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class RoleSecurityHandler implements SecurityHandlerInterface
@@ -33,7 +32,7 @@ class RoleSecurityHandler implements SecurityHandlerInterface
 
     /**
      * @param AuthorizationCheckerInterface|SecurityContextInterface $authorizationChecker
-     * @param array                                          $superAdminRoles
+     * @param array                                                  $superAdminRoles
      *
      * @todo Go back to signature class check when bumping requirements to SF 2.6+
      */
@@ -75,7 +74,7 @@ class RoleSecurityHandler implements SecurityHandlerInterface
      */
     public function getBaseRole(AdminInterface $admin)
     {
-        return 'ROLE_' . str_replace('.', '_', strtoupper($admin->getCode())) . '_%s';
+        return 'ROLE_'.str_replace('.', '_', strtoupper($admin->getCode())).'_%s';
     }
 
     /**

--- a/Security/Handler/SecurityHandlerInterface.php
+++ b/Security/Handler/SecurityHandlerInterface.php
@@ -14,9 +14,8 @@ namespace Sonata\AdminBundle\Security\Handler;
 use Sonata\AdminBundle\Admin\AdminInterface;
 
 /**
- * Interface SecurityHandlerInterface
+ * Interface SecurityHandlerInterface.
  *
- * @package Sonata\AdminBundle\Security\Handler
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface SecurityHandlerInterface
@@ -26,12 +25,12 @@ interface SecurityHandlerInterface
      * @param string|array                             $attributes
      * @param null                                     $object
      *
-     * @return boolean
+     * @return bool
      */
     public function isGranted(AdminInterface $admin, $attributes, $object = null);
 
     /**
-     * Get a sprintf template to get the role
+     * Get a sprintf template to get the role.
      *
      * @param \Sonata\AdminBundle\Admin\AdminInterface $admin
      *
@@ -45,22 +44,18 @@ interface SecurityHandlerInterface
     public function buildSecurityInformation(AdminInterface $admin);
 
     /**
-     * Create object security, fe. make the current user owner of the object
+     * Create object security, fe. make the current user owner of the object.
      *
      * @param \Sonata\AdminBundle\Admin\AdminInterface $admin
      * @param mixed                                    $object
-     *
-     * @return void
      */
     public function createObjectSecurity(AdminInterface $admin, $object);
 
     /**
-     * Remove object security
+     * Remove object security.
      *
      * @param \Sonata\AdminBundle\Admin\AdminInterface $admin
      * @param mixed                                    $object
-     *
-     * @return void
      */
     public function deleteObjectSecurity(AdminInterface $admin, $object);
 }

--- a/Show/ShowMapper.php
+++ b/Show/ShowMapper.php
@@ -13,16 +13,15 @@
 namespace Sonata\AdminBundle\Show;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
 
 /**
  * Class ShowMapper
- * This class is used to simulate the Form API
+ * This class is used to simulate the Form API.
  *
- * @package Sonata\AdminBundle\Show
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ShowMapper extends BaseGroupedMapper

--- a/SonataAdminBundle.php
+++ b/SonataAdminBundle.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sonata project.
  *
@@ -10,12 +11,12 @@
 
 namespace Sonata\AdminBundle;
 
-use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SonataAdminBundle extends Bundle
 {

--- a/Tests/Admin/AdminHelperTest.php
+++ b/Tests/Admin/AdminHelperTest.php
@@ -14,11 +14,6 @@ namespace Sonata\AdminBundle\Tests\Admin;
 use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\Pool;
 use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Symfony\Component\Form\FormView;
 
 class AdminHelperTest extends \PHPUnit_Framework_TestCase

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -12,18 +12,18 @@
 namespace Sonata\AdminBundle\Tests\Admin;
 
 use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Route\DefaultRouteGenerator;
 use Sonata\AdminBundle\Route\RoutesCache;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentAdmin;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\FieldDescription;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\ModelAdmin;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Tag;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToStringNull;
-use Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin;
-use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentAdmin;
 use Symfony\Component\HttpFoundation\Request;
-use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Tests\Fixtures\Admin\ModelAdmin;
-use Sonata\AdminBundle\Tests\Fixtures\Admin\FieldDescription;
 
 class AdminTest extends \PHPUnit_Framework_TestCase
 {
@@ -385,59 +385,59 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         return array(
             array(
                 'Application\Sonata\NewsBundle\Entity\Post',
-                '/sonata/news/post'
+                '/sonata/news/post',
             ),
             array(
                 'Application\Sonata\NewsBundle\Document\Post',
-                '/sonata/news/post'
+                '/sonata/news/post',
             ),
             array(
                 'MyApplication\MyBundle\Entity\Post',
-                '/myapplication/my/post'
+                '/myapplication/my/post',
             ),
             array(
                 'MyApplication\MyBundle\Entity\Post\Category',
-                '/myapplication/my/post-category'
+                '/myapplication/my/post-category',
             ),
             array(
                 'MyApplication\MyBundle\Entity\Product\Category',
-                '/myapplication/my/product-category'
+                '/myapplication/my/product-category',
             ),
             array(
                 'MyApplication\MyBundle\Entity\Other\Product\Category',
-                '/myapplication/my/other-product-category'
+                '/myapplication/my/other-product-category',
             ),
             array(
                 'Symfony\Cmf\Bundle\FooBundle\Document\Menu',
-                '/cmf/foo/menu'
+                '/cmf/foo/menu',
             ),
             array(
                 'Symfony\Cmf\Bundle\FooBundle\Doctrine\Phpcr\Menu',
-                '/cmf/foo/menu'
+                '/cmf/foo/menu',
             ),
             array(
                 'Symfony\Bundle\BarBarBundle\Doctrine\Phpcr\Menu',
-                '/symfony/barbar/menu'
+                '/symfony/barbar/menu',
             ),
             array(
                 'Symfony\Bundle\BarBarBundle\Doctrine\Phpcr\Menu\Item',
-                '/symfony/barbar/menu-item'
+                '/symfony/barbar/menu-item',
             ),
             array(
                 'Symfony\Cmf\Bundle\FooBundle\Doctrine\Orm\Menu',
-                '/cmf/foo/menu'
+                '/cmf/foo/menu',
             ),
             array(
                 'Symfony\Cmf\Bundle\FooBundle\Doctrine\MongoDB\Menu',
-                '/cmf/foo/menu'
+                '/cmf/foo/menu',
             ),
             array(
                 'Symfony\Cmf\Bundle\FooBundle\Doctrine\CouchDB\Menu',
-                '/cmf/foo/menu'
+                '/cmf/foo/menu',
             ),
             array(
                 'AppBundle\Entity\User',
-                '/app/user'
+                '/app/user',
             ),
         );
     }
@@ -474,59 +474,59 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         return array(
             array(
                 'Application\Sonata\NewsBundle\Entity\Post',
-                'admin_sonata_news_post'
+                'admin_sonata_news_post',
             ),
             array(
                 'Application\Sonata\NewsBundle\Document\Post',
-                'admin_sonata_news_post'
+                'admin_sonata_news_post',
             ),
             array(
                 'MyApplication\MyBundle\Entity\Post',
-                'admin_myapplication_my_post'
+                'admin_myapplication_my_post',
             ),
             array(
                 'MyApplication\MyBundle\Entity\Post\Category',
-                'admin_myapplication_my_post_category'
+                'admin_myapplication_my_post_category',
             ),
             array(
                 'MyApplication\MyBundle\Entity\Product\Category',
-                'admin_myapplication_my_product_category'
+                'admin_myapplication_my_product_category',
             ),
             array(
                 'MyApplication\MyBundle\Entity\Other\Product\Category',
-                'admin_myapplication_my_other_product_category'
+                'admin_myapplication_my_other_product_category',
             ),
             array(
                 'Symfony\Cmf\Bundle\FooBundle\Document\Menu',
-                'admin_cmf_foo_menu'
+                'admin_cmf_foo_menu',
             ),
             array(
                 'Symfony\Cmf\Bundle\FooBundle\Doctrine\Phpcr\Menu',
-                'admin_cmf_foo_menu'
+                'admin_cmf_foo_menu',
             ),
             array(
                 'Symfony\Bundle\BarBarBundle\Doctrine\Phpcr\Menu',
-                'admin_symfony_barbar_menu'
+                'admin_symfony_barbar_menu',
             ),
             array(
                 'Symfony\Bundle\BarBarBundle\Doctrine\Phpcr\Menu\Item',
-                'admin_symfony_barbar_menu_item'
+                'admin_symfony_barbar_menu_item',
             ),
             array(
                 'Symfony\Cmf\Bundle\FooBundle\Doctrine\Orm\Menu',
-                'admin_cmf_foo_menu'
+                'admin_cmf_foo_menu',
             ),
             array(
                 'Symfony\Cmf\Bundle\FooBundle\Doctrine\MongoDB\Menu',
-                'admin_cmf_foo_menu'
+                'admin_cmf_foo_menu',
             ),
             array(
                 'Symfony\Cmf\Bundle\FooBundle\Doctrine\CouchDB\Menu',
-                'admin_cmf_foo_menu'
+                'admin_cmf_foo_menu',
             ),
             array(
                 'AppBundle\Entity\User',
-                'admin_app_user'
+                'admin_app_user',
             ),
         );
     }
@@ -609,7 +609,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $s = new FooToStringNull();
         $this->assertNotEmpty($admin->toString($s));
 
-        $this->assertEquals("", $admin->toString(false));
+        $this->assertEquals('', $admin->toString(false));
     }
 
     public function testIsAclEnabled()
@@ -646,7 +646,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         // Just for the record, if there is no inheritance set, the getSubject is not used
         // the getSubject can also lead to some issue
          $admin->setSubject(new \stdClass());
-         $this->assertEquals('stdClass', $admin->getClass());
+        $this->assertEquals('stdClass', $admin->getClass());
 
         $admin->setSubClasses(array('extended1' => 'NewsBundle\Entity\PostExtended1', 'extended2' => 'NewsBundle\Entity\PostExtended2'));
         $this->assertFalse($admin->hasSubClass('test'));
@@ -1031,7 +1031,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $templates = array(
             'list' => 'FooAdminBundle:CRUD:list.html.twig',
             'show' => 'FooAdminBundle:CRUD:show.html.twig',
-            'edit' => 'FooAdminBundle:CRUD:edit.html.twig'
+            'edit' => 'FooAdminBundle:CRUD:edit.html.twig',
         );
 
         $admin->setTemplates($templates);
@@ -1060,7 +1060,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $templates = array(
             'list' => 'FooAdminBundle:CRUD:list.html.twig',
             'show' => 'FooAdminBundle:CRUD:show.html.twig',
-            'edit' => 'FooAdminBundle:CRUD:edit.html.twig'
+            'edit' => 'FooAdminBundle:CRUD:edit.html.twig',
         );
 
         $admin->setTemplates($templates);
@@ -1133,7 +1133,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $entity = new \stdClass();
 
-        $securityHandler=$this->getMock('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface');
+        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface');
         $securityHandler->expects($this->any())
             ->method('isGranted')
             ->will($this->returnCallback(function (AdminInterface $adminIn, $attributes, $object = null) use ($admin, $entity) {
@@ -1174,7 +1174,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $securityHandler=$this->getMock('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface');
+        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface');
         $securityHandler->expects($this->any())
             ->method('isGranted')
             ->will($this->returnCallback(function (AdminInterface $adminIn, $attributes, $object = null) use ($admin) {
@@ -1231,10 +1231,10 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $translator->expects($this->once())
             ->method('trans')
-            ->with($this->equalTo('foo'), $this->equalTo(array('name'=>'Andrej')), $this->equalTo('fooMessageDomain'))
+            ->with($this->equalTo('foo'), $this->equalTo(array('name' => 'Andrej')), $this->equalTo('fooMessageDomain'))
             ->will($this->returnValue('fooTranslated'));
 
-        $this->assertEquals('fooTranslated', $admin->trans('foo', array('name'=>'Andrej'), 'fooMessageDomain'));
+        $this->assertEquals('fooTranslated', $admin->trans('foo', array('name' => 'Andrej'), 'fooMessageDomain'));
     }
 
     public function testTransChoiceWithNoTranslator()
@@ -1269,10 +1269,10 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $translator->expects($this->once())
             ->method('transChoice')
-            ->with($this->equalTo('foo'), $this->equalTo(2), $this->equalTo(array('name'=>'Andrej')), $this->equalTo('fooMessageDomain'))
+            ->with($this->equalTo('foo'), $this->equalTo(2), $this->equalTo(array('name' => 'Andrej')), $this->equalTo('fooMessageDomain'))
             ->will($this->returnValue('fooTranslated'));
 
-        $this->assertEquals('fooTranslated', $admin->transChoice('foo', 2, array('name'=>'Andrej'), 'fooMessageDomain'));
+        $this->assertEquals('fooTranslated', $admin->transChoice('foo', 2, array('name' => 'Andrej'), 'fooMessageDomain'));
     }
 
     public function testSetPersistFilters()
@@ -1359,7 +1359,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     public function testGetPersistentParametersWithValidExtension()
     {
         $expected = array(
-            'context' => 'foobar'
+            'context' => 'foobar',
         );
 
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
@@ -1454,7 +1454,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
                     'foo' => 'foo',
                     'bar' => 'bar',
                 ),
-            )
+            ),
         );
 
         $admin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
@@ -1466,7 +1466,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
                 'fields' => array(
                     'bar' => 'bar',
                 ),
-            )
+            ),
         ));
 
         $admin->removeFieldFromFormGroup('bar');
@@ -1562,7 +1562,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $modelAdmin->setDatagridBuilder($datagridBuilder);
 
-        $this->assertSame(array('foo'=>$fooFieldDescription, 'bar'=>$barFieldDescription, 'baz'=>$bazFieldDescription), $modelAdmin->getFilterFieldDescriptions());
+        $this->assertSame(array('foo' => $fooFieldDescription, 'bar' => $barFieldDescription, 'baz' => $bazFieldDescription), $modelAdmin->getFilterFieldDescriptions());
         $this->assertFalse($modelAdmin->hasFilterFieldDescription('fooBar'));
         $this->assertTrue($modelAdmin->hasFilterFieldDescription('foo'));
         $this->assertTrue($modelAdmin->hasFilterFieldDescription('bar'));

--- a/Tests/Admin/BaseAdminModelManagerTest.php
+++ b/Tests/Admin/BaseAdminModelManagerTest.php
@@ -12,11 +12,9 @@
 namespace Sonata\AdminBundle\Tests\Admin;
 
 use Sonata\AdminBundle\Admin\Admin;
-use Sonata\AdminBundle\Model\ModelManagerInterface;
 
 class BaseAdminModelManager_Admin extends Admin
 {
-
 }
 
 class BaseAdminModelManagerTest extends \PHPUnit_Framework_TestCase

--- a/Tests/Admin/BaseFieldDescriptionTest.php
+++ b/Tests/Admin/BaseFieldDescriptionTest.php
@@ -12,7 +12,6 @@
 namespace Sonata\AdminBundle\Tests\Admin;
 
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\FieldDescription;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooCall;
@@ -107,7 +106,7 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(42, $description->getFieldValue($mock, 'fake'));
 
-        /**
+        /*
          * Test with One parameter int
          */
         $arg1 = 38;
@@ -122,7 +121,7 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(40, $description1->getFieldValue($mock1, 'fake'));
 
-        /**
+        /*
          * Test with Two parameters int
          */
         $arg2 = 4;
@@ -133,10 +132,10 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
 
         $mock2 = $this->getMock('stdClass', array('getWithTwoParameters'));
         $returnValue2 = $arg1 + $arg2;
-        $mock2->expects($this->any())->method('getWithTwoParameters')->with($this->equalTo($arg1),$this->equalTo($arg2))->will($this->returnValue($returnValue2));
+        $mock2->expects($this->any())->method('getWithTwoParameters')->with($this->equalTo($arg1), $this->equalTo($arg2))->will($this->returnValue($returnValue2));
         $this->assertEquals(42, $description2->getFieldValue($mock2, 'fake'));
 
-        /**
+        /*
          * Test with underscored attribute name
          */
         $description3  = new FieldDescription();

--- a/Tests/Admin/FieldDescriptionCollectionTest.php
+++ b/Tests/Admin/FieldDescriptionCollectionTest.php
@@ -12,7 +12,6 @@
 namespace Sonata\AdminBundle\Tests\Admin;
 
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 
 class FieldDescriptionCollectionTest extends \PHPUnit_Framework_TestCase
 {

--- a/Tests/Admin/PoolTest.php
+++ b/Tests/Admin/PoolTest.php
@@ -22,7 +22,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->pool = new Pool($this->getContainer(), 'Sonata Admin', '/path/to/pic.png', array('foo'=>'bar'));
+        $this->pool = new Pool($this->getContainer(), 'Sonata Admin', '/path/to/pic.png', array('foo' => 'bar'));
     }
 
     public function testGetGroups()
@@ -30,13 +30,13 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $this->pool->setAdminServiceIds(array('sonata.user.admin.group1'));
 
         $this->pool->setAdminGroups(array(
-            'adminGroup1' => array('sonata.user.admin.group1' => array())
+            'adminGroup1' => array('sonata.user.admin.group1' => array()),
         ));
 
         $expectedOutput = array(
             'adminGroup1' => array(
-                'sonata.user.admin.group1' => 'adminUserClass'
-            )
+                'sonata.user.admin.group1' => 'adminUserClass',
+            ),
         );
 
         $this->assertEquals($expectedOutput, $this->pool->getGroups());
@@ -45,7 +45,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     public function testHasGroup()
     {
         $this->pool->setAdminGroups(array(
-                'adminGroup1' => array()
+                'adminGroup1' => array(),
             ));
 
         $this->assertTrue($this->pool->hasGroup('adminGroup1'));
@@ -74,13 +74,13 @@ class PoolTest extends \PHPUnit_Framework_TestCase
 
         $pool->setAdminGroups(array(
             'adminGroup1' => array(
-                'items' => array('itemKey' =>  array('admin' => 'sonata.user.admin.group1', 'label' => '', 'route' => '', 'route_params' => array()))
+                'items' => array('itemKey' => array('admin' => 'sonata.user.admin.group1', 'label' => '', 'route' => '', 'route_params' => array())),
             ),
             'adminGroup2' => array(
-                'items' => array('itemKey' =>  array('admin' => 'sonata.user.admin.group2', 'label' => '', 'route' => '', 'route_params' => array()))
+                'items' => array('itemKey' => array('admin' => 'sonata.user.admin.group2', 'label' => '', 'route' => '', 'route_params' => array())),
             ),
             'adminGroup3' => array(
-                'items' => array('itemKey' =>  array('admin' => 'sonata.user.admin.group3', 'label' => '', 'route' => '', 'route_params' => array()))
+                'items' => array('itemKey' => array('admin' => 'sonata.user.admin.group3', 'label' => '', 'route' => '', 'route_params' => array())),
             ),
         ));
 
@@ -96,7 +96,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     public function testGetAdminsByGroupWhenGroupNotSet()
     {
         $this->pool->setAdminGroups(array(
-                'adminGroup1' => array()
+                'adminGroup1' => array(),
             ));
 
         $this->pool->getAdminsByGroup('adminGroup2');
@@ -105,7 +105,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     public function testGetAdminsByGroupWhenGroupIsEmpty()
     {
         $this->pool->setAdminGroups(array(
-                'adminGroup1' => array()
+                'adminGroup1' => array(),
             ));
 
         $this->assertEquals(array(), $this->pool->getAdminsByGroup('adminGroup1'));
@@ -116,7 +116,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $this->pool->setAdminServiceIds(array('sonata.admin1', 'sonata.admin2', 'sonata.admin3'));
         $this->pool->setAdminGroups(array(
             'adminGroup1' => array('items' => array('sonata.admin1', 'sonata.admin2')),
-            'adminGroup2' => array('items' => array('sonata.admin3'))
+            'adminGroup2' => array('items' => array('sonata.admin3')),
         ));
 
         $this->assertCount(2, $this->pool->getAdminsByGroup('adminGroup1'));
@@ -131,7 +131,6 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     *
      * @expectedException \RuntimeException
      */
     public function testGetAdminForClassWithInvalidFormat()
@@ -143,7 +142,6 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     *
      * @expectedException \RuntimeException
      */
     public function testGetAdminForClassWithTooManyRegisteredAdmin()

--- a/Tests/Command/CreateClassCacheCommandTest.php
+++ b/Tests/Command/CreateClassCacheCommandTest.php
@@ -11,10 +11,9 @@
 
 namespace Sonata\AdminBundle\Tests\Command;
 
+use Sonata\AdminBundle\Command\CreateClassCacheCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Sonata\AdminBundle\Command\CreateClassCacheCommand;
-use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -66,7 +65,7 @@ class CreateClassCacheCommandTest extends \PHPUnit_Framework_TestCase
                         return $kernel;
                     }
 
-                    return null;
+                    return;
                 }));
 
         $command->setContainer($container);

--- a/Tests/Command/ExplainAdminCommandTest.php
+++ b/Tests/Command/ExplainAdminCommandTest.php
@@ -11,21 +11,14 @@
 
 namespace Sonata\AdminBundle\Tests\Command;
 
-use Sonata\AdminBundle\Command\ExplainAdminCommand;
-use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Console\Application;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Command\ExplainAdminCommand;
 use Sonata\AdminBundle\Route\RouteCollection;
-use Symfony\Component\Validator\MetadataFactoryInterface;
-use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Symfony\Component\Form\FormBuilderInterface;
-use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
-use Sonata\AdminBundle\Builder\ListBuilderInterface;
-use Symfony\Component\Form\FormBuilder;
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
-use Symfony\Component\Validator\Constraints\NotNull;
-use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotNull;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -98,11 +91,11 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->admin->expects($this->any())
             ->method('getListFieldDescriptions')
-            ->will($this->returnValue(array('fooTextField'=>$fieldDescription1, 'barDateTimeField'=>$fieldDescription2)));
+            ->will($this->returnValue(array('fooTextField' => $fieldDescription1, 'barDateTimeField' => $fieldDescription2)));
 
         $this->admin->expects($this->any())
             ->method('getFilterFieldDescriptions')
-            ->will($this->returnValue(array('fooTextField'=>$fieldDescription1, 'barDateTimeField'=>$fieldDescription2)));
+            ->will($this->returnValue(array('fooTextField' => $fieldDescription1, 'barDateTimeField' => $fieldDescription2)));
 
         $this->admin->expects($this->any())
             ->method('getFormTheme')
@@ -110,7 +103,7 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->admin->expects($this->any())
             ->method('getFormFieldDescriptions')
-            ->will($this->returnValue(array('fooTextField'=>$fieldDescription1, 'barDateTimeField'=>$fieldDescription2)));
+            ->will($this->returnValue(array('fooTextField' => $fieldDescription1, 'barDateTimeField' => $fieldDescription2)));
 
         $this->admin->expects($this->any())
             ->method('isChild')
@@ -153,7 +146,7 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
                         return $admin;
                 }
 
-                return null;
+                return;
             }));
 
         $command->setContainer($container);
@@ -178,11 +171,11 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
         }
 
         $propertyMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\\'.$class);
-        $propertyMetadata->constraints = array(new NotNull(), new Length(array('min' => 2, 'max' => 50, 'groups' => array('create', 'edit'),)));
+        $propertyMetadata->constraints = array(new NotNull(), new Length(array('min' => 2, 'max' => 50, 'groups' => array('create', 'edit'))));
         $metadata->properties = array('firstName' => $propertyMetadata);
 
         $getterMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\\'.$class);
-        $getterMetadata->constraints = array(new NotNull(), new Email(array('groups' => array('registration', 'edit'),)));
+        $getterMetadata->constraints = array(new NotNull(), new Email(array('groups' => array('registration', 'edit'))));
         $metadata->getters = array('email' => $getterMetadata);
 
         $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
@@ -213,7 +206,7 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
 
         $command = $this->application->find('sonata:admin:explain');
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array('command' => $command->getName(), 'admin'=>'acme.admin.foo'));
+        $commandTester->execute(array('command' => $command->getName(), 'admin' => 'acme.admin.foo'));
 
         $this->assertEquals(sprintf(str_replace("\n", PHP_EOL, file_get_contents(__DIR__.'/../Fixtures/Command/explain_admin.txt')), get_class($this->admin), get_class($modelManager), get_class($datagridBuilder), get_class($listBuilder)), $commandTester->getDisplay());
     }
@@ -258,7 +251,7 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
 
         $command = $this->application->find('sonata:admin:explain');
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array('command' => $command->getName(), 'admin'=>'acme.admin.foo'));
+        $commandTester->execute(array('command' => $command->getName(), 'admin' => 'acme.admin.foo'));
 
         $this->assertEquals(sprintf(str_replace("\n", PHP_EOL, file_get_contents(__DIR__.'/../Fixtures/Command/explain_admin_empty_validator.txt')), get_class($this->admin), get_class($modelManager), get_class($datagridBuilder), get_class($listBuilder)), $commandTester->getDisplay());
     }
@@ -268,8 +261,7 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
         try {
             $command = $this->application->find('sonata:admin:explain');
             $commandTester = new CommandTester($command);
-            $commandTester->execute(array('command' => $command->getName(), 'admin'=>'nonexistent.service'));
-
+            $commandTester->execute(array('command' => $command->getName(), 'admin' => 'nonexistent.service'));
         } catch (\RuntimeException $e) {
             $this->assertEquals('Service "nonexistent.service" is not an admin class', $e->getMessage());
 

--- a/Tests/Command/GenerateAdminCommandTest.php
+++ b/Tests/Command/GenerateAdminCommandTest.php
@@ -11,17 +11,15 @@
 
 namespace Sonata\AdminBundle\Tests\Command;
 
-use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\Console\Tester\CommandTester;
 use Sonata\AdminBundle\Command\GenerateAdminCommand;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\DemoAdminBundle;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -125,14 +123,14 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         $command = $this->application->find('sonata:admin:generate');
         $commandTester = new CommandTester($command);
         $commandTester->execute(array(
-            'command' => $command->getName(),
-            'model'=>'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo',
-            '--bundle'=>'AcmeDemoBundle',
-            '--admin'=>'FooAdmin',
-            '--controller'=>'FooAdminController',
-            '--services'=>'admin.yml',
-            '--id'=>'acme_demo_admin.admin.foo',
-            ), array('interactive'=>false,));
+            'command'      => $command->getName(),
+            'model'        => 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo',
+            '--bundle'     => 'AcmeDemoBundle',
+            '--admin'      => 'FooAdmin',
+            '--controller' => 'FooAdminController',
+            '--services'   => 'admin.yml',
+            '--id'         => 'acme_demo_admin.admin.foo',
+        ), array('interactive' => false));
 
         $expectedOutput = '';
         $expectedOutput .= sprintf('%3$sThe admin class "Sonata\AdminBundle\Tests\Fixtures\Bundle\Admin\FooAdmin" has been generated under the file "%1$s%2$sAdmin%2$sFooAdmin.php".%3$s', $this->tempDirectory, DIRECTORY_SEPARATOR, PHP_EOL);
@@ -175,14 +173,14 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         $command = $this->application->find('sonata:admin:generate');
         $commandTester = new CommandTester($command);
         $commandTester->execute(array(
-            'command' => $command->getName(),
-            'model'=>'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo',
-            '--bundle'=>'AcmeDemoBundle',
-            '--admin'=>'FooAdmin',
-            '--controller'=>'FooAdminController',
-            '--services'=>'admin.yml',
-            '--id'=>'acme_demo_admin.admin.foo',
-            ), array('interactive'=>false,));
+            'command'      => $command->getName(),
+            'model'        => 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo',
+            '--bundle'     => 'AcmeDemoBundle',
+            '--admin'      => 'FooAdmin',
+            '--controller' => 'FooAdminController',
+            '--services'   => 'admin.yml',
+            '--id'         => 'acme_demo_admin.admin.foo',
+        ), array('interactive' => false));
     }
 
     /**
@@ -199,12 +197,12 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         // @todo remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping  support for Symfony 2.3
         // DialogHelper does not exist in SensioGeneratorBundle 2.5+
         if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
-           $dialog = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper', array('askConfirmation', 'askAndValidate'));
+            $dialog = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper', array('askConfirmation', 'askAndValidate'));
 
             $dialog->expects($this->any())
                 ->method('askConfirmation')
                 ->will($this->returnCallback(function (OutputInterface $output, $question, $default) {
-                    $questionClean = substr($question, 6, strpos($question, '</info>')-6);
+                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
 
                     switch ($questionClean) {
                         case 'Do you want to generate a controller':
@@ -221,7 +219,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
                 ->method('askAndValidate')
                 ->will($this->returnCallback(function (OutputInterface $output, $question, $validator, $attempts = false, $default = null) use ($modelEntity) {
 
-                    $questionClean = substr($question, 6, strpos($question, '</info>')-6);
+                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
 
                     switch ($questionClean) {
                         case 'The fully qualified model class':
@@ -256,7 +254,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
             $questionHelper->expects($this->any())
                 ->method('ask')
                 ->will($this->returnCallback(function (InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity) {
-                    $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>')-6);
+                    $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>') - 6);
 
                     switch ($questionClean) {
                         // confirmations
@@ -298,7 +296,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array(
             'command' => $command->getName(),
-            'model' => $modelEntity,
+            'model'   => $modelEntity,
             ));
 
         $expectedOutput = PHP_EOL.str_pad('', 41, ' ').PHP_EOL.'  Welcome to the Sonata admin generator  '.PHP_EOL.str_pad('', 41, ' ').PHP_EOL.PHP_EOL;

--- a/Tests/Command/ListAdminCommandTest.php
+++ b/Tests/Command/ListAdminCommandTest.php
@@ -11,10 +11,10 @@
 
 namespace Sonata\AdminBundle\Tests\Command;
 
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Tester\CommandTester;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Command\ListAdminCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -55,7 +55,7 @@ class ListAdminCommandTest extends \PHPUnit_Framework_TestCase
                         return $admin2;
                 }
 
-                return null;
+                return;
             }));
 
         $command->setContainer($container);

--- a/Tests/Command/SetupAclCommandTest.php
+++ b/Tests/Command/SetupAclCommandTest.php
@@ -11,11 +11,11 @@
 
 namespace Sonata\AdminBundle\Tests\Command;
 
+use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Command\SetupAclCommand;
+use Sonata\AdminBundle\Util\AdminAclManipulatorInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Sonata\AdminBundle\Admin\Pool;
-use Sonata\AdminBundle\Util\AdminAclManipulatorInterface;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -48,7 +48,7 @@ class SetupAclCommandTest extends \PHPUnit_Framework_TestCase
                         return $admin;
                 }
 
-                return null;
+                return;
             }));
 
         $command->setContainer($container);
@@ -118,7 +118,7 @@ class SetupAclCommandTest extends \PHPUnit_Framework_TestCase
                         return $admin;
                 }
 
-                return null;
+                return;
             }));
 
         $command->setContainer($container);

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -11,29 +11,29 @@
 
 namespace Sonata\AdminBundle\Tests\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Request;
-use Sonata\AdminBundle\Controller\CRUDController;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\Pool;
-use Symfony\Component\HttpFoundation\Response;
+use Sonata\AdminBundle\Controller\CRUDController;
+use Sonata\AdminBundle\Exception\ModelManagerException;
+use Sonata\AdminBundle\Tests\Fixtures\Controller\BatchAdminController;
+use Sonata\AdminBundle\Tests\Fixtures\Controller\PreCRUDController;
+use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
 use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
-use Sonata\AdminBundle\Exception\ModelManagerException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
-use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
-use Sonata\AdminBundle\Tests\Fixtures\Controller\BatchAdminController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
-use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Tests\Fixtures\Controller\PreCRUDController;
 
 /**
- * Test for CRUDController
+ * Test for CRUDController.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
@@ -720,7 +720,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->logger->expects($this->once())
             ->method('error')
             ->with($message, array(
-                'exception' => $exception,
+                'exception'                  => $exception,
                 'previous_exception_message' => $previousExceptionMessage,
             ));
     }

--- a/Tests/Controller/CoreControllerTest.php
+++ b/Tests/Controller/CoreControllerTest.php
@@ -11,11 +11,8 @@
 
 namespace Sonata\AdminBundle\Tests\Controller;
 
-use Sonata\AdminBundle\Controller\CoreController;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\Response;
 use Sonata\AdminBundle\Admin\Pool;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Sonata\AdminBundle\Controller\CoreController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -43,7 +40,7 @@ class CoreControllerTest extends \PHPUnit_Framework_TestCase
             'sonata.admin.pool' => $pool,
             'templating'        => $templating,
             'request'           => $request,
-            'request_stack'     => $requestStack
+            'request_stack'     => $requestStack,
         );
 
         $container->expects($this->any())->method('get')->will($this->returnCallback(function ($id) use ($values) {
@@ -65,7 +62,6 @@ class CoreControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testdashboardActionAjaxLayout()
     {
-
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $pool = new Pool($container, 'title', 'logo.png');
@@ -87,7 +83,7 @@ class CoreControllerTest extends \PHPUnit_Framework_TestCase
             'sonata.admin.pool' => $pool,
             'templating'        => $templating,
             'request'           => $request,
-            'request_stack'     => $requestStack
+            'request_stack'     => $requestStack,
         );
 
         $container->expects($this->any())->method('get')->will($this->returnCallback(function ($id) use ($values) {
@@ -106,5 +102,4 @@ class CoreControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
     }
-
 }

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -12,22 +12,17 @@
 namespace Sonata\AdminBundle\Tests\Controller;
 
 use Sonata\AdminBundle\Admin\AdminHelper;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Controller\HelperController;
+use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
+use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
-use \Twig_Environment as Twig;
-use \Twig_ExtensionInterface as Twig_ExtensionInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
-use Symfony\Component\Form\Form;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\FormView;
-use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
+use Twig_Environment as Twig;
+use Twig_ExtensionInterface as Twig_ExtensionInterface;
 
 class AdminControllerHelper_Foo
 {
@@ -40,7 +35,6 @@ class AdminControllerHelper_Foo
 
     public function setEnabled($value)
     {
-
     }
 
     public function setBar(AdminControllerHelper_Bar $bar)
@@ -109,7 +103,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
                         return $admin;
                 }
 
-                return null;
+                return;
             }));
 
         return;
@@ -125,7 +119,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
-            'uniqid'   => 'asdasd123'
+            'uniqid'   => 'asdasd123',
         ));
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(array('sonata.post.admin'));
@@ -153,7 +147,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
-            'uniqid'   => 'asdasd123'
+            'uniqid'   => 'asdasd123',
         ));
 
         $pool = new Pool($container, 'title', 'logo');
@@ -179,9 +173,9 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $twig = new Twig();
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
-            'objectId' => "",
+            'objectId' => '',
             'uniqid'   => 'asdasd123',
-            '_format'  => 'html'
+            '_format'  => 'html',
         ));
 
         $pool = new Pool($container, 'title', 'logo');
@@ -204,7 +198,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->once())->method('getTemplate')->will($this->returnValue($mockTemplate));
         $admin->expects($this->once())->method('getObject')->will($this->returnValue(new AdminControllerHelper_Foo()));
         $admin->expects($this->once())->method('toString')->will($this->returnValue('bar'));
-        $admin->expects($this->once())->method('generateObjectUrl')->will($this->returnCallback(function($type, $object, $parameters = array()) {
+        $admin->expects($this->once())->method('generateObjectUrl')->will($this->returnCallback(function ($type, $object, $parameters = array()) {
             if ($type != 'edit') {
                 return 'invalid name';
             }
@@ -227,7 +221,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
             'uniqid'   => 'asdasd123',
-            '_format'  => 'html'
+            '_format'  => 'html',
         ));
 
         $pool = new Pool($container, 'title', 'logo');
@@ -269,9 +263,9 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
-            'field'   => 'enabled',
-            'value'   => 1,
-            'context' => 'list',
+            'field'    => 'enabled',
+            'value'    => 1,
+            'context'  => 'list',
         ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'));
 
         $pool = new Pool($container, 'title', 'logo');
@@ -285,7 +279,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $response = $controller->setObjectFieldValueAction($request);
 
-        $this->assertEquals('{"status":"OK","content":"\u003Cfoo \/\u003E"}', $response->getContent() );
+        $this->assertEquals('{"status":"OK","content":"\u003Cfoo \/\u003E"}', $response->getContent());
     }
 
     public function testappendFormFieldElementAction()
@@ -328,9 +322,9 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
-            'field'   => 'enabled',
-            'value'   => 1,
-            'context' => 'list',
+            'field'    => 'enabled',
+            'value'    => 1,
+            'context'  => 'list',
         ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'POST'));
 
         $pool = new Pool($container, 'title', 'logo');
@@ -352,7 +346,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $helper = $this->getMock('Sonata\AdminBundle\Admin\AdminHelper', array('appendFormFieldElement', 'getChildFormView'), array($pool));
         $helper->expects($this->once())->method('appendFormFieldElement')->will($this->returnValue(array(
             $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface'),
-            $mockForm
+            $mockForm,
         )));
         $helper->expects($this->once())->method('getChildFormView')->will($this->returnValue($mockView));
 
@@ -411,9 +405,9 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
-            'field'   => 'enabled',
-            'value'   => 1,
-            'context' => 'list',
+            'field'    => 'enabled',
+            'value'    => 1,
+            'context'  => 'list',
         ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'POST'));
 
         $pool = new Pool($container, 'title', 'logo');
@@ -454,9 +448,9 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $request = new Request(array(
             'code'     => 'sonata.post.admin',
             'objectId' => 42,
-            'field'   => 'bar.enabled',
-            'value'   => 1,
-            'context' => 'list',
+            'field'    => 'bar.enabled',
+            'value'    => 1,
+            'context'  => 'list',
         ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'));
 
         $pool = new Pool($container, 'title', 'logo');
@@ -481,7 +475,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $response = $controller->setObjectFieldValueAction($request);
 
-        $this->assertEquals('{"status":"KO","message":"error1\nerror2"}', $response->getContent() );
+        $this->assertEquals('{"status":"KO","message":"error1\nerror2"}', $response->getContent());
     }
 
     /**
@@ -497,7 +491,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
                     return false;
                 }
 
-                return null;
+                return;
             }));
 
         $request = new Request(array(
@@ -575,7 +569,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $request = new Request(array(
             'admin_code'  => 'foo.admin',
-            'field' => 'barField'
+            'field'       => 'barField',
         ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'));
 
         $this->controller->retrieveAutocompleteItemsAction($request);
@@ -661,7 +655,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
                     case 'property':
                         return 'fooProperty';
                     case 'callback':
-                        return null;
+                        return;
                     case 'minimum_input_length':
                         return 3;
                     case 'items_per_page':
@@ -669,15 +663,15 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
                     case 'req_param_name_page_number':
                         return '_page';
                     case 'to_string_callback':
-                        return null;
+                        return;
                 }
 
-                return null;
+                return;
             }));
 
         $request = new Request(array(
             'admin_code'  => 'foo.admin',
-            'field' => 'barField'
+            'field'       => 'barField',
         ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'));
 
         $this->controller->retrieveAutocompleteItemsAction($request);

--- a/Tests/Datagrid/DatagridMapperTest.php
+++ b/Tests/Datagrid/DatagridMapperTest.php
@@ -12,8 +12,8 @@
 
 namespace Sonata\AdminBundle\Tests\Datagrid;
 
-use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\Datagrid;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -110,12 +110,12 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('required' => false), $filter->getFieldOptions());
         $this->assertEquals(array(
             'foo_default_option' => 'bar_default',
-            'label' => 'fooLabel',
-            'field_name' => 'fooFilterName',
-            'placeholder' => 'short_object_description_placeholder',
-            'link_parameters' => array(),
-            'show_filter' => null,
-            'advanced_filter' => true,
+            'label'              => 'fooLabel',
+            'field_name'         => 'fooFilterName',
+            'placeholder'        => 'short_object_description_placeholder',
+            'link_parameters'    => array(),
+            'show_filter'        => null,
+            'advanced_filter'    => true,
         ), $filter->getOptions());
     }
 
@@ -136,15 +136,15 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo_field_option' => 'baz'), $filter->getFieldOptions());
         $this->assertEquals(array(
             'foo_default_option' => 'bar_custom',
-            'label' => 'fooLabel',
-            'field_name' => 'fooFilterName',
-            'field_options' => array('foo_field_option' => 'baz'),
-            'field_type' => 'foo_field_type',
-            'placeholder' => 'short_object_description_placeholder',
-            'foo_filter_option' => 'foo_filter_option_value',
-            'link_parameters' => array(),
-            'show_filter' => null,
-            'advanced_filter' => true,
+            'label'              => 'fooLabel',
+            'field_name'         => 'fooFilterName',
+            'field_options'      => array('foo_field_option' => 'baz'),
+            'field_type'         => 'foo_field_type',
+            'placeholder'        => 'short_object_description_placeholder',
+            'foo_filter_option'  => 'foo_filter_option_value',
+            'link_parameters'    => array(),
+            'show_filter'        => null,
+            'advanced_filter'    => true,
         ), $filter->getOptions());
     }
 

--- a/Tests/Datagrid/DatagridTest.php
+++ b/Tests/Datagrid/DatagridTest.php
@@ -12,11 +12,10 @@
 
 namespace Sonata\AdminBundle\Tests\Datagrid;
 
-use Sonata\AdminBundle\Datagrid\Datagrid;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
-use Sonata\AdminBundle\Filter\FilterInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\Form\FormBuilder;
 
 /**
@@ -66,7 +65,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->formBuilder->expects($this->any())
             ->method('get')
-            ->will($this->returnCallback(function ($name) use (& $formTypes) {
+            ->will($this->returnCallback(function ($name) use (&$formTypes) {
                 if (isset($formTypes[$name])) {
                     return $formTypes[$name];
                 }
@@ -80,7 +79,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->formBuilder->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type, $options) use (& $formTypes, $eventDispatcher, $formFactory) {
+            ->will($this->returnCallback(function ($name, $type, $options) use (&$formTypes, $eventDispatcher, $formFactory) {
                 $formTypes[$name] = new FormBuilder($name, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Form\TestEntity', $eventDispatcher, $formFactory, $options);
 
                 return;

--- a/Tests/Datagrid/ListMapperTest.php
+++ b/Tests/Datagrid/ListMapperTest.php
@@ -13,9 +13,8 @@
 namespace Sonata\AdminBundle\Tests\Datagrid;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
-use Sonata\AdminBundle\Builder\ListBuilderInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
 
@@ -58,7 +57,7 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
 
         $modelManager->expects($this->any())
             ->method('getNewFieldDescriptionInstance')
-            ->will($this->returnCallback(function($class, $name, array $options = array()) use ($fieldDescription) {
+            ->will($this->returnCallback(function ($class, $name, array $options = array()) use ($fieldDescription) {
                 $fieldDescriptionClone = clone $fieldDescription;
                 $fieldDescriptionClone->setName($name);
                 $fieldDescriptionClone->setOptions($options);
@@ -129,7 +128,7 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
 
         try {
             $this->assertFalse($this->listMapper->has('_action'));
-            $this->listMapper->add('_action', 'actions', array('actions'=>array('view'=>array())));
+            $this->listMapper->add('_action', 'actions', array('actions' => array('view' => array())));
         } catch (\PHPUnit_Framework_Error $e) {
             restore_error_handler();
 
@@ -146,7 +145,7 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
         $terminateErrorIgnore = \PHPUnit_Util_ErrorHandler::handleErrorOnce(E_USER_DEPRECATED);
 
         $this->assertFalse($this->listMapper->has('_action'));
-        $this->listMapper->add('_action', 'actions', array('actions'=>array('view'=>array())));
+        $this->listMapper->add('_action', 'actions', array('actions' => array('view' => array())));
 
         $this->assertTrue($this->listMapper->has('_action'));
 
@@ -155,7 +154,7 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
         $this->assertEquals('_action', $fieldDescription->getName());
         $this->assertCount(1, $fieldDescription->getOption('actions'));
-        $this->assertEquals(array('show'=>array()), $fieldDescription->getOption('actions'));
+        $this->assertEquals(array('show' => array()), $fieldDescription->getOption('actions'));
 
         $terminateErrorIgnore();
     }
@@ -219,7 +218,7 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
         }
 
         foreach ($this->fieldDescriptionCollection as $field) {
-           $this->assertTrue($field->isVirtual(), 'Failed asserting that FieldDescription with type "'.$field->getType().'" is tagged with virtual flag.');
+            $this->assertTrue($field->isVirtual(), 'Failed asserting that FieldDescription with type "'.$field->getType().'" is tagged with virtual flag.');
         }
     }
 
@@ -236,22 +235,21 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
         $this->listMapper->add($fieldDescription4);
 
         $this->assertEquals(array(
-            'fooName1'=>$fieldDescription1,
-            'fooName2'=>$fieldDescription2,
-            'fooName3'=>$fieldDescription3,
-            'fooName4'=>$fieldDescription4,
+            'fooName1' => $fieldDescription1,
+            'fooName2' => $fieldDescription2,
+            'fooName3' => $fieldDescription3,
+            'fooName4' => $fieldDescription4,
         ), $this->fieldDescriptionCollection->getElements());
 
         $this->listMapper->reorder(array('fooName3', 'fooName2', 'fooName1', 'fooName4'));
 
         // print_r is used to compare order of items in associative arrays
         $this->assertEquals(print_r(array(
-            'fooName3'=>$fieldDescription3,
-            'fooName2'=>$fieldDescription2,
-            'fooName1'=>$fieldDescription1,
-            'fooName4'=>$fieldDescription4,
+            'fooName3' => $fieldDescription3,
+            'fooName2' => $fieldDescription2,
+            'fooName1' => $fieldDescription1,
+            'fooName4' => $fieldDescription4,
         ), true), print_r($this->fieldDescriptionCollection->getElements(), true));
-
     }
 
     private function getFieldDescriptionMock($name = null, $label = null)

--- a/Tests/Datagrid/PagerTest.php
+++ b/Tests/Datagrid/PagerTest.php
@@ -280,7 +280,7 @@ class PagerTest extends \PHPUnit_Framework_TestCase
         $values = array();
         foreach ($this->pager as $key => $value) {
             $values[$key] = $value;
-            $counter++;
+            ++$counter;
         }
 
         $this->assertEquals(3, $counter);
@@ -384,7 +384,7 @@ class PagerTest extends \PHPUnit_Framework_TestCase
                         return array($object3);
                 }
 
-                return null;
+                return;
             }));
 
         $this->pager->setQuery($query);
@@ -512,7 +512,7 @@ class PagerTest extends \PHPUnit_Framework_TestCase
                         return array($object3);
                 }
 
-                return null;
+                return;
             }));
 
         $this->pager->setQuery($query);
@@ -520,13 +520,13 @@ class PagerTest extends \PHPUnit_Framework_TestCase
         $this->pager->setCursor(1);
         $this->assertEquals($object1, $this->pager->getCurrent());
 
-        $id++;
+        ++$id;
         $this->assertEquals($object2, $this->pager->getNext());
 
-        $id++;
+        ++$id;
         $this->assertEquals($object3, $this->pager->getNext());
 
-        $id++;
+        ++$id;
         $this->assertEquals(null, $this->pager->getNext());
     }
 
@@ -570,7 +570,7 @@ class PagerTest extends \PHPUnit_Framework_TestCase
                         return array($object3);
                 }
 
-                return null;
+                return;
             }));
 
         $this->pager->setQuery($query);
@@ -578,13 +578,13 @@ class PagerTest extends \PHPUnit_Framework_TestCase
         $this->pager->setCursor(2);
         $this->assertEquals($object3, $this->pager->getCurrent());
 
-        $id--;
+        --$id;
         $this->assertEquals($object2, $this->pager->getPrevious());
 
-        $id--;
+        --$id;
         $this->assertEquals($object1, $this->pager->getPrevious());
 
-        $id--;
+        --$id;
         $this->assertEquals(null, $this->pager->getPrevious());
     }
 
@@ -605,16 +605,16 @@ class PagerTest extends \PHPUnit_Framework_TestCase
     public function testUnserialize()
     {
         $serialized = array(
-            'page' => 6,
-            'maxPerPage' => 7,
-            'maxPageLinks' => 5,
-            'lastPage' => 4,
-            'nbResults' => 30,
-            'cursor' => 3,
-            'parameters' => array('foo'=>'bar'),
+            'page'           => 6,
+            'maxPerPage'     => 7,
+            'maxPageLinks'   => 5,
+            'lastPage'       => 4,
+            'nbResults'      => 30,
+            'cursor'         => 3,
+            'parameters'     => array('foo' => 'bar'),
             'currentMaxLink' => 2,
             'maxRecordLimit' => 22,
-            'countColumn' => array('idx'),
+            'countColumn'    => array('idx'),
         );
 
         $this->pager->expects($this->any())
@@ -631,7 +631,7 @@ class PagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('idx'), $this->pager->getCountColumn());
         $this->assertEquals(30, $this->pager->getNbResults());
         $this->assertEquals(3, $this->pager->getCursor());
-        $this->assertEquals(array('foo'=>'bar'), $this->pager->getParameters());
+        $this->assertEquals(array('foo' => 'bar'), $this->pager->getParameters());
         $this->assertEquals(2, $this->pager->getCurrentMaxLink());
         $this->assertEquals(22, $this->pager->getMaxRecordLimit());
         $this->assertEquals(null, $this->pager->getQuery());

--- a/Tests/Datagrid/SimplePagerTest.php
+++ b/Tests/Datagrid/SimplePagerTest.php
@@ -12,11 +12,11 @@
 
 namespace Sonata\AdminBundle\Tests\Datagrid;
 
-use Sonata\AdminBundle\Datagrid\SimplePager;
 use Doctrine\Common\Collections\ArrayCollection;
+use Sonata\AdminBundle\Datagrid\SimplePager;
 
 /**
- * Simple pager
+ * Simple pager.
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  * @author Sjoerd Peters <sjoerd.peters@gmail.com>

--- a/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\AdminBundle\Tests\DependencyInjection;
 
-use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -103,7 +103,7 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $dashboardGroupsSettings['sonata_group_one']['items'][2]['admin']);
         $this->assertEquals('blog_article', $dashboardGroupsSettings['sonata_group_one']['items'][2]['route']);
         $this->assertEquals('Article', $dashboardGroupsSettings['sonata_group_one']['items'][2]['label']);
-        $this->assertEquals(array('articleId' => 3) , $dashboardGroupsSettings['sonata_group_one']['items'][2]['route_params']);
+        $this->assertEquals(array('articleId' => 3), $dashboardGroupsSettings['sonata_group_one']['items'][2]['route_params']);
         $this->assertContains('sonata_news_admin', $dashboardGroupsSettings['sonata_group_one']['item_adds']);
         $this->assertContains('ROLE_ONE', $dashboardGroupsSettings['sonata_group_one']['roles']);
 
@@ -195,8 +195,8 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
             'dashboard' => array(
                 'groups' => array(
                     '%sonata.admin.parameter.groupname%' => array(),
-                )
-            )
+                ),
+            ),
         );
 
         $container = $this->getContainer();
@@ -275,44 +275,44 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
             'dashboard' => array(
                 'groups' => array(
                     'sonata_group_one' => array(
-                        'label' => 'Group One Label',
+                        'label'           => 'Group One Label',
                         'label_catalogue' => 'SonataAdminBundle',
-                        'items' => array(
+                        'items'           => array(
                             'sonata_post_admin',
                             array(
                                 'route' => 'blog_name',
-                                'label' => 'Blog'
+                                'label' => 'Blog',
                             ),
                             array(
                                 'route'        => 'blog_article',
                                 'label'        => 'Article',
-                                'route_params' => array('articleId' => 3)
+                                'route_params' => array('articleId' => 3),
                             ),
                         ),
                         'item_adds' => array(
-                            'sonata_news_admin'
+                            'sonata_news_admin',
                         ),
                         'roles' => array('ROLE_ONE'),
                     ),
                     'sonata_group_two' => array(
                         'provider' => 'my_menu',
                     ),
-                )
+                ),
             ),
             'admin_services' => array(
                 'sonata_post_admin' => array(
                     'templates' => array(
-                        'view' => array('user_block' => 'foobar.twig.html')
-                    )
+                        'view' => array('user_block' => 'foobar.twig.html'),
+                    ),
                 ),
                 'sonata_news_admin' => array(
-                    'label' => 'Foo',
+                    'label'      => 'Foo',
                     'pager_type' => 'simple',
                     'templates'  => array(
-                        'view' => array('user_block' => 'foo.twig.html')
-                    )
-                )
-            )
+                        'view' => array('user_block' => 'foo.twig.html'),
+                    ),
+                ),
+            ),
         );
 
         return $config;
@@ -323,7 +323,7 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder();
         $container->setParameter('kernel.bundles', array(
             'SonataCoreBundle' => true,
-            'KnpMenuBundle' => true
+            'KnpMenuBundle'    => true,
         ));
         $container->setParameter('kernel.cache_dir', '/tmp');
         $container->setParameter('kernel.debug', true);
@@ -352,7 +352,7 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->setClass('Symfony\Component\Form\FormFactoryInterface');
         foreach (array(
             'doctrine_phpcr' => 'PHPCR',
-            'orm'            => 'ORM') as $key => $bundleSubstring) {
+            'orm'            => 'ORM', ) as $key => $bundleSubstring) {
             $container
                 ->register(sprintf('sonata.admin.manager.%s', $key))
                 ->setClass(sprintf(

--- a/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -11,10 +11,10 @@
 
 namespace Sonata\AdminBundle\Tests\DependencyInjection;
 
-use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
-use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
 {
@@ -33,7 +33,7 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
     private $hasTraits;
 
     /**
-     * Root name of the configuration
+     * Root name of the configuration.
      *
      * @var string
      */
@@ -61,8 +61,8 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
     {
         $this->extension->load(array(), $container = $this->getContainer());
 
-        $this->assertTrue($container->hasParameter($this->root . ".extension.map"));
-        $this->assertTrue(is_array($extensionMap = $container->getParameter($this->root . ".extension.map")));
+        $this->assertTrue($container->hasParameter($this->root.'.extension.map'));
+        $this->assertTrue(is_array($extensionMap = $container->getParameter($this->root.'.extension.map')));
 
         $this->assertArrayHasKey('admins', $extensionMap);
         $this->assertArrayHasKey('excludes', $extensionMap);
@@ -78,7 +78,7 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
     public function testFlattenEmptyExtensionConfiguration()
     {
         $this->extension->load(array(), $container = $this->getContainer());
-        $extensionMap = $container->getParameter($this->root . ".extension.map");
+        $extensionMap = $container->getParameter($this->root.'.extension.map');
 
         $method = new \ReflectionMethod(
             'Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass', 'flattenExtensionConfiguration'
@@ -109,7 +109,7 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
     {
         $config = $this->getConfig();
         $this->extension->load(array($config), $container = $this->getContainer());
-        $extensionMap = $container->getParameter($this->root . ".extension.map");
+        $extensionMap = $container->getParameter($this->root.'.extension.map');
 
         $method = new \ReflectionMethod(
             'Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass', 'flattenExtensionConfiguration'
@@ -185,10 +185,10 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
         $config = array(
             'extensions' => array(
                 'sonata_extension_unknown' => array(
-                    'excludes' => array('sonata_article_admin'),
+                    'excludes'   => array('sonata_article_admin'),
                     'instanceof' => array('Sonata\AdminBundle\Tests\DependencyInjection\Post'),
                 ),
-            )
+            ),
         );
 
         $container = $this->getContainer();
@@ -207,10 +207,10 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
         $config = array(
             'extensions' => array(
                 'sonata_extension_publish' => array(
-                    'admins' => array('sonata_unknown_admin'),
+                    'admins'     => array('sonata_unknown_admin'),
                     'implements' => array('Sonata\AdminBundle\Tests\DependencyInjection\Publishable'),
                 ),
-            )
+            ),
         );
 
         $container = $this->getContainer();
@@ -282,7 +282,7 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
                 'sonata_extension_post' => array(
                     'uses' => array('Sonata\AdminBundle\Tests\Fixtures\DependencyInjection\TimestampableTrait'),
                 ),
-            )
+            ),
         );
 
         $container = $this->getContainer();
@@ -301,19 +301,19 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
         $config = array(
             'extensions' => array(
                 'sonata_extension_publish' => array(
-                    'admins' => array('sonata_post_admin'),
+                    'admins'     => array('sonata_post_admin'),
                     'implements' => array('Sonata\AdminBundle\Tests\DependencyInjection\Publishable'),
                 ),
                 'sonata_extension_history' => array(
-                    'excludes' => array('sonata_article_admin'),
+                    'excludes'   => array('sonata_article_admin'),
                     'instanceof' => array('Sonata\AdminBundle\Tests\DependencyInjection\Post'),
                 ),
                 'sonata_extension_order' => array(
-                    'excludes' => array('sonata_post_admin'),
-                    'extends' => array('Sonata\AdminBundle\Tests\DependencyInjection\Post'),
+                    'excludes'   => array('sonata_post_admin'),
+                    'extends'    => array('Sonata\AdminBundle\Tests\DependencyInjection\Post'),
                     'implements' => array('Sonata\AdminBundle\Tests\DependencyInjection\Publishable'),
                 ),
-            )
+            ),
         );
 
         if ($this->hasTraits) {
@@ -328,7 +328,7 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder();
         $container->setParameter('kernel.bundles', array(
             'SonataCoreBundle' => true,
-            'KnpMenuBundle' => true
+            'KnpMenuBundle'    => true,
         ));
         $container->setParameter('kernel.cache_dir', '/tmp');
         $container->setParameter('kernel.debug', true);
@@ -409,9 +409,19 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class MockAdmin extends Admin {}
+class MockAdmin extends Admin
+{
+}
 
-class Post {}
-interface Publishable {}
-class News extends Post {}
-class Article implements Publishable {}
+class Post
+{
+}
+interface Publishable
+{
+}
+class News extends Post
+{
+}
+class Article implements Publishable
+{
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -36,8 +36,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $config = $processor->processConfiguration(new Configuration(), array(array(
             'options' => array(
-                'html5_validate' => '1'
-            )
+                'html5_validate' => '1',
+            ),
         )));
     }
 
@@ -51,10 +51,10 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     'templates' => array(
                         'form'   => array('form.twig.html', 'form_extra.twig.html'),
                         'view'   => array('user_block' => 'SonataAdminBundle:mycustomtemplate.html.twig'),
-                        'filter' => array()
-                    )
-                )
-            )
+                        'filter' => array(),
+                    ),
+                ),
+            ),
         )));
 
         $this->assertEquals('SonataAdminBundle:mycustomtemplate.html.twig', $config['admin_services']['my_admin_id']['templates']['view']['user_block']);
@@ -65,31 +65,31 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $processor = new Processor();
 
         $config = $processor->processConfiguration(new Configuration(), array(array(
-            'admin_services' => array('my_admin_id' => array())
+            'admin_services' => array('my_admin_id' => array()),
         )));
 
         $this->assertEquals(array(
-            'model_manager' => null,
-            'form_contractor' => null,
-            'show_builder' => null,
-            'list_builder' => null,
-            'datagrid_builder' => null,
-            'translator' => null,
-            'configuration_pool' => null,
-            'validator' => null,
-            'security_handler' => null,
-            'label' => null,
-            'templates' => array(),
-            'route_generator' => null,
-            'menu_factory' => null,
-            'route_builder' => null,
+            'model_manager'             => null,
+            'form_contractor'           => null,
+            'show_builder'              => null,
+            'list_builder'              => null,
+            'datagrid_builder'          => null,
+            'translator'                => null,
+            'configuration_pool'        => null,
+            'validator'                 => null,
+            'security_handler'          => null,
+            'label'                     => null,
+            'templates'                 => array(),
+            'route_generator'           => null,
+            'menu_factory'              => null,
+            'route_builder'             => null,
             'label_translator_strategy' => null,
-            'pager_type' => null,
-            'templates' => array(
-                'form' => array(),
+            'pager_type'                => null,
+            'templates'                 => array(
+                'form'   => array(),
                 'filter' => array(),
-                'view' => array(),
-            )
+                'view'   => array(),
+            ),
         ), $config['admin_services']['my_admin_id']);
     }
 
@@ -98,86 +98,86 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), array());
 
-        $this->assertEmpty($config['dashboard']["blocks"][0]["roles"]);
+        $this->assertEmpty($config['dashboard']['blocks'][0]['roles']);
     }
 
     public function testDashboardWithRoles()
     {
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), array(array(
-            "dashboard" => array(
-                "blocks" => array(array(
-                    "roles" => array("ROLE_ADMIN"),
-                    "type"  => "my.type"
-                ))
-            )
+            'dashboard' => array(
+                'blocks' => array(array(
+                    'roles' => array('ROLE_ADMIN'),
+                    'type'  => 'my.type',
+                )),
+            ),
         )));
 
-        $this->assertEquals($config['dashboard']["blocks"][0]["roles"], array("ROLE_ADMIN"));
+        $this->assertEquals($config['dashboard']['blocks'][0]['roles'], array('ROLE_ADMIN'));
     }
 
     public function testDashboardGroups()
     {
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), array(array(
-            "dashboard" => array(
-                "groups" => array(
-                    "bar" => array(
-                        "label" => "foo",
-                        "icon"  => '<i class="fa fa-edit"></i>',
-                        "items" => array(
-                            "item1",
-                            "item2",
+            'dashboard' => array(
+                'groups' => array(
+                    'bar' => array(
+                        'label' => 'foo',
+                        'icon'  => '<i class="fa fa-edit"></i>',
+                        'items' => array(
+                            'item1',
+                            'item2',
                             array(
-                                "label" => "fooLabel",
-                                "route" => "fooRoute",
-                                "route_params" => array("bar" => "foo")
+                                'label'        => 'fooLabel',
+                                'route'        => 'fooRoute',
+                                'route_params' => array('bar' => 'foo'),
                             ),
                             array(
-                                "label" => "barLabel",
-                                "route" => "barRoute",
-                            )
-                        )
-                    )
-                )
-            )
+                                'label' => 'barLabel',
+                                'route' => 'barRoute',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
         )));
 
-        $this->assertCount(4, $config['dashboard']["groups"]["bar"]["items"]);
+        $this->assertCount(4, $config['dashboard']['groups']['bar']['items']);
         $this->assertEquals(
-            $config['dashboard']["groups"]["bar"]["items"][0],
+            $config['dashboard']['groups']['bar']['items'][0],
             array(
-                "admin"        => "item1",
-                "route"        => "",
-                "route_params" => array(),
-                "label"        => "",
+                'admin'        => 'item1',
+                'route'        => '',
+                'route_params' => array(),
+                'label'        => '',
             )
         );
         $this->assertEquals(
-            $config['dashboard']["groups"]["bar"]["items"][1],
+            $config['dashboard']['groups']['bar']['items'][1],
             array(
-                "admin"        => "item2",
-                "route"        => "",
-                "route_params" => array(),
-                "label"        => "",
+                'admin'        => 'item2',
+                'route'        => '',
+                'route_params' => array(),
+                'label'        => '',
             )
         );
         $this->assertEquals(
-            $config['dashboard']["groups"]["bar"]["items"][2],
+            $config['dashboard']['groups']['bar']['items'][2],
             array(
-                "admin"        => "",
-                "route"        => "fooRoute",
-                "route_params" => array("bar" => "foo"),
-                "label"        => "fooLabel",
+                'admin'        => '',
+                'route'        => 'fooRoute',
+                'route_params' => array('bar' => 'foo'),
+                'label'        => 'fooLabel',
             )
         );
         $this->assertEquals(
-            $config['dashboard']["groups"]["bar"]["items"][3],
+            $config['dashboard']['groups']['bar']['items'][3],
             array(
-                "admin"        => "",
-                "route"        => "barRoute",
-                "route_params" => array(),
-                "label"        => "barLabel",
+                'admin'        => '',
+                'route'        => 'barRoute',
+                'route_params' => array(),
+                'label'        => 'barLabel',
             )
         );
     }
@@ -188,21 +188,21 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), array(array(
-            "dashboard" => array(
-                "groups" => array(
-                    "bar" => array(
-                        "label" => "foo",
-                        "icon" => '<i class="fa fa-edit"></i>',
-                        "items" => array(
-                            "item1",
-                            "item2",
+            'dashboard' => array(
+                'groups' => array(
+                    'bar' => array(
+                        'label' => 'foo',
+                        'icon'  => '<i class="fa fa-edit"></i>',
+                        'items' => array(
+                            'item1',
+                            'item2',
                             array(
-                                "route" => "fooRoute"
-                            )
-                        )
-                    )
-                )
-            )
+                                'route' => 'fooRoute',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
         )));
     }
 }

--- a/Tests/Event/AdminEventExtensionTest.php
+++ b/Tests/Event/AdminEventExtensionTest.php
@@ -39,6 +39,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param $type
+     *
      * @return callable
      */
     public function getConfigureEventClosure($type)
@@ -58,6 +59,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param $type
+     *
      * @return callable
      */
     public function getConfigurePersistenceClosure($type)
@@ -80,7 +82,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
         $this
             ->getExtension(array(
                 $this->equalTo('sonata.admin.event.configure.form'),
-                $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_FORM))
+                $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_FORM)),
             ))
             ->configureFormFields($this->getMapper('Sonata\AdminBundle\Form\FormMapper'));
     }
@@ -90,7 +92,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
         $this
             ->getExtension(array(
                 $this->equalTo('sonata.admin.event.configure.list'),
-                $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_LIST))
+                $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_LIST)),
             ))
             ->configureListFields($this->getMapper('Sonata\AdminBundle\Datagrid\ListMapper'));
     }
@@ -100,7 +102,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
         $this
             ->getExtension(array(
                 $this->equalTo('sonata.admin.event.configure.datagrid'),
-                $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_DATAGRID))
+                $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_DATAGRID)),
             ))
             ->configureDatagridFilters($this->getMapper('Sonata\AdminBundle\Datagrid\DatagridMapper'));
     }
@@ -110,7 +112,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
         $this
             ->getExtension(array(
                 $this->equalTo('sonata.admin.event.configure.show'),
-                $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_SHOW))
+                $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_SHOW)),
             ))
             ->configureShowFields($this->getMapper('Sonata\AdminBundle\Show\ShowMapper'));
     }
@@ -119,7 +121,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->getExtension(array(
             $this->equalTo('sonata.admin.event.persistence.pre_update'),
-            $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_UPDATE))
+            $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_UPDATE)),
         ))->preUpdate($this->getMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
     }
 
@@ -134,7 +136,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->getExtension(array(
             $this->equalTo('sonata.admin.event.persistence.post_update'),
-            $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_UPDATE))
+            $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_UPDATE)),
         ))->postUpdate($this->getMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
     }
 
@@ -142,7 +144,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->getExtension(array(
             $this->equalTo('sonata.admin.event.persistence.pre_persist'),
-            $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_PERSIST))
+            $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_PERSIST)),
         ))->prePersist($this->getMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
     }
 
@@ -150,7 +152,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->getExtension(array(
             $this->equalTo('sonata.admin.event.persistence.post_persist'),
-            $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_PERSIST))
+            $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_PERSIST)),
         ))->postPersist($this->getMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
     }
 
@@ -158,7 +160,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->getExtension(array(
             $this->equalTo('sonata.admin.event.persistence.pre_remove'),
-            $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_REMOVE))
+            $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_REMOVE)),
         ))->preRemove($this->getMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
     }
 
@@ -166,8 +168,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->getExtension(array(
             $this->equalTo('sonata.admin.event.persistence.post_remove'),
-            $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_REMOVE))
+            $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_REMOVE)),
         ))->postRemove($this->getMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
     }
-
 }

--- a/Tests/Event/ConfigureEventTest.php
+++ b/Tests/Event/ConfigureEventTest.php
@@ -12,8 +12,8 @@
 namespace Sonata\AdminBundle\Tests\Event;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Mapper\BaseMapper;
 use Sonata\AdminBundle\Event\ConfigureEvent;
+use Sonata\AdminBundle\Mapper\BaseMapper;
 
 class ConfigureEventTest extends \PHPUnit_Framework_TestCase
 {

--- a/Tests/Export/ExporterTest.php
+++ b/Tests/Export/ExporterTest.php
@@ -11,10 +11,8 @@
 
 namespace Sonata\AdminBundle\Tests\Filter;
 
-use Sonata\AdminBundle\Export\Exporter;
-use Exporter\Source\SourceIteratorInterface;
 use Exporter\Source\ArraySourceIterator;
-use Symfony\Component\HttpFoundation\Response;
+use Sonata\AdminBundle\Export\Exporter;
 
 class ExporterTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,7 +33,7 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
     public function testGetResponse($format, $filename, $contentType)
     {
         $source = new ArraySourceIterator(array(
-            array('foo' => 'bar')
+            array('foo' => 'bar'),
         ));
 
         $exporter = new Exporter();

--- a/Tests/Filter/FilterTest.php
+++ b/Tests/Filter/FilterTest.php
@@ -126,9 +126,9 @@ class FilterTest extends \PHPUnit_Framework_TestCase
         return array(
             array(false, array()),
             array(false, array('value' => null)),
-            array(false, array('value' => "")),
+            array(false, array('value' => '')),
             array(false, array('value' => false)),
-            array(true, array('value' => "active")),
+            array(true, array('value' => 'active')),
         );
     }
 
@@ -177,8 +177,8 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     {
         $parentAssociationMapping = array(
             0 => array('fieldName'    => 'user',
-                'targetEntity' => 'Foo\Bar\User',
-                'joinColumns'  => array(
+                'targetEntity'        => 'Foo\Bar\User',
+                'joinColumns'         => array(
                     0 => array(
                         'name'                 => 'user_id',
                         'referencedColumnName' => 'user_id',

--- a/Tests/Form/DataTransformer/ArrayToModelTransformerTest.php
+++ b/Tests/Form/DataTransformer/ArrayToModelTransformerTest.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
 
-use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Form\DataTransformer\ArrayToModelTransformer;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity;
 
@@ -54,7 +53,7 @@ class ArrayToModelTransformerTest extends \PHPUnit_Framework_TestCase
         return array(
             array('Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity'),
             array(array()),
-            array(array('foo'=>'bar')),
+            array(array('foo' => 'bar')),
             array('foo'),
             array(123),
             array(null),

--- a/Tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
@@ -11,10 +11,10 @@
 
 namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdPropertyTransformer;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooArrayAccess;
-use Doctrine\Common\Collections\ArrayCollection;
 
 class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
 {
@@ -40,7 +40,7 @@ class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
                     return $entity;
                 }
 
-                return null;
+                return;
             }));
 
         $this->assertNull($transformer->reverseTransform(null));
@@ -64,7 +64,7 @@ class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
             ->method('find')
             ->will($this->returnCallback(function ($className, $value) use ($entity1, $entity2, $entity3) {
                 if ($className != 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo') {
-                    return null;
+                    return;
                 }
 
                 if ($value == 123) {
@@ -79,7 +79,7 @@ class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
                     return $entity3;
                 }
 
-                return null;
+                return;
             }));
 
         $collection = new ArrayCollection();

--- a/Tests/Form/DataTransformer/ModelToIdTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelToIdTransformerTest.php
@@ -31,7 +31,7 @@ class ModelToIdTransformerTest extends \PHPUnit_Framework_TestCase
                 ->method('find')
                 ->will($this->returnValue(true));
 
-        $this->assertFalse(in_array(false, array("0", 0), true));
+        $this->assertFalse(in_array(false, array('0', 0), true));
 
         // we pass 0 as integer
         $this->assertTrue($transformer->reverseTransform(0));
@@ -64,7 +64,7 @@ class ModelToIdTransformerTest extends \PHPUnit_Framework_TestCase
             array(null, null),
             array(false, false),
             array(array(), null),
-            array("", null)
+            array('', null),
         );
     }
 

--- a/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -11,19 +11,16 @@
 
 namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
 
-use Symfony\Component\Form\Exception\UnexpectedTypeException;
-use Symfony\Component\Form\Exception\TransformationFailedException;
-use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
-use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
-use Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity;
 use Doctrine\Common\Collections\ArrayCollection;
+use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
+use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
+use Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
 class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
 {
-
     private $modelChoiceList;
 
     private $modelManager;
@@ -72,10 +69,10 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
                 return $identifiers;
             }));
 
-       $this->modelChoiceList->expects($this->any())
+        $this->modelChoiceList->expects($this->any())
             ->method('getEntities')
             ->will($this->returnCallback(function () {
-                return array('bcd'=>new FooEntity(array('bcd')), 'efg'=>new FooEntity(array('efg')), 'abc'=>new FooEntity(array('abc')));
+                return array('bcd' => new FooEntity(array('bcd')), 'efg' => new FooEntity(array('efg')), 'abc' => new FooEntity(array('abc')));
             }));
 
         $this->assertEquals($expected, $transformer->transform($collection));
@@ -166,7 +163,7 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
                         return $entity3;
                 }
 
-                return null;
+                return;
             }));
 
         $collection = $transformer->reverseTransform(array('foo', 'bar'));

--- a/Tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
+++ b/Tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
@@ -12,12 +12,10 @@
 namespace Sonata\AdminBundle\Tests\Form\Extension\Field\Type;
 
 use Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension;
-use Symfony\Component\Form\FormConfigBuilder;
 use Symfony\Component\Form\Form;
-use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\FormConfigBuilder;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
 {
@@ -94,7 +92,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
         $config = new FormConfigBuilder('test', 'stdClass', $eventDispatcher, $options);
         $config->setAttribute('sonata_admin', array(
             'admin' => $admin,
-            'name' => 'name'
+            'name'  => 'name',
         ));
         $config->setAttribute('sonata_admin_enabled', true);
 
@@ -107,7 +105,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
 
         $extension = new FormTypeFieldExtension(array(), array());
         $extension->buildView($formView, $form, array(
-            'sonata_help' => 'help text'
+            'sonata_help' => 'help text',
         ));
 
         $this->assertArrayHasKey('block_prefixes', $formView->vars);
@@ -150,7 +148,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
 
         $extension = new FormTypeFieldExtension(array(), array());
         $extension->buildView($formView, $form, array(
-            'sonata_help' => 'help text'
+            'sonata_help' => 'help text',
         ));
 
         $this->assertArrayHasKey('block_prefixes', $formView->vars);
@@ -158,9 +156,9 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('sonata_admin', $formView->vars);
 
         $expected = array(
-            'value' => null,
-            'attr'  => array(),
-            'name'  => 'format',
+            'value'          => null,
+            'attr'           => array(),
+            'name'           => 'format',
             'block_prefixes' => array(
                 'form',
                 'field',
@@ -170,7 +168,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
                 'parent_code_text_settings_settings_format',
             ),
             'sonata_admin_enabled' => true,
-            'sonata_admin' => array(
+            'sonata_admin'         => array(
                  'admin'             => false,
                  'field_description' => false,
                  'name'              => false,
@@ -197,7 +195,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
 
         $extension = new FormTypeFieldExtension(array(), array());
         $extension->buildView($formView, $form, array(
-            'sonata_help' => 'help text'
+            'sonata_help' => 'help text',
         ));
 
         $this->assertArrayNotHasKey('block_prefixes', $formView->vars);

--- a/Tests/Form/FormMapperTest.php
+++ b/Tests/Form/FormMapperTest.php
@@ -55,7 +55,7 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->modelManager->expects($this->any())
             ->method('getNewFieldDescriptionInstance')
-            ->will($this->returnCallback(function($class, $name, array $options = array()) use ($fieldDescription) {
+            ->will($this->returnCallback(function ($class, $name, array $options = array()) use ($fieldDescription) {
                 $fieldDescriptionClone = clone $fieldDescription;
                 $fieldDescriptionClone->setName($name);
                 $fieldDescriptionClone->setOptions($options);
@@ -79,26 +79,26 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
     {
         $this->formMapper->with('foobar');
 
-        $this->assertEquals(array('default' => array (
-            'collapsed' => false,
-            'class' => false,
-            'description' => false,
+        $this->assertEquals(array('default' => array(
+            'collapsed'          => false,
+            'class'              => false,
+            'description'        => false,
             'translation_domain' => null,
-            'auto_created' => true,
-            'groups' => array('foobar'),
-            'tab' => true,
-            'name' => 'default',
-            'box_class' => 'box box-primary'
+            'auto_created'       => true,
+            'groups'             => array('foobar'),
+            'tab'                => true,
+            'name'               => 'default',
+            'box_class'          => 'box box-primary',
         )), $this->admin->getFormTabs());
 
         $this->assertEquals(array('foobar' => array(
-            'collapsed' => false,
-            'class' => false,
-            'description' => false,
+            'collapsed'          => false,
+            'class'              => false,
+            'description'        => false,
             'translation_domain' => null,
-            'fields' => array (),
-            'name' => 'foobar',
-            'box_class' => 'box box-primary'
+            'fields'             => array(),
+            'name'               => 'foobar',
+            'box_class'          => 'box box-primary',
         )), $this->admin->getFormGroups());
     }
 
@@ -109,25 +109,25 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->assertEquals(array('foobar' => array(
-            'collapsed' => false,
-            'class' => false,
-            'description' => false,
+            'collapsed'          => false,
+            'class'              => false,
+            'description'        => false,
             'translation_domain' => 'Foobar',
-            'fields' => array (),
-            'name' => 'foobar',
-            'box_class' => 'box box-primary'
+            'fields'             => array(),
+            'name'               => 'foobar',
+            'box_class'          => 'box box-primary',
         )), $this->admin->getFormGroups());
 
-        $this->assertEquals(array('default' => array (
-            'collapsed' => false,
-            'class' => false,
-            'description' => false,
+        $this->assertEquals(array('default' => array(
+            'collapsed'          => false,
+            'class'              => false,
+            'description'        => false,
             'translation_domain' => 'Foobar',
-            'auto_created' => true,
-            'groups' => array('foobar'),
-            'tab' => true,
-            'name' => 'default',
-            'box_class' => 'box box-primary'
+            'auto_created'       => true,
+            'groups'             => array('foobar'),
+            'tab'                => true,
+            'name'               => 'default',
+            'box_class'          => 'box box-primary',
         )), $this->admin->getFormTabs());
     }
 
@@ -138,7 +138,7 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(array()));
 
         $this->formMapper->with('foobar', array(
-                'translation_domain' => 'Foobar'
+                'translation_domain' => 'Foobar',
             ))
             ->add('foo', 'bar')
         ->end();
@@ -150,28 +150,28 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($this->formMapper->has('foo'));
 
-        $this->assertEquals(array('default' => array (
-            'collapsed' => false,
-            'class' => false,
-            'description' => false,
+        $this->assertEquals(array('default' => array(
+            'collapsed'          => false,
+            'class'              => false,
+            'description'        => false,
             'translation_domain' => 'Foobar',
-            'auto_created' => true,
-            'groups' => array ('foobar'),
-            'tab' => true,
-            'name' => 'default',
-            'box_class' => 'box box-primary'
+            'auto_created'       => true,
+            'groups'             => array('foobar'),
+            'tab'                => true,
+            'name'               => 'default',
+            'box_class'          => 'box box-primary',
         )), $this->admin->getFormTabs());
 
         $this->assertEquals(array('foobar' => array(
-            'collapsed' => false,
-            'class' => false,
-            'description' => false,
+            'collapsed'          => false,
+            'class'              => false,
+            'description'        => false,
             'translation_domain' => 'Foobar',
-            'fields' => array(
-                'foo' => 'foo'
+            'fields'             => array(
+                'foo' => 'foo',
             ),
-            'name' => 'foobar',
-            'box_class' => 'box box-primary'
+            'name'      => 'foobar',
+            'box_class' => 'box box-primary',
         )), $this->admin->getFormGroups());
     }
 
@@ -317,7 +317,7 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
         $this->formMapper->ifTrue(false);
     }
 
-   /**
+    /**
      * @expectedException        RuntimeException
      * @expectedExceptionMessage Cannot nest ifTrue or ifFalse call
      */

--- a/Tests/Form/Type/AclMatrixTypeTest.php
+++ b/Tests/Form/Type/AclMatrixTypeTest.php
@@ -28,9 +28,9 @@ class AclMatrixTypeTest extends TypeTestCase
         $permissions = array(
             'OWNER' => array(
                 'required' => false,
-                'data' => false,
+                'data'     => false,
                 'disabled' => false,
-                'attr' => array(),
+                'attr'     => array(),
             ),
         );
 
@@ -39,7 +39,7 @@ class AclMatrixTypeTest extends TypeTestCase
         $type->setDefaultOptions($optionResolver);
 
         $options = $optionResolver->resolve(array(
-            'acl_value' => $user,
+            'acl_value'   => $user,
             'permissions' => $permissions,
         ));
 

--- a/Tests/Form/Type/ChoiceFieldMaskTypeTest.php
+++ b/Tests/Form/Type/ChoiceFieldMaskTypeTest.php
@@ -12,14 +12,13 @@
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType;
-
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ChoiceFieldMaskTypeTest extends TypeTestCase
 {
     public function testGetDefaultOptions()
-        {
+    {
         $type = new ChoiceFieldMaskType();
 
         $optionResolver = new OptionsResolver();
@@ -28,13 +27,12 @@ class ChoiceFieldMaskTypeTest extends TypeTestCase
         $options = $optionResolver->resolve(
             array(
                 'map' => array(
-                    'foo' => array( 'field1', 'field2'),
-                    'bar' => array( 'field3')
-            )
+                    'foo' => array('field1', 'field2'),
+                    'bar' => array('field3'),
+            ),
         ));
 
-        $this->assertSame( array('foo'=> array('field1', 'field2'), 'bar'=> array('field3')), $options['map']);
-
+        $this->assertSame(array('foo' => array('field1', 'field2'), 'bar' => array('field3')), $options['map']);
     }
 
     public function testGetName()
@@ -48,5 +46,4 @@ class ChoiceFieldMaskTypeTest extends TypeTestCase
         $type = new ChoiceFieldMaskType();
         $this->assertEquals('choice', $type->getParent());
     }
-
 }

--- a/Tests/Form/Type/Filter/DateTimeRangeTypeTest.php
+++ b/Tests/Form/Type/Filter/DateTimeRangeTypeTest.php
@@ -22,7 +22,7 @@ class DateTimeRangeTypeTest extends TypeTestCase
 
         $expected = array(
             'field_type'       => 'sonata_type_datetime_range',
-            'field_options'    => array('date_format' => 'yyyy-MM-dd')
+            'field_options'    => array('date_format' => 'yyyy-MM-dd'),
         );
         $this->assertEquals($expected, $options);
     }

--- a/Tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/Tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -12,7 +12,6 @@
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
-
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -26,7 +25,7 @@ class ModelAutocompleteTypeTest extends TypeTestCase
 
         $type->setDefaultOptions($optionResolver);
 
-        $options = $optionResolver->resolve(array('model_manager' => $modelManager, 'class' => 'Foo', 'property'=>'bar'));
+        $options = $optionResolver->resolve(array('model_manager' => $modelManager, 'class' => 'Foo', 'property' => 'bar'));
 
         $this->assertEquals(array(), $options['attr']);
         $this->assertFalse($options['compound']);
@@ -43,7 +42,7 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $this->assertFalse($options['dropdown_auto_width']);
 
         $this->assertEquals('', $options['url']);
-        $this->assertEquals(array('name'=>'sonata_admin_retrieve_autocomplete_items', 'parameters'=>array()), $options['route']);
+        $this->assertEquals(array('name' => 'sonata_admin_retrieve_autocomplete_items', 'parameters' => array()), $options['route']);
         $this->assertEquals(array(), $options['req_params']);
         $this->assertEquals('q', $options['req_param_name_search']);
         $this->assertEquals('_page', $options['req_param_name_page_number']);

--- a/Tests/Form/Type/ModelHiddenTypeTest.php
+++ b/Tests/Form/Type/ModelHiddenTypeTest.php
@@ -12,7 +12,6 @@
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Sonata\AdminBundle\Form\Type\ModelHiddenType;
-
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 

--- a/Tests/Form/Type/ModelTypeTest.php
+++ b/Tests/Form/Type/ModelTypeTest.php
@@ -12,7 +12,6 @@
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Sonata\AdminBundle\Form\Type\ModelType;
-
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -56,7 +55,7 @@ class ModelTypeTest extends TypeTestCase
 
         $type->setDefaultOptions($optionResolver);
 
-        $options = $optionResolver->resolve(array('model_manager' => $modelManager, 'choices' => array(), 'multiple'=>$multiple, 'expanded'=>$expanded));
+        $options = $optionResolver->resolve(array('model_manager' => $modelManager, 'choices' => array(), 'multiple' => $multiple, 'expanded' => $expanded));
 
         $this->assertEquals($expectedCompound, $options['compound']);
         $this->assertEquals('choice', $options['template']);

--- a/Tests/Generator/AdminGeneratorTest.php
+++ b/Tests/Generator/AdminGeneratorTest.php
@@ -37,7 +37,7 @@ class AdminGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->adminGenerator = new AdminGenerator(
             $this->createModelManagerMock(),
-            __DIR__ . '/../../Resources/skeleton'
+            __DIR__.'/../../Resources/skeleton'
         );
         $this->bundleMock = $this->createBundleMock();
         $this->bundlePath = $this->bundleMock->getPath();
@@ -58,7 +58,7 @@ class AdminGeneratorTest extends \PHPUnit_Framework_TestCase
         $file = $this->adminGenerator->getFile();
         $this->assertEquals('Sonata\AdminBundle\Tests\Fixtures\Admin\ModelAdmin', $this->adminGenerator->getClass());
         $this->assertEquals('ModelAdmin.php', basename($file));
-        $this->assertFileEquals(__DIR__ . '/../Fixtures/Admin/ModelAdmin.php', $file);
+        $this->assertFileEquals(__DIR__.'/../Fixtures/Admin/ModelAdmin.php', $file);
 
         try {
             $this->adminGenerator->generate($this->bundleMock, 'ModelAdmin', 'Model');

--- a/Tests/Generator/ControllerGeneratorTest.php
+++ b/Tests/Generator/ControllerGeneratorTest.php
@@ -34,7 +34,7 @@ class ControllerGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->controllerGenerator = new ControllerGenerator(__DIR__ . '/../../Resources/skeleton');
+        $this->controllerGenerator = new ControllerGenerator(__DIR__.'/../../Resources/skeleton');
         $this->bundleMock = $this->createBundleMock();
         $this->bundlePath = $this->bundleMock->getPath();
     }
@@ -57,7 +57,7 @@ class ControllerGeneratorTest extends \PHPUnit_Framework_TestCase
             $this->controllerGenerator->getClass()
         );
         $this->assertEquals('ModelAdminController.php', basename($file));
-        $this->assertFileEquals(__DIR__ . '/../Fixtures/Controller/ModelAdminController.php', $file);
+        $this->assertFileEquals(__DIR__.'/../Fixtures/Controller/ModelAdminController.php', $file);
 
         try {
             $this->controllerGenerator->generate($this->bundleMock, 'ModelAdminController');

--- a/Tests/Guesser/TypeGuesserChainTest.php
+++ b/Tests/Guesser/TypeGuesserChainTest.php
@@ -12,15 +12,12 @@
 
 namespace Sonata\AdminBundle\Tests\Guesser;
 
-use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
-use Symfony\Component\Form\Exception\UnexpectedTypeException;
-use Symfony\Component\Form\Guess\Guess;
-use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserChain;
+use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
 /**
- * TypeGuesserChain Test
+ * TypeGuesserChain Test.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */

--- a/Tests/Mapper/BaseGroupedMapperTest.php
+++ b/Tests/Mapper/BaseGroupedMapperTest.php
@@ -14,13 +14,12 @@ namespace Sonata\AdminBundle\Tests\Mapper;
 use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
 
 /**
- * Test for BaseGroupedMapper
+ * Test for BaseGroupedMapper.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
 class BaseGroupedMapperTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var BaseGroupedMapper
      */
@@ -93,7 +92,7 @@ class BaseGroupedMapperTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertCount(0, $this->tabs);
         $this->assertCount(0, $this->groups);
-        $this->assertEquals($this->baseGroupedMapper, $this->baseGroupedMapper->with('fooTab', array('tab'=>true)));
+        $this->assertEquals($this->baseGroupedMapper, $this->baseGroupedMapper->with('fooTab', array('tab' => true)));
         $this->assertCount(1, $this->tabs);
         $this->assertCount(0, $this->groups);
     }
@@ -132,14 +131,14 @@ class BaseGroupedMapperTest extends \PHPUnit_Framework_TestCase
         $this->baseGroupedMapper->tab('fooTab');
         $this->baseGroupedMapper->tab('barTab');
     }
-    
+
     public function testHasOpenTab()
     {
         $this->assertFalse($this->baseGroupedMapper->hasOpenTab(), '->hasOpenTab() returns false when there are no tabs');
-        
+
         $this->baseGroupedMapper->tab('fooTab');
         $this->assertTrue($this->baseGroupedMapper->hasOpenTab(), '->hasOpenTab() returns true when there is an open tab');
-        
+
         $this->baseGroupedMapper->end();
         $this->assertFalse($this->baseGroupedMapper->hasOpenTab(), '->hasOpenTab() returns false when all tabs are closed');
     }

--- a/Tests/Mapper/BaseMapperTest.php
+++ b/Tests/Mapper/BaseMapperTest.php
@@ -13,11 +13,10 @@
 namespace Sonata\AdminBundle\Tests\Mapper;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Builder\BuilderInterface;
 use Sonata\AdminBundle\Mapper\BaseMapper;
 
 /**
- * Test for BaseMapperTest
+ * Test for BaseMapperTest.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */

--- a/Tests/Menu/MenuBuilderTest.php
+++ b/Tests/Menu/MenuBuilderTest.php
@@ -35,20 +35,20 @@ class MenuBuilderTest extends \PHPUnit_Framework_TestCase
     public function testGetKnpMenu()
     {
         $adminGroups = array(
-            "bar" => array(
-                "label" => "foo",
-                "icon"  => '<i class="fa fa-edit"></i>',
-                "label_catalogue"  => 'SonataAdminBundle',
-                "items" => array(
+            'bar' => array(
+                'label'            => 'foo',
+                'icon'             => '<i class="fa fa-edit"></i>',
+                'label_catalogue'  => 'SonataAdminBundle',
+                'items'            => array(
                     array(
-                        "admin"        => "",
-                        "label"        => "fooLabel",
-                        "route"        => "FooRoute",
-                        "route_params" => array("foo" => "bar"),
+                        'admin'        => '',
+                        'label'        => 'fooLabel',
+                        'route'        => 'FooRoute',
+                        'route_params' => array('foo' => 'bar'),
                     ),
                 ),
-                "item_adds" => array(),
-                "roles"     => array(),
+                'item_adds' => array(),
+                'roles'     => array(),
 
             ),
         );
@@ -62,8 +62,8 @@ class MenuBuilderTest extends \PHPUnit_Framework_TestCase
 
         foreach ($menu->getChildren() as $key => $child) {
             $this->assertInstanceOf('Knp\Menu\MenuItem', $child);
-            $this->assertEquals("bar", $child->getName());
-            $this->assertEquals($adminGroups["bar"]["label"], $child->getLabel());
+            $this->assertEquals('bar', $child->getName());
+            $this->assertEquals($adminGroups['bar']['label'], $child->getLabel());
 
             // menu items
             $children = $child->getChildren();
@@ -78,10 +78,10 @@ class MenuBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $adminGroups = array(
             'bar' => array(
-                'label' => 'foo',
-                'icon'  => '<i class="fa fa-edit"></i>',
+                'label'            => 'foo',
+                'icon'             => '<i class="fa fa-edit"></i>',
                 'label_catalogue'  => 'SonataAdminBundle',
-                'items' => array(
+                'items'            => array(
                     array(
                         'admin'        => 'sonata_admin_foo_service',
                         'label'        => 'fooLabel',
@@ -139,10 +139,10 @@ class MenuBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $adminGroups = array(
             'bar' => array(
-                'label' => 'foo',
-                'icon'  => '<i class="fa fa-edit"></i>',
+                'label'            => 'foo',
+                'icon'             => '<i class="fa fa-edit"></i>',
                 'label_catalogue'  => 'SonataAdminBundle',
-                'items' => array(
+                'items'            => array(
                     array(
                         'admin'        => 'sonata_admin_foo_service',
                         'label'        => 'fooLabel',
@@ -172,10 +172,10 @@ class MenuBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $adminGroups = array(
             'bar' => array(
-                'label' => 'foo',
-                'icon'  => '<i class="fa fa-edit"></i>',
+                'label'            => 'foo',
+                'icon'             => '<i class="fa fa-edit"></i>',
                 'label_catalogue'  => 'SonataAdminBundle',
-                'items' => array(
+                'items'            => array(
                     array(
                         'admin'        => 'sonata_admin_foo_service',
                         'label'        => 'fooLabel',
@@ -210,11 +210,11 @@ class MenuBuilderTest extends \PHPUnit_Framework_TestCase
     public function testGetKnpMenuWithProvider()
     {
         $adminGroups = array(
-            "bar" => array(
-                "provider"        => 'my_menu',
-                "label_catalogue" => '',
-                "icon"            => '<i class="fa fa-edit"></i>',
-                "roles"           => array(),
+            'bar' => array(
+                'provider'        => 'my_menu',
+                'label_catalogue' => '',
+                'icon'            => '<i class="fa fa-edit"></i>',
+                'roles'           => array(),
             ),
         );
 
@@ -233,8 +233,8 @@ class MenuBuilderTest extends \PHPUnit_Framework_TestCase
 
         foreach ($menu->getChildren() as $key => $child) {
             $this->assertInstanceOf('Knp\Menu\MenuItem', $child);
-            $this->assertEquals("bar", $child->getName());
-            $this->assertEquals("bar", $child->getLabel());
+            $this->assertEquals('bar', $child->getName());
+            $this->assertEquals('bar', $child->getLabel());
 
             // menu items
             $children = $child->getChildren();
@@ -248,13 +248,13 @@ class MenuBuilderTest extends \PHPUnit_Framework_TestCase
     public function testGetKnpMenuAndDispatchEvent()
     {
         $adminGroups = array(
-            "bar" => array(
-                "label" => "foo",
-                "icon"  => '<i class="fa fa-edit"></i>',
-                "label_catalogue"  => 'SonataAdminBundle',
-                "items" => array(),
-                "item_adds" => array(),
-                "roles"     => array(),
+            'bar' => array(
+                'label'            => 'foo',
+                'icon'             => '<i class="fa fa-edit"></i>',
+                'label_catalogue'  => 'SonataAdminBundle',
+                'items'            => array(),
+                'item_adds'        => array(),
+                'roles'            => array(),
             ),
         );
 

--- a/Tests/Model/AuditManagerTest.php
+++ b/Tests/Model/AuditManagerTest.php
@@ -11,11 +11,10 @@
 
 namespace Sonata\AdminBundle\Tests\Model;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Sonata\AdminBundle\Model\AuditManager;
 
 /**
- * Test for AuditManager
+ * Test for AuditManager.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
@@ -39,7 +38,7 @@ class AuditManagerTest extends \PHPUnit_Framework_TestCase
                         return $barReader;
                 }
 
-                return null;
+                return;
             }));
 
         $auditManager = new AuditManager($container);

--- a/Tests/Resources/XliffTest.php
+++ b/Tests/Resources/XliffTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sonata project.
  *

--- a/Tests/Route/AdminPoolLoaderTest.php
+++ b/Tests/Route/AdminPoolLoaderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sonata project.
  *
@@ -10,8 +11,8 @@
 
 namespace Sonata\AdminBundle\Tests\Route;
 
-use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Route\AdminPoolLoader;
+use Sonata\AdminBundle\Route\RouteCollection;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -63,7 +64,7 @@ class AdminPoolLoaderTest extends \PHPUnit_Framework_TestCase
                         return $admin2;
                 }
 
-                return null;
+                return;
             }));
 
         $collection = $adminPoolLoader->load('foo', 'sonata_admin');

--- a/Tests/Route/DefaultRouteGeneratorTest.php
+++ b/Tests/Route/DefaultRouteGeneratorTest.php
@@ -58,14 +58,14 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->once())->method('hasRequest')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('foo_code'));
-        $admin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array('abc'=>'a123', 'efg'=>'e456')));
+        $admin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
         $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
         $router->expects($this->once())
             ->method('generate')
-            ->will($this->returnCallback(function($name, array $parameters = array()) {
+            ->will($this->returnCallback(function ($name, array $parameters = array()) {
                 $params = '';
                 if (!empty($parameters)) {
                     $params .= '?'.http_build_query($parameters);
@@ -78,7 +78,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
                         return '/foo/bar'.$params;
                 }
 
-                return null;
+                return;
             }));
 
         $cache = new RoutesCache($this->cacheTempFolder, true);
@@ -91,8 +91,8 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
     public function getGenerateUrlTests()
     {
         return array(
-            array('/foo?abc=a123&efg=e456&default_param=default_val', 'foo', array('default_param'=>'default_val')),
-            array('/foo/bar?abc=a123&efg=e456&default_param=default_val', 'base.Code.Bar.bar', array('default_param'=>'default_val')),
+            array('/foo?abc=a123&efg=e456&default_param=default_val', 'foo', array('default_param' => 'default_val')),
+            array('/foo/bar?abc=a123&efg=e456&default_param=default_val', 'base.Code.Bar.bar', array('default_param' => 'default_val')),
         );
     }
 
@@ -138,7 +138,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->any())->method('hasRequest')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('foo_code'));
-        $admin->expects($this->any())->method('getPersistentParameters')->will($this->returnValue(array('abc'=>'a123', 'efg'=>'e456')));
+        $admin->expects($this->any())->method('getPersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($childCollection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
@@ -149,7 +149,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $parentAdmin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
         // no request attached in this test, so this will not be used
-        $parentAdmin->expects($this->never())->method('getPersistentParameters')->will($this->returnValue(array('from'=>'parent')));
+        $parentAdmin->expects($this->never())->method('getPersistentParameters')->will($this->returnValue(array('from' => 'parent')));
 
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
         $request->attributes = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
@@ -161,7 +161,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
                     return '987654';
                 }
 
-                return null;
+                return;
             }));
 
         $admin->expects($this->any())->method('getRequest')->will($this->returnValue($request));
@@ -170,7 +170,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $router = $this->getMock('\Symfony\Component\Routing\RouterInterface');
         $router->expects($this->once())
             ->method('generate')
-            ->will($this->returnCallback(function($name, array $parameters = array()) {
+            ->will($this->returnCallback(function ($name, array $parameters = array()) {
                 $params = '';
                 if (!empty($parameters)) {
                     $params .= '?'.http_build_query($parameters);
@@ -183,7 +183,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
                         return '/foo/bar'.$params;
                 }
 
-                return null;
+                return;
             }));
 
         $cache = new RoutesCache($this->cacheTempFolder, true);
@@ -196,9 +196,9 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
     public function getGenerateUrlChildTests()
     {
         return array(
-            array('parent', '/foo?id=123&default_param=default_val', 'foo', array('id'=>123, 'default_param'=>'default_val')),
-            array('parent', '/foo/bar?id=123&default_param=default_val', 'base.Code.Child.bar', array('id'=>123, 'default_param'=>'default_val')),
-            array('child', '/foo/bar?abc=a123&efg=e456&default_param=default_val&childId=987654', 'bar', array('id'=>123, 'default_param'=>'default_val')),
+            array('parent', '/foo?id=123&default_param=default_val', 'foo', array('id' => 123, 'default_param' => 'default_val')),
+            array('parent', '/foo/bar?id=123&default_param=default_val', 'base.Code.Child.bar', array('id' => 123, 'default_param' => 'default_val')),
+            array('child', '/foo/bar?abc=a123&efg=e456&default_param=default_val&childId=987654', 'bar', array('id' => 123, 'default_param' => 'default_val')),
         );
     }
 
@@ -222,14 +222,14 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->once())->method('hasRequest')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('foo_code'));
-        $admin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array('abc'=>'a123', 'efg'=>'e456')));
+        $admin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
 
         $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
         $router->expects($this->once())
             ->method('generate')
-            ->will($this->returnCallback(function($name, array $parameters = array()) {
+            ->will($this->returnCallback(function ($name, array $parameters = array()) {
                 $params = '';
                 if (!empty($parameters)) {
                     $params .= '?'.http_build_query($parameters);
@@ -242,7 +242,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
                         return '/foo/bar'.$params;
                 }
 
-                return null;
+                return;
             }));
 
         $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
@@ -266,9 +266,9 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
     public function getGenerateUrlParentFieldDescriptionTests()
     {
         return array(
-            array('/foo?abc=a123&efg=e456&default_param=default_val&uniqid=foo_uniqueid&code=base.Code.Parent&pcode=parent_foo_code&puniqid=parent_foo_uniqueid', 'foo', array('default_param'=>'default_val')),
+            array('/foo?abc=a123&efg=e456&default_param=default_val&uniqid=foo_uniqueid&code=base.Code.Parent&pcode=parent_foo_code&puniqid=parent_foo_uniqueid', 'foo', array('default_param' => 'default_val')),
             // this second test does not make sense as we cannot have embeded admin with nested admin....
-            array('/foo/bar?abc=a123&efg=e456&default_param=default_val&uniqid=foo_uniqueid&code=base.Code.Parent&pcode=parent_foo_code&puniqid=parent_foo_uniqueid', 'base.Code.Child.bar', array('default_param'=>'default_val')),
+            array('/foo/bar?abc=a123&efg=e456&default_param=default_val&uniqid=foo_uniqueid&code=base.Code.Parent&pcode=parent_foo_code&puniqid=parent_foo_uniqueid', 'base.Code.Child.bar', array('default_param' => 'default_val')),
         );
     }
 
@@ -295,7 +295,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->any())->method('hasParentFieldDescription')->will($this->returnValue(false));
         $admin->expects($this->any())->method('hasRequest')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
-        $admin->expects($this->any())->method('getPersistentParameters')->will($this->returnValue(array('abc'=>'a123', 'efg'=>'e456')));
+        $admin->expects($this->any())->method('getPersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($childCollection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
@@ -306,19 +306,19 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $parentAdmin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
         // no request attached in this test, so this will not be used
-        $parentAdmin->expects($this->never())->method('getPersistentParameters')->will($this->returnValue(array('from'=>'parent')));
+        $parentAdmin->expects($this->never())->method('getPersistentParameters')->will($this->returnValue(array('from' => 'parent')));
 
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
         $request->attributes = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
         $request->attributes->expects($this->any())->method('has')->will($this->returnValue(true));
         $request->attributes->expects($this->any())
             ->method('get')
-            ->will($this->returnCallback(function($key) {
+            ->will($this->returnCallback(function ($key) {
                 if ($key == 'childId') {
                     return '987654';
                 }
 
-                return null;
+                return;
             }));
 
         $admin->expects($this->any())->method('getRequest')->will($this->returnValue($request));
@@ -330,14 +330,14 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $standaloneAdmin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(false));
         $standaloneAdmin->expects($this->once())->method('hasRequest')->will($this->returnValue(true));
         $standaloneAdmin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
-        $standaloneAdmin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array('abc'=>'a123', 'efg'=>'e456')));
+        $standaloneAdmin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
         $standaloneAdmin->expects($this->any())->method('getRoutes')->will($this->returnValue($standaloneCollection));
         $standaloneAdmin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
         $router = $this->getMock('\Symfony\Component\Routing\RouterInterface');
         $router->expects($this->exactly(2))
             ->method('generate')
-            ->will($this->returnCallback(function($name, array $parameters = array()) {
+            ->will($this->returnCallback(function ($name, array $parameters = array()) {
                 $params = '';
                 if (!empty($parameters)) {
                     $params .= '?'.http_build_query($parameters);
@@ -350,7 +350,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
                         return '/bar'.$params;
                 }
 
-                return null;
+                return;
             }));
 
         $cache = new RoutesCache($this->cacheTempFolder, true);
@@ -365,7 +365,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
     public function getGenerateUrlLoadCacheTests()
     {
         return array(
-            array('/bar?abc=a123&efg=e456&id=123&default_param=default_val', 'bar', array('id'=>123, 'default_param'=>'default_val')),
+            array('/bar?abc=a123&efg=e456&id=123&default_param=default_val', 'bar', array('id' => 123, 'default_param' => 'default_val')),
         );
     }
 }

--- a/Tests/Route/PathInfoBuilderTest.php
+++ b/Tests/Route/PathInfoBuilderTest.php
@@ -16,7 +16,6 @@ use Sonata\AdminBundle\Route\RouteCollection;
 
 class PathInfoBuilderTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testBuild()
     {
         $audit = $this->getMock('Sonata\AdminBundle\Model\AuditManagerInterface');

--- a/Tests/Route/RouteCollectionTest.php
+++ b/Tests/Route/RouteCollectionTest.php
@@ -75,7 +75,7 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $routeCollection->add('view');
         $routeCollection->add('edit');
         $routeCollection->add('list');
-        $routeCollection->clearExcept(array('create','edit'));
+        $routeCollection->clearExcept(array('create', 'edit'));
         $this->assertTrue($routeCollection->has('create'));
         $this->assertTrue($routeCollection->has('edit'));
         $this->assertFalse($routeCollection->has('view'));

--- a/Tests/Search/SearchHandlerTest.php
+++ b/Tests/Search/SearchHandlerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sonata project.
  *
@@ -13,13 +14,10 @@ namespace Sonata\AdminBundle\Tests\Search;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Search\SearchHandler;
-use Sonata\AdminBundle\Datagrid\DatagridInterface;
-use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class SearchHandlerTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @param AdminInterface $admin
      *

--- a/Tests/Security/Handler/AclSecurityHandlerTest.php
+++ b/Tests/Security/Handler/AclSecurityHandlerTest.php
@@ -8,11 +8,11 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Sonata\AdminBundle\Tests\Security\Handler;
 
 use Sonata\AdminBundle\Security\Handler\AclSecurityHandler;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
-use Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder;
 
 class AclSecurityHandlerTest extends \PHPUnit_Framework_TestCase
 {
@@ -72,7 +72,7 @@ class AclSecurityHandlerTest extends \PHPUnit_Framework_TestCase
     public function testBuildInformation()
     {
         $informations = array(
-            'EDIT' => array('EDIT')
+            'EDIT' => array('EDIT'),
         );
 
         $authorizationChecker = $this->getAuthorizationCheckerMock();

--- a/Tests/Security/Handler/NoopSecurityHandlerTest.php
+++ b/Tests/Security/Handler/NoopSecurityHandlerTest.php
@@ -8,10 +8,11 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Sonata\AdminBundle\Tests\Security\Handler;
 
-use Sonata\AdminBundle\Security\Handler\NoopSecurityHandler;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Security\Handler\NoopSecurityHandler;
 
 class NoopSecurityHandlerTest extends \PHPUnit_Framework_TestCase
 {

--- a/Tests/Security/Handler/RoleSecurityHandlerTest.php
+++ b/Tests/Security/Handler/RoleSecurityHandlerTest.php
@@ -11,14 +11,14 @@
 
 namespace Sonata\AdminBundle\Tests\Security\Handler;
 
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Security\Handler\RoleSecurityHandler;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
- * Test for RoleSecurityHandler
+ * Test for RoleSecurityHandler.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */

--- a/Tests/Show/ShowMapperTest.php
+++ b/Tests/Show/ShowMapperTest.php
@@ -12,15 +12,14 @@
 namespace Sonata\AdminBundle\Tests\Show;
 
 use Sonata\AdminBundle\Admin\Admin;
-use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
+use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
 
 /**
- * Test for ShowMapper
+ * Test for ShowMapper.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
@@ -68,7 +67,7 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
         $this->groups = array();
 
         // php 5.3 BC
-        $groups = & $this->groups;
+        $groups = &$this->groups;
 
         $this->admin->expects($this->any())
             ->method('getShowGroups')
@@ -97,7 +96,7 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
 
         $modelManager->expects($this->any())
             ->method('getNewFieldDescriptionInstance')
-            ->will($this->returnCallback(function($class, $name, array $options = array()) use ($fieldDescription) {
+            ->will($this->returnCallback(function ($class, $name, array $options = array()) use ($fieldDescription) {
                 $fieldDescriptionClone = clone $fieldDescription;
                 $fieldDescriptionClone->setName($name);
                 $fieldDescriptionClone->setOptions($options);
@@ -284,7 +283,7 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
         $this->showMapper->ifTrue(false);
     }
 
-   /**
+    /**
      * @expectedException        RuntimeException
      * @expectedExceptionMessage Cannot nest ifTrue or ifFalse call
      */
@@ -336,29 +335,29 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
         $this->showMapper->add($fieldDescription4);
 
         $this->assertEquals(array(
-            'Group1' =>array(
-                'collapsed' => false,
-                'fields' => array('fooName1'=>'fooName1', 'fooName2'=>'fooName2', 'fooName3'=>'fooName3', 'fooName4'=>'fooName4'),
-                'description' => false,
+            'Group1' => array(
+                'collapsed'          => false,
+                'fields'             => array('fooName1' => 'fooName1', 'fooName2' => 'fooName2', 'fooName3' => 'fooName3', 'fooName4' => 'fooName4'),
+                'description'        => false,
                 'translation_domain' => null,
-                'class' => false,
-                'name' => 'Group1',
-                'box_class' => 'box box-primary'
-            )), $this->admin->getShowGroups());
+                'class'              => false,
+                'name'               => 'Group1',
+                'box_class'          => 'box box-primary',
+            ), ), $this->admin->getShowGroups());
 
         $this->showMapper->reorder(array('fooName3', 'fooName2', 'fooName1', 'fooName4'));
 
         // print_r is used to compare order of items in associative arrays
         $this->assertEquals(print_r(array(
-            'Group1' =>array(
-                'collapsed' => false,
-                'class' => false,
-                'description' => false,
+            'Group1' => array(
+                'collapsed'          => false,
+                'class'              => false,
+                'description'        => false,
                 'translation_domain' => null,
-                'name' => 'Group1',
-                'box_class' => 'box box-primary',
-                'fields' => array('fooName3'=>'fooName3', 'fooName2'=>'fooName2', 'fooName1'=>'fooName1', 'fooName4'=>'fooName4'),
-            )), true), print_r($this->admin->getShowGroups(), true));
+                'name'               => 'Group1',
+                'box_class'          => 'box box-primary',
+                'fields'             => array('fooName3' => 'fooName3', 'fooName2' => 'fooName2', 'fooName1' => 'fooName1', 'fooName4' => 'fooName4'),
+            ), ), true), print_r($this->admin->getShowGroups(), true));
     }
 
     private function getFieldDescriptionMock($name = null, $label = null)

--- a/Tests/SonataAdminBundleTest.php
+++ b/Tests/SonataAdminBundleTest.php
@@ -11,17 +11,16 @@
 
 namespace Sonata\AdminBundle\Tests;
 
-use Sonata\AdminBundle\SonataAdminBundle;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Sonata\AdminBundle\SonataAdminBundle;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 
 /**
- * Test for SonataAdminBundle
+ * Test for SonataAdminBundle.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */

--- a/Tests/Translator/BCLabelTranslatorStrategyTest.php
+++ b/Tests/Translator/BCLabelTranslatorStrategyTest.php
@@ -8,6 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Sonata\AdminBundle\Tests\Translator;
 
 use Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy;

--- a/Tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
+++ b/Tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
@@ -2,15 +2,13 @@
 
 namespace Sonata\AdminBundle\Tests\Translator\Extractor\JMSTranslatorBundle;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
-use Sonata\AdminBundle\Admin\Pool;
-use Sonata\AdminBundle\Admin\AdminInterface;
-use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Model\Message;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Translator\Extractor\JMSTranslatorBundle\AdminExtractor;
 
 /**
- * Test for AdminExtractor
+ * Test for AdminExtractor.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
@@ -60,7 +58,7 @@ class AdminExtractorTest extends \PHPUnit_Framework_TestCase
                         return $barAdmin;
                 }
 
-                return null;
+                return;
             }));
 
         $logger = $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
@@ -92,7 +90,7 @@ class AdminExtractorTest extends \PHPUnit_Framework_TestCase
                 $tester->assertEquals('foo', $translator->trans('foo', array(), 'foo_admin_domain'));
                 $tester->assertEquals('foo', $translator->transChoice('foo', 1, array(), 'foo_admin_domain'));
 
-                return null;
+                return;
             }));
 
         $catalogue = $this->adminExtractor->extract();

--- a/Tests/Translator/FormLabelTranslatorStrategyTest.php
+++ b/Tests/Translator/FormLabelTranslatorStrategyTest.php
@@ -8,6 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Sonata\AdminBundle\Tests\Translator;
 
 use Sonata\AdminBundle\Translator\FormLabelTranslatorStrategy;

--- a/Tests/Translator/NativeLabelTranslatorStrategyTest.php
+++ b/Tests/Translator/NativeLabelTranslatorStrategyTest.php
@@ -15,7 +15,6 @@ use Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy;
 
 class NativeLabelTranslatorStrategyTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @dataProvider getLabelTests
      */

--- a/Tests/Translator/NoopLabelTranslatorStrategyTest.php
+++ b/Tests/Translator/NoopLabelTranslatorStrategyTest.php
@@ -8,6 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Sonata\AdminBundle\Tests\Translator;
 
 use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;

--- a/Tests/Translator/UnderscoreLabelTranslatorStrategyTest.php
+++ b/Tests/Translator/UnderscoreLabelTranslatorStrategyTest.php
@@ -8,6 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Sonata\AdminBundle\Tests\Translator;
 
 use Sonata\AdminBundle\Translator\UnderscoreLabelTranslatorStrategy;

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\AdminBundle\Tests\Twig\Extension;
 
-use Sonata\AdminBundle\Admin\Pool;
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Psr\Log\LoggerInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Exception\NoValueException;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
@@ -23,13 +24,12 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\RequestContext;
-use Symfony\Component\Translation\Translator;
-use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
-use Psr\Log\LoggerInterface;
+use Symfony\Component\Translation\MessageSelector;
+use Symfony\Component\Translation\Translator;
 
 /**
- * Test for SonataAdminExtension
+ * Test for SonataAdminExtension.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
@@ -787,7 +787,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
             }));
 
         $element = new \stdClass();
-        $element->foo = "bar";
+        $element->foo = 'bar';
 
         $this->assertEquals('bar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
     }
@@ -806,7 +806,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
             }));
 
         $element = new \stdClass();
-        $element->foo = "bar";
+        $element->foo = 'bar';
 
         $this->assertEquals('closure bar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
     }

--- a/Tests/Util/AdminObjectAclDataTest.php
+++ b/Tests/Util/AdminObjectAclDataTest.php
@@ -18,7 +18,6 @@ use Sonata\AdminBundle\Util\AdminObjectAclData;
  */
 class AdminObjectAclDataTest extends \PHPUnit_Framework_TestCase
 {
-
     protected static function createAclUsers()
     {
         return new \ArrayIterator();

--- a/Tests/tests/bootstrap.php
+++ b/Tests/tests/bootstrap.php
@@ -10,7 +10,7 @@
  */
 
 // fix encoding issue while running text on different host with different locale configuration
-setlocale(LC_ALL, "en_US.UTF-8");
+setlocale(LC_ALL, 'en_US.UTF-8');
 
 if (file_exists($file = __DIR__.'/autoload.php')) {
     require_once $file;

--- a/Translator/BCLabelTranslatorStrategy.php
+++ b/Translator/BCLabelTranslatorStrategy.php
@@ -12,9 +12,8 @@
 namespace Sonata\AdminBundle\Translator;
 
 /**
- * Class BCLabelTranslatorStrategy
+ * Class BCLabelTranslatorStrategy.
  *
- * @package Sonata\AdminBundle\Translator
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class BCLabelTranslatorStrategy implements LabelTranslatorStrategyInterface

--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -2,18 +2,16 @@
 
 namespace Sonata\AdminBundle\Translator\Extractor\JMSTranslatorBundle;
 
-use Symfony\Component\Translation\TranslatorInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
-
+use JMS\TranslationBundle\Model\FileSource;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Translation\ExtractorInterface;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
-
-use JMS\TranslationBundle\Translation\ExtractorInterface;
-use JMS\TranslationBundle\Model\MessageCatalogue;
-use JMS\TranslationBundle\Model\Message;
-use JMS\TranslationBundle\Model\FileSource;
+use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class AdminExtractor implements ExtractorInterface, TranslatorInterface, SecurityHandlerInterface, LabelTranslatorStrategyInterface
 {
@@ -49,7 +47,7 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
     }
 
     /**
-     * Extract messages to MessageCatalogue
+     * Extract messages to MessageCatalogue.
      *
      * @return MessageCatalogue
      *
@@ -91,7 +89,7 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
                     array('update'),
                     array('batch'),
                     array('delete'),
-                )
+                ),
             );
 
             if ($this->logger) {

--- a/Translator/FormLabelTranslatorStrategy.php
+++ b/Translator/FormLabelTranslatorStrategy.php
@@ -12,9 +12,8 @@
 namespace Sonata\AdminBundle\Translator;
 
 /**
- * Class FormLabelTranslatorStrategy
+ * Class FormLabelTranslatorStrategy.
  *
- * @package Sonata\AdminBundle\Translator
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class FormLabelTranslatorStrategy implements LabelTranslatorStrategyInterface

--- a/Translator/LabelTranslatorStrategyInterface.php
+++ b/Translator/LabelTranslatorStrategyInterface.php
@@ -12,9 +12,8 @@
 namespace Sonata\AdminBundle\Translator;
 
 /**
- * Interface LabelTranslatorStrategyInterface
+ * Interface LabelTranslatorStrategyInterface.
  *
- * @package Sonata\AdminBundle\Translator
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface LabelTranslatorStrategyInterface

--- a/Translator/NativeLabelTranslatorStrategy.php
+++ b/Translator/NativeLabelTranslatorStrategy.php
@@ -12,9 +12,8 @@
 namespace Sonata\AdminBundle\Translator;
 
 /**
- * Class NativeLabelTranslatorStrategy
+ * Class NativeLabelTranslatorStrategy.
  *
- * @package Sonata\AdminBundle\Translator
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class NativeLabelTranslatorStrategy implements LabelTranslatorStrategyInterface

--- a/Translator/NoopLabelTranslatorStrategy.php
+++ b/Translator/NoopLabelTranslatorStrategy.php
@@ -12,9 +12,8 @@
 namespace Sonata\AdminBundle\Translator;
 
 /**
- * Class NoopLabelTranslatorStrategy
+ * Class NoopLabelTranslatorStrategy.
  *
- * @package Sonata\AdminBundle\Translator
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class NoopLabelTranslatorStrategy implements LabelTranslatorStrategyInterface

--- a/Translator/UnderscoreLabelTranslatorStrategy.php
+++ b/Translator/UnderscoreLabelTranslatorStrategy.php
@@ -12,9 +12,8 @@
 namespace Sonata\AdminBundle\Translator;
 
 /**
- * Class UnderscoreLabelTranslatorStrategy
+ * Class UnderscoreLabelTranslatorStrategy.
  *
- * @package Sonata\AdminBundle\Translator
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class UnderscoreLabelTranslatorStrategy implements LabelTranslatorStrategyInterface

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -20,9 +20,8 @@ use Sonata\AdminBundle\Exception\NoValueException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
- * Class SonataAdminExtension
+ * Class SonataAdminExtension.
  *
- * @package Sonata\AdminBundle\Twig\Extension
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class SonataAdminExtension extends \Twig_Extension
@@ -100,7 +99,7 @@ class SonataAdminExtension extends \Twig_Extension
     }
 
     /**
-     * Get template
+     * Get template.
      *
      * @param FieldDescriptionInterface $fieldDescription
      * @param string                    $defaultTemplate
@@ -125,7 +124,7 @@ class SonataAdminExtension extends \Twig_Extension
     }
 
     /**
-     * render a list element from the FieldDescription
+     * render a list element from the FieldDescription.
      *
      * @param mixed                     $object
      * @param FieldDescriptionInterface $fieldDescription
@@ -171,7 +170,7 @@ class SonataAdminExtension extends \Twig_Extension
 
     /**
      * return the value related to FieldDescription, if the associated object does no
-     * exists => a temporary one is created
+     * exists => a temporary one is created.
      *
      * @param object                    $object
      * @param FieldDescriptionInterface $fieldDescription
@@ -200,7 +199,7 @@ class SonataAdminExtension extends \Twig_Extension
     }
 
     /**
-     * render a view element
+     * render a view element.
      *
      * @param FieldDescriptionInterface $fieldDescription
      * @param mixed                     $object
@@ -226,7 +225,7 @@ class SonataAdminExtension extends \Twig_Extension
     }
 
     /**
-     * render a compared view element
+     * render a compared view element.
      *
      * @param FieldDescriptionInterface $fieldDescription
      * @param mixed                     $baseObject

--- a/Twig/GlobalVariables.php
+++ b/Twig/GlobalVariables.php
@@ -11,13 +11,12 @@
 
 namespace Sonata\AdminBundle\Twig;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class GlobalVariables
+ * Class GlobalVariables.
  *
- * @package Sonata\AdminBundle\Twig
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class GlobalVariables

--- a/Util/AdminAclManipulator.php
+++ b/Util/AdminAclManipulator.php
@@ -11,18 +11,16 @@
 
 namespace Sonata\AdminBundle\Util;
 
-use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
-use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
-use Symfony\Component\Security\Acl\Model\AclInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
+use Symfony\Component\Security\Acl\Model\AclInterface;
 
 /**
- * Class AdminAclManipulator
+ * Class AdminAclManipulator.
  *
- * @package Sonata\AdminBundle\Util
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AdminAclManipulator implements AdminAclManipulatorInterface

--- a/Util/AdminAclManipulatorInterface.php
+++ b/Util/AdminAclManipulatorInterface.php
@@ -11,38 +11,35 @@
 
 namespace Sonata\AdminBundle\Util;
 
-use Symfony\Component\Security\Acl\Model\AclInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Security\Acl\Model\AclInterface;
 
 /**
- * Interface AdminAclManipulatorInterface
+ * Interface AdminAclManipulatorInterface.
  *
- * @package Sonata\AdminBundle\Util
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface AdminAclManipulatorInterface
 {
     /**
-     * Batch configure the ACLs for all objects handled by an Admin
+     * Batch configure the ACLs for all objects handled by an Admin.
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @param \Sonata\AdminBundle\Admin\AdminInterface          $admin
-     *
-     * @return void
      */
     public function configureAcls(OutputInterface $output, AdminInterface $admin);
 
     /**
-     * Add the class ACE's to the admin ACL
+     * Add the class ACE's to the admin ACL.
      *
      * @param \Symfony\Component\Console\Output\OutputInterface                $output
      * @param \Symfony\Component\Security\Acl\Model\AclInterface               $acl
      * @param \Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface $securityHandler
      * @param array                                                            $roleInformation
      *
-     * @return boolean TRUE if admin class ACEs are added, FALSE if not
+     * @return bool TRUE if admin class ACEs are added, FALSE if not
      */
     public function addAdminClassAces(OutputInterface $output, AclInterface $acl, AclSecurityHandlerInterface $securityHandler, array $roleInformation = array());
 }

--- a/Util/AdminObjectAclData.php
+++ b/Util/AdminObjectAclData.php
@@ -11,10 +11,9 @@
 
 namespace Sonata\AdminBundle\Util;
 
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Security\Acl\Domain\Acl;
-
-use Sonata\AdminBundle\Admin\AdminInterface;
 
 /**
  * AdminObjectAclData holds data manipulated by {@link AdminObjectAclManipulator}.
@@ -65,7 +64,7 @@ class AdminObjectAclData
     protected $maskBuilderClass;
 
     /**
-     * Cache masks
+     * Cache masks.
      */
     protected function updateMasks()
     {
@@ -74,7 +73,7 @@ class AdminObjectAclData
         $reflectionClass = new \ReflectionClass(new $this->maskBuilderClass());
         $this->masks = array();
         foreach ($permissions as $permission) {
-            $this->masks[$permission] = $reflectionClass->getConstant('MASK_' . $permission);
+            $this->masks[$permission] = $reflectionClass->getConstant('MASK_'.$permission);
         }
     }
 
@@ -101,7 +100,7 @@ class AdminObjectAclData
     }
 
     /**
-     * Gets admin
+     * Gets admin.
      *
      * @return \Sonata\AdminBundle\Admin\AdminInterface
      */
@@ -111,7 +110,7 @@ class AdminObjectAclData
     }
 
     /**
-     * Gets object
+     * Gets object.
      *
      * @return mixed
      */
@@ -121,7 +120,7 @@ class AdminObjectAclData
     }
 
     /**
-     * Gets ACL users
+     * Gets ACL users.
      *
      * @return \Traversable
      */
@@ -131,7 +130,7 @@ class AdminObjectAclData
     }
 
     /**
-     * Gets ACL roles
+     * Gets ACL roles.
      *
      * @return \Traversable
      */
@@ -141,9 +140,10 @@ class AdminObjectAclData
     }
 
     /**
-     * Sets ACL
+     * Sets ACL.
      *
-     * @param  \Symfony\Component\Security\Acl\Domain\Acl  $acl
+     * @param \Symfony\Component\Security\Acl\Domain\Acl $acl
+     *
      * @return \Sonata\AdminBundle\Util\AdminObjectAclData
      */
     public function setAcl(Acl $acl)
@@ -154,7 +154,7 @@ class AdminObjectAclData
     }
 
     /**
-     * Gets ACL
+     * Gets ACL.
      *
      * @return \Symfony\Component\Security\Acl\Domain\Acl
      */
@@ -164,7 +164,7 @@ class AdminObjectAclData
     }
 
     /**
-     * Gets masks
+     * Gets masks.
      *
      * @return array
      */
@@ -174,9 +174,10 @@ class AdminObjectAclData
     }
 
     /**
-     * Sets form
+     * Sets form.
      *
-     * @param  \Symfony\Component\Form\Form                $form
+     * @param \Symfony\Component\Form\Form $form
+     *
      * @return \Sonata\AdminBundle\Util\AdminObjectAclData
      *
      * @deprecated Deprecated since version 2.4. Use setAclUsersForm() instead.
@@ -189,7 +190,7 @@ class AdminObjectAclData
     }
 
     /**
-     * Gets form
+     * Gets form.
      *
      * @return \Symfony\Component\Form\Form
      *
@@ -203,9 +204,10 @@ class AdminObjectAclData
     }
 
     /**
-     * Sets ACL users form
+     * Sets ACL users form.
      *
-     * @param  \Symfony\Component\Form\Form                $form
+     * @param \Symfony\Component\Form\Form $form
+     *
      * @return \Sonata\AdminBundle\Util\AdminObjectAclData
      */
     public function setAclUsersForm(Form $form)
@@ -216,7 +218,7 @@ class AdminObjectAclData
     }
 
     /**
-     * Gets ACL users form
+     * Gets ACL users form.
      *
      * @return \Symfony\Component\Form\Form
      */
@@ -226,9 +228,10 @@ class AdminObjectAclData
     }
 
     /**
-     * Sets ACL roles form
+     * Sets ACL roles form.
      *
-     * @param  \Symfony\Component\Form\Form                $form
+     * @param \Symfony\Component\Form\Form $form
+     *
      * @return \Sonata\AdminBundle\Util\AdminObjectAclData
      */
     public function setAclRolesForm(Form $form)
@@ -239,7 +242,7 @@ class AdminObjectAclData
     }
 
     /**
-     * Gets ACL roles form
+     * Gets ACL roles form.
      *
      * @return \Symfony\Component\Form\Form
      */
@@ -249,7 +252,7 @@ class AdminObjectAclData
     }
 
     /**
-     * Gets permissions
+     * Gets permissions.
      *
      * @return array
      */
@@ -259,7 +262,7 @@ class AdminObjectAclData
     }
 
     /**
-     * Get permissions that the current user can set
+     * Get permissions that the current user can set.
      *
      * @return array
      */
@@ -280,9 +283,9 @@ class AdminObjectAclData
     }
 
     /**
-     * Tests if the current user as the OWNER right
+     * Tests if the current user as the OWNER right.
      *
-     * @return boolean
+     * @return bool
      */
     public function isOwner()
     {
@@ -291,7 +294,7 @@ class AdminObjectAclData
     }
 
     /**
-     * Gets security handler
+     * Gets security handler.
      *
      * @return \Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface
      */

--- a/Util/AdminObjectAclManipulator.php
+++ b/Util/AdminObjectAclManipulator.php
@@ -17,8 +17,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
-use Symfony\Component\Security\Acl\Exception\NoAceFoundException;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
+use Symfony\Component\Security\Acl\Exception\NoAceFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -52,7 +52,7 @@ class AdminObjectAclManipulator
     }
 
     /**
-     * Gets mask builder class name
+     * Gets mask builder class name.
      *
      * @return string
      */
@@ -62,9 +62,10 @@ class AdminObjectAclManipulator
     }
 
     /**
-     * Gets the form
+     * Gets the form.
      *
-     * @param  \Sonata\AdminBundle\Util\AdminObjectAclData $data
+     * @param \Sonata\AdminBundle\Util\AdminObjectAclData $data
+     *
      * @return \Symfony\Component\Form\Form
      *
      * @deprecated Deprecated since version 2.4. Use createAclUsersForm() instead.
@@ -77,9 +78,10 @@ class AdminObjectAclManipulator
     }
 
     /**
-     * Gets the ACL users form
+     * Gets the ACL users form.
      *
-     * @param  \Sonata\AdminBundle\Util\AdminObjectAclData $data
+     * @param \Sonata\AdminBundle\Util\AdminObjectAclData $data
+     *
      * @return \Symfony\Component\Form\Form
      */
     public function createAclUsersForm(AdminObjectAclData $data)
@@ -93,9 +95,10 @@ class AdminObjectAclManipulator
     }
 
     /**
-     * Gets the ACL roles form
+     * Gets the ACL roles form.
      *
-     * @param  \Sonata\AdminBundle\Util\AdminObjectAclData $data
+     * @param \Sonata\AdminBundle\Util\AdminObjectAclData $data
+     *
      * @return \Symfony\Component\Form\Form
      */
     public function createAclRolesForm(AdminObjectAclData $data)
@@ -109,7 +112,7 @@ class AdminObjectAclManipulator
     }
 
     /**
-     * Updates ACL users
+     * Updates ACL users.
      *
      * @param \Sonata\AdminBundle\Util\AdminObjectAclData $data
      */
@@ -122,7 +125,7 @@ class AdminObjectAclManipulator
     }
 
     /**
-     * Updates ACL roles
+     * Updates ACL roles.
      *
      * @param \Sonata\AdminBundle\Util\AdminObjectAclData $data
      */
@@ -135,7 +138,7 @@ class AdminObjectAclManipulator
     }
 
     /**
-     * Updates ACl
+     * Updates ACl.
      *
      * @param \Sonata\AdminBundle\Util\AdminObjectAclData $data
      *
@@ -149,7 +152,7 @@ class AdminObjectAclManipulator
     }
 
     /**
-     * Builds ACL
+     * Builds ACL.
      *
      * @param \Sonata\AdminBundle\Util\AdminObjectAclData $data
      * @param \Symfony\Component\Form\Form                $form
@@ -219,11 +222,12 @@ class AdminObjectAclManipulator
     }
 
     /**
-     * Builds the form
+     * Builds the form.
      *
-     * @param  \Sonata\AdminBundle\Util\AdminObjectAclData  $data
-     * @param  \Symfony\Component\Form\FormBuilderInterface $formBuilder
-     * @param  \Traversable                                 $aclValues
+     * @param \Sonata\AdminBundle\Util\AdminObjectAclData  $data
+     * @param \Symfony\Component\Form\FormBuilderInterface $formBuilder
+     * @param \Traversable                                 $aclValues
+     *
      * @return \Symfony\Component\Form\Form
      */
     protected function buildForm(AdminObjectAclData $data, FormBuilderInterface $formBuilder, \Traversable $aclValues)
@@ -262,9 +266,9 @@ class AdminObjectAclManipulator
 
                 $permissions[$permission] = array(
                     'required' => false,
-                    'data' => $checked,
+                    'data'     => $checked,
                     'disabled' => array_key_exists('disabled', $attr),
-                    'attr' => $attr,
+                    'attr'     => $attr,
                 );
             }
 
@@ -275,9 +279,10 @@ class AdminObjectAclManipulator
     }
 
     /**
-     * Gets a user or a role security identity
+     * Gets a user or a role security identity.
      *
-     * @param  string|\Symfony\Component\Security\Core\User\UserInterface                                                              $aclValue
+     * @param string|\Symfony\Component\Security\Core\User\UserInterface $aclValue
+     *
      * @return \Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity|\Symfony\Component\Security\Acl\Domain\UserSecurityIdentity
      */
     protected function getSecurityIdentity($aclValue)

--- a/Util/FormBuilderIterator.php
+++ b/Util/FormBuilderIterator.php
@@ -14,9 +14,8 @@ namespace Sonata\AdminBundle\Util;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Class FormBuilderIterator
+ * Class FormBuilderIterator.
  *
- * @package Sonata\AdminBundle\Util
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class FormBuilderIterator extends \RecursiveArrayIterator

--- a/Util/FormViewIterator.php
+++ b/Util/FormViewIterator.php
@@ -14,9 +14,8 @@ namespace Sonata\AdminBundle\Util;
 use Symfony\Component\Form\FormView;
 
 /**
- * Class FormViewIterator
+ * Class FormViewIterator.
  *
- * @package Sonata\AdminBundle\Util
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class FormViewIterator implements \RecursiveIterator
@@ -38,7 +37,7 @@ class FormViewIterator implements \RecursiveIterator
      */
     public function getChildren()
     {
-        return new FormViewIterator($this->current());
+        return new self($this->current());
     }
 
     /**

--- a/Util/ObjectAclManipulator.php
+++ b/Util/ObjectAclManipulator.php
@@ -11,21 +11,20 @@
 
 namespace Sonata\AdminBundle\Util;
 
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 
 /**
- * Class ObjectAclManipulator
+ * Class ObjectAclManipulator.
  *
- * @package Sonata\AdminBundle\Util
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 abstract class ObjectAclManipulator implements ObjectAclManipulatorInterface
 {
     /**
-     * Configure the object ACL for the passed object identities
+     * Configure the object ACL for the passed object identities.
      *
      * @param OutputInterface      $output
      * @param AdminInterface       $admin
@@ -52,10 +51,10 @@ abstract class ObjectAclManipulator implements ObjectAclManipulatorInterface
         foreach ($oids as $oid) {
             if ($acls->contains($oid)) {
                 $acl = $acls->offsetGet($oid);
-                $countUpdated++;
+                ++$countUpdated;
             } else {
                 $acl = $securityHandler->createAcl($oid);
-                $countAdded++;
+                ++$countAdded;
             }
 
             if (!is_null($securityIdentity)) {

--- a/Util/ObjectAclManipulatorInterface.php
+++ b/Util/ObjectAclManipulatorInterface.php
@@ -11,20 +11,19 @@
 
 namespace Sonata\AdminBundle\Util;
 
-use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
-use Symfony\Component\Console\Output\OutputInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 
 /**
- * Interface ObjectAclManipulatorInterface
+ * Interface ObjectAclManipulatorInterface.
  *
- * @package Sonata\AdminBundle\Util
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface ObjectAclManipulatorInterface
 {
     /**
-     * Batch configure the ACLs for all objects handled by an Admin
+     * Batch configure the ACLs for all objects handled by an Admin.
      *
      * @abstract
      *
@@ -33,7 +32,6 @@ interface ObjectAclManipulatorInterface
      * @param UserSecurityIdentity $securityIdentity
      *
      * @throws \Sonata\AdminBundle\Exception\ModelManagerException
-     * @return void
      */
     public function batchConfigureAcls(OutputInterface $output, AdminInterface $admin, UserSecurityIdentity $securityIdentity = null);
 }

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "sensio/generator-bundle": "~2.3",
         "symfony/yaml": "~2.3",
         "sonata-project/intl-bundle": "~2.1",
-        "symfony/phpunit-bridge": "~2.7|~3.0"
+        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "fabpot/php-cs-fixer": "~0.5|~1.0"
     },
     "suggest": {
         "jms/translation-bundle": "Extract message keys from Admins",


### PR DESCRIPTION
This is a proposal for [php-cs-fixer](http://cs.sensiolabs.org/) usage.

@rande, you said me you are following Symfony coding style (with possible some tweaks :) ).

So I propose to use php-cs-fixer to fix this code and encourage contributors to use it for each PR.

If this is accepted, this could be apply on other sonata bundles. For that, we can imagine a "coding-standards-tools" to include on it for logic refactor. What do you think?

For the moment, please review changes and don't hesitate to comment every change/rules that you do not want or want in other way, I will then update this PR to make it like you want.

Best regards.