### PR TITLE
Better translation for subclass admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+### 2015-09-28
+ * Update subclass translation
+
 ### 2015-06-18
  * Add missing Route constructor parameters to ``RouteCollection:add`` method
 

--- a/Resources/translations/SonataAdminBundle.ar.xliff
+++ b/Resources/translations/SonataAdminBundle.ar.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>إضافة جديدة</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>العودة إلى القائمة</target>

--- a/Resources/translations/SonataAdminBundle.bg.xliff
+++ b/Resources/translations/SonataAdminBundle.bg.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Нов елемент</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Към списъка</target>

--- a/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/Resources/translations/SonataAdminBundle.ca.xliff
@@ -62,6 +62,10 @@
                 <source>link_action_list</source>
                 <target>Torna a la llista</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_show">
                 <source>link_action_show</source>
                 <target>Mostra</target>

--- a/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/Resources/translations/SonataAdminBundle.cs.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Přidat nový</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Zpět na výpis</target>

--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Neu</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>Neu %class%</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Zurück zur Liste</target>

--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Add new</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>Add new %class%</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Return to list</target>

--- a/Resources/translations/SonataAdminBundle.es.xliff
+++ b/Resources/translations/SonataAdminBundle.es.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Agregar nuevo</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Volver a la lista</target>

--- a/Resources/translations/SonataAdminBundle.eu.xliff
+++ b/Resources/translations/SonataAdminBundle.eu.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Sortu</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Zerrendara itzuli</target>

--- a/Resources/translations/SonataAdminBundle.fa.xliff
+++ b/Resources/translations/SonataAdminBundle.fa.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>اضافه کردن جدید</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>بازگشت به لیست</target>

--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Ajouter</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Retourner à la liste</target>

--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Novi unos</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Povratak na listu</target>

--- a/Resources/translations/SonataAdminBundle.hu.xliff
+++ b/Resources/translations/SonataAdminBundle.hu.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Új hozzáadása</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Vissza a listára</target>

--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Aggiungi nuovo</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Torna alla lista</target>

--- a/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/Resources/translations/SonataAdminBundle.ja.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>新規作成</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>一覧に戻る</target>

--- a/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/Resources/translations/SonataAdminBundle.lb.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Nei</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Zréck bei d'Lëscht</target>

--- a/Resources/translations/SonataAdminBundle.lt.xliff
+++ b/Resources/translations/SonataAdminBundle.lt.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Sukurti naują</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Grįžti į sąrašą</target>

--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Nieuwe toevoegen</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Terug naar lijst</target>

--- a/Resources/translations/SonataAdminBundle.no.xliff
+++ b/Resources/translations/SonataAdminBundle.no.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Lag ny</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Returner til liste</target>

--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Dodaj nowy</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Powrót do listy</target>

--- a/Resources/translations/SonataAdminBundle.pt.xliff
+++ b/Resources/translations/SonataAdminBundle.pt.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Adicionar novo</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Voltar à lista</target>

--- a/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Adicionar novo</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Retornar para a listagem</target>

--- a/Resources/translations/SonataAdminBundle.ro.xliff
+++ b/Resources/translations/SonataAdminBundle.ro.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Adăugați</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Reveniți la listă</target>

--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Добавить новый</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Вернуться к списку</target>

--- a/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/Resources/translations/SonataAdminBundle.sk.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Pridať nový</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Späť na zoznam</target>

--- a/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/Resources/translations/SonataAdminBundle.sl.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Dodaj</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Vrnitev na seznam</target>

--- a/Resources/translations/SonataAdminBundle.sv_SE.xliff
+++ b/Resources/translations/SonataAdminBundle.sv_SE.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Lägg till ny</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Tillbaka till listan</target>

--- a/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/Resources/translations/SonataAdminBundle.uk.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>Додати новий</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>Повернутись до списку</target>

--- a/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -58,6 +58,10 @@
                 <source>link_action_create</source>
                 <target>添加</target>
             </trans-unit>
+            <trans-unit id="link_action_create_subclass">
+                <source>link_action_create_subclass</source>
+                <target>link_action_create_subclass</target>
+            </trans-unit>
             <trans-unit id="link_action_list">
                 <source>link_action_list</source>
                 <target>返回列表</target>

--- a/Resources/views/Button/create_button.html.twig
+++ b/Resources/views/Button/create_button.html.twig
@@ -20,7 +20,7 @@ file that was distributed with this source code.
             <li>
                 <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
                     <i class="fa fa-plus-circle"></i>
-                    {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
+                    {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ (admin.label ~ '_' ~ subclass)|trans({}, admin.translationdomain) }}
                 </a>
             </li>
         {% endfor %}

--- a/Resources/views/Button/create_button.html.twig
+++ b/Resources/views/Button/create_button.html.twig
@@ -20,7 +20,8 @@ file that was distributed with this source code.
             <li>
                 <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
                     <i class="fa fa-plus-circle"></i>
-                    {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ (admin.label ~ '_' ~ subclass)|trans({}, admin.translationdomain) }}
+                    {% set classLabel = (admin.label ~ '_' ~ subclass)|trans({}, admin.translationdomain) %}
+                    {{ 'link_action_create_subclass'|trans({'%class%': classLabel}, 'SonataAdminBundle') }}
                 </a>
             </li>
         {% endfor %}

--- a/Resources/views/CRUD/select_subclass.html.twig
+++ b/Resources/views/CRUD/select_subclass.html.twig
@@ -26,7 +26,7 @@ file that was distributed with this source code.
                        class="btn btn-app btn-block"
                             >
                         <i class="fa fa-plus-square"></i>
-                        {{ subclass|trans({}, admin.translationdomain|default('SonataAdminBundle')) }}
+                        {{ (admin.label ~ '_' ~ subclass)|trans({}, admin.translationdomain|default('SonataAdminBundle')) }}
                     </a>
                 </div>
             {% else %}

--- a/Resources/views/Core/add_block.html.twig
+++ b/Resources/views/Core/add_block.html.twig
@@ -54,7 +54,7 @@
                         {% else %}
                             {% for subclass in admin.subclasses|keys %}
                                 <li role="presentation">
-                                    <a role="menuitem" tabindex="-1" href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">{{ subclass|trans({}, admin.translationdomain) }}</a>
+                                    <a role="menuitem" tabindex="-1" href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">{{ (admin.label ~ '_' ~ subclass)|trans({}, admin.translationdomain) }}</a>
                                 </li>
                             {% endfor %}
                         {% endif %}


### PR DESCRIPTION
With this commit you have a better translation key if you are using the same subclass for multiple admins.

Before:
If you have a child class with the key "bar" in the FooAdmin, the translation label would be "bar".

After:
If you have a child class with the key "bar" in the FooAdmin, the translation label would be "foo_bar".