### PR TITLE
Fix #2630 : Checkbox labels NOT showing with Bootstrap SF2.6 form theme

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -78,6 +78,28 @@ file that was distributed with this source code.
     {% endspaceless %}
 {% endblock percent_widget %}
 
+{% block checkbox_widget -%}
+    {% set parent_label_class = parent_label_class|default('') -%}
+    {% if 'checkbox-inline' in parent_label_class or sonata_admin.options['use_icheck'] %}
+        {{- form_label(form, null, { widget: parent() }) -}}
+    {% else -%}
+        <div class="checkbox">
+            {{- form_label(form, null, { widget: parent() }) -}}
+        </div>
+    {%- endif %}
+{%- endblock checkbox_widget %}
+
+{% block radio_widget -%}
+    {%- set parent_label_class = parent_label_class|default('') -%}
+    {% if 'radio-inline' in parent_label_class or sonata_admin.options['use_icheck'] %}
+        {{- form_label(form, null, { widget: parent() }) -}}
+    {% else -%}
+        <div class="radio">
+            {{- form_label(form, null, { widget: parent() }) -}}
+        </div>
+    {%- endif %}
+{%- endblock radio_widget %}
+
 {# Labels #}
 {% block form_label %}
 {% spaceless %}
@@ -108,29 +130,46 @@ file that was distributed with this source code.
             {%- endif -%}
         {% endif %}
 
-        {% if in_list_checkbox is defined and in_list_checkbox and widget is defined %}
-            <label{% for attrname,attrvalue in attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>
-                {{ widget|raw }}
-                <span>
-                    {% if not sonata_admin.admin %}
-                        {{- label|trans({}, translation_domain) -}}
-                    {% else %}
-                        {{- label|trans({}, sonata_admin.field_description.translationDomain) -}}
-                    {% endif%}
-                </span>
-            </label>
-        {% else %}
-            <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-                {% if not sonata_admin.admin%}
-                    {{- label|trans({}, translation_domain) -}}
-                {% else %}
-                    {{ sonata_admin.admin.trans(label, {}, sonata_admin.field_description.translationDomain) }}
-                {% endif %}
-            </label>
-        {% endif %}
+        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+            {% if not sonata_admin.admin %}
+                {{- label|trans({}, translation_domain) -}}
+            {% else %}
+                {{ sonata_admin.admin.trans(label, {}, sonata_admin.field_description.translationDomain) }}
+            {% endif %}
+        </label>
     {% endif %}
 {% endspaceless %}
 {% endblock form_label %}
+
+{% block checkbox_label -%}
+    {{- block('checkbox_radio_label') -}}
+{%- endblock checkbox_label %}
+
+{% block radio_label -%}
+    {{- block('checkbox_radio_label') -}}
+{%- endblock radio_label %}
+
+{% block checkbox_radio_label %}
+    {% if sonata_admin.admin %}
+        {% set translation_domain = sonata_admin.field_description.translationDomain %}
+    {% endif %}
+    {# Do not display the label if widget is not defined in order to prevent double label rendering #}
+    {% if widget is defined %}
+        {% if required %}
+            {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) %}
+        {% endif %}
+        {% if parent_label_class is defined %}
+            {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) %}
+        {% endif %}
+        {% if label is not same as(false) and label is empty %}
+            {% set label = name|humanize %}
+        {% endif %}
+        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+            {{- widget|raw -}}
+            {{- label is not same as(false) ? label|trans({}, translation_domain) -}}
+        </label>
+    {% endif %}
+{% endblock checkbox_radio_label %}
 
 {% block choice_widget_expanded %}
 {% spaceless %}
@@ -138,10 +177,7 @@ file that was distributed with this source code.
     <ul {{ block('widget_container_attributes') }}>
     {% for child in form %}
         <li>
-            {% set form_widget_content %}
-                {{ form_widget(child, {'horizontal': false, 'horizontal_input_wrapper_class': ''}) }} {# {'horizontal': false, 'horizontal_input_wrapper_class': ''} needed to avoid MopaBootstrapBundle messing with the DOM #}
-            {% endset %}
-            {{ form_label(child, child.vars.label|default(null), { 'in_list_checkbox' : true, 'widget' : form_widget_content } ) }}
+            {{ form_widget(child, {'horizontal': false, 'horizontal_input_wrapper_class': ''}) }} {# {'horizontal': false, 'horizontal_input_wrapper_class': ''} needed to avoid MopaBootstrapBundle messing with the DOM #}
         </li>
     {% endfor %}
     </ul>
@@ -257,6 +293,7 @@ file that was distributed with this source code.
 {% endblock datetime_widget %}
 
 {% block form_row %}
+    {% set show_label = show_label|default(true) %}
     <div class="form-group{% if errors|length > 0 %} has-error{% endif %}" id="sonata-ba-field-container-{{ id }}">
         {% if sonata_admin.field_description.options is defined %}
             {% set label = sonata_admin.field_description.options.name|default(label)  %}
@@ -268,7 +305,7 @@ file that was distributed with this source code.
             {% set div_class = div_class ~ ' sonata-collection-row-without-label' %}
         {% endif %}
 
-        {% if sonata_admin.options['form_type'] == 'horizontal' %}
+        {% if sonata_admin is defined and sonata_admin.options['form_type'] == 'horizontal' %}
             {% if label is same as(false) %}
                 {% if 'collection' in form.parent.vars.block_prefixes %}
                     {% set div_class = div_class ~ ' col-sm-12' %}
@@ -280,7 +317,9 @@ file that was distributed with this source code.
             {% endif %}
         {% endif %}
 
-        {{ form_label(form, label|default(null)) }}
+        {% if show_label %}
+            {{ form_label(form, label|default(null)) }}
+        {% endif %}
 
         {% if sonata_admin is defined and sonata_admin_enabled %}
             {% set div_class = div_class ~ ' sonata-ba-field-' ~ sonata_admin.edit ~ '-' ~ sonata_admin.inline %}
@@ -305,6 +344,16 @@ file that was distributed with this source code.
         </div>
     </div>
 {% endblock form_row %}
+
+{% block checkbox_row -%}
+    {% set show_label = false %}
+    {{ block('form_row') }}
+{%- endblock checkbox_row %}
+
+{% block radio_row -%}
+    {% set show_label = false %}
+    {{ block('form_row') }}
+{%- endblock radio_row %}
 
 {% block sonata_type_native_collection_widget_row %}
 {% spaceless %}

--- a/Tests/Form/Widget/BaseWidgetTest.php
+++ b/Tests/Form/Widget/BaseWidgetTest.php
@@ -36,11 +36,33 @@ abstract class BaseWidgetTest extends TypeTestCase
     protected $extension;
 
     /**
+     * @var \Twig_Environment
+     */
+    protected $environment;
+
+    /**
      * Current template type, form or filter.
      *
      * @var string
      */
     protected $type = null;
+
+    /**
+     * @var array
+     */
+    protected $sonataAdmin = array(
+        'name'              => null,
+        'admin'             => null,
+        'value'             => null,
+        'edit'              => 'standard',
+        'inline'            => 'natural',
+        'field_description' => null,
+        'block_name'        => false,
+        'options'           => array(
+            'form_type'  => 'vertical',
+            'use_icheck' => true,
+        ),
+    );
 
     /**
      * {@inheritdoc}
@@ -81,29 +103,18 @@ abstract class BaseWidgetTest extends TypeTestCase
 
         $loader = new StubFilesystemLoader($twigPaths);
 
-        $environment = new \Twig_Environment($loader, array('strict_variables' => true));
-        $environment->addGlobal('sonata_admin', $this->getSonataAdmin());
-        $environment->addExtension(new TranslationExtension(new StubTranslator()));
+        $this->environment = new \Twig_Environment($loader, array('strict_variables' => true));
+        $this->environment->addGlobal('sonata_admin', $this->getSonataAdmin());
+        $this->environment->addExtension(new TranslationExtension(new StubTranslator()));
 
-        $environment->addExtension($this->extension);
+        $this->environment->addExtension($this->extension);
 
-        $this->extension->initRuntime($environment);
+        $this->extension->initRuntime($this->environment);
     }
 
     protected function getSonataAdmin()
     {
-        return array(
-            'name'              => null,
-            'admin'             => null,
-            'value'             => null,
-            'edit'              => 'standard',
-            'inline'            => 'natural',
-            'field_description' => null,
-            'block_name'        => false,
-            'options'           => array(
-                'form_type' => 'vertical',
-            ),
-        );
+        return $this->sonataAdmin;
     }
 
     /**

--- a/Tests/Form/Widget/FormChoiceWidgetTest.php
+++ b/Tests/Form/Widget/FormChoiceWidgetTest.php
@@ -41,7 +41,35 @@ class FormChoiceWidgetTest extends BaseWidgetTest
         $html = $this->renderWidget($choice->createView());
 
         $this->assertContains(
-            '<span>[trans]some[/trans]</span>',
+            '<li><label><input type="checkbox" id="choice_0" name="choice[]" value="0" />[trans]some[/trans]</label></li>',
+            $this->cleanHtmlWhitespace($html)
+        );
+    }
+
+    public function testBootstrapLabelRendering()
+    {
+        $sonataAdmin = $this->getSonataAdmin();
+        $sonataAdmin['options']['use_icheck'] = false;
+        $this->environment->addGlobal('sonata_admin', $sonataAdmin);
+
+        $choices = array('some', 'choices');
+        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choices = array_flip($choices);
+        }
+
+        $choice = $this->factory->create(
+            $this->getChoiceClass(),
+            null,
+            $this->getDefaultOption() + array(
+                'multiple' => true,
+                'expanded' => true,
+            ) + compact('choices')
+        );
+
+        $html = $this->renderWidget($choice->createView());
+
+        $this->assertContains(
+            '<li><div class="checkbox"><label><input type="checkbox" id="choice_0" name="choice[]" value="0" />[trans]some[/trans]</label></div></li>',
             $this->cleanHtmlWhitespace($html)
         );
     }


### PR DESCRIPTION
This PR fix #2630

Before (with option `use_icheck` to true)
![before icheck](https://cloud.githubusercontent.com/assets/2057992/13577821/cce26d14-e494-11e5-8b69-470594358661.PNG)

After (with option `use_icheck` to true)
![after icheck](https://cloud.githubusercontent.com/assets/2057992/13577843/e4e5e350-e494-11e5-95eb-d9d744700123.PNG)

Before (with option `use_icheck` to false)
![before](https://cloud.githubusercontent.com/assets/2057992/13577854/f4f9777a-e494-11e5-888d-25c0cf14beb0.PNG)

After (with option `use_icheck` to false)
![after](https://cloud.githubusercontent.com/assets/2057992/13577860/fdaca72a-e494-11e5-8a3c-e4fbf60a767b.PNG)
