### PR TITLE
[AdminPoolLoader] Added missing "array" type hint in constructor

### DIFF
--- a/Route/AdminPoolLoader.php
+++ b/Route/AdminPoolLoader.php
@@ -43,7 +43,7 @@ class AdminPoolLoader extends FileLoader
      * @param array                                                     $adminServiceIds
      * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
      */
-    public function __construct(Pool $pool, $adminServiceIds, ContainerInterface $container)
+    public function __construct(Pool $pool, array $adminServiceIds, ContainerInterface $container)
     {
         $this->pool             = $pool;
         $this->adminServiceIds  = $adminServiceIds;

--- a/UPGRADE-2.4.md
+++ b/UPGRADE-2.4.md
@@ -26,3 +26,7 @@ AdminLTE version 2 has been integrated, this should work out of the box if you h
 ## AclSecurityHandler
 
 In order to fix deprecated issue by spiting `SecurityContextInterface`, `AclSecurityHandler` constructor got a new argument.
+
+## AdminPoolLoader
+
+If you're using a custom implementation of `sonata.admin.route_loader` service, make sure to provide an array as 2nd argument since the type for this argument is now hinted to `array`.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Added missing ```array``` type hint for 2nd argument in ```AdminPoolLoader::__construct()```.