### PR TITLE
[WIP] Add support for child base route pattern in admin class

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -140,6 +140,13 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     protected $baseRouteName;
 
     /**
+     * The cached base route name
+     *
+     * @var string
+     */
+    protected $cachedBaseRouteName;
+
+    /**
      * The base route pattern used to generate the routing information
      *
      * @var string
@@ -994,28 +1001,40 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
      */
     public function getBaseRouteName()
     {
-        if (!$this->baseRouteName) {
+        if (null !== $this->cachedBaseRouteName) {
+            return $this->cachedBaseRouteName;
+        }
+
+        if ($this->isChild()) { // the admin class is a child, prefix it with the parent route name
+            if (!$this->baseRouteName) {
+                preg_match(self::CLASS_REGEX, $this->class, $matches);
+
+                if (!$matches) {
+                    throw new \RuntimeException(sprintf('Cannot automatically determine base route name, please define a default `baseRouteName` value for the admin class `%s`', get_class($this)));
+                }
+            }
+
+            $this->cachedBaseRouteName = sprintf('%s_%s',
+                $this->getParent()->getBaseRouteName(),
+                $this->baseRouteName ?: $this->urlize($matches[5])
+            );
+        } else if ($this->baseRouteName) {
+            $this->cachedBaseRouteName = $this->baseRouteName;
+        } else {
             preg_match(self::CLASS_REGEX, $this->class, $matches);
 
             if (!$matches) {
                 throw new \RuntimeException(sprintf('Cannot automatically determine base route name, please define a default `baseRouteName` value for the admin class `%s`', get_class($this)));
             }
 
-            if ($this->isChild()) { // the admin class is a child, prefix it with the parent route name
-                $this->baseRouteName = sprintf('%s_%s',
-                    $this->getParent()->getBaseRouteName(),
-                    $this->urlize($matches[5])
-                );
-            } else {
-                $this->baseRouteName = sprintf('admin_%s%s_%s',
-                    empty($matches[1]) ? '' : $this->urlize($matches[1]).'_',
-                    $this->urlize($matches[3]),
-                    $this->urlize($matches[5])
-                );
-            }
+            $this->cachedBaseRouteName = sprintf('admin_%s%s_%s',
+                empty($matches[1]) ? '' : $this->urlize($matches[1]).'_',
+                $this->urlize($matches[3]),
+                $this->urlize($matches[5])
+            );
         }
 
-        return $this->baseRouteName;
+        return $this->cachedBaseRouteName;
     }
 
     /**

--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -147,6 +147,12 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     protected $baseRoutePattern;
 
     /**
+     * The cached base route pattern
+     * @var string
+     */
+    protected $cachedBaseRoutePattern;
+
+    /**
      * The base name controller used to generate the routing information
      *
      * @var string
@@ -943,29 +949,40 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
      */
     public function getBaseRoutePattern()
     {
-        if (!$this->baseRoutePattern) {
+        if (null !== $this->cachedBaseRoutePattern) {
+            return $this->cachedBaseRoutePattern;
+        }
+
+        if ($this->isChild()) { // the admin class is a child, prefix it with the parent route pattern
+            if (!$this->baseRoutePattern) {
+                preg_match(self::CLASS_REGEX, $this->class, $matches);
+
+                if (!$matches) {
+                    throw new \RuntimeException(sprintf('Please define a default `baseRoutePattern` value for the admin class `%s`', get_class($this)));
+                }
+            }
+
+            $this->cachedBaseRoutePattern = sprintf('%s/{id}/%s',
+                $this->getParent()->getBaseRoutePattern(),
+                $this->baseRoutePattern ?: $this->urlize($matches[5], '-')
+            );
+        } else if ($this->baseRoutePattern) {
+            $this->cachedBaseRoutePattern = $this->baseRoutePattern;
+        } else {
             preg_match(self::CLASS_REGEX, $this->class, $matches);
 
             if (!$matches) {
                 throw new \RuntimeException(sprintf('Please define a default `baseRoutePattern` value for the admin class `%s`', get_class($this)));
             }
 
-            if ($this->isChild()) { // the admin class is a child, prefix it with the parent route name
-                $this->baseRoutePattern = sprintf('%s/{id}/%s',
-                    $this->getParent()->getBaseRoutePattern(),
-                    $this->urlize($matches[5], '-')
-                );
-            } else {
-
-                $this->baseRoutePattern = sprintf('/%s%s/%s',
-                    empty($matches[1]) ? '' : $this->urlize($matches[1], '-').'/',
-                    $this->urlize($matches[3], '-'),
-                    $this->urlize($matches[5], '-')
-                );
-            }
+            $this->cachedBaseRoutePattern = sprintf('/%s%s/%s',
+                empty($matches[1]) ? '' : $this->urlize($matches[1], '-').'/',
+                $this->urlize($matches[3], '-'),
+                $this->urlize($matches[5], '-')
+            );
         }
 
-        return $this->baseRoutePattern;
+        return $this->cachedBaseRoutePattern;
     }
 
     /**


### PR DESCRIPTION
Hello,

I have tried to set the `$baseRoutePattern` in a child admin class and the behavior is that the parent base route pattern prefix is overridden by the child base route pattern.

Example:
```php
// ParentAdmin.php
protected $baseRoutePattern = 'my-parent';

// ChildAdmin.php
protected $baseRoutePattern = 'my-child';
```

So currently the generated route is : `/admin/my-child/list` (which is generated twice: once for the generic admin and once for the child (parent specific) admin)

This prevents filtering the children of my `Parent` instance.

With this pull request the generated route will be : `/admin/my-parent/{id}/my-child/list`

The pull request is not complete. It's missing tests but I prefer to ask you before if the feature interest you.

Thanks with advance.

Virgile