### PR TITLE
DefaultRouteGenerator must use the route to child admin 

### DIFF
--- a/Route/DefaultRouteGenerator.php
+++ b/Route/DefaultRouteGenerator.php
@@ -130,14 +130,14 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
             return $admin->getBaseCodeRoute().'.'.$name;
         }
 
+        // someone provide a code, so it is a child
+        if (strpos($name, '.') && array_key_exists($admin->getCode().'|'.$name, $this->caches)) {
+            return $admin->getCode().'|'.$name;
+        }
+
         // someone provide the fullname
         if (array_key_exists($name, $this->caches)) {
             return $name;
-        }
-
-        // someone provide a code, so it is a child
-        if (strpos($name, '.')) {
-            return $admin->getCode().'|'.$name;
         }
 
         return $admin->getCode().'.'.$name;

--- a/Tests/Route/DefaultRouteGeneratorTest.php
+++ b/Tests/Route/DefaultRouteGeneratorTest.php
@@ -51,6 +51,10 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $collection->add('foo');
         $collection->addCollection($childCollection);
 
+        $nochildCollection = new RouteCollection('base.Code.Child', 'admin_child', '/foo/', 'BundleName:ControllerName');
+        $nochildCollection->add('bar');
+        $collection->addCollection($nochildCollection);
+
         $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(false));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Foo'));


### PR DESCRIPTION
if route name contains a dot and if child route exists