### PR TITLE
Remove global vendor folder from cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache
-    - $HOME/.composer/vendor
     - $HOME/.cache/pip
 
 env:


### PR DESCRIPTION
This cause issue on PR for update: https://travis-ci.org/sonata-project/SonataAdminBundle/jobs/72089785#L127

Must be applied on other sonata projects.