### PR TITLE
Sort default Groups and Admins

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -95,7 +95,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
                 $groupDefaults[$resolvedGroupName]['items'][] = array(
                     'admin'        => $id,
-                    'label'        => '',
+                    'label'        => !empty($attributes['label']) ? $attributes['label'] : '',
                     'route'        => '',
                     'route_params' => array()
                 );
@@ -140,6 +140,31 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     $groups[$resolvedGroupName]['roles'] = $groupDefaults[$resolvedGroupName]['roles'];
                 }
             }
+        } elseif ($container->getParameter('sonata.admin.configuration.sort_admins')) {
+            $groups = $groupDefaults;
+
+            $elementSort = function (&$element) {
+                usort(
+                    $element['items'],
+                    function ($a, $b) {
+                        $a = !empty($a['label']) ? $a['label'] : $a['admin'];
+                        $b = !empty($b['label']) ? $b['label'] : $b['admin'];
+
+                        if ($a === $b) {
+                            return 0;
+                        }
+
+                        return $a < $b ? -1 : 1;
+                    }
+                );
+            };
+
+            /*
+             * 1) sort the groups by their index
+             * 2) sort the elements within each group by label/admin
+             */
+            ksort($groups);
+            array_walk($groups, $elementSort);
         } else {
             $groups = $groupDefaults;
         }
@@ -304,7 +329,6 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     || $definedTemplates['pager_results'] === 'SonataAdminBundle:Pager:results.html.twig'
                 )
             ) {
-
                 $definedTemplates['pager_results'] = 'SonataAdminBundle:Pager:simple_pager_results.html.twig';
             }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -76,6 +76,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('html5_validate')->defaultTrue()->end()
+                        ->booleanNode('sort_admins')->defaultFalse()->info('Auto order groups and admins by label or id')->end()
                         ->booleanNode('confirm_exit')->defaultTrue()->end()
                         ->booleanNode('use_select2')->defaultTrue()->end()
                         ->booleanNode('use_icheck')->defaultTrue()->end()

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -99,6 +99,7 @@ BOOM
         $container->setParameter('sonata.admin.configuration.admin_services', $config['admin_services']);
         $container->setParameter('sonata.admin.configuration.dashboard_groups', $config['dashboard']['groups']);
         $container->setParameter('sonata.admin.configuration.dashboard_blocks', $config['dashboard']['blocks']);
+        $container->setParameter('sonata.admin.configuration.sort_admins', $config['options']['sort_admins']);
 
         if (null === $config['security']['acl_user_manager'] && isset($bundles['FOSUserBundle'])) {
             $container->setParameter('sonata.admin.security.acl_user_manager', 'fos_user.user_manager');

--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -57,6 +57,9 @@ Full Configuration Options
             title_logo:           bundles/sonataadmin/logo_title.png
             options:
                 html5_validate:       true
+
+                # Auto order groups and admins by label or id
+                sort_admins:          false
                 confirm_exit:         true
                 use_select2:          true
                 use_icheck:           true

--- a/Resources/doc/reference/dashboard.rst
+++ b/Resources/doc/reference/dashboard.rst
@@ -51,6 +51,9 @@ Configuring the ``Admin`` list
 As you probably noticed by now, the ``Admin`` list groups ``Admin`` mappings together.
 There are several ways in which you can configure these groups.
 
+By default the admins are ordered the way you defined them. With the setting ``sort_admins``
+groups and admins will be orderd by their respective label with a fallback to the admin id.
+
 Using the ``Admin`` service declaration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -186,9 +186,27 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @covers Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass::process
-     */
+    public function testProcessSortAdmins()
+    {
+        $container = $this->getContainer();
+
+        $config = $this->config;
+        $config['options']['sort_admins'] = true;
+        unset($config['dashboard']['groups']);
+
+        $this->extension->load(array($config), $container);
+
+        $compilerPass = new AddDependencyCallsCompilerPass();
+        $compilerPass->process($container);
+        $container->compile();
+
+        // use array_values to check groups position
+        $adminGroups = array_values($container->get('sonata.admin.pool')->getAdminGroups());
+
+        $this->assertEquals('sonata_group_one', $adminGroups['0']['label'], 'second group in configuration, first in list');
+        $this->assertEquals('1 Entry', $adminGroups[0]['items'][0]['label'], 'second entry for group in configuration, first in list');
+    }
+
     public function testProcessGroupNameAsParameter()
     {
         $config = array(
@@ -402,20 +420,20 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
 
         // Add admin definition's
         $container
+            ->register('sonata_news_admin')
+            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
+            ->setArguments(array('', 'Sonata\AdminBundle\Tests\DependencyInjection\News', 'SonataAdminBundle:CRUD'))
+            ->addTag('sonata.admin', array('group' => 'sonata_group_two', 'label' => '5 Entry', 'manager_type' => 'orm'));
+        $container
             ->register('sonata_post_admin')
             ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
             ->setArguments(array('', 'Sonata\AdminBundle\Tests\DependencyInjection\Post', 'SonataAdminBundle:CRUD'))
             ->addTag('sonata.admin', array('group' => 'sonata_group_one', 'manager_type' => 'orm'));
         $container
-            ->register('sonata_news_admin')
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
-            ->setArguments(array('', 'Sonata\AdminBundle\Tests\DependencyInjection\News', 'SonataAdminBundle:CRUD'))
-            ->addTag('sonata.admin', array('group' => 'sonata_group_two', 'manager_type' => 'orm'));
-        $container
             ->register('sonata_article_admin')
             ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
             ->setArguments(array('', 'Sonata\AdminBundle\Tests\DependencyInjection\Article', 'SonataAdminBundle:CRUD'))
-            ->addTag('sonata.admin', array('group' => 'sonata_group_one', 'manager_type' => 'doctrine_phpcr'));
+            ->addTag('sonata.admin', array('group' => 'sonata_group_one', 'label' => '1 Entry', 'manager_type' => 'doctrine_phpcr'));
 
         // translator
         $container


### PR DESCRIPTION
Sorts all admins and groups regardless of their order in configuration. (https://github.com/sonata-project/SonataAdminBundle/issues/3018)

to activate you have to set the config option admins_sort to true

* ```<tag name="sonata.admin" group="Z-Group" label="A-Admin"/>```
* ```<tag name="sonata.admin" group="Y-Group" label="C-Admin"/>```
* ```<tag name="sonata.admin" group="Y-Group" label="B-Admin"/>```

would result in the following order:

- Y-Group:
 - B-Admin
 - C-Admin
- Z-Group:
 - A-Admin