### PR TITLE
Don't create dropdown if there is only one action

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -261,12 +261,16 @@ file that was distributed with this source code.
 
                                                 {% if _actions|replace({ '<li>': '', '</li>': '' })|trim is not empty %}
                                                     <ul class="nav navbar-nav navbar-right">
+                                                    {% if _actions|split('<li>')|length > 2 %}
                                                         <li class="dropdown sonata-actions">
                                                             <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ 'link_actions'|trans({}, 'SonataAdminBundle') }} <b class="caret"></b></a>
                                                             <ul class="dropdown-menu" role="menu">
                                                                 {{ _actions|raw }}
                                                             </ul>
                                                         </li>
+                                                    {% else %}
+                                                        {{ _actions|raw }}
+                                                    {% endif %}
                                                     </ul>
                                                 {% endif %}
 


### PR DESCRIPTION
Actually, when there is one action, the navbar render a dropdown like that:

![avant_modif](https://cloud.githubusercontent.com/assets/1649453/8795147/981eafa8-2f8a-11e5-8aaa-f77843d48fd8.PNG)

I think that it is unnecessary and not user friendly, so this pull request will render it like that:

![apres_modif](https://cloud.githubusercontent.com/assets/1649453/8795184/082b0f58-2f8b-11e5-89b1-0ef2a9569a47.PNG)

When there is more than one action, a dropdown is still rendered like before.
