### PR TITLE
Global phpunit and fabpot/php-cs-fixer install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,12 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache
+    - $HOME/.composer/vendor
     - $HOME/.cache/pip
 
 env:
   global:
+    - PATH="$HOME/.composer/vendor/bin:$PATH"
     - SYMFONY_DEPRECATIONS_HELPER=weak
 
 matrix:
@@ -46,6 +48,8 @@ before_script:
   - mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d && echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer selfupdate
   - composer config -q github-oauth.github.com $GITHUB_OAUTH_TOKEN
+  - composer global require phpunit/phpunit fabpot/php-cs-fixer --no-update
+  - composer global update --prefer-dist --no-interaction
   - if [ "$SYMFONY_VERSION" = "2.8.*@dev" ] || [ "$SYMFONY_VERSION" = "3.0.x-dev as 2.8" ]; then SYMFONY_DEPRECATIONS_HELPER=strict; fi;
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - travis_wait composer update --prefer-dist --no-interaction $COMPOSER_FLAGS

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 cs:
-	./vendor/bin/php-cs-fixer fix --verbose
+	php-cs-fixer fix --verbose
 
 cs_dry_run:
-	./vendor/bin/php-cs-fixer fix --verbose --dry-run
+	php-cs-fixer fix --verbose --dry-run
 
 test:
 	phpunit

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,7 @@
         "sensio/generator-bundle": "~2.3",
         "symfony/yaml": "~2.3",
         "sonata-project/intl-bundle": "~2.1",
-        "symfony/phpunit-bridge": "~2.7|~3.0",
-        "fabpot/php-cs-fixer": "~0.5|~1.0"
+        "symfony/phpunit-bridge": "~2.7|~3.0"
     },
     "suggest": {
         "jms/translation-bundle": "Extract message keys from Admins",


### PR DESCRIPTION
Use composer to install dev binaries on global home.

This will permit to remove dependencies on project composer that could make conflicts and always get the latest versions.