### PR TITLE
Ignore unnecessary files for realease tar balls

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/Tests              export-ignore
+/.*                 export-ignore
+/*.md               export-ignore
+/composer.*         export-ignore
+/build.xml          export-ignore
+/phpunit.xml.dist   export-ignore


### PR DESCRIPTION
Just a `.gitattributes` file to specify which unnecessary must be ignored when you downloading a tar ball of this project.

This will improve composer dist deployment speed by lighten download size.

@rande I need your approbation. If you are OK this could be applied on others sonata projects.