### PR TITLE
[WIP] Add cs-fixer rules for PHPUnit

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -26,6 +26,8 @@ return Symfony\CS\Config\Config::create()
         'newline_after_open_tag',
         'ordered_use',
         'long_array_syntax',
+        'php_unit_construct',
+        'php_unit_strict',
     ))
     ->setUsingCache(true)
     ->finder($finder)

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -44,8 +44,8 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
         $this->assertInstanceOf('Sonata\AdminBundle\Admin\Admin', $admin);
-        $this->assertEquals($class, $admin->getClass());
-        $this->assertEquals($baseControllerName, $admin->getBaseControllerName());
+        $this->assertSame($class, $admin->getClass());
+        $this->assertSame($baseControllerName, $admin->getBaseControllerName());
     }
 
     public function testGetClass()
@@ -57,18 +57,18 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $testObject = new \stdClass();
         $admin->setSubject($testObject);
-        $this->assertEquals('stdClass', $admin->getClass());
+        $this->assertSame('stdClass', $admin->getClass());
 
         $admin->setSubClasses(array('foo'));
-        $this->assertEquals('stdClass', $admin->getClass());
+        $this->assertSame('stdClass', $admin->getClass());
 
         $admin->setSubject(null);
         $admin->setSubClasses(array());
-        $this->assertEquals($class, $admin->getClass());
+        $this->assertSame($class, $admin->getClass());
 
         $admin->setSubClasses(array('foo' => 'bar'));
         $admin->setRequest(new Request(array('subclass' => 'foo')));
-        $this->assertEquals('bar', $admin->getClass());
+        $this->assertSame('bar', $admin->getClass());
     }
 
     /**
@@ -340,14 +340,14 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($postAdmin->hasChildren());
         $this->assertTrue($postAdmin->hasChild('sonata.post.admin.comment'));
 
-        $this->assertEquals('sonata.post.admin.comment', $postAdmin->getChild('sonata.post.admin.comment')->getCode());
-        $this->assertEquals('sonata.post.admin.post|sonata.post.admin.comment', $postAdmin->getChild('sonata.post.admin.comment')->getBaseCodeRoute());
-        $this->assertEquals($postAdmin, $postAdmin->getChild('sonata.post.admin.comment')->getParent());
+        $this->assertSame('sonata.post.admin.comment', $postAdmin->getChild('sonata.post.admin.comment')->getCode());
+        $this->assertSame('sonata.post.admin.post|sonata.post.admin.comment', $postAdmin->getChild('sonata.post.admin.comment')->getBaseCodeRoute());
+        $this->assertSame($postAdmin, $postAdmin->getChild('sonata.post.admin.comment')->getParent());
 
         $this->assertFalse($postAdmin->isChild());
         $this->assertTrue($commentAdmin->isChild());
 
-        $this->assertEquals(array('sonata.post.admin.comment' => $commentAdmin), $postAdmin->getChildren());
+        $this->assertSame(array('sonata.post.admin.comment' => $commentAdmin), $postAdmin->getChildren());
     }
 
     /**
@@ -360,13 +360,13 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $admin->initialize();
         $this->assertNotNull($admin->getUniqid());
-        $this->assertEquals('Post', $admin->getClassnameLabel());
+        $this->assertSame('Post', $admin->getClassnameLabel());
 
         $admin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
         $admin->setClassnameLabel('postcomment');
 
         $admin->initialize();
-        $this->assertEquals('postcomment', $admin->getClassnameLabel());
+        $this->assertSame('postcomment', $admin->getClassnameLabel());
     }
 
     public function testConfigureWithValidParentAssociationMapping()
@@ -375,7 +375,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $admin->setParentAssociationMapping('Category');
 
         $admin->initialize();
-        $this->assertEquals('Category', $admin->getParentAssociationMapping());
+        $this->assertSame('Category', $admin->getParentAssociationMapping());
     }
 
     public function provideGetBaseRoutePattern()
@@ -446,7 +446,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     public function testGetBaseRoutePattern($objFqn, $expected)
     {
         $admin = new PostAdmin('sonata.post.admin.post', $objFqn, 'SonataNewsBundle:PostAdmin');
-        $this->assertEquals($expected, $admin->getBaseRoutePattern());
+        $this->assertSame($expected, $admin->getBaseRoutePattern());
     }
 
     public function testGetBaseRoutePatternWithChildAdmin()
@@ -455,7 +455,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
         $commentAdmin->setParent($postAdmin);
 
-        $this->assertEquals('/sonata/news/post/{id}/comment', $commentAdmin->getBaseRoutePattern());
+        $this->assertSame('/sonata/news/post/{id}/comment', $commentAdmin->getBaseRoutePattern());
     }
 
     /**
@@ -536,7 +536,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', $objFqn, 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals($expected, $admin->getBaseRouteName());
+        $this->assertSame($expected, $admin->getBaseRouteName());
     }
 
     public function testGetBaseRouteNameWithChildAdmin()
@@ -559,7 +559,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $postAdmin->addChild($commentAdmin);
 
-        $this->assertEquals('admin_sonata_news_post_comment', $commentAdmin->getBaseRouteName());
+        $this->assertSame('admin_sonata_news_post_comment', $commentAdmin->getBaseRouteName());
 
         $this->assertTrue($postAdmin->hasRoute('show'));
         $this->assertTrue($postAdmin->hasRoute('sonata.post.admin.post.show'));
@@ -589,7 +589,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $uniqid = uniqid();
         $admin->setUniqid($uniqid);
 
-        $this->assertEquals($uniqid, $admin->getUniqid());
+        $this->assertSame($uniqid, $admin->getUniqid());
     }
 
     public function testToString()
@@ -601,13 +601,13 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($admin->toString($s));
 
         $s = new FooToString();
-        $this->assertEquals('salut', $admin->toString($s));
+        $this->assertSame('salut', $admin->toString($s));
 
         // To string method is implemented, but returns null
         $s = new FooToStringNull();
         $this->assertNotEmpty($admin->toString($s));
 
-        $this->assertEquals('', $admin->toString(false));
+        $this->assertSame('', $admin->toString(false));
     }
 
     public function testIsAclEnabled()
@@ -639,12 +639,12 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $admin->getSubClasses());
         $this->assertNull($admin->getActiveSubClass());
         $this->assertNull($admin->getActiveSubclassCode());
-        $this->assertEquals('NewsBundle\Entity\Post', $admin->getClass());
+        $this->assertSame('NewsBundle\Entity\Post', $admin->getClass());
 
         // Just for the record, if there is no inheritance set, the getSubject is not used
         // the getSubject can also lead to some issue
          $admin->setSubject(new \stdClass());
-        $this->assertEquals('stdClass', $admin->getClass());
+        $this->assertSame('stdClass', $admin->getClass());
 
         $admin->setSubClasses(array('extended1' => 'NewsBundle\Entity\PostExtended1', 'extended2' => 'NewsBundle\Entity\PostExtended2'));
         $this->assertFalse($admin->hasSubClass('test'));
@@ -653,7 +653,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $admin->getSubClasses());
         $this->assertNull($admin->getActiveSubClass());
         $this->assertNull($admin->getActiveSubclassCode());
-        $this->assertEquals('stdClass', $admin->getClass());
+        $this->assertSame('stdClass', $admin->getClass());
 
         $request = new \Symfony\Component\HttpFoundation\Request(array('subclass' => 'extended1'));
         $admin->setRequest($request);
@@ -661,9 +661,9 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($admin->hasSubClass('extended1'));
         $this->assertTrue($admin->hasActiveSubClass());
         $this->assertCount(2, $admin->getSubClasses());
-        $this->assertEquals('stdClass', $admin->getActiveSubClass());
-        $this->assertEquals('extended1', $admin->getActiveSubclassCode());
-        $this->assertEquals('stdClass', $admin->getClass());
+        $this->assertSame('stdClass', $admin->getActiveSubClass());
+        $this->assertSame('extended1', $admin->getActiveSubclassCode());
+        $this->assertSame('stdClass', $admin->getClass());
 
         $request->query->set('subclass', 'inject');
         $this->assertNull($admin->getActiveSubclassCode());
@@ -700,9 +700,9 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals(array(15, 25, 50, 100, 150, 200), $admin->getPerPageOptions());
+        $this->assertSame(array(15, 25, 50, 100, 150, 200), $admin->getPerPageOptions());
         $admin->setPerPageOptions(array(500, 1000));
-        $this->assertEquals(array(500, 1000), $admin->getPerPageOptions());
+        $this->assertSame(array(500, 1000), $admin->getPerPageOptions());
     }
 
     public function testGetLabelTranslatorStrategy()
@@ -713,7 +713,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $labelTranslatorStrategy = $this->getMock('Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface');
         $admin->setLabelTranslatorStrategy($labelTranslatorStrategy);
-        $this->assertEquals($labelTranslatorStrategy, $admin->getLabelTranslatorStrategy());
+        $this->assertSame($labelTranslatorStrategy, $admin->getLabelTranslatorStrategy());
     }
 
     public function testGetRouteBuilder()
@@ -724,7 +724,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $routeBuilder = $this->getMock('Sonata\AdminBundle\Builder\RouteBuilderInterface');
         $admin->setRouteBuilder($routeBuilder);
-        $this->assertEquals($routeBuilder, $admin->getRouteBuilder());
+        $this->assertSame($routeBuilder, $admin->getRouteBuilder());
     }
 
     public function testGetMenuFactory()
@@ -735,42 +735,42 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $menuFactory = $this->getMock('Knp\Menu\FactoryInterface');
         $admin->setMenuFactory($menuFactory);
-        $this->assertEquals($menuFactory, $admin->getMenuFactory());
+        $this->assertSame($menuFactory, $admin->getMenuFactory());
     }
 
     public function testGetExtensions()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals(array(), $admin->getExtensions());
+        $this->assertSame(array(), $admin->getExtensions());
 
         $adminExtension1 = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
         $adminExtension2 = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
 
         $admin->addExtension($adminExtension1);
         $admin->addExtension($adminExtension2);
-        $this->assertEquals(array($adminExtension1, $adminExtension2), $admin->getExtensions());
+        $this->assertSame(array($adminExtension1, $adminExtension2), $admin->getExtensions());
     }
 
     public function testGetFilterTheme()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals(array(), $admin->getFilterTheme());
+        $this->assertSame(array(), $admin->getFilterTheme());
 
         $admin->setFilterTheme(array('FooTheme'));
-        $this->assertEquals(array('FooTheme'), $admin->getFilterTheme());
+        $this->assertSame(array('FooTheme'), $admin->getFilterTheme());
     }
 
     public function testGetFormTheme()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals(array(), $admin->getFormTheme());
+        $this->assertSame(array(), $admin->getFormTheme());
 
         $admin->setFormTheme(array('FooTheme'));
 
-        $this->assertEquals(array('FooTheme'), $admin->getFormTheme());
+        $this->assertSame(array('FooTheme'), $admin->getFormTheme());
     }
 
     public function testGetValidator()
@@ -781,7 +781,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
         $admin->setValidator($validator);
-        $this->assertEquals($validator, $admin->getValidator());
+        $this->assertSame($validator, $admin->getValidator());
     }
 
     public function testGetSecurityHandler()
@@ -792,19 +792,19 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
         $admin->setSecurityHandler($securityHandler);
-        $this->assertEquals($securityHandler, $admin->getSecurityHandler());
+        $this->assertSame($securityHandler, $admin->getSecurityHandler());
     }
 
     public function testGetSecurityInformation()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals(array(), $admin->getSecurityInformation());
+        $this->assertSame(array(), $admin->getSecurityInformation());
 
         $securityInformation = array('ROLE_FOO', 'ROLE_BAR');
 
         $admin->setSecurityInformation($securityInformation);
-        $this->assertEquals($securityInformation, $admin->getSecurityInformation());
+        $this->assertSame($securityInformation, $admin->getSecurityInformation());
     }
 
     public function testGetManagerType()
@@ -814,7 +814,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($admin->getManagerType());
 
         $admin->setManagerType('foo_orm');
-        $this->assertEquals('foo_orm', $admin->getManagerType());
+        $this->assertSame('foo_orm', $admin->getManagerType());
     }
 
     public function testGetModelManager()
@@ -826,7 +826,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $admin->setModelManager($modelManager);
-        $this->assertEquals($modelManager, $admin->getModelManager());
+        $this->assertSame($modelManager, $admin->getModelManager());
     }
 
     public function testGetBaseCodeRoute()
@@ -836,7 +836,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('', $admin->getBaseCodeRoute());
 
         $admin->setBaseCodeRoute('foo');
-        $this->assertEquals('foo', $admin->getBaseCodeRoute());
+        $this->assertSame('foo', $admin->getBaseCodeRoute());
     }
 
     public function testGetRouteGenerator()
@@ -848,7 +848,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $routeGenerator = $this->getMock('Sonata\AdminBundle\Route\RouteGeneratorInterface');
 
         $admin->setRouteGenerator($routeGenerator);
-        $this->assertEquals($routeGenerator, $admin->getRouteGenerator());
+        $this->assertSame($routeGenerator, $admin->getRouteGenerator());
     }
 
     public function testGetConfigurationPool()
@@ -862,7 +862,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $admin->setConfigurationPool($pool);
-        $this->assertEquals($pool, $admin->getConfigurationPool());
+        $this->assertSame($pool, $admin->getConfigurationPool());
     }
 
     public function testGetShowBuilder()
@@ -874,7 +874,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $showBuilder = $this->getMock('Sonata\AdminBundle\Builder\ShowBuilderInterface');
 
         $admin->setShowBuilder($showBuilder);
-        $this->assertEquals($showBuilder, $admin->getShowBuilder());
+        $this->assertSame($showBuilder, $admin->getShowBuilder());
     }
 
     public function testGetListBuilder()
@@ -886,7 +886,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $listBuilder = $this->getMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
 
         $admin->setListBuilder($listBuilder);
-        $this->assertEquals($listBuilder, $admin->getListBuilder());
+        $this->assertSame($listBuilder, $admin->getListBuilder());
     }
 
     public function testGetDatagridBuilder()
@@ -898,7 +898,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $datagridBuilder = $this->getMock('Sonata\AdminBundle\Builder\DatagridBuilderInterface');
 
         $admin->setDatagridBuilder($datagridBuilder);
-        $this->assertEquals($datagridBuilder, $admin->getDatagridBuilder());
+        $this->assertSame($datagridBuilder, $admin->getDatagridBuilder());
     }
 
     public function testGetFormContractor()
@@ -910,7 +910,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $formContractor = $this->getMock('Sonata\AdminBundle\Builder\FormContractorInterface');
 
         $admin->setFormContractor($formContractor);
-        $this->assertEquals($formContractor, $admin->getFormContractor());
+        $this->assertSame($formContractor, $admin->getFormContractor());
     }
 
     public function testGetRequest()
@@ -922,7 +922,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
 
         $admin->setRequest($request);
-        $this->assertEquals($request, $admin->getRequest());
+        $this->assertSame($request, $admin->getRequest());
         $this->assertTrue($admin->hasRequest());
     }
 
@@ -938,10 +938,10 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals('messages', $admin->getTranslationDomain());
+        $this->assertSame('messages', $admin->getTranslationDomain());
 
         $admin->setTranslationDomain('foo');
-        $this->assertEquals('foo', $admin->getTranslationDomain());
+        $this->assertSame('foo', $admin->getTranslationDomain());
     }
 
     public function testGetTranslator()
@@ -953,14 +953,14 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
 
         $admin->setTranslator($translator);
-        $this->assertEquals($translator, $admin->getTranslator());
+        $this->assertSame($translator, $admin->getTranslator());
     }
 
     public function testGetShowGroups()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals(false, $admin->getShowGroups());
+        $this->assertSame(false, $admin->getShowGroups());
 
         $groups = array('foo', 'bar', 'baz');
 
@@ -972,7 +972,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals(false, $admin->getFormGroups());
+        $this->assertSame(false, $admin->getFormGroups());
 
         $groups = array('foo', 'bar', 'baz');
 
@@ -984,7 +984,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals(25, $admin->getMaxPageLinks());
+        $this->assertSame(25, $admin->getMaxPageLinks());
 
         $admin->setMaxPageLinks(14);
         $this->assertSame(14, $admin->getMaxPageLinks());
@@ -994,7 +994,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals(25, $admin->getMaxPerPage());
+        $this->assertSame(25, $admin->getMaxPerPage());
 
         $admin->setMaxPerPage(94);
         $this->assertSame(94, $admin->getMaxPerPage());
@@ -1014,7 +1014,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals('SonataNewsBundle:PostAdmin', $admin->getBaseControllerName());
+        $this->assertSame('SonataNewsBundle:PostAdmin', $admin->getBaseControllerName());
 
         $admin->setBaseControllerName('SonataNewsBundle:FooAdmin');
         $this->assertSame('SonataNewsBundle:FooAdmin', $admin->getBaseControllerName());
@@ -1024,7 +1024,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals(array(), $admin->getTemplates());
+        $this->assertSame(array(), $admin->getTemplates());
 
         $templates = array(
             'list' => 'FooAdminBundle:CRUD:list.html.twig',
@@ -1051,8 +1051,8 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $admin->setTemplate('edit', 'FooAdminBundle:CRUD:edit.html.twig');
         $admin->setTemplate('show', 'FooAdminBundle:CRUD:show.html.twig');
 
-        $this->assertEquals('FooAdminBundle:CRUD:edit.html.twig', $admin->getTemplate('edit'));
-        $this->assertEquals('FooAdminBundle:CRUD:show.html.twig', $admin->getTemplate('show'));
+        $this->assertSame('FooAdminBundle:CRUD:edit.html.twig', $admin->getTemplate('edit'));
+        $this->assertSame('FooAdminBundle:CRUD:show.html.twig', $admin->getTemplate('show'));
     }
 
     public function testGetTemplate2()
@@ -1069,29 +1069,29 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $admin->setTemplates($templates);
 
-        $this->assertEquals('FooAdminBundle:CRUD:edit.html.twig', $admin->getTemplate('edit'));
-        $this->assertEquals('FooAdminBundle:CRUD:show.html.twig', $admin->getTemplate('show'));
+        $this->assertSame('FooAdminBundle:CRUD:edit.html.twig', $admin->getTemplate('edit'));
+        $this->assertSame('FooAdminBundle:CRUD:show.html.twig', $admin->getTemplate('show'));
     }
 
     public function testGetIdParameter()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals('id', $admin->getIdParameter());
+        $this->assertSame('id', $admin->getIdParameter());
         $this->assertFalse($admin->isChild());
 
         $parentAdmin = new PostAdmin('sonata.post.admin.post_parent', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostParentAdmin');
         $admin->setParent($parentAdmin);
 
         $this->assertTrue($admin->isChild());
-        $this->assertEquals('childId', $admin->getIdParameter());
+        $this->assertSame('childId', $admin->getIdParameter());
     }
 
     public function testGetExportFormats()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals(array('json', 'xml', 'csv', 'xls'), $admin->getExportFormats());
+        $this->assertSame(array('json', 'xml', 'csv', 'xls'), $admin->getExportFormats());
     }
 
     public function testGetUrlsafeIdentifier()
@@ -1107,7 +1107,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('foo'));
         $admin->setModelManager($modelManager);
 
-        $this->assertEquals('foo', $admin->getUrlsafeIdentifier($entity));
+        $this->assertSame('foo', $admin->getUrlsafeIdentifier($entity));
     }
 
     public function testDeterminedPerPageValue()
@@ -1170,9 +1170,9 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals(array('LIST'), $admin->getPermissionsShow(Admin::CONTEXT_DASHBOARD));
-        $this->assertEquals(array('LIST'), $admin->getPermissionsShow(Admin::CONTEXT_MENU));
-        $this->assertEquals(array('LIST'), $admin->getPermissionsShow('foo'));
+        $this->assertSame(array('LIST'), $admin->getPermissionsShow(Admin::CONTEXT_DASHBOARD));
+        $this->assertSame(array('LIST'), $admin->getPermissionsShow(Admin::CONTEXT_MENU));
+        $this->assertSame(array('LIST'), $admin->getPermissionsShow('foo'));
     }
 
     public function testShowIn()
@@ -1201,14 +1201,14 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals('sonata.post.admin.post', $admin->getObjectIdentifier());
+        $this->assertSame('sonata.post.admin.post', $admin->getObjectIdentifier());
     }
 
     public function testTransWithNoTranslator()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals('foo', $admin->trans('foo'));
+        $this->assertSame('foo', $admin->trans('foo'));
     }
 
     public function testTrans()
@@ -1224,7 +1224,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('foo'), $this->equalTo(array()), $this->equalTo('fooMessageDomain'))
             ->will($this->returnValue('fooTranslated'));
 
-        $this->assertEquals('fooTranslated', $admin->trans('foo'));
+        $this->assertSame('fooTranslated', $admin->trans('foo'));
     }
 
     public function testTransWithMessageDomain()
@@ -1239,14 +1239,14 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('foo'), $this->equalTo(array('name' => 'Andrej')), $this->equalTo('fooMessageDomain'))
             ->will($this->returnValue('fooTranslated'));
 
-        $this->assertEquals('fooTranslated', $admin->trans('foo', array('name' => 'Andrej'), 'fooMessageDomain'));
+        $this->assertSame('fooTranslated', $admin->trans('foo', array('name' => 'Andrej'), 'fooMessageDomain'));
     }
 
     public function testTransChoiceWithNoTranslator()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals('foo', $admin->transChoice('foo', 2));
+        $this->assertSame('foo', $admin->transChoice('foo', 2));
     }
 
     public function testTransChoice()
@@ -1262,7 +1262,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('foo'), $this->equalTo(2), $this->equalTo(array()), $this->equalTo('fooMessageDomain'))
             ->will($this->returnValue('fooTranslated'));
 
-        $this->assertEquals('fooTranslated', $admin->transChoice('foo', 2));
+        $this->assertSame('fooTranslated', $admin->transChoice('foo', 2));
     }
 
     public function testTransChoiceWithMessageDomain()
@@ -1277,23 +1277,23 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('foo'), $this->equalTo(2), $this->equalTo(array('name' => 'Andrej')), $this->equalTo('fooMessageDomain'))
             ->will($this->returnValue('fooTranslated'));
 
-        $this->assertEquals('fooTranslated', $admin->transChoice('foo', 2, array('name' => 'Andrej'), 'fooMessageDomain'));
+        $this->assertSame('fooTranslated', $admin->transChoice('foo', 2, array('name' => 'Andrej'), 'fooMessageDomain'));
     }
 
     public function testSetPersistFilters()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertAttributeEquals(false, 'persistFilters', $admin);
+        $this->assertAttributeSame(false, 'persistFilters', $admin);
         $admin->setPersistFilters(true);
-        $this->assertAttributeEquals(true, 'persistFilters', $admin);
+        $this->assertAttributeSame(true, 'persistFilters', $admin);
     }
 
     public function testGetRootCode()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals('sonata.post.admin.post', $admin->getRootCode());
+        $this->assertSame('sonata.post.admin.post', $admin->getRootCode());
 
         $parentAdmin = new PostAdmin('sonata.post.admin.post.parent', 'NewsBundle\Entity\PostParent', 'SonataNewsBundle:PostParentAdmin');
         $parentFieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
@@ -1303,15 +1303,15 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getParentFieldDescription());
         $admin->setParentFieldDescription($parentFieldDescription);
-        $this->assertEquals($parentFieldDescription, $admin->getParentFieldDescription());
-        $this->assertEquals('sonata.post.admin.post.parent', $admin->getRootCode());
+        $this->assertSame($parentFieldDescription, $admin->getParentFieldDescription());
+        $this->assertSame('sonata.post.admin.post.parent', $admin->getRootCode());
     }
 
     public function testGetRoot()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertEquals($admin, $admin->getRoot());
+        $this->assertSame($admin, $admin->getRoot());
 
         $parentAdmin = new PostAdmin('sonata.post.admin.post.parent', 'NewsBundle\Entity\PostParent', 'SonataNewsBundle:PostParentAdmin');
         $parentFieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
@@ -1321,8 +1321,8 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getParentFieldDescription());
         $admin->setParentFieldDescription($parentFieldDescription);
-        $this->assertEquals($parentFieldDescription, $admin->getParentFieldDescription());
-        $this->assertEquals($parentAdmin, $admin->getRoot());
+        $this->assertSame($parentFieldDescription, $admin->getParentFieldDescription());
+        $this->assertSame($parentAdmin, $admin->getRoot());
     }
 
     public function testGetExportFields()
@@ -1374,7 +1374,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $admin->addExtension($extension);
 
-        $this->assertEquals($expected, $admin->getPersistentParameters());
+        $this->assertSame($expected, $admin->getPersistentParameters());
     }
 
     public function testGetFormWithNonCollectionParentValue()
@@ -1466,7 +1466,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $admin->setFormGroups($formGroups);
 
         $admin->removeFieldFromFormGroup('foo');
-        $this->assertEquals($admin->getFormGroups(), array(
+        $this->assertSame($admin->getFormGroups(), array(
             'foobar' => array(
                 'fields' => array(
                     'bar' => 'bar',
@@ -1475,7 +1475,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         ));
 
         $admin->removeFieldFromFormGroup('bar');
-        $this->assertEquals($admin->getFormGroups(), array());
+        $this->assertSame($admin->getFormGroups(), array());
     }
 
     public function testGetFilterParameters()
@@ -1505,7 +1505,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $parameters = $commentAdmin->getFilterParameters();
 
         $this->assertTrue(isset($parameters['post__author']));
-        $this->assertEquals(array('value' => $authorId), $parameters['post__author']);
+        $this->assertSame(array('value' => $authorId), $parameters['post__author']);
     }
 }
 

--- a/Tests/Admin/BaseFieldDescriptionTest.php
+++ b/Tests/Admin/BaseFieldDescriptionTest.php
@@ -20,8 +20,8 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $description = new FieldDescription();
         $description->setName('foo');
 
-        $this->assertEquals('foo', $description->getFieldName());
-        $this->assertEquals('foo', $description->getName());
+        $this->assertSame('foo', $description->getFieldName());
+        $this->assertSame('foo', $description->getName());
     }
 
     public function testOptions()
@@ -30,38 +30,38 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $description->setOption('foo', 'bar');
 
         $this->assertNull($description->getOption('bar'));
-        $this->assertEquals('bar', $description->getOption('foo'));
+        $this->assertSame('bar', $description->getOption('foo'));
 
         $description->mergeOptions(array('settings' => array('value_1', 'value_2')));
         $description->mergeOptions(array('settings' => array('value_1', 'value_3')));
 
-        $this->assertEquals(array('value_1', 'value_2', 'value_1', 'value_3'), $description->getOption('settings'));
+        $this->assertSame(array('value_1', 'value_2', 'value_1', 'value_3'), $description->getOption('settings'));
 
         $description->mergeOption('settings', array('value_4'));
-        $this->assertEquals(array('value_1', 'value_2', 'value_1', 'value_3', 'value_4'), $description->getOption('settings'));
+        $this->assertSame(array('value_1', 'value_2', 'value_1', 'value_3', 'value_4'), $description->getOption('settings'));
 
         $description->mergeOption('bar', array('hello'));
 
         $this->assertCount(1, $description->getOption('bar'));
 
         $description->setOption('label', 'trucmuche');
-        $this->assertEquals('trucmuche', $description->getLabel());
+        $this->assertSame('trucmuche', $description->getLabel());
         $this->assertNull($description->getTemplate());
         $description->setOptions(array('type' => 'integer', 'template' => 'foo.twig.html', 'help' => 'fooHelp'));
 
-        $this->assertEquals('integer', $description->getType());
-        $this->assertEquals('foo.twig.html', $description->getTemplate());
-        $this->assertEquals('fooHelp', $description->getHelp());
+        $this->assertSame('integer', $description->getType());
+        $this->assertSame('foo.twig.html', $description->getTemplate());
+        $this->assertSame('fooHelp', $description->getHelp());
 
         $this->assertCount(2, $description->getOptions());
 
         $description->setHelp('Please enter an integer');
-        $this->assertEquals('Please enter an integer', $description->getHelp());
+        $this->assertSame('Please enter an integer', $description->getHelp());
 
         $description->setMappingType('int');
-        $this->assertEquals('int', $description->getMappingType());
+        $this->assertSame('int', $description->getMappingType());
 
-        $this->assertEquals('short_object_description_placeholder', $description->getOption('placeholder'));
+        $this->assertSame('short_object_description_placeholder', $description->getOption('placeholder'));
         $description->setOptions(array('placeholder' => false));
         $this->assertFalse($description->getOption('placeholder'));
 
@@ -101,7 +101,7 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $mock = $this->getMock('stdClass', array('getFoo'));
         $mock->expects($this->once())->method('getFoo')->will($this->returnValue(42));
 
-        $this->assertEquals(42, $description->getFieldValue($mock, 'fake'));
+        $this->assertSame(42, $description->getFieldValue($mock, 'fake'));
 
 /*
          * Test with One parameter int
@@ -116,7 +116,7 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $returnValue1 = $arg1 + 2;
         $mock1->expects($this->once())->method('getWithOneParameter')->with($this->equalTo($arg1))->will($this->returnValue($returnValue1));
 
-        $this->assertEquals(40, $description1->getFieldValue($mock1, 'fake'));
+        $this->assertSame(40, $description1->getFieldValue($mock1, 'fake'));
 
 /*
          * Test with Two parameters int
@@ -130,7 +130,7 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $mock2 = $this->getMock('stdClass', array('getWithTwoParameters'));
         $returnValue2 = $arg1 + $arg2;
         $mock2->expects($this->any())->method('getWithTwoParameters')->with($this->equalTo($arg1), $this->equalTo($arg2))->will($this->returnValue($returnValue2));
-        $this->assertEquals(42, $description2->getFieldValue($mock2, 'fake'));
+        $this->assertSame(42, $description2->getFieldValue($mock2, 'fake'));
     }
 
     /**
@@ -165,19 +165,19 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
             ->method('getTranslationDomain')
             ->will($this->returnValue('AdminDomain'));
 
-        $this->assertEquals('AdminDomain', $description->getTranslationDomain());
+        $this->assertSame('AdminDomain', $description->getTranslationDomain());
 
         $admin->expects($this->never())
             ->method('getTranslationDomain');
         $description->setOption('translation_domain', 'ExtensionDomain');
-        $this->assertEquals('ExtensionDomain', $description->getTranslationDomain());
+        $this->assertSame('ExtensionDomain', $description->getTranslationDomain());
     }
 
     public function testCamelize()
     {
-        $this->assertEquals('FooBar', BaseFieldDescription::camelize('foo_bar'));
-        $this->assertEquals('FooBar', BaseFieldDescription::camelize('foo bar'));
-        $this->assertEquals('FOoBar', BaseFieldDescription::camelize('fOo bar'));
+        $this->assertSame('FooBar', BaseFieldDescription::camelize('foo_bar'));
+        $this->assertSame('FooBar', BaseFieldDescription::camelize('foo bar'));
+        $this->assertSame('FOoBar', BaseFieldDescription::camelize('fOo bar'));
     }
 }
 

--- a/Tests/Admin/PoolTest.php
+++ b/Tests/Admin/PoolTest.php
@@ -39,7 +39,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expectedOutput, $this->pool->getGroups());
+        $this->assertSame($expectedOutput, $this->pool->getGroups());
     }
 
     public function testHasGroup()
@@ -107,7 +107,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
                 'adminGroup1' => array(),
             ));
 
-        $this->assertEquals(array(), $this->pool->getAdminsByGroup('adminGroup1'));
+        $this->assertSame(array(), $this->pool->getAdminsByGroup('adminGroup1'));
     }
 
     public function testGetAdminsByGroup()
@@ -147,7 +147,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     {
         $this->pool->setAdminClasses(array('someclass' => array('sonata.user.admin.group1', 'sonata.user.admin.group2')));
         $this->assertTrue($this->pool->hasAdminByClass('someclass'));
-        $this->assertEquals('adminUserClass', $this->pool->getAdminByClass('someclass'));
+        $this->assertSame('adminUserClass', $this->pool->getAdminByClass('someclass'));
     }
 
     public function testGetAdminForClassWhenAdminClassIsSet()
@@ -155,7 +155,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $this->pool->setAdminServiceIds(array('sonata.user.admin.group1'));
         $this->pool->setAdminClasses(array('someclass' => array('sonata.user.admin.group1')));
         $this->assertTrue($this->pool->hasAdminByClass('someclass'));
-        $this->assertEquals('adminUserClass', $this->pool->getAdminByClass('someclass'));
+        $this->assertSame('adminUserClass', $this->pool->getAdminByClass('someclass'));
     }
 
     /**
@@ -170,7 +170,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     public function testGetAdminByAdminCode()
     {
         $this->pool->setAdminServiceIds(array('sonata.news.admin.post'));
-        $this->assertEquals('adminUserClass', $this->pool->getAdminByAdminCode('sonata.news.admin.post'));
+        $this->assertSame('adminUserClass', $this->pool->getAdminByAdminCode('sonata.news.admin.post'));
     }
 
     public function testGetAdminByAdminCodeForChildClass()
@@ -194,25 +194,25 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $this->pool = new Pool($containerMock, 'Sonata', '/path/to/logo.png');
         $this->pool->setAdminServiceIds(array('sonata.news.admin.post'));
 
-        $this->assertEquals('commentAdminClass', $this->pool->getAdminByAdminCode('sonata.news.admin.post|sonata.news.admin.comment'));
+        $this->assertSame('commentAdminClass', $this->pool->getAdminByAdminCode('sonata.news.admin.post|sonata.news.admin.comment'));
     }
 
     public function testGetAdminClasses()
     {
         $this->pool->setAdminClasses(array('someclass' => 'sonata.user.admin.group1'));
-        $this->assertEquals(array('someclass' => 'sonata.user.admin.group1'), $this->pool->getAdminClasses());
+        $this->assertSame(array('someclass' => 'sonata.user.admin.group1'), $this->pool->getAdminClasses());
     }
 
     public function testGetAdminGroups()
     {
         $this->pool->setAdminGroups(array('adminGroup1' => 'sonata.user.admin.group1'));
-        $this->assertEquals(array('adminGroup1' => 'sonata.user.admin.group1'), $this->pool->getAdminGroups());
+        $this->assertSame(array('adminGroup1' => 'sonata.user.admin.group1'), $this->pool->getAdminGroups());
     }
 
     public function testGetAdminServiceIds()
     {
         $this->pool->setAdminServiceIds(array('sonata.user.admin.group1', 'sonata.user.admin.group2', 'sonata.user.admin.group3'));
-        $this->assertEquals(array('sonata.user.admin.group1', 'sonata.user.admin.group2', 'sonata.user.admin.group3'), $this->pool->getAdminServiceIds());
+        $this->assertSame(array('sonata.user.admin.group1', 'sonata.user.admin.group2', 'sonata.user.admin.group3'), $this->pool->getAdminServiceIds());
     }
 
     public function testGetContainer()
@@ -227,29 +227,29 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $this->pool->setTemplates(array('ajax' => 'Foo.html.twig'));
 
         $this->assertNull($this->pool->getTemplate('bar'));
-        $this->assertEquals('Foo.html.twig', $this->pool->getTemplate('ajax'));
+        $this->assertSame('Foo.html.twig', $this->pool->getTemplate('ajax'));
     }
 
     public function testGetTitleLogo()
     {
-        $this->assertEquals('/path/to/pic.png', $this->pool->getTitleLogo());
+        $this->assertSame('/path/to/pic.png', $this->pool->getTitleLogo());
     }
 
     public function testGetTitle()
     {
-        $this->assertEquals('Sonata Admin', $this->pool->getTitle());
+        $this->assertSame('Sonata Admin', $this->pool->getTitle());
     }
 
     public function testGetOption()
     {
-        $this->assertEquals('bar', $this->pool->getOption('foo'));
+        $this->assertSame('bar', $this->pool->getOption('foo'));
 
-        $this->assertEquals(null, $this->pool->getOption('non_existent_option'));
+        $this->assertSame(null, $this->pool->getOption('non_existent_option'));
     }
 
     public function testOptionDefault()
     {
-        $this->assertEquals(array(), $this->pool->getOption('nonexistantarray', array()));
+        $this->assertSame(array(), $this->pool->getOption('nonexistantarray', array()));
     }
 
     /**

--- a/Tests/Command/CreateClassCacheCommandTest.php
+++ b/Tests/Command/CreateClassCacheCommandTest.php
@@ -116,7 +116,7 @@ class CreateClassCacheCommandTest extends \PHPUnit_Framework_TestCase
             $commandTester = new CommandTester($command);
             $commandTester->execute(array('command' => $command->getName()));
         } catch (\RuntimeException $e) {
-            $this->assertEquals(sprintf('The file %s/classes.map does not exist', $this->tempDirectory), $e->getMessage());
+            $this->assertSame(sprintf('The file %s/classes.map does not exist', $this->tempDirectory), $e->getMessage());
 
             return;
         }

--- a/Tests/Command/ExplainAdminCommandTest.php
+++ b/Tests/Command/ExplainAdminCommandTest.php
@@ -201,7 +201,7 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), 'admin' => 'acme.admin.foo'));
 
-        $this->assertEquals(sprintf(str_replace("\n", PHP_EOL, file_get_contents(__DIR__.'/../Fixtures/Command/explain_admin.txt')), get_class($this->admin), get_class($modelManager), get_class($datagridBuilder), get_class($listBuilder)), $commandTester->getDisplay());
+        $this->assertSame(sprintf(str_replace("\n", PHP_EOL, file_get_contents(__DIR__.'/../Fixtures/Command/explain_admin.txt')), get_class($this->admin), get_class($modelManager), get_class($datagridBuilder), get_class($listBuilder)), $commandTester->getDisplay());
     }
 
     public function testExecuteEmptyValidator()
@@ -246,7 +246,7 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), 'admin' => 'acme.admin.foo'));
 
-        $this->assertEquals(sprintf(str_replace("\n", PHP_EOL, file_get_contents(__DIR__.'/../Fixtures/Command/explain_admin_empty_validator.txt')), get_class($this->admin), get_class($modelManager), get_class($datagridBuilder), get_class($listBuilder)), $commandTester->getDisplay());
+        $this->assertSame(sprintf(str_replace("\n", PHP_EOL, file_get_contents(__DIR__.'/../Fixtures/Command/explain_admin_empty_validator.txt')), get_class($this->admin), get_class($modelManager), get_class($datagridBuilder), get_class($listBuilder)), $commandTester->getDisplay());
     }
 
     public function testExecuteNonAdminService()
@@ -256,7 +256,7 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
             $commandTester = new CommandTester($command);
             $commandTester->execute(array('command' => $command->getName(), 'admin' => 'nonexistent.service'));
         } catch (\RuntimeException $e) {
-            $this->assertEquals('Service "nonexistent.service" is not an admin class', $e->getMessage());
+            $this->assertSame('Service "nonexistent.service" is not an admin class', $e->getMessage());
 
             return;
         }

--- a/Tests/Command/GenerateAdminCommandTest.php
+++ b/Tests/Command/GenerateAdminCommandTest.php
@@ -137,7 +137,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         $expectedOutput .= sprintf('%3$sThe controller class "Sonata\AdminBundle\Tests\Fixtures\Bundle\Controller\FooAdminController" has been generated under the file "%1$s%2$sController%2$sFooAdminController.php".%3$s', $this->tempDirectory, DIRECTORY_SEPARATOR, PHP_EOL);
         $expectedOutput .= sprintf('%3$sThe service "acme_demo_admin.admin.foo" has been appended to the file "%1$s%2$sResources%2$sconfig%2$sadmin.yml".%3$s', $this->tempDirectory, DIRECTORY_SEPARATOR, PHP_EOL);
 
-        $this->assertEquals($expectedOutput, $commandTester->getDisplay());
+        $this->assertSame($expectedOutput, $commandTester->getDisplay());
 
         $this->assertFileExists($this->tempDirectory.'/Admin/FooAdmin.php');
         $this->assertFileExists($this->tempDirectory.'/Controller/FooAdminController.php');
@@ -322,7 +322,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         $expectedOutput .= sprintf('%3$sThe controller class "Sonata\AdminBundle\Tests\Fixtures\Bundle\Controller\FooAdminController" has been generated under the file "%1$s%2$sController%2$sFooAdminController.php".%3$s', $this->tempDirectory, DIRECTORY_SEPARATOR, PHP_EOL);
         $expectedOutput .= sprintf('%3$sThe service "acme_demo_admin.admin.foo" has been appended to the file "%1$s%2$sResources%2$sconfig%2$sadmin.yml".%3$s', $this->tempDirectory, DIRECTORY_SEPARATOR, PHP_EOL);
 
-        $this->assertEquals($expectedOutput, str_replace("\n", PHP_EOL, str_replace(PHP_EOL, "\n", $commandTester->getDisplay())));
+        $this->assertSame($expectedOutput, str_replace("\n", PHP_EOL, str_replace(PHP_EOL, "\n", $commandTester->getDisplay())));
 
         $this->assertFileExists($this->tempDirectory.'/Admin/FooAdmin.php');
         $this->assertFileExists($this->tempDirectory.'/Controller/FooAdminController.php');
@@ -366,7 +366,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         $this->container->set('sonata.admin.manager.foo', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
         $this->container->set('sonata.admin.manager.bar', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
 
-        $this->assertEquals($expected, $this->command->validateManagerType($managerType));
+        $this->assertSame($expected, $this->command->validateManagerType($managerType));
     }
 
     public function getValidateManagerTypeTests()

--- a/Tests/Command/ValidatorsTest.php
+++ b/Tests/Command/ValidatorsTest.php
@@ -23,7 +23,7 @@ class ValidatorsTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidateUsername($expected, $value)
     {
-        $this->assertEquals($expected, Validators::validateUsername($value));
+        $this->assertSame($expected, Validators::validateUsername($value));
     }
 
     public function getValidateUsernameTests()
@@ -56,7 +56,7 @@ class ValidatorsTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidateEntityName($expected, $value)
     {
-        $this->assertEquals($expected, Validators::validateEntityName($value));
+        $this->assertSame($expected, Validators::validateEntityName($value));
     }
 
     public function getValidateEntityNameTests()
@@ -96,7 +96,7 @@ class ValidatorsTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidateClass($expected, $value)
     {
-        $this->assertEquals($expected, Validators::validateClass($value));
+        $this->assertSame($expected, Validators::validateClass($value));
     }
 
     public function getValidateClassTests()
@@ -131,7 +131,7 @@ class ValidatorsTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidateAdminClassBasename($expected, $value)
     {
-        $this->assertEquals($expected, Validators::validateAdminClassBasename($value));
+        $this->assertSame($expected, Validators::validateAdminClassBasename($value));
     }
 
     public function getValidateAdminClassBasenameTests()
@@ -167,7 +167,7 @@ class ValidatorsTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidateControllerClassBasename($expected, $value)
     {
-        $this->assertEquals($expected, Validators::validateControllerClassBasename($value));
+        $this->assertSame($expected, Validators::validateControllerClassBasename($value));
     }
 
     public function getValidateControllerClassBasenameTests()
@@ -220,7 +220,7 @@ class ValidatorsTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidateServicesFile($expected, $value)
     {
-        $this->assertEquals($expected, Validators::validateServicesFile($value));
+        $this->assertSame($expected, Validators::validateServicesFile($value));
     }
 
     public function getValidateServicesFileTests()
@@ -241,7 +241,7 @@ class ValidatorsTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidateServiceId($value)
     {
-        $this->assertEquals($value, Validators::validateServiceId($value));
+        $this->assertSame($value, Validators::validateServiceId($value));
     }
 
     public function getValidateServiceIdTests()

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -382,8 +382,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->headers->set('Content-Type', 'application/x-www-form-urlencoded');
         $response = $this->protectedTestedMethods['renderJson']->invoke($this->controller, $data);
 
-        $this->assertEquals($response->headers->get('Content-Type'), 'application/json');
-        $this->assertEquals(json_encode($data), $response->getContent());
+        $this->assertSame($response->headers->get('Content-Type'), 'application/json');
+        $this->assertSame(json_encode($data), $response->getContent());
     }
 
     public function testRenderJson2()
@@ -393,8 +393,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->headers->set('Content-Type', 'multipart/form-data');
         $response = $this->protectedTestedMethods['renderJson']->invoke($this->controller, $data);
 
-        $this->assertEquals($response->headers->get('Content-Type'), 'application/json');
-        $this->assertEquals(json_encode($data), $response->getContent());
+        $this->assertSame($response->headers->get('Content-Type'), 'application/json');
+        $this->assertSame(json_encode($data), $response->getContent());
     }
 
     public function testRenderJsonAjax()
@@ -405,8 +405,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->headers->set('Content-Type', 'multipart/form-data');
         $response = $this->protectedTestedMethods['renderJson']->invoke($this->controller, $data);
 
-        $this->assertEquals($response->headers->get('Content-Type'), 'text/plain');
-        $this->assertEquals(json_encode($data), $response->getContent());
+        $this->assertSame($response->headers->get('Content-Type'), 'text/plain');
+        $this->assertSame(json_encode($data), $response->getContent());
     }
 
     public function testIsXmlHttpRequest()
@@ -437,8 +437,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->query->set('uniqid', 123456);
         $this->protectedTestedMethods['configure']->invoke($this->controller);
 
-        $this->assertEquals(123456, $uniqueId);
-        $this->assertAttributeEquals($this->admin, 'admin', $this->controller);
+        $this->assertSame(123456, $uniqueId);
+        $this->assertAttributeSame($this->admin, 'admin', $this->controller);
     }
 
     public function testConfigureChild()
@@ -463,8 +463,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->query->set('uniqid', 123456);
         $this->protectedTestedMethods['configure']->invoke($this->controller);
 
-        $this->assertEquals(123456, $uniqueId);
-        $this->assertAttributeEquals($adminParent, 'admin', $this->controller);
+        $this->assertSame(123456, $uniqueId);
+        $this->assertAttributeInstanceOf(get_class($adminParent), 'admin', $this->controller);
     }
 
     public function testConfigureWithException()
@@ -493,25 +493,25 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetBaseTemplate()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'SonataAdminBundle::standard_layout.html.twig',
             $this->protectedTestedMethods['getBaseTemplate']->invoke($this->controller)
         );
 
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
-        $this->assertEquals(
+        $this->assertSame(
             'SonataAdminBundle::ajax_layout.html.twig',
             $this->protectedTestedMethods['getBaseTemplate']->invoke($this->controller)
         );
 
         $this->request->headers->remove('X-Requested-With');
-        $this->assertEquals(
+        $this->assertSame(
             'SonataAdminBundle::standard_layout.html.twig',
             $this->protectedTestedMethods['getBaseTemplate']->invoke($this->controller)
         );
 
         $this->request->attributes->set('_xml_http_request', true);
-        $this->assertEquals(
+        $this->assertSame(
             'SonataAdminBundle::ajax_layout.html.twig',
             $this->protectedTestedMethods['getBaseTemplate']->invoke($this->controller)
         );
@@ -524,10 +524,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             'Symfony\Component\HttpFoundation\Response',
             $this->controller->render('FooAdminBundle::foo.html.twig', array())
         );
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
-        $this->assertEquals('FooAdminBundle::foo.html.twig', $this->template);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame('FooAdminBundle::foo.html.twig', $this->template);
     }
 
     public function testRenderWithResponse()
@@ -537,12 +537,12 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $response->headers->set('X-foo', 'bar');
         $responseResult = $this->controller->render('FooAdminBundle::foo.html.twig', array(), $response);
 
-        $this->assertEquals($response, $responseResult);
-        $this->assertEquals('bar', $responseResult->headers->get('X-foo'));
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
-        $this->assertEquals('FooAdminBundle::foo.html.twig', $this->template);
+        $this->assertSame($response, $responseResult);
+        $this->assertSame('bar', $responseResult->headers->get('X-foo'));
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame('FooAdminBundle::foo.html.twig', $this->template);
     }
 
     public function testRenderCustomParams()
@@ -553,11 +553,11 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             $this->controller->render('FooAdminBundle::foo.html.twig',
             array('foo' => 'bar'))
         );
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
-        $this->assertEquals('bar', $this->parameters['foo']);
-        $this->assertEquals('FooAdminBundle::foo.html.twig', $this->template);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame('bar', $this->parameters['foo']);
+        $this->assertSame('FooAdminBundle::foo.html.twig', $this->template);
     }
 
     public function testRenderAjax()
@@ -565,11 +565,11 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->parameters = array();
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->render('FooAdminBundle::foo.html.twig', array('foo' => 'bar')));
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::ajax_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
-        $this->assertEquals('bar', $this->parameters['foo']);
-        $this->assertEquals('FooAdminBundle::foo.html.twig', $this->template);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::ajax_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame('bar', $this->parameters['foo']);
+        $this->assertSame('FooAdminBundle::foo.html.twig', $this->template);
     }
 
     public function testListActionAccessDenied()
@@ -612,16 +612,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->parameters = array();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->listAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('list', $this->parameters['action']);
+        $this->assertSame('list', $this->parameters['action']);
         $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
         $this->assertInstanceOf('Sonata\AdminBundle\Datagrid\DatagridInterface', $this->parameters['datagrid']);
-        $this->assertEquals('csrf-token-123_sonata.batch', $this->parameters['csrf_token']);
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:list.html.twig', $this->template);
+        $this->assertSame('csrf-token-123_sonata.batch', $this->parameters['csrf_token']);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:list.html.twig', $this->template);
     }
 
     public function testBatchActionDeleteAccessDenied()
@@ -657,7 +657,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_delete_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
-        $this->assertEquals('list?filter%5Bfoo%5D=bar', $result->getTargetUrl());
+        $this->assertSame('list?filter%5Bfoo%5D=bar', $result->getTargetUrl());
     }
 
     private function assertLoggerLogsModelManagerException($subject, $method)
@@ -699,7 +699,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_delete_error'), $this->session->getFlashBag()->get('sonata_flash_error'));
-        $this->assertEquals('list?filter%5Bfoo%5D=bar', $result->getTargetUrl());
+        $this->assertSame('list?filter%5Bfoo%5D=bar', $result->getTargetUrl());
     }
 
     public function testShowActionNotFoundException()
@@ -750,16 +750,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->showAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('show', $this->parameters['action']);
+        $this->assertSame('show', $this->parameters['action']);
         $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionCollection', $this->parameters['elements']);
-        $this->assertEquals($object, $this->parameters['object']);
+        $this->assertSame($object, $this->parameters['object']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:show.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:show.html.twig', $this->template);
     }
 
     /**
@@ -779,7 +779,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $response = $this->protectedTestedMethods['redirectTo']->invoke($this->controller, $object);
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
-        $this->assertEquals($expected, $response->getTargetUrl());
+        $this->assertSame($expected, $response->getTargetUrl());
     }
 
     public function getRedirectToTests()
@@ -841,16 +841,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->deleteAction(1));
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('delete', $this->parameters['action']);
-        $this->assertEquals($object, $this->parameters['object']);
-        $this->assertEquals('csrf-token-123_sonata.delete', $this->parameters['csrf_token']);
+        $this->assertSame('delete', $this->parameters['action']);
+        $this->assertSame($object, $this->parameters['object']);
+        $this->assertSame('csrf-token-123_sonata.delete', $this->parameters['csrf_token']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:delete.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:delete.html.twig', $this->template);
     }
 
     public function testDeleteActionNoCsrfToken()
@@ -870,16 +870,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->deleteAction(1));
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('delete', $this->parameters['action']);
-        $this->assertEquals($object, $this->parameters['object']);
-        $this->assertEquals('', $this->parameters['csrf_token']);
+        $this->assertSame('delete', $this->parameters['action']);
+        $this->assertSame($object, $this->parameters['object']);
+        $this->assertSame(false, $this->parameters['csrf_token']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:delete.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:delete.html.twig', $this->template);
     }
 
     public function testDeleteActionAjaxSuccess1()
@@ -903,8 +903,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $response = $this->controller->deleteAction(1);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
-        $this->assertEquals(json_encode(array('result' => 'ok')), $response->getContent());
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
+        $this->assertSame(json_encode(array('result' => 'ok')), $response->getContent());
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
     }
 
     public function testDeleteActionAjaxSuccess2()
@@ -929,8 +929,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $response = $this->controller->deleteAction(1);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
-        $this->assertEquals(json_encode(array('result' => 'ok')), $response->getContent());
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
+        $this->assertSame(json_encode(array('result' => 'ok')), $response->getContent());
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
     }
 
     public function testDeleteActionAjaxError()
@@ -956,8 +956,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $response = $this->controller->deleteAction(1);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
-        $this->assertEquals(json_encode(array('result' => 'error')), $response->getContent());
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
+        $this->assertSame(json_encode(array('result' => 'error')), $response->getContent());
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
     }
 
     /**
@@ -991,7 +991,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertSame(array('flash_delete_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
-        $this->assertEquals('list', $response->getTargetUrl());
+        $this->assertSame('list', $response->getTargetUrl());
     }
 
     /**
@@ -1026,7 +1026,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertSame(array('flash_delete_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
-        $this->assertEquals('list', $response->getTargetUrl());
+        $this->assertSame('list', $response->getTargetUrl());
     }
 
     /**
@@ -1061,7 +1061,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertSame(array('flash_delete_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
-        $this->assertEquals('list', $response->getTargetUrl());
+        $this->assertSame('list', $response->getTargetUrl());
     }
 
     public function testDeleteActionWrongRequestMethod()
@@ -1082,16 +1082,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->deleteAction(1));
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('delete', $this->parameters['action']);
-        $this->assertEquals($object, $this->parameters['object']);
-        $this->assertEquals('csrf-token-123_sonata.delete', $this->parameters['csrf_token']);
+        $this->assertSame('delete', $this->parameters['action']);
+        $this->assertSame($object, $this->parameters['object']);
+        $this->assertSame('csrf-token-123_sonata.delete', $this->parameters['csrf_token']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:delete.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:delete.html.twig', $this->template);
     }
 
     /**
@@ -1126,7 +1126,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertSame(array('flash_delete_error'), $this->session->getFlashBag()->get('sonata_flash_error'));
-        $this->assertEquals('list', $response->getTargetUrl());
+        $this->assertSame('list', $response->getTargetUrl());
     }
 
     public function testDeleteActionInvalidCsrfToken()
@@ -1149,8 +1149,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         try {
             $this->controller->deleteAction(1);
         } catch (HttpException $e) {
-            $this->assertEquals('The csrf token is not valid, CSRF attack?', $e->getMessage());
-            $this->assertEquals(400, $e->getStatusCode());
+            $this->assertSame('The csrf token is not valid, CSRF attack?', $e->getMessage());
+            $this->assertSame(400, $e->getStatusCode());
         }
     }
 
@@ -1210,15 +1210,15 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('edit', $this->parameters['action']);
+        $this->assertSame('edit', $this->parameters['action']);
         $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
-        $this->assertEquals($object, $this->parameters['object']);
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:edit.html.twig', $this->template);
+        $this->assertSame($object, $this->parameters['object']);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:edit.html.twig', $this->template);
     }
 
     /**
@@ -1266,7 +1266,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertSame(array('flash_edit_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
-        $this->assertEquals('stdClass_edit', $response->getTargetUrl());
+        $this->assertSame('stdClass_edit', $response->getTargetUrl());
     }
 
     /**
@@ -1314,16 +1314,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('edit', $this->parameters['action']);
+        $this->assertSame('edit', $this->parameters['action']);
         $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
-        $this->assertEquals($object, $this->parameters['object']);
+        $this->assertSame($object, $this->parameters['object']);
 
-        $this->assertEquals(array('sonata_flash_error' => array('flash_edit_error')), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:edit.html.twig', $this->template);
+        $this->assertSame(array('sonata_flash_error' => array('flash_edit_error')), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:edit.html.twig', $this->template);
     }
 
     public function testEditActionAjaxSuccess()
@@ -1366,8 +1366,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $response = $this->controller->editAction();
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
-        $this->assertEquals(json_encode(array('result' => 'ok', 'objectId'  => 'foo_normalized')), $response->getContent());
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
+        $this->assertSame(json_encode(array('result' => 'ok', 'objectId'  => 'foo_normalized')), $response->getContent());
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
     }
 
     public function testEditActionAjaxError()
@@ -1406,16 +1406,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::ajax_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::ajax_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('edit', $this->parameters['action']);
+        $this->assertSame('edit', $this->parameters['action']);
         $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
-        $this->assertEquals($object, $this->parameters['object']);
+        $this->assertSame($object, $this->parameters['object']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:edit.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:edit.html.twig', $this->template);
     }
 
     public function testEditActionWithPreview()
@@ -1458,16 +1458,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('edit', $this->parameters['action']);
+        $this->assertSame('edit', $this->parameters['action']);
         $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
-        $this->assertEquals($object, $this->parameters['object']);
+        $this->assertSame($object, $this->parameters['object']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:preview.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:preview.html.twig', $this->template);
     }
 
     public function testCreateActionAccessDenied()
@@ -1511,16 +1511,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('create', $this->parameters['action']);
+        $this->assertSame('create', $this->parameters['action']);
         $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
-        $this->assertEquals($object, $this->parameters['object']);
+        $this->assertSame($object, $this->parameters['object']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:edit.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:edit.html.twig', $this->template);
     }
 
     /**
@@ -1577,7 +1577,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertSame(array('flash_create_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
-        $this->assertEquals('stdClass_edit', $response->getTargetUrl());
+        $this->assertSame('stdClass_edit', $response->getTargetUrl());
     }
 
     public function testCreateActionAccessDenied2()
@@ -1665,16 +1665,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('create', $this->parameters['action']);
+        $this->assertSame('create', $this->parameters['action']);
         $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
-        $this->assertEquals($object, $this->parameters['object']);
+        $this->assertSame($object, $this->parameters['object']);
 
-        $this->assertEquals(array('sonata_flash_error' => array('flash_create_error')), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:edit.html.twig', $this->template);
+        $this->assertSame(array('sonata_flash_error' => array('flash_create_error')), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:edit.html.twig', $this->template);
     }
 
     public function testCreateActionAjaxSuccess()
@@ -1726,8 +1726,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $response = $this->controller->createAction();
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
-        $this->assertEquals(json_encode(array('result' => 'ok', 'objectId'  => 'foo_normalized')), $response->getContent());
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
+        $this->assertSame(json_encode(array('result' => 'ok', 'objectId'  => 'foo_normalized')), $response->getContent());
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
     }
 
     public function testCreateActionAjaxError()
@@ -1766,16 +1766,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::ajax_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::ajax_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('create', $this->parameters['action']);
+        $this->assertSame('create', $this->parameters['action']);
         $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
-        $this->assertEquals($object, $this->parameters['object']);
+        $this->assertSame($object, $this->parameters['object']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:edit.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:edit.html.twig', $this->template);
     }
 
     public function testCreateActionWithPreview()
@@ -1818,16 +1818,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('create', $this->parameters['action']);
+        $this->assertSame('create', $this->parameters['action']);
         $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
-        $this->assertEquals($object, $this->parameters['object']);
+        $this->assertSame($object, $this->parameters['object']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:preview.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:preview.html.twig', $this->template);
     }
 
     public function testExportActionAccessDenied()
@@ -1885,8 +1885,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $response = $this->controller->exportAction($this->request);
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\StreamedResponse', $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
     }
 
     public function testHistoryActionAccessDenied()
@@ -1983,16 +1983,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->historyAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('history', $this->parameters['action']);
-        $this->assertEquals(array(), $this->parameters['revisions']);
-        $this->assertEquals($object, $this->parameters['object']);
+        $this->assertSame('history', $this->parameters['action']);
+        $this->assertSame(array(), $this->parameters['revisions']);
+        $this->assertSame($object, $this->parameters['object']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:history.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:history.html.twig', $this->template);
     }
 
     public function testAclActionAclNotEnabled()
@@ -2088,18 +2088,18 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->aclAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('acl', $this->parameters['action']);
-        $this->assertEquals(array(), $this->parameters['permissions']);
-        $this->assertEquals($object, $this->parameters['object']);
+        $this->assertSame('acl', $this->parameters['action']);
+        $this->assertSame(array(), $this->parameters['permissions']);
+        $this->assertSame($object, $this->parameters['object']);
         $this->assertInstanceOf('\ArrayIterator', $this->parameters['users']);
         $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:acl.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:acl.html.twig', $this->template);
     }
 
     public function testAclActionInvalidUpdate()
@@ -2157,18 +2157,18 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->aclAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('acl', $this->parameters['action']);
-        $this->assertEquals(array(), $this->parameters['permissions']);
-        $this->assertEquals($object, $this->parameters['object']);
+        $this->assertSame('acl', $this->parameters['action']);
+        $this->assertSame(array(), $this->parameters['permissions']);
+        $this->assertSame($object, $this->parameters['object']);
         $this->assertInstanceOf('\ArrayIterator', $this->parameters['users']);
         $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:acl.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:acl.html.twig', $this->template);
     }
 
     public function testAclActionSuccessfulUpdate()
@@ -2229,7 +2229,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
 
         $this->assertSame(array('flash_acl_edit_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
-        $this->assertEquals('stdClass_acl', $response->getTargetUrl());
+        $this->assertSame('stdClass_acl', $response->getTargetUrl());
     }
 
     public function testHistoryViewRevisionActionAccessDenied()
@@ -2382,16 +2382,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->historyViewRevisionAction(123, 456));
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('show', $this->parameters['action']);
-        $this->assertEquals($objectRevision, $this->parameters['object']);
-        $this->assertEquals($fieldDescriptionCollection, $this->parameters['elements']);
+        $this->assertSame('show', $this->parameters['action']);
+        $this->assertSame($objectRevision, $this->parameters['object']);
+        $this->assertSame($fieldDescriptionCollection, $this->parameters['elements']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:show.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:show.html.twig', $this->template);
     }
 
     public function testhistoryCompareRevisionsActionAccessDenied()
@@ -2604,17 +2604,17 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->historyCompareRevisionsAction(123, 456, 789));
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('show', $this->parameters['action']);
-        $this->assertEquals($objectRevision, $this->parameters['object']);
-        $this->assertEquals($compareObjectRevision, $this->parameters['object_compare']);
-        $this->assertEquals($fieldDescriptionCollection, $this->parameters['elements']);
+        $this->assertSame('show', $this->parameters['action']);
+        $this->assertSame($objectRevision, $this->parameters['object']);
+        $this->assertSame($compareObjectRevision, $this->parameters['object_compare']);
+        $this->assertSame($fieldDescriptionCollection, $this->parameters['elements']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:show_compare.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:show_compare.html.twig', $this->template);
     }
 
     public function testBatchActionWrongMethod()
@@ -2650,8 +2650,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         try {
             $this->controller->batchAction();
         } catch (HttpException $e) {
-            $this->assertEquals('The csrf token is not valid, CSRF attack?', $e->getMessage());
-            $this->assertEquals(400, $e->getStatusCode());
+            $this->assertSame('The csrf token is not valid, CSRF attack?', $e->getMessage());
+            $this->assertSame(400, $e->getStatusCode());
         }
     }
 
@@ -2724,7 +2724,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_delete_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
-        $this->assertEquals('list?', $result->getTargetUrl());
+        $this->assertSame('list?', $result->getTargetUrl());
     }
 
     public function testBatchActionWithoutConfirmation2()
@@ -2775,7 +2775,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_delete_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
-        $this->assertEquals('list?', $result->getTargetUrl());
+        $this->assertSame('list?', $result->getTargetUrl());
     }
 
     public function testBatchActionWithConfirmation()
@@ -2812,19 +2812,19 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->batchAction());
 
-        $this->assertEquals($this->admin, $this->parameters['admin']);
-        $this->assertEquals('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
-        $this->assertEquals($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
-        $this->assertEquals('list', $this->parameters['action']);
-        $this->assertEquals($datagrid, $this->parameters['datagrid']);
+        $this->assertSame('list', $this->parameters['action']);
+        $this->assertSame($datagrid, $this->parameters['datagrid']);
         $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
-        $this->assertEquals($data, $this->parameters['data']);
-        $this->assertEquals('csrf-token-123_sonata.batch', $this->parameters['csrf_token']);
-        $this->assertEquals('Foo Bar', $this->parameters['action_label']);
+        $this->assertSame($data, $this->parameters['data']);
+        $this->assertSame('csrf-token-123_sonata.batch', $this->parameters['csrf_token']);
+        $this->assertSame('Foo Bar', $this->parameters['action_label']);
 
-        $this->assertEquals(array(), $this->session->getFlashBag()->all());
-        $this->assertEquals('SonataAdminBundle:CRUD:batch_confirmation.html.twig', $this->template);
+        $this->assertSame(array(), $this->session->getFlashBag()->all());
+        $this->assertSame('SonataAdminBundle:CRUD:batch_confirmation.html.twig', $this->template);
     }
 
     public function testBatchActionNonRelevantAction()
@@ -2853,7 +2853,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_empty'), $this->session->getFlashBag()->get('sonata_flash_info'));
-        $this->assertEquals('list?', $result->getTargetUrl());
+        $this->assertSame('list?', $result->getTargetUrl());
     }
 
     public function testBatchActionNonRelevantAction2()
@@ -2882,7 +2882,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_foo_error'), $this->session->getFlashBag()->get('sonata_flash_info'));
-        $this->assertEquals('list?', $result->getTargetUrl());
+        $this->assertSame('list?', $result->getTargetUrl());
     }
 
     public function testBatchActionNoItems()
@@ -2908,7 +2908,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_empty'), $this->session->getFlashBag()->get('sonata_flash_info'));
-        $this->assertEquals('list?', $result->getTargetUrl());
+        $this->assertSame('list?', $result->getTargetUrl());
     }
 
     public function testBatchActionNoItemsEmptyQuery()
@@ -2951,7 +2951,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $result = $controller->batchAction();
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $result);
-        $this->assertEquals('batchActionBar executed', $result->getContent());
+        $this->assertSame('batchActionBar executed', $result->getContent());
     }
 
     public function getCsrfProvider()

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -236,7 +236,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $response = $controller->getShortObjectDescriptionAction($request);
 
         $expected = '<a href="/ok/url" target="new">bar</a>';
-        $this->assertEquals($expected, $response->getContent());
+        $this->assertSame($expected, $response->getContent());
     }
 
     public function testsetObjectFieldValueAction()
@@ -279,7 +279,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $response = $controller->setObjectFieldValueAction($request);
 
-        $this->assertEquals('{"status":"OK","content":"\u003Cfoo \/\u003E"}', $response->getContent());
+        $this->assertSame('{"status":"OK","content":"\u003Cfoo \/\u003E"}', $response->getContent());
     }
 
     public function testappendFormFieldElementAction()
@@ -475,7 +475,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $response = $controller->setObjectFieldValueAction($request);
 
-        $this->assertEquals('{"status":"KO","message":"error1\nerror2"}', $response->getContent());
+        $this->assertSame('{"status":"KO","message":"error1\nerror2"}', $response->getContent());
     }
 
     /**

--- a/Tests/Datagrid/DatagridMapperTest.php
+++ b/Tests/Datagrid/DatagridMapperTest.php
@@ -87,9 +87,9 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
     {
         $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
 
-        $this->assertEquals($this->datagridMapper, $this->datagridMapper->add($fieldDescription, null, array('field_name' => 'fooFilterName')));
-        $this->assertEquals($this->datagridMapper, $this->datagridMapper->remove('fooName'));
-        $this->assertEquals($this->datagridMapper, $this->datagridMapper->reorder(array()));
+        $this->assertSame($this->datagridMapper, $this->datagridMapper->add($fieldDescription, null, array('field_name' => 'fooFilterName')));
+        $this->assertSame($this->datagridMapper, $this->datagridMapper->remove('fooName'));
+        $this->assertSame($this->datagridMapper, $this->datagridMapper->reorder(array()));
     }
 
     public function testGet()
@@ -102,12 +102,12 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
 
         $filter = $this->datagridMapper->get('foo.name');
         $this->assertInstanceOf('Sonata\AdminBundle\Filter\FilterInterface', $filter);
-        $this->assertEquals('foo.name', $filter->getName());
-        $this->assertEquals('foo__name', $filter->getFormName());
-        $this->assertEquals('text', $filter->getFieldType());
-        $this->assertEquals('fooLabel', $filter->getLabel());
-        $this->assertEquals(array('required' => false), $filter->getFieldOptions());
-        $this->assertEquals(array(
+        $this->assertSame('foo.name', $filter->getName());
+        $this->assertSame('foo__name', $filter->getFormName());
+        $this->assertSame('text', $filter->getFieldType());
+        $this->assertSame('fooLabel', $filter->getLabel());
+        $this->assertSame(array('required' => false), $filter->getFieldOptions());
+        $this->assertSame(array(
             'foo_default_option' => 'bar_default',
             'label'              => 'fooLabel',
             'field_name'         => 'fooFilterName',
@@ -126,19 +126,19 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
 
         $filter = $this->datagridMapper->get('fooName');
         $this->assertInstanceOf('Sonata\AdminBundle\Filter\FilterInterface', $filter);
-        $this->assertEquals('fooName', $filter->getName());
-        $this->assertEquals('fooName', $filter->getFormName());
-        $this->assertEquals('foo_field_type', $filter->getFieldType());
-        $this->assertEquals('fooLabel', $filter->getLabel());
-        $this->assertEquals(array('foo_field_option' => 'baz'), $filter->getFieldOptions());
-        $this->assertEquals(array(
+        $this->assertSame('fooName', $filter->getName());
+        $this->assertSame('fooName', $filter->getFormName());
+        $this->assertSame('foo_field_type', $filter->getFieldType());
+        $this->assertSame('fooLabel', $filter->getLabel());
+        $this->assertSame(array('foo_field_option' => 'baz'), $filter->getFieldOptions());
+        $this->assertSame(array(
             'foo_default_option' => 'bar_custom',
             'label'              => 'fooLabel',
             'field_name'         => 'fooFilterName',
+            'foo_filter_option'  => 'foo_filter_option_value',
             'field_options'      => array('foo_field_option' => 'baz'),
             'field_type'         => 'foo_field_type',
             'placeholder'        => 'short_object_description_placeholder',
-            'foo_filter_option'  => 'foo_filter_option_value',
             'link_parameters'    => array(),
         ), $filter->getOptions());
     }
@@ -152,7 +152,7 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
         $fieldDescription = $this->datagridMapper->get('fooName');
 
         $this->assertInstanceOf('Sonata\AdminBundle\Filter\FilterInterface', $fieldDescription);
-        $this->assertEquals('fooName', $fieldDescription->getName());
+        $this->assertSame('fooName', $fieldDescription->getName());
     }
 
     public function testAddRemove()
@@ -211,7 +211,7 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
         $this->datagridMapper->add($fieldDescription3, null, array('field_name' => 'fooFilterName3'));
         $this->datagridMapper->add($fieldDescription4, null, array('field_name' => 'fooFilterName4'));
 
-        $this->assertEquals(array(
+        $this->assertSame(array(
             'fooName1',
             'fooName2',
             'fooName3',
@@ -220,7 +220,7 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->datagridMapper->reorder(array('fooName3', 'fooName2', 'fooName1', 'fooName4'));
 
-        $this->assertEquals(array(
+        $this->assertSame(array(
             'fooName3',
             'fooName2',
             'fooName1',

--- a/Tests/Datagrid/DatagridTest.php
+++ b/Tests/Datagrid/DatagridTest.php
@@ -102,7 +102,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
     public function testGetPager()
     {
-        $this->assertEquals($this->pager, $this->datagrid->getPager());
+        $this->assertSame($this->pager, $this->datagrid->getPager());
     }
 
     public function testFilter()
@@ -119,7 +119,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($this->datagrid->hasFilter('foo'));
         $this->assertFalse($this->datagrid->hasFilter('nonexistent'));
-        $this->assertEquals($filter, $this->datagrid->getFilter('foo'));
+        $this->assertSame($filter, $this->datagrid->getFilter('foo'));
 
         $this->datagrid->removeFilter('foo');
 
@@ -128,7 +128,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
     public function testGetFilters()
     {
-        $this->assertEquals(array(), $this->datagrid->getFilters());
+        $this->assertSame(array(), $this->datagrid->getFilters());
 
         $filter1 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter1->expects($this->once())
@@ -149,16 +149,16 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
         $this->datagrid->addFilter($filter2);
         $this->datagrid->addFilter($filter3);
 
-        $this->assertEquals(array('foo' => $filter1, 'bar' => $filter2, 'baz' => $filter3), $this->datagrid->getFilters());
+        $this->assertSame(array('foo' => $filter1, 'bar' => $filter2, 'baz' => $filter3), $this->datagrid->getFilters());
 
         $this->datagrid->removeFilter('bar');
 
-        $this->assertEquals(array('foo' => $filter1, 'baz' => $filter3), $this->datagrid->getFilters());
+        $this->assertSame(array('foo' => $filter1, 'baz' => $filter3), $this->datagrid->getFilters());
     }
 
     public function testReorderFilters()
     {
-        $this->assertEquals(array(), $this->datagrid->getFilters());
+        $this->assertSame(array(), $this->datagrid->getFilters());
 
         $filter1 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter1->expects($this->once())
@@ -179,32 +179,32 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
         $this->datagrid->addFilter($filter2);
         $this->datagrid->addFilter($filter3);
 
-        $this->assertEquals(array('foo' => $filter1, 'bar' => $filter2, 'baz' => $filter3), $this->datagrid->getFilters());
-        $this->assertEquals(array('foo', 'bar', 'baz'), array_keys($this->datagrid->getFilters()));
+        $this->assertSame(array('foo' => $filter1, 'bar' => $filter2, 'baz' => $filter3), $this->datagrid->getFilters());
+        $this->assertSame(array('foo', 'bar', 'baz'), array_keys($this->datagrid->getFilters()));
 
         $this->datagrid->reorderFilters(array('bar', 'baz', 'foo'));
 
-        $this->assertEquals(array('bar' => $filter2, 'baz' => $filter3, 'foo' => $filter1), $this->datagrid->getFilters());
-        $this->assertEquals(array('bar', 'baz', 'foo'), array_keys($this->datagrid->getFilters()));
+        $this->assertSame(array('bar' => $filter2, 'baz' => $filter3, 'foo' => $filter1), $this->datagrid->getFilters());
+        $this->assertSame(array('bar', 'baz', 'foo'), array_keys($this->datagrid->getFilters()));
     }
 
     public function testGetValues()
     {
-        $this->assertEquals(array(), $this->datagrid->getValues());
+        $this->assertSame(array(), $this->datagrid->getValues());
 
         $this->datagrid->setValue('foo', 'bar', 'baz');
 
-        $this->assertEquals(array('foo' => array('type' => 'bar', 'value' => 'baz')), $this->datagrid->getValues());
+        $this->assertSame(array('foo' => array('type' => 'bar', 'value' => 'baz')), $this->datagrid->getValues());
     }
 
     public function testGetColumns()
     {
-        $this->assertEquals($this->columns, $this->datagrid->getColumns());
+        $this->assertSame($this->columns, $this->datagrid->getColumns());
     }
 
     public function testGetQuery()
     {
-        $this->assertEquals($this->query, $this->datagrid->getQuery());
+        $this->assertSame($this->query, $this->datagrid->getQuery());
     }
 
     public function testHasActiveFilters()
@@ -243,13 +243,13 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
     public function testGetResults()
     {
-        $this->assertEquals(null, $this->datagrid->getResults());
+        $this->assertSame(null, $this->datagrid->getResults());
 
         $this->pager->expects($this->once())
             ->method('getResults')
             ->will($this->returnValue(array('foo', 'bar')));
 
-        $this->assertEquals(array('foo', 'bar'), $this->datagrid->getResults());
+        $this->assertSame(array('foo', 'bar'), $this->datagrid->getResults());
     }
 
     public function testBuildPager()
@@ -288,11 +288,11 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->datagrid->buildPager();
 
-        $this->assertEquals(array('foo' => null, 'bar' => null), $this->datagrid->getValues());
+        $this->assertSame(array('foo' => null, 'bar' => null), $this->datagrid->getValues());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('fooFormName'));
-        $this->assertEquals(array('bar1' => 'baz1'), $this->formBuilder->get('fooFormName')->getOptions());
+        $this->assertSame(array('bar1' => 'baz1'), $this->formBuilder->get('fooFormName')->getOptions());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('barFormName'));
-        $this->assertEquals(array('bar2' => 'baz2'), $this->formBuilder->get('barFormName')->getOptions());
+        $this->assertSame(array('bar2' => 'baz2'), $this->formBuilder->get('barFormName')->getOptions());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_by'));
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_order'));
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_page'));
@@ -360,9 +360,9 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->datagrid->buildPager();
 
-        $this->assertEquals(array('_sort_by' => $sortBy, 'foo' => null), $this->datagrid->getValues());
+        $this->assertSame(array('_sort_by' => $sortBy, 'foo' => null), $this->datagrid->getValues());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('fooFormName'));
-        $this->assertEquals(array('bar' => 'baz'), $this->formBuilder->get('fooFormName')->getOptions());
+        $this->assertSame(array('bar' => 'baz'), $this->formBuilder->get('fooFormName')->getOptions());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_by'));
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_order'));
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_page'));
@@ -409,9 +409,14 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->datagrid->buildPager();
 
-        $this->assertEquals(array('_sort_by' => $sortBy, 'foo' => null, '_page' => 3, '_per_page' => 50), $this->datagrid->getValues());
+        $this->assertSame(array(
+            '_sort_by'  => $sortBy,
+            '_page'     => $page,
+            '_per_page' => $perPage,
+            'foo'       => null,
+        ), $this->datagrid->getValues());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('fooFormName'));
-        $this->assertEquals(array('bar' => 'baz'), $this->formBuilder->get('fooFormName')->getOptions());
+        $this->assertSame(array('bar' => 'baz'), $this->formBuilder->get('fooFormName')->getOptions());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_by'));
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_order'));
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_page'));
@@ -450,7 +455,10 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->datagrid->buildPager();
 
-        $this->assertEquals(array('_page' => array('type' => null, 'value' => 3), '_per_page' => array('type' => null, 'value' => 50)), $this->datagrid->getValues());
+        $this->assertSame(array(
+            '_per_page' => array('type' => null, 'value' => $perPage),
+            '_page'     => array('type' => null, 'value' => $page),
+        ), $this->datagrid->getValues());
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_by'));
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_order'));
         $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_page'));

--- a/Tests/Datagrid/ListMapperTest.php
+++ b/Tests/Datagrid/ListMapperTest.php
@@ -81,9 +81,9 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
     {
         $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
 
-        $this->assertEquals($this->listMapper, $this->listMapper->add($fieldDescription));
-        $this->assertEquals($this->listMapper, $this->listMapper->remove('fooName'));
-        $this->assertEquals($this->listMapper, $this->listMapper->reorder(array()));
+        $this->assertSame($this->listMapper, $this->listMapper->add($fieldDescription));
+        $this->assertSame($this->listMapper, $this->listMapper->remove('fooName'));
+        $this->assertSame($this->listMapper, $this->listMapper->reorder(array()));
     }
 
     public function testGet()
@@ -93,7 +93,7 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
         $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
 
         $this->listMapper->add($fieldDescription);
-        $this->assertEquals($fieldDescription, $this->listMapper->get('fooName'));
+        $this->assertSame($fieldDescription, $this->listMapper->get('fooName'));
     }
 
     public function testAddIdentifier()
@@ -115,8 +115,8 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
         $fieldDescription = $this->listMapper->get('fooName');
 
         $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
-        $this->assertEquals('fooName', $fieldDescription->getName());
-        $this->assertEquals('fooName', $fieldDescription->getOption('label'));
+        $this->assertSame('fooName', $fieldDescription->getName());
+        $this->assertSame('fooName', $fieldDescription->getOption('label'));
     }
 
     public function testAddViewInlineAction()
@@ -129,9 +129,9 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
         $fieldDescription = $this->listMapper->get('_action');
 
         $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
-        $this->assertEquals('_action', $fieldDescription->getName());
+        $this->assertSame('_action', $fieldDescription->getName());
         $this->assertCount(1, $fieldDescription->getOption('actions'));
-        $this->assertEquals(array('show' => array()), $fieldDescription->getOption('actions'));
+        $this->assertSame(array('show' => array()), $fieldDescription->getOption('actions'));
     }
 
     public function testAddRemove()
@@ -198,7 +198,7 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
         $this->listMapper->add($fieldDescription3);
         $this->listMapper->add($fieldDescription4);
 
-        $this->assertEquals(array(
+        $this->assertSame(array(
             'fooName1' => $fieldDescription1,
             'fooName2' => $fieldDescription2,
             'fooName3' => $fieldDescription3,
@@ -208,7 +208,7 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
         $this->listMapper->reorder(array('fooName3', 'fooName2', 'fooName1', 'fooName4'));
 
         // print_r is used to compare order of items in associative arrays
-        $this->assertEquals(print_r(array(
+        $this->assertSame(print_r(array(
             'fooName3' => $fieldDescription3,
             'fooName2' => $fieldDescription2,
             'fooName1' => $fieldDescription1,

--- a/Tests/Datagrid/PagerTest.php
+++ b/Tests/Datagrid/PagerTest.php
@@ -33,8 +33,8 @@ class PagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetMaxPerPage1($expectedMaxPerPage, $expectedPage, $maxPerPage, $page)
     {
-        $this->assertEquals(10, $this->pager->getMaxPerPage());
-        $this->assertEquals(1, $this->pager->getPage());
+        $this->assertSame(10, $this->pager->getMaxPerPage());
+        $this->assertSame(1, $this->pager->getPage());
 
         if ($page !== null) {
             $this->pager->setPage($page);
@@ -42,8 +42,8 @@ class PagerTest extends \PHPUnit_Framework_TestCase
 
         $this->pager->setMaxPerPage($maxPerPage);
 
-        $this->assertEquals($expectedPage, $this->pager->getPage());
-        $this->assertEquals($expectedMaxPerPage, $this->pager->getMaxPerPage());
+        $this->assertSame($expectedPage, $this->pager->getPage());
+        $this->assertSame($expectedMaxPerPage, $this->pager->getMaxPerPage());
     }
 
     public function getGetMaxPerPage1Tests()
@@ -62,77 +62,77 @@ class PagerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetMaxPerPage2()
     {
-        $this->assertEquals(10, $this->pager->getMaxPerPage());
-        $this->assertEquals(1, $this->pager->getPage());
+        $this->assertSame(10, $this->pager->getMaxPerPage());
+        $this->assertSame(1, $this->pager->getPage());
 
         $this->pager->setMaxPerPage(0);
         $this->pager->setPage(0);
 
-        $this->assertEquals(0, $this->pager->getMaxPerPage());
-        $this->assertEquals(0, $this->pager->getPage());
+        $this->assertSame(0, $this->pager->getMaxPerPage());
+        $this->assertSame(0, $this->pager->getPage());
 
         $this->pager->setMaxPerPage(12);
 
-        $this->assertEquals(12, $this->pager->getMaxPerPage());
-        $this->assertEquals(1, $this->pager->getPage());
+        $this->assertSame(12, $this->pager->getMaxPerPage());
+        $this->assertSame(1, $this->pager->getPage());
     }
 
     public function testGetMaxPerPage3()
     {
-        $this->assertEquals(10, $this->pager->getMaxPerPage());
-        $this->assertEquals(1, $this->pager->getPage());
+        $this->assertSame(10, $this->pager->getMaxPerPage());
+        $this->assertSame(1, $this->pager->getPage());
 
         $this->pager->setMaxPerPage(0);
 
-        $this->assertEquals(0, $this->pager->getMaxPerPage());
-        $this->assertEquals(0, $this->pager->getPage());
+        $this->assertSame(0, $this->pager->getMaxPerPage());
+        $this->assertSame(0, $this->pager->getPage());
 
         $this->pager->setMaxPerPage(-1);
 
-        $this->assertEquals(1, $this->pager->getMaxPerPage());
-        $this->assertEquals(1, $this->pager->getPage());
+        $this->assertSame(1, $this->pager->getMaxPerPage());
+        $this->assertSame(1, $this->pager->getPage());
     }
 
     public function testGetCurrentMaxLink()
     {
-        $this->assertEquals(1, $this->pager->getCurrentMaxLink());
+        $this->assertSame(1, $this->pager->getCurrentMaxLink());
 
         $this->pager->getLinks();
-        $this->assertEquals(1, $this->pager->getCurrentMaxLink());
+        $this->assertSame(1, $this->pager->getCurrentMaxLink());
 
         $this->callMethod($this->pager, 'setLastPage', array(20));
         $this->pager->getLinks(10);
-        $this->assertEquals(10, $this->pager->getCurrentMaxLink());
+        $this->assertSame(10, $this->pager->getCurrentMaxLink());
 
         $this->pager->setMaxPageLinks(5);
         $this->pager->setPage(2);
-        $this->assertEquals(10, $this->pager->getCurrentMaxLink());
+        $this->assertSame(10, $this->pager->getCurrentMaxLink());
     }
 
     public function testGetMaxRecordLimit()
     {
-        $this->assertEquals(false, $this->pager->getMaxRecordLimit());
+        $this->assertSame(false, $this->pager->getMaxRecordLimit());
 
         $this->pager->setMaxRecordLimit(99);
-        $this->assertEquals(99, $this->pager->getMaxRecordLimit());
+        $this->assertSame(99, $this->pager->getMaxRecordLimit());
     }
 
     public function testGetNbResults()
     {
-        $this->assertEquals(0, $this->pager->getNbResults());
+        $this->assertSame(0, $this->pager->getNbResults());
 
         $this->callMethod($this->pager, 'setNbResults', array(100));
 
-        $this->assertEquals(100, $this->pager->getNbResults());
+        $this->assertSame(100, $this->pager->getNbResults());
     }
 
     public function testCount()
     {
-        $this->assertEquals(0, $this->pager->count());
+        $this->assertSame(0, $this->pager->count());
 
         $this->callMethod($this->pager, 'setNbResults', array(100));
 
-        $this->assertEquals(100, $this->pager->count());
+        $this->assertSame(100, $this->pager->count());
     }
 
     public function testGetQuery()
@@ -140,52 +140,52 @@ class PagerTest extends \PHPUnit_Framework_TestCase
         $query = $this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
 
         $this->pager->setQuery($query);
-        $this->assertEquals($query, $this->pager->getQuery());
+        $this->assertSame($query, $this->pager->getQuery());
     }
 
     public function testGetCountColumn()
     {
-        $this->assertEquals(array('id'), $this->pager->getCountColumn());
+        $this->assertSame(array('id'), $this->pager->getCountColumn());
 
         $this->pager->setCountColumn(array('foo'));
-        $this->assertEquals(array('foo'), $this->pager->getCountColumn());
+        $this->assertSame(array('foo'), $this->pager->getCountColumn());
     }
 
     public function testParameters()
     {
-        $this->assertEquals(null, $this->pager->getParameter('foo', null));
-        $this->assertEquals('bar', $this->pager->getParameter('foo', 'bar'));
+        $this->assertSame(null, $this->pager->getParameter('foo', null));
+        $this->assertSame('bar', $this->pager->getParameter('foo', 'bar'));
         $this->assertFalse($this->pager->hasParameter('foo'));
-        $this->assertEquals(array(), $this->pager->getParameters());
+        $this->assertSame(array(), $this->pager->getParameters());
 
         $this->pager->setParameter('foo', 'foo_value');
 
         $this->assertTrue($this->pager->hasParameter('foo'));
-        $this->assertEquals('foo_value', $this->pager->getParameter('foo', null));
-        $this->assertEquals('foo_value', $this->pager->getParameter('foo', 'bar'));
-        $this->assertEquals(array('foo' => 'foo_value'), $this->pager->getParameters());
+        $this->assertSame('foo_value', $this->pager->getParameter('foo', null));
+        $this->assertSame('foo_value', $this->pager->getParameter('foo', 'bar'));
+        $this->assertSame(array('foo' => 'foo_value'), $this->pager->getParameters());
 
         $this->pager->setParameter('foo', 'baz');
 
         $this->assertTrue($this->pager->hasParameter('foo'));
-        $this->assertEquals('baz', $this->pager->getParameter('foo', null));
-        $this->assertEquals('baz', $this->pager->getParameter('foo', 'bar'));
-        $this->assertEquals(array('foo' => 'baz'), $this->pager->getParameters());
+        $this->assertSame('baz', $this->pager->getParameter('foo', null));
+        $this->assertSame('baz', $this->pager->getParameter('foo', 'bar'));
+        $this->assertSame(array('foo' => 'baz'), $this->pager->getParameters());
 
         $this->pager->setParameter('foo2', 'foo2_value');
 
         $this->assertTrue($this->pager->hasParameter('foo2'));
-        $this->assertEquals('foo2_value', $this->pager->getParameter('foo2', null));
-        $this->assertEquals('foo2_value', $this->pager->getParameter('foo2', 'bar'));
-        $this->assertEquals(array('foo'  => 'baz', 'foo2' => 'foo2_value'), $this->pager->getParameters());
+        $this->assertSame('foo2_value', $this->pager->getParameter('foo2', null));
+        $this->assertSame('foo2_value', $this->pager->getParameter('foo2', 'bar'));
+        $this->assertSame(array('foo'  => 'baz', 'foo2' => 'foo2_value'), $this->pager->getParameters());
     }
 
     public function testGetMaxPageLinks()
     {
-        $this->assertEquals(0, $this->pager->getMaxPageLinks());
+        $this->assertSame(0, $this->pager->getMaxPageLinks());
 
         $this->pager->setMaxPageLinks(123);
-        $this->assertEquals(123, $this->pager->getMaxPageLinks());
+        $this->assertSame(123, $this->pager->getMaxPageLinks());
     }
 
     public function testIsFirstPage()
@@ -199,51 +199,51 @@ class PagerTest extends \PHPUnit_Framework_TestCase
     public function testIsLastPage()
     {
         $this->assertTrue($this->pager->isLastPage());
-        $this->assertEquals(1, $this->pager->getLastPage());
+        $this->assertSame(1, $this->pager->getLastPage());
 
         $this->pager->setPage(10);
         $this->callMethod($this->pager, 'setLastPage', array(50));
-        $this->assertEquals(50, $this->pager->getLastPage());
+        $this->assertSame(50, $this->pager->getLastPage());
         $this->assertFalse($this->pager->isLastPage());
 
         $this->pager->setPage(50);
         $this->assertTrue($this->pager->isLastPage());
 
         $this->callMethod($this->pager, 'setLastPage', array(20));
-        $this->assertEquals(20, $this->pager->getPage());
-        $this->assertEquals(20, $this->pager->getLastPage());
+        $this->assertSame(20, $this->pager->getPage());
+        $this->assertSame(20, $this->pager->getLastPage());
         $this->assertTrue($this->pager->isLastPage());
     }
 
     public function testGetLinks()
     {
-        $this->assertEquals(array(), $this->pager->getLinks());
+        $this->assertSame(array(), $this->pager->getLinks());
 
         $this->pager->setPage(1);
         $this->pager->setMaxPageLinks(1);
-        $this->assertEquals(array(1), $this->pager->getLinks());
-        $this->assertEquals(array(1), $this->pager->getLinks(10));
+        $this->assertSame(array(1), $this->pager->getLinks());
+        $this->assertSame(array(1), $this->pager->getLinks(10));
 
         $this->pager->setPage(1);
         $this->pager->setMaxPageLinks(7);
         $this->callMethod($this->pager, 'setLastPage', array(50));
-        $this->assertEquals(7, count($this->pager->getLinks()));
-        $this->assertEquals(array(1, 2, 3, 4, 5, 6, 7), $this->pager->getLinks());
+        $this->assertSame(7, count($this->pager->getLinks()));
+        $this->assertSame(array(1, 2, 3, 4, 5, 6, 7), $this->pager->getLinks());
 
         $this->pager->setPage(10);
         $this->pager->setMaxPageLinks(12);
-        $this->assertEquals(5, count($this->pager->getLinks(5)));
-        $this->assertEquals(array(8, 9, 10, 11, 12), $this->pager->getLinks(5));
+        $this->assertSame(5, count($this->pager->getLinks(5)));
+        $this->assertSame(array(8, 9, 10, 11, 12), $this->pager->getLinks(5));
 
         $this->pager->setPage(10);
         $this->pager->setMaxPageLinks(6);
-        $this->assertEquals(6, count($this->pager->getLinks()));
-        $this->assertEquals(array(7, 8, 9, 10, 11, 12), $this->pager->getLinks());
+        $this->assertSame(6, count($this->pager->getLinks()));
+        $this->assertSame(array(7, 8, 9, 10, 11, 12), $this->pager->getLinks());
 
         $this->pager->setPage(50);
         $this->pager->setMaxPageLinks(6);
-        $this->assertEquals(6, count($this->pager->getLinks()));
-        $this->assertEquals(array(45, 46, 47, 48, 49, 50), $this->pager->getLinks());
+        $this->assertSame(6, count($this->pager->getLinks()));
+        $this->assertSame(array(45, 46, 47, 48, 49, 50), $this->pager->getLinks());
     }
 
     public function testHaveToPaginate()
@@ -283,9 +283,9 @@ class PagerTest extends \PHPUnit_Framework_TestCase
             ++$counter;
         }
 
-        $this->assertEquals(3, $counter);
-        $this->assertEquals($object3, $value);
-        $this->assertEquals($expectedObjects, $values);
+        $this->assertSame(3, $counter);
+        $this->assertSame($object3, $value);
+        $this->assertSame($expectedObjects, $values);
 
         $this->assertFalse($this->pager->valid());
 
@@ -313,7 +313,7 @@ class PagerTest extends \PHPUnit_Framework_TestCase
             ->method('getResults')
             ->will($this->returnValue(array(123 => new \stdClass())));
 
-        $this->assertEquals(123, $this->pager->key());
+        $this->assertSame(123, $this->pager->key());
     }
 
     public function testCurrent()
@@ -324,26 +324,26 @@ class PagerTest extends \PHPUnit_Framework_TestCase
             ->method('getResults')
             ->will($this->returnValue(array($object)));
 
-        $this->assertEquals($object, $this->pager->current());
+        $this->assertSame($object, $this->pager->current());
     }
 
     public function testGetCursor()
     {
-        $this->assertEquals(1, $this->pager->getCursor());
+        $this->assertSame(1, $this->pager->getCursor());
 
         $this->pager->setCursor(0);
-        $this->assertEquals(1, $this->pager->getCursor());
+        $this->assertSame(1, $this->pager->getCursor());
 
         $this->pager->setCursor(300);
-        $this->assertEquals(0, $this->pager->getCursor());
+        $this->assertSame(0, $this->pager->getCursor());
 
         $this->callMethod($this->pager, 'setNbResults', array(100));
 
         $this->pager->setCursor(5);
-        $this->assertEquals(5, $this->pager->getCursor());
+        $this->assertSame(5, $this->pager->getCursor());
 
         $this->pager->setCursor(300);
-        $this->assertEquals(100, $this->pager->getCursor());
+        $this->assertSame(100, $this->pager->getCursor());
     }
 
     public function testGetObjectByCursor()
@@ -392,92 +392,92 @@ class PagerTest extends \PHPUnit_Framework_TestCase
 
         $this->pager->setQuery($query);
 
-        $this->assertEquals($object1, $this->pager->getObjectByCursor(1));
-        $this->assertEquals(1, $this->pager->getCursor());
+        $this->assertSame($object1, $this->pager->getObjectByCursor(1));
+        $this->assertSame(1, $this->pager->getCursor());
 
         $id = 1;
-        $this->assertEquals($object2, $this->pager->getObjectByCursor(2));
-        $this->assertEquals(2, $this->pager->getCursor());
+        $this->assertSame($object2, $this->pager->getObjectByCursor(2));
+        $this->assertSame(2, $this->pager->getCursor());
 
         $id = 2;
-        $this->assertEquals($object3, $this->pager->getObjectByCursor(3));
-        $this->assertEquals(3, $this->pager->getCursor());
+        $this->assertSame($object3, $this->pager->getObjectByCursor(3));
+        $this->assertSame(3, $this->pager->getCursor());
 
         $id = 3;
-        $this->assertEquals(null, $this->pager->getObjectByCursor(4));
-        $this->assertEquals(3, $this->pager->getCursor());
+        $this->assertSame(null, $this->pager->getObjectByCursor(4));
+        $this->assertSame(3, $this->pager->getCursor());
     }
 
     public function testGetFirstPage()
     {
-        $this->assertEquals(1, $this->pager->getFirstPage());
+        $this->assertSame(1, $this->pager->getFirstPage());
     }
 
     public function testGetNextPage()
     {
-        $this->assertEquals(1, $this->pager->getNextPage());
+        $this->assertSame(1, $this->pager->getNextPage());
 
         $this->pager->setPage(3);
         $this->callMethod($this->pager, 'setLastPage', array(20));
-        $this->assertEquals(4, $this->pager->getNextPage());
+        $this->assertSame(4, $this->pager->getNextPage());
 
         $this->pager->setPage(21);
-        $this->assertEquals(20, $this->pager->getNextPage());
+        $this->assertSame(20, $this->pager->getNextPage());
     }
 
     public function testGetPreviousPage()
     {
-        $this->assertEquals(1, $this->pager->getPreviousPage());
+        $this->assertSame(1, $this->pager->getPreviousPage());
 
         $this->pager->setPage(3);
-        $this->assertEquals(2, $this->pager->getPreviousPage());
+        $this->assertSame(2, $this->pager->getPreviousPage());
 
         $this->pager->setPage(21);
-        $this->assertEquals(20, $this->pager->getPreviousPage());
+        $this->assertSame(20, $this->pager->getPreviousPage());
     }
 
     public function testGetFirstIndice()
     {
-        $this->assertEquals(1, $this->pager->getFirstIndice());
+        $this->assertSame(1, $this->pager->getFirstIndice());
 
         $this->pager->setMaxPerPage(0);
         $this->pager->setPage(0);
-        $this->assertEquals(1, $this->pager->getFirstIndice());
+        $this->assertSame(1, $this->pager->getFirstIndice());
 
         $this->pager->setPage(2);
         $this->pager->setMaxPerPage(10);
-        $this->assertEquals(11, $this->pager->getFirstIndice());
+        $this->assertSame(11, $this->pager->getFirstIndice());
 
         $this->pager->setPage(4);
         $this->pager->setMaxPerPage(7);
-        $this->assertEquals(22, $this->pager->getFirstIndice());
+        $this->assertSame(22, $this->pager->getFirstIndice());
     }
 
     public function testGetLastIndice()
     {
-        $this->assertEquals(0, $this->pager->getLastIndice());
+        $this->assertSame(0, $this->pager->getLastIndice());
 
         $this->pager->setMaxPerPage(0);
         $this->pager->setPage(0);
-        $this->assertEquals(0, $this->pager->getLastIndice());
+        $this->assertSame(0, $this->pager->getLastIndice());
 
         $this->callMethod($this->pager, 'setNbResults', array(100));
 
-        $this->assertEquals(100, $this->pager->getLastIndice());
+        $this->assertSame(100, $this->pager->getLastIndice());
 
         $this->pager->setPage(2);
-        $this->assertEquals(0, $this->pager->getLastIndice());
+        $this->assertSame(0, $this->pager->getLastIndice());
 
         $this->pager->setMaxPerPage(10);
-        $this->assertEquals(20, $this->pager->getLastIndice());
+        $this->assertSame(20, $this->pager->getLastIndice());
 
         $this->pager->setPage(11);
-        $this->assertEquals(100, $this->pager->getLastIndice());
+        $this->assertSame(100, $this->pager->getLastIndice());
     }
 
     public function testGetNext()
     {
-        $this->assertEquals(null, $this->pager->getNext());
+        $this->assertSame(null, $this->pager->getNext());
 
         $object1 = new \stdClass();
         $object1->foo = 'bar1';
@@ -524,21 +524,21 @@ class PagerTest extends \PHPUnit_Framework_TestCase
         $this->pager->setQuery($query);
 
         $this->pager->setCursor(1);
-        $this->assertEquals($object1, $this->pager->getCurrent());
+        $this->assertSame($object1, $this->pager->getCurrent());
 
         ++$id;
-        $this->assertEquals($object2, $this->pager->getNext());
+        $this->assertSame($object2, $this->pager->getNext());
 
         ++$id;
-        $this->assertEquals($object3, $this->pager->getNext());
+        $this->assertSame($object3, $this->pager->getNext());
 
         ++$id;
-        $this->assertEquals(null, $this->pager->getNext());
+        $this->assertSame(null, $this->pager->getNext());
     }
 
     public function testGetPrevious()
     {
-        $this->assertEquals(null, $this->pager->getPrevious());
+        $this->assertSame(null, $this->pager->getPrevious());
 
         $object1 = new \stdClass();
         $object1->foo = 'bar1';
@@ -585,16 +585,16 @@ class PagerTest extends \PHPUnit_Framework_TestCase
         $this->pager->setQuery($query);
 
         $this->pager->setCursor(2);
-        $this->assertEquals($object3, $this->pager->getCurrent());
+        $this->assertSame($object3, $this->pager->getCurrent());
 
         --$id;
-        $this->assertEquals($object2, $this->pager->getPrevious());
+        $this->assertSame($object2, $this->pager->getPrevious());
 
         --$id;
-        $this->assertEquals($object1, $this->pager->getPrevious());
+        $this->assertSame($object1, $this->pager->getPrevious());
 
         --$id;
-        $this->assertEquals(null, $this->pager->getPrevious());
+        $this->assertSame(null, $this->pager->getPrevious());
     }
 
     public function testSerialize()
@@ -608,7 +608,9 @@ class PagerTest extends \PHPUnit_Framework_TestCase
         $this->pager->setMaxPageLinks(6);
 
         $this->pager->unserialize($data);
-        $this->assertEquals($pagerClone, $this->pager);
+        $this->assertSame($pagerClone->getPage(), $this->pager->getPage());
+        $this->assertSame($pagerClone->getMaxPerPage(), $this->pager->getMaxPerPage());
+        $this->assertSame($pagerClone->getMaxPageLinks(), $this->pager->getMaxPageLinks());
     }
 
     public function testUnserialize()
@@ -633,17 +635,17 @@ class PagerTest extends \PHPUnit_Framework_TestCase
 
         $this->pager->unserialize(serialize($serialized));
 
-        $this->assertEquals(7, $this->pager->getMaxPerPage());
-        $this->assertEquals(6, $this->pager->getPage());
-        $this->assertEquals(5, $this->pager->getMaxPageLinks());
-        $this->assertEquals(4, $this->pager->getLastPage());
-        $this->assertEquals(array('idx'), $this->pager->getCountColumn());
-        $this->assertEquals(30, $this->pager->getNbResults());
-        $this->assertEquals(3, $this->pager->getCursor());
-        $this->assertEquals(array('foo' => 'bar'), $this->pager->getParameters());
-        $this->assertEquals(2, $this->pager->getCurrentMaxLink());
-        $this->assertEquals(22, $this->pager->getMaxRecordLimit());
-        $this->assertEquals(null, $this->pager->getQuery());
+        $this->assertSame(7, $this->pager->getMaxPerPage());
+        $this->assertSame(6, $this->pager->getPage());
+        $this->assertSame(5, $this->pager->getMaxPageLinks());
+        $this->assertSame(4, $this->pager->getLastPage());
+        $this->assertSame(array('idx'), $this->pager->getCountColumn());
+        $this->assertSame(30, $this->pager->getNbResults());
+        $this->assertSame(3, $this->pager->getCursor());
+        $this->assertSame(array('foo' => 'bar'), $this->pager->getParameters());
+        $this->assertSame(2, $this->pager->getCurrentMaxLink());
+        $this->assertSame(22, $this->pager->getMaxRecordLimit());
+        $this->assertSame(null, $this->pager->getQuery());
     }
 
     protected function callMethod($obj, $name, array $args = array())

--- a/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -58,8 +58,8 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('item_adds', $dashboardGroupsSettings['sonata_group_one']);
         $this->assertArrayHasKey('roles', $dashboardGroupsSettings['sonata_group_one']);
 
-        $this->assertEquals('Group One Label', $dashboardGroupsSettings['sonata_group_one']['label']);
-        $this->assertEquals('SonataAdminBundle', $dashboardGroupsSettings['sonata_group_one']['label_catalogue']);
+        $this->assertSame('Group One Label', $dashboardGroupsSettings['sonata_group_one']['label']);
+        $this->assertSame('SonataAdminBundle', $dashboardGroupsSettings['sonata_group_one']['label_catalogue']);
         $this->assertContains('sonata_post_admin', $dashboardGroupsSettings['sonata_group_one']['items']);
         $this->assertContains('sonata_news_admin', $dashboardGroupsSettings['sonata_group_one']['item_adds']);
         $this->assertContains('ROLE_ONE', $dashboardGroupsSettings['sonata_group_one']['roles']);
@@ -97,8 +97,8 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('items', $adminGroups['sonata_group_one']);
         $this->assertArrayHasKey('item_adds', $adminGroups['sonata_group_one']);
         $this->assertArrayHasKey('roles', $adminGroups['sonata_group_one']);
-        $this->assertEquals('Group One Label', $adminGroups['sonata_group_one']['label']);
-        $this->assertEquals('SonataAdminBundle', $adminGroups['sonata_group_one']['label_catalogue']);
+        $this->assertSame('Group One Label', $adminGroups['sonata_group_one']['label']);
+        $this->assertSame('SonataAdminBundle', $adminGroups['sonata_group_one']['label_catalogue']);
         $this->assertContains('sonata_post_admin', $adminGroups['sonata_group_one']['items']);
         $this->assertContains('sonata_news_admin', $adminGroups['sonata_group_one']['items']);
         $this->assertContains('sonata_news_admin', $adminGroups['sonata_group_one']['item_adds']);

--- a/Tests/Event/ConfigureEventTest.php
+++ b/Tests/Event/ConfigureEventTest.php
@@ -44,7 +44,7 @@ class ConfigureEventTest extends \PHPUnit_Framework_TestCase
 
     public function testGetType()
     {
-        $this->assertEquals('Foo', $this->event->getType());
+        $this->assertSame('Foo', $this->event->getType());
     }
 
     public function testGetAdmin()
@@ -52,7 +52,7 @@ class ConfigureEventTest extends \PHPUnit_Framework_TestCase
         $result = $this->event->getAdmin();
 
         $this->assertInstanceOf('Sonata\AdminBundle\Admin\AdminInterface', $result);
-        $this->assertEquals($this->admin, $result);
+        $this->assertSame($this->admin, $result);
     }
 
     public function testGetMapper()
@@ -60,6 +60,6 @@ class ConfigureEventTest extends \PHPUnit_Framework_TestCase
         $result = $this->event->getMapper();
 
         $this->assertInstanceOf('Sonata\AdminBundle\Mapper\BaseMapper', $result);
-        $this->assertEquals($this->mapper, $result);
+        $this->assertSame($this->mapper, $result);
     }
 }

--- a/Tests/Event/ConfigureQueryEventTest.php
+++ b/Tests/Event/ConfigureQueryEventTest.php
@@ -42,7 +42,7 @@ class ConfigureQueryEventTest extends \PHPUnit_Framework_TestCase
 
     public function testGetContext()
     {
-        $this->assertEquals('Foo', $this->event->getContext());
+        $this->assertSame('Foo', $this->event->getContext());
     }
 
     public function testGetAdmin()
@@ -50,7 +50,7 @@ class ConfigureQueryEventTest extends \PHPUnit_Framework_TestCase
         $result = $this->event->getAdmin();
 
         $this->assertInstanceOf('Sonata\AdminBundle\Admin\AdminInterface', $result);
-        $this->assertEquals($this->admin, $result);
+        $this->assertSame($this->admin, $result);
     }
 
     public function testGetProxyQuery()
@@ -58,6 +58,6 @@ class ConfigureQueryEventTest extends \PHPUnit_Framework_TestCase
         $result = $this->event->getProxyQuery();
 
         $this->assertInstanceOf('Sonata\AdminBundle\Datagrid\ProxyQueryInterface', $result);
-        $this->assertEquals($this->proxyQuery, $result);
+        $this->assertSame($this->proxyQuery, $result);
     }
 }

--- a/Tests/Event/PersistenceEventTest.php
+++ b/Tests/Event/PersistenceEventTest.php
@@ -41,7 +41,7 @@ class PersistenceEventTest extends \PHPUnit_Framework_TestCase
 
     public function testGetType()
     {
-        $this->assertEquals('Foo', $this->event->getType());
+        $this->assertSame('Foo', $this->event->getType());
     }
 
     public function testGetAdmin()
@@ -49,11 +49,11 @@ class PersistenceEventTest extends \PHPUnit_Framework_TestCase
         $result = $this->event->getAdmin();
 
         $this->assertInstanceOf('Sonata\AdminBundle\Admin\AdminInterface', $result);
-        $this->assertEquals($this->admin, $result);
+        $this->assertSame($this->admin, $result);
     }
 
     public function testGetObject()
     {
-        $this->assertEquals($this->object, $this->event->getObject());
+        $this->assertSame($this->object, $this->event->getObject());
     }
 }

--- a/Tests/Export/ExporterTest.php
+++ b/Tests/Export/ExporterTest.php
@@ -40,7 +40,7 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
         $response = $exporter->getResponse($format, $filename, $source);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
-        $this->assertEquals($contentType, $response->headers->get('Content-Type'));
+        $this->assertSame($contentType, $response->headers->get('Content-Type'));
         // Quotes does not appear on some sonata versions.
         $this->assertRegExp('/attachment; filename="?'.$filename.'"?/', $response->headers->get('Content-Disposition'));
     }

--- a/Tests/Filter/FilterTest.php
+++ b/Tests/Filter/FilterTest.php
@@ -19,8 +19,8 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FooFilter();
 
-        $this->assertEquals('text', $filter->getFieldType());
-        $this->assertEquals(array('required' => false), $filter->getFieldOptions());
+        $this->assertSame('text', $filter->getFieldType());
+        $this->assertSame(array('required' => false), $filter->getFieldOptions());
         $this->assertNull($filter->getLabel());
 
         $options = array(
@@ -32,22 +32,21 @@ class FilterTest extends \PHPUnit_Framework_TestCase
 
         $filter->setOptions($options);
 
-        $this->assertEquals('foo', $filter->getOption('label'));
-        $this->assertEquals('foo', $filter->getLabel());
+        $this->assertSame('foo', $filter->getOption('label'));
+        $this->assertSame('foo', $filter->getLabel());
 
-        $expected = $options;
-        $expected['foo'] = 'bar';
+        $expected = array_merge(array('foo' => 'bar'), $options);
 
-        $this->assertEquals($expected, $filter->getOptions());
-        $this->assertEquals('name', $filter->getFieldName());
+        $this->assertSame($expected, $filter->getOptions());
+        $this->assertSame('name', $filter->getFieldName());
 
-        $this->assertEquals('default', $filter->getOption('fake', 'default'));
+        $this->assertSame('default', $filter->getOption('fake', 'default'));
 
         $filter->setValue(42);
-        $this->assertEquals(42, $filter->getValue());
+        $this->assertSame(42, $filter->getValue());
 
         $filter->setCondition('>');
-        $this->assertEquals('>', $filter->getCondition());
+        $this->assertSame('>', $filter->getCondition());
     }
 
     public function testInitialize()
@@ -57,9 +56,9 @@ class FilterTest extends \PHPUnit_Framework_TestCase
             'field_name' => 'bar',
         ));
 
-        $this->assertEquals('name', $filter->getName());
-        $this->assertEquals('bar', $filter->getOption('field_name'));
-        $this->assertEquals('bar', $filter->getFieldName());
+        $this->assertSame('name', $filter->getName());
+        $this->assertSame('bar', $filter->getOption('field_name'));
+        $this->assertSame('bar', $filter->getFieldName());
     }
 
     public function testLabel()
@@ -67,7 +66,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
         $filter = new FooFilter();
         $filter->setLabel('foo');
 
-        $this->assertEquals('foo', $filter->getLabel());
+        $this->assertSame('foo', $filter->getLabel());
     }
 
     /**
@@ -91,7 +90,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
         $filter = new FooFilter();
         $filter->setValue($value);
 
-        $this->assertEquals($expected, $filter->isActive());
+        $this->assertSame($expected, $filter->isActive());
     }
 
     public function isActiveData()
@@ -108,9 +107,9 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     public function testGetTranslationDomain()
     {
         $filter = new FooFilter();
-        $this->assertEquals(null, $filter->getTranslationDomain());
+        $this->assertSame(null, $filter->getTranslationDomain());
         $filter->setOption('translation_domain', 'baz');
-        $this->assertEquals('baz', $filter->getTranslationDomain());
+        $this->assertSame('baz', $filter->getTranslationDomain());
     }
 
     public function testGetFieldMappingException()
@@ -143,7 +142,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
 
         $filter = new FooFilter();
         $filter->setOption('field_mapping', $fieldMapping);
-        $this->assertEquals($fieldMapping, $filter->getFieldMapping());
+        $this->assertSame($fieldMapping, $filter->getFieldMapping());
     }
 
     public function testGetParentAssociationMappings()
@@ -163,9 +162,9 @@ class FilterTest extends \PHPUnit_Framework_TestCase
         );
 
         $filter = new FooFilter();
-        $this->assertEquals(array(), $filter->getParentAssociationMappings());
+        $this->assertSame(array(), $filter->getParentAssociationMappings());
         $filter->setOption('parent_association_mappings', $parentAssociationMapping);
-        $this->assertEquals($parentAssociationMapping, $filter->getParentAssociationMappings());
+        $this->assertSame($parentAssociationMapping, $filter->getParentAssociationMappings());
     }
 
     public function testGetAssociationMappingException()
@@ -200,6 +199,6 @@ class FilterTest extends \PHPUnit_Framework_TestCase
 
         $filter = new FooFilter();
         $filter->setOption('association_mapping', $associationMapping);
-        $this->assertEquals($associationMapping, $filter->getAssociationMapping());
+        $this->assertSame($associationMapping, $filter->getAssociationMapping());
     }
 }

--- a/Tests/Form/DataTransformer/ArrayToModelTransformerTest.php
+++ b/Tests/Form/DataTransformer/ArrayToModelTransformerTest.php
@@ -31,7 +31,7 @@ class ArrayToModelTransformerTest extends \PHPUnit_Framework_TestCase
         $transformer = new ArrayToModelTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity');
 
         $entity = new FooEntity();
-        $this->assertEquals($entity, $transformer->reverseTransform($entity));
+        $this->assertSame($entity, $transformer->reverseTransform($entity));
     }
 
     /**
@@ -68,7 +68,7 @@ class ArrayToModelTransformerTest extends \PHPUnit_Framework_TestCase
     {
         $transformer = new ArrayToModelTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity');
 
-        $this->assertEquals($expected, $transformer->transform($value));
+        $this->assertSame($expected, $transformer->transform($value));
     }
 
     public function getTransformTests()

--- a/Tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
@@ -41,7 +41,7 @@ class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($transformer->reverseTransform(null));
         $this->assertNull($transformer->reverseTransform(false));
         $this->assertNull($transformer->reverseTransform(12));
-        $this->assertEquals($entity, $transformer->reverseTransform(array('identifiers' => array(123), 'titles' => array('example'))));
+        $this->assertSame($entity, $transformer->reverseTransform(array('identifiers' => array(123), 'titles' => array('example'))));
     }
 
     /**
@@ -83,7 +83,7 @@ class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
 
         $result = $transformer->reverseTransform($params);
         $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $result);
-        $this->assertEquals($expected, $result->getValues());
+        $this->assertSame($expected, $result->getValues());
     }
 
     public function getReverseTransformMultipleTests()
@@ -121,12 +121,12 @@ class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
 
         $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', false);
 
-        $this->assertEquals(array('identifiers' => array(), 'labels' => array()), $transformer->transform(null));
-        $this->assertEquals(array('identifiers' => array(), 'labels' => array()), $transformer->transform(false));
-        $this->assertEquals(array('identifiers' => array(), 'labels' => array()), $transformer->transform(0));
-        $this->assertEquals(array('identifiers' => array(), 'labels' => array()), $transformer->transform('0'));
+        $this->assertSame(array('identifiers' => array(), 'labels' => array()), $transformer->transform(null));
+        $this->assertSame(array('identifiers' => array(), 'labels' => array()), $transformer->transform(false));
+        $this->assertSame(array('identifiers' => array(), 'labels' => array()), $transformer->transform(0));
+        $this->assertSame(array('identifiers' => array(), 'labels' => array()), $transformer->transform('0'));
 
-        $this->assertEquals(array('identifiers' => array(123), 'labels' => array('example')), $transformer->transform($entity));
+        $this->assertSame(array('identifiers' => array(123), 'labels' => array('example')), $transformer->transform($entity));
     }
 
     public function testTransformWorksWithArrayAccessEntity()
@@ -140,7 +140,7 @@ class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
 
         $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\FooArrayAccess', 'bar', false);
 
-        $this->assertEquals(array('identifiers' => array(123), 'labels' => array('example')), $transformer->transform($entity));
+        $this->assertSame(array('identifiers' => array(123), 'labels' => array('example')), $transformer->transform($entity));
     }
 
     public function testTransformToStringCallback()
@@ -157,7 +157,7 @@ class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
             return $entity->getBaz();
         });
 
-        $this->assertEquals(array('identifiers' => array(123), 'labels' => array('bazz')), $transformer->transform($entity));
+        $this->assertSame(array('identifiers' => array(123), 'labels' => array('bazz')), $transformer->transform($entity));
     }
 
     /**
@@ -215,12 +215,12 @@ class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
 
         $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', true);
 
-        $this->assertEquals(array('identifiers' => array(), 'labels' => array()), $transformer->transform(null));
-        $this->assertEquals(array('identifiers' => array(), 'labels' => array()), $transformer->transform(false));
-        $this->assertEquals(array('identifiers' => array(), 'labels' => array()), $transformer->transform(0));
-        $this->assertEquals(array('identifiers' => array(), 'labels' => array()), $transformer->transform('0'));
+        $this->assertSame(array('identifiers' => array(), 'labels' => array()), $transformer->transform(null));
+        $this->assertSame(array('identifiers' => array(), 'labels' => array()), $transformer->transform(false));
+        $this->assertSame(array('identifiers' => array(), 'labels' => array()), $transformer->transform(0));
+        $this->assertSame(array('identifiers' => array(), 'labels' => array()), $transformer->transform('0'));
 
-        $this->assertEquals(array('identifiers' => array(123, 456, 789), 'labels' => array('foo', 'bar', 'baz')), $transformer->transform($collection));
+        $this->assertSame(array('identifiers' => array(123, 456, 789), 'labels' => array('foo', 'bar', 'baz')), $transformer->transform($collection));
     }
 
     /**

--- a/Tests/Form/DataTransformer/ModelToIdTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelToIdTransformerTest.php
@@ -55,14 +55,14 @@ class ModelToIdTransformerTest extends \PHPUnit_Framework_TestCase
 
         $this->modelManager->expects($this->any())->method('find');
 
-        $this->assertEquals($expected, $transformer->reverseTransform($value));
+        $this->assertSame($expected, $transformer->reverseTransform($value));
     }
 
     public function getReverseTransformValues()
     {
         return array(
             array(null, null),
-            array(false, false),
+            array(false, null),
             array(array(), null),
             array('', null),
         );
@@ -81,6 +81,6 @@ class ModelToIdTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($transformer->transform(0));
         $this->assertNull($transformer->transform('0'));
 
-        $this->assertEquals(123, $transformer->transform(new \stdClass()));
+        $this->assertSame(123, $transformer->transform(new \stdClass()));
     }
 }

--- a/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -80,7 +80,7 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
                 return array('bcd' => new FooEntity(array('bcd')), 'efg' => new FooEntity(array('efg')), 'abc' => new FooEntity(array('abc')));
             }));
 
-        $this->assertEquals($expected, $transformer->transform($collection));
+        $this->assertSame($expected, $transformer->transform($collection));
     }
 
     public function getTransformTests()
@@ -176,7 +176,7 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
 
         $collection = $transformer->reverseTransform(array('foo', 'bar'));
         $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $collection);
-        $this->assertEquals(array($entity1, $entity2), $collection->getValues());
+        $this->assertSame(array($entity1, $entity2), $collection->getValues());
         $this->assertCount(2, $collection);
     }
 

--- a/Tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
+++ b/Tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
@@ -23,7 +23,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $extension = new FormTypeFieldExtension();
 
-        $this->assertEquals('field', $extension->getExtendedType());
+        $this->assertSame('field', $extension->getExtendedType());
     }
 
     public function testDefaultOptions()
@@ -113,8 +113,8 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
             'my_admin_reference_name_text_username',
         );
 
-        $this->assertEquals($expected, $formView->vars['block_prefixes']);
+        $this->assertSame($expected, $formView->vars['block_prefixes']);
         $this->assertTrue($formView->vars['sonata_admin_enabled']);
-        $this->assertEquals('help text', $formView->vars['sonata_help']);
+        $this->assertSame('help text', $formView->vars['sonata_help']);
     }
 }

--- a/Tests/Form/FormMapperTest.php
+++ b/Tests/Form/FormMapperTest.php
@@ -79,24 +79,24 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
     {
         $this->formMapper->with('foobar');
 
-        $this->assertEquals(array('default' => array(
+        $this->assertSame(array('default' => array(
             'collapsed'          => false,
             'class'              => false,
             'description'        => false,
             'translation_domain' => null,
+            'name'               => 'default',
             'auto_created'       => true,
             'groups'             => array('foobar'),
             'tab'                => true,
-            'name'               => 'default',
         )), $this->admin->getFormTabs());
 
-        $this->assertEquals(array('foobar' => array(
+        $this->assertSame(array('foobar' => array(
             'collapsed'          => false,
             'class'              => false,
             'description'        => false,
             'translation_domain' => null,
-            'fields'             => array(),
             'name'               => 'foobar',
+            'fields'             => array(),
         )), $this->admin->getFormGroups());
     }
 
@@ -106,40 +106,29 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
             'translation_domain' => 'Foobar',
         ));
 
-        $this->assertEquals(array('foobar' => array(
+        $this->assertSame(array('foobar' => array(
             'collapsed'          => false,
             'class'              => false,
             'description'        => false,
             'translation_domain' => 'Foobar',
-            'fields'             => array(),
             'name'               => 'foobar',
+            'fields'             => array(),
         )), $this->admin->getFormGroups());
 
-        $this->assertEquals(array('default' => array(
+        $this->assertSame(array('default' => array(
             'collapsed'          => false,
             'class'              => false,
             'description'        => false,
             'translation_domain' => 'Foobar',
+            'name'               => 'default',
             'auto_created'       => true,
             'groups'             => array('foobar'),
             'tab'                => true,
-            'name'               => 'default',
         )), $this->admin->getFormTabs());
     }
 
     public function testWithFieldsCascadeTranslationDomain()
     {
-        $formGroups = array(
-            'foobar' => array(
-                'collapsed'          => false,
-                'fields'             => array(),
-                'description'        => false,
-                'translation_domain' => 'Foobar',
-                'class'              => false,
-                'name'               => 'foobar',
-            ),
-        );
-
         $this->admin->setModelManager($this->modelManager);
 
         $this->modelManager->expects($this->once())
@@ -166,26 +155,26 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
             ->add('foo', 'bar')
         ->end();
 
-        $this->assertEquals(array('default' => array(
+        $this->assertSame(array('default' => array(
             'collapsed'          => false,
             'class'              => false,
             'description'        => false,
             'translation_domain' => 'Foobar',
+            'name'               => 'default',
             'auto_created'       => true,
             'groups'             => array('foobar'),
             'tab'                => true,
-            'name'               => 'default',
         )), $this->admin->getFormTabs());
 
-        $this->assertEquals(array('foobar' => array(
+        $this->assertSame(array('foobar' => array(
             'collapsed'          => false,
             'class'              => false,
             'description'        => false,
             'translation_domain' => 'Foobar',
+            'name'               => 'foobar',
             'fields'             => array(
                 'foo' => 'foo',
             ),
-            'name' => 'foobar',
         )), $this->admin->getFormGroups());
     }
 

--- a/Tests/Form/Type/AdminTypeTest.php
+++ b/Tests/Form/Type/AdminTypeTest.php
@@ -29,9 +29,9 @@ class AdminTypeTest extends TypeTestCase
 
         $this->assertTrue($options['delete']);
         $this->assertFalse($options['auto_initialize']);
-        $this->assertEquals('link_add', $options['btn_add']);
-        $this->assertEquals('link_list', $options['btn_list']);
-        $this->assertEquals('link_delete', $options['btn_delete']);
-        $this->assertEquals('SonataAdminBundle', $options['btn_catalogue']);
+        $this->assertSame('link_add', $options['btn_add']);
+        $this->assertSame('link_list', $options['btn_list']);
+        $this->assertSame('link_delete', $options['btn_delete']);
+        $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);
     }
 }

--- a/Tests/Form/Type/Filter/DateTimeRangeTypeTest.php
+++ b/Tests/Form/Type/Filter/DateTimeRangeTypeTest.php
@@ -33,6 +33,6 @@ class DateTimeRangeTypeTest extends TypeTestCase
             'field_type'       => 'sonata_type_datetime_range',
             'field_options'    => array('date_format' => 'yyyy-MM-dd'),
         );
-        $this->assertEquals($expected, $options);
+        $this->assertSame($expected, $options);
     }
 }

--- a/Tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/Tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -27,24 +27,24 @@ class ModelAutocompleteTypeTest extends TypeTestCase
 
         $options = $optionResolver->resolve(array('model_manager' => $modelManager, 'class' => 'Foo', 'property' => 'bar'));
 
-        $this->assertEquals(array(), $options['attr']);
+        $this->assertSame(array(), $options['attr']);
         $this->assertTrue($options['compound']);
         $this->assertInstanceOf('Sonata\AdminBundle\Model\ModelManagerInterface', $options['model_manager']);
-        $this->assertEquals($modelManager, $options['model_manager']);
-        $this->assertEquals('Foo', $options['class']);
-        $this->assertEquals('bar', $options['property']);
+        $this->assertSame($modelManager, $options['model_manager']);
+        $this->assertSame('Foo', $options['class']);
+        $this->assertSame('bar', $options['property']);
         $this->assertNull($options['callback']);
 
-        $this->assertEquals('', $options['placeholder']);
-        $this->assertEquals(3, $options['minimum_input_length']);
-        $this->assertEquals(10, $options['items_per_page']);
+        $this->assertSame('', $options['placeholder']);
+        $this->assertSame(3, $options['minimum_input_length']);
+        $this->assertSame(10, $options['items_per_page']);
 
-        $this->assertEquals('', $options['url']);
-        $this->assertEquals(array('name' => 'sonata_admin_retrieve_autocomplete_items', 'parameters' => array()), $options['route']);
-        $this->assertEquals(array(), $options['req_params']);
-        $this->assertEquals('q', $options['req_param_name_search']);
-        $this->assertEquals('_page', $options['req_param_name_page_number']);
-        $this->assertEquals('_per_page', $options['req_param_name_items_per_page']);
-        $this->assertEquals('sonata-autocomplete-dropdown', $options['dropdown_css_class']);
+        $this->assertSame('', $options['url']);
+        $this->assertSame(array('name' => 'sonata_admin_retrieve_autocomplete_items', 'parameters' => array()), $options['route']);
+        $this->assertSame(array(), $options['req_params']);
+        $this->assertSame('q', $options['req_param_name_search']);
+        $this->assertSame('_page', $options['req_param_name_page_number']);
+        $this->assertSame('_per_page', $options['req_param_name_items_per_page']);
+        $this->assertSame('sonata-autocomplete-dropdown', $options['dropdown_css_class']);
     }
 }

--- a/Tests/Form/Type/ModelHiddenTypeTest.php
+++ b/Tests/Form/Type/ModelHiddenTypeTest.php
@@ -28,19 +28,19 @@ class ModelHiddenTypeTest extends TypeTestCase
         $options = $optionResolver->resolve(array('model_manager' => $modelManager, 'class' => '\Foo'));
 
         $this->assertInstanceOf('Sonata\AdminBundle\Model\ModelManagerInterface', $options['model_manager']);
-        $this->assertEquals($modelManager, $options['model_manager']);
-        $this->assertEquals('\Foo', $options['class']);
+        $this->assertSame($modelManager, $options['model_manager']);
+        $this->assertSame('\Foo', $options['class']);
     }
 
     public function testGetName()
     {
         $type = new ModelHiddenType();
-        $this->assertEquals('sonata_type_model_hidden', $type->getName());
+        $this->assertSame('sonata_type_model_hidden', $type->getName());
     }
 
     public function testGetParent()
     {
         $type = new ModelHiddenType();
-        $this->assertEquals('hidden', $type->getParent());
+        $this->assertSame('hidden', $type->getParent());
     }
 }

--- a/Tests/Form/Type/ModelTypeListTest.php
+++ b/Tests/Form/Type/ModelTypeListTest.php
@@ -29,9 +29,9 @@ class ModelTypeListTest extends TypeTestCase
 
         $this->assertNull($options['model_manager']);
         $this->assertNull($options['class']);
-        $this->assertEquals('link_add', $options['btn_add']);
-        $this->assertEquals('link_list', $options['btn_list']);
-        $this->assertEquals('link_delete', $options['btn_delete']);
-        $this->assertEquals('SonataAdminBundle', $options['btn_catalogue']);
+        $this->assertSame('link_add', $options['btn_add']);
+        $this->assertSame('link_list', $options['btn_list']);
+        $this->assertSame('link_delete', $options['btn_delete']);
+        $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);
     }
 }

--- a/Tests/Form/Type/ModelTypeTest.php
+++ b/Tests/Form/Type/ModelTypeTest.php
@@ -28,19 +28,19 @@ class ModelTypeTest extends TypeTestCase
         $options = $optionResolver->resolve(array('model_manager' => $modelManager, 'choices' => array()));
 
         $this->assertFalse($options['compound']);
-        $this->assertEquals('choice', $options['template']);
+        $this->assertSame('choice', $options['template']);
         $this->assertFalse($options['multiple']);
         $this->assertFalse($options['expanded']);
         $this->assertInstanceOf('Sonata\AdminBundle\Model\ModelManagerInterface', $options['model_manager']);
         $this->assertNull($options['class']);
         $this->assertNull($options['property']);
         $this->assertNull($options['query']);
-        $this->assertEquals(0, count($options['choices']));
-        $this->assertEquals(0, count($options['preferred_choices']));
-        $this->assertEquals('link_add', $options['btn_add']);
-        $this->assertEquals('link_list', $options['btn_list']);
-        $this->assertEquals('link_delete', $options['btn_delete']);
-        $this->assertEquals('SonataAdminBundle', $options['btn_catalogue']);
+        $this->assertSame(0, count($options['choices']));
+        $this->assertSame(0, count($options['preferred_choices']));
+        $this->assertSame('link_add', $options['btn_add']);
+        $this->assertSame('link_list', $options['btn_list']);
+        $this->assertSame('link_delete', $options['btn_delete']);
+        $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);
         $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList', $options['choice_list']);
     }
 
@@ -57,20 +57,20 @@ class ModelTypeTest extends TypeTestCase
 
         $options = $optionResolver->resolve(array('model_manager' => $modelManager, 'choices' => array(), 'multiple' => $multiple, 'expanded' => $expanded));
 
-        $this->assertEquals($expectedCompound, $options['compound']);
-        $this->assertEquals('choice', $options['template']);
-        $this->assertEquals($multiple, $options['multiple']);
-        $this->assertEquals($expanded, $options['expanded']);
+        $this->assertSame($expectedCompound, $options['compound']);
+        $this->assertSame('choice', $options['template']);
+        $this->assertSame($multiple, $options['multiple']);
+        $this->assertSame($expanded, $options['expanded']);
         $this->assertInstanceOf('Sonata\AdminBundle\Model\ModelManagerInterface', $options['model_manager']);
         $this->assertNull($options['class']);
         $this->assertNull($options['property']);
         $this->assertNull($options['query']);
-        $this->assertEquals(0, count($options['choices']));
-        $this->assertEquals(0, count($options['preferred_choices']));
-        $this->assertEquals('link_add', $options['btn_add']);
-        $this->assertEquals('link_list', $options['btn_list']);
-        $this->assertEquals('link_delete', $options['btn_delete']);
-        $this->assertEquals('SonataAdminBundle', $options['btn_catalogue']);
+        $this->assertSame(0, count($options['choices']));
+        $this->assertSame(0, count($options['preferred_choices']));
+        $this->assertSame('link_add', $options['btn_add']);
+        $this->assertSame('link_list', $options['btn_list']);
+        $this->assertSame('link_delete', $options['btn_delete']);
+        $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);
         $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList', $options['choice_list']);
     }
 

--- a/Tests/Generator/AdminGeneratorTest.php
+++ b/Tests/Generator/AdminGeneratorTest.php
@@ -56,8 +56,8 @@ class AdminGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->adminGenerator->generate($this->bundleMock, 'ModelAdmin', 'Model');
         $file = $this->adminGenerator->getFile();
-        $this->assertEquals('Sonata\AdminBundle\Tests\Fixtures\Admin\ModelAdmin', $this->adminGenerator->getClass());
-        $this->assertEquals('ModelAdmin.php', basename($file));
+        $this->assertSame('Sonata\AdminBundle\Tests\Fixtures\Admin\ModelAdmin', $this->adminGenerator->getClass());
+        $this->assertSame('ModelAdmin.php', basename($file));
         $this->assertFileEquals(__DIR__.'/../Fixtures/Admin/ModelAdmin.php', $file);
 
         try {

--- a/Tests/Generator/ControllerGeneratorTest.php
+++ b/Tests/Generator/ControllerGeneratorTest.php
@@ -52,11 +52,11 @@ class ControllerGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->controllerGenerator->generate($this->bundleMock, 'ModelAdminController');
         $file = $this->controllerGenerator->getFile();
-        $this->assertEquals(
+        $this->assertSame(
             'Sonata\AdminBundle\Tests\Fixtures\Controller\ModelAdminController',
             $this->controllerGenerator->getClass()
         );
-        $this->assertEquals('ModelAdminController.php', basename($file));
+        $this->assertSame('ModelAdminController.php', basename($file));
         $this->assertFileEquals(__DIR__.'/../Fixtures/Controller/ModelAdminController.php', $file);
 
         try {

--- a/Tests/Guesser/TypeGuesserChainTest.php
+++ b/Tests/Guesser/TypeGuesserChainTest.php
@@ -55,7 +55,7 @@ class TypeGuesserChainTest extends \PHPUnit_Framework_TestCase
         $property = 'firstName';
 
         $typeGuesserChain = new TypeGuesserChain(array($guesser1, $guesser2, $guesser3));
-        $this->assertEquals($typeGuess2, $typeGuesserChain->guessType($class, $property, $modelManager));
+        $this->assertSame($typeGuess2, $typeGuesserChain->guessType($class, $property, $modelManager));
 
         $typeGuess4 = new TypeGuess('foo4', array(), Guess::LOW_CONFIDENCE);
         $guesser4 = $this->getMock('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
@@ -64,6 +64,6 @@ class TypeGuesserChainTest extends \PHPUnit_Framework_TestCase
                 ->will($this->returnValue($typeGuess4));
 
         $typeGuesserChain = new TypeGuesserChain(array($guesser4, $typeGuesserChain));
-        $this->assertEquals($typeGuess2, $typeGuesserChain->guessType($class, $property, $modelManager));
+        $this->assertSame($typeGuess2, $typeGuesserChain->guessType($class, $property, $modelManager));
     }
 }

--- a/Tests/Manipulator/ServicesManipulatorTest.php
+++ b/Tests/Manipulator/ServicesManipulatorTest.php
@@ -50,7 +50,7 @@ class ServicesManipulatorTest extends \PHPUnit_Framework_TestCase
             'controller_name',
             'manager_type'
         );
-        $this->assertEquals(
+        $this->assertSame(
             "services:
     service_id:
         class: admin_class
@@ -66,7 +66,7 @@ class ServicesManipulatorTest extends \PHPUnit_Framework_TestCase
             'another_controller_name',
             'another_manager_type'
         );
-        $this->assertEquals(
+        $this->assertSame(
             "services:
     service_id:
         class: admin_class
@@ -115,7 +115,7 @@ class ServicesManipulatorTest extends \PHPUnit_Framework_TestCase
             'controller_name',
             'manager_type'
         );
-        $this->assertEquals(
+        $this->assertSame(
             "services:
     service_id:
         class: admin_class

--- a/Tests/Mapper/BaseGroupedMapperTest.php
+++ b/Tests/Mapper/BaseGroupedMapperTest.php
@@ -69,21 +69,21 @@ class BaseGroupedMapperTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertCount(0, $this->tabs);
         $this->assertCount(0, $this->groups);
-        $this->assertEquals($this->baseGroupedMapper, $this->baseGroupedMapper->with('fooGroup'));
+        $this->assertSame($this->baseGroupedMapper, $this->baseGroupedMapper->with('fooGroup'));
         $this->assertCount(1, $this->tabs);
         $this->assertCount(1, $this->groups);
     }
 
     public function testEnd()
     {
-        $this->assertEquals($this->baseGroupedMapper, $this->baseGroupedMapper->with('fooGroup'));
+        $this->assertSame($this->baseGroupedMapper, $this->baseGroupedMapper->with('fooGroup'));
     }
 
     public function testTab()
     {
         $this->assertCount(0, $this->tabs);
         $this->assertCount(0, $this->groups);
-        $this->assertEquals($this->baseGroupedMapper, $this->baseGroupedMapper->tab('fooTab'));
+        $this->assertSame($this->baseGroupedMapper, $this->baseGroupedMapper->tab('fooTab'));
         $this->assertCount(1, $this->tabs);
         $this->assertCount(0, $this->groups);
     }
@@ -92,14 +92,14 @@ class BaseGroupedMapperTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertCount(0, $this->tabs);
         $this->assertCount(0, $this->groups);
-        $this->assertEquals($this->baseGroupedMapper, $this->baseGroupedMapper->with('fooTab', array('tab' => true)));
+        $this->assertSame($this->baseGroupedMapper, $this->baseGroupedMapper->with('fooTab', array('tab' => true)));
         $this->assertCount(1, $this->tabs);
         $this->assertCount(0, $this->groups);
     }
 
     public function testFluidInterface()
     {
-        $this->assertEquals($this->baseGroupedMapper, $this->baseGroupedMapper->tab('fooTab')->with('fooGroup1')->end()->with('fooGroup2')->end()->with('fooGroup3')->end()->end()->tab('barTab')->with('barGroup1')->end()->with('barGroup2')->end()->with('barGroup3')->end()->end());
+        $this->assertSame($this->baseGroupedMapper, $this->baseGroupedMapper->tab('fooTab')->with('fooGroup1')->end()->with('fooGroup2')->end()->with('fooGroup3')->end()->end()->tab('barTab')->with('barGroup1')->end()->with('barGroup2')->end()->with('barGroup3')->end()->end());
     }
 
     /**

--- a/Tests/Mapper/BaseMapperTest.php
+++ b/Tests/Mapper/BaseMapperTest.php
@@ -41,6 +41,6 @@ class BaseMapperTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAdmin()
     {
-        $this->assertEquals($this->admin, $this->baseMapper->getAdmin());
+        $this->assertSame($this->admin, $this->baseMapper->getAdmin());
     }
 }

--- a/Tests/Route/DefaultRouteGeneratorTest.php
+++ b/Tests/Route/DefaultRouteGeneratorTest.php
@@ -36,7 +36,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $generator = new DefaultRouteGenerator($router, $cache);
 
-        $this->assertEquals('/foo/bar', $generator->generate('foo_bar'));
+        $this->assertSame('/foo/bar', $generator->generate('foo_bar'));
     }
 
     /**
@@ -85,7 +85,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $generator = new DefaultRouteGenerator($router, $cache);
 
-        $this->assertEquals($expected, $generator->generateUrl($admin, $name, $parameters));
+        $this->assertSame($expected, $generator->generateUrl($admin, $name, $parameters));
     }
 
     public function getGenerateUrlTests()
@@ -190,7 +190,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $generator = new DefaultRouteGenerator($router, $cache);
 
-        $this->assertEquals($expected, $generator->generateUrl($type == 'child' ? $admin : $parentAdmin, $name, $parameters));
+        $this->assertSame($expected, $generator->generateUrl($type == 'child' ? $admin : $parentAdmin, $name, $parameters));
     }
 
     public function getGenerateUrlChildTests()
@@ -260,7 +260,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $generator = new DefaultRouteGenerator($router, $cache);
 
-        $this->assertEquals($expected, $generator->generateUrl($admin, $name, $parameters));
+        $this->assertSame($expected, $generator->generateUrl($admin, $name, $parameters));
     }
 
     public function getGenerateUrlParentFieldDescriptionTests()
@@ -359,7 +359,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
 
         // Generate once to populate cache
         $generator->generateUrl($admin, 'bar', $parameters);
-        $this->assertEquals($expected, $generator->generateUrl($standaloneAdmin, $name, $parameters));
+        $this->assertSame($expected, $generator->generateUrl($standaloneAdmin, $name, $parameters));
     }
 
     public function getGenerateUrlLoadCacheTests()

--- a/Tests/Route/RouteCollectionTest.php
+++ b/Tests/Route/RouteCollectionTest.php
@@ -19,34 +19,34 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
     {
         $routeCollection = new RouteCollection('base.Code.Route', 'baseRouteName', 'baseRoutePattern', 'baseControllerName');
 
-        $this->assertEquals('base.Code.Route', $routeCollection->getBaseCodeRoute());
-        $this->assertEquals('baseRouteName', $routeCollection->getBaseRouteName());
-        $this->assertEquals('baseRoutePattern', $routeCollection->getBaseRoutePattern());
-        $this->assertEquals('baseControllerName', $routeCollection->getBaseControllerName());
+        $this->assertSame('base.Code.Route', $routeCollection->getBaseCodeRoute());
+        $this->assertSame('baseRouteName', $routeCollection->getBaseRouteName());
+        $this->assertSame('baseRoutePattern', $routeCollection->getBaseRoutePattern());
+        $this->assertSame('baseControllerName', $routeCollection->getBaseControllerName());
     }
 
     public function testActionify()
     {
         $routeCollection = new RouteCollection('base.Code.Route', 'baseRouteName', 'baseRoutePattern', 'BundleName:ControllerName');
 
-        $this->assertEquals('fooBar', $routeCollection->actionify('Foo bar'));
-        $this->assertEquals('bar', $routeCollection->actionify('Foo.bar'));
+        $this->assertSame('fooBar', $routeCollection->actionify('Foo bar'));
+        $this->assertSame('bar', $routeCollection->actionify('Foo.bar'));
     }
 
     public function testActionifyService()
     {
         $routeCollection = new RouteCollection('base.Code.Route', 'baseRouteName', 'baseRoutePattern', 'baseControllerService');
 
-        $this->assertEquals('fooBarAction', $routeCollection->actionify('Foo bar'));
-        $this->assertEquals('barAction', $routeCollection->actionify('Foo.bar'));
+        $this->assertSame('fooBarAction', $routeCollection->actionify('Foo bar'));
+        $this->assertSame('barAction', $routeCollection->actionify('Foo.bar'));
     }
 
     public function testCode()
     {
         $routeCollection = new RouteCollection('base.Code.Route', 'baseRouteName', 'baseRoutePattern', 'baseControllerName');
 
-        $this->assertEquals('base.Code.Route.test', $routeCollection->getCode('test'));
-        $this->assertEquals('base.Code.Route.test', $routeCollection->getCode('base.Code.Route.test'));
+        $this->assertSame('base.Code.Route.test', $routeCollection->getCode('test'));
+        $this->assertSame('base.Code.Route.test', $routeCollection->getCode('base.Code.Route.test'));
     }
 
     public function testCollection()
@@ -117,9 +117,9 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
 
         $route = $routeCollection->get('view');
 
-        $this->assertEquals('BundleName:ControllerName:view', $route->getDefault('_controller'));
-        $this->assertEquals('baseCodeRoute', $route->getDefault('_sonata_admin'));
-        $this->assertEquals('baseRouteName_view', $route->getDefault('_sonata_name'));
+        $this->assertSame('BundleName:ControllerName:view', $route->getDefault('_controller'));
+        $this->assertSame('baseCodeRoute', $route->getDefault('_sonata_admin'));
+        $this->assertSame('baseRouteName_view', $route->getDefault('_sonata_name'));
     }
 
     public function testRouteControllerService()
@@ -130,8 +130,8 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
 
         $route = $routeCollection->get('view');
 
-        $this->assertEquals('baseControllerServiceName:viewAction', $route->getDefault('_controller'));
-        $this->assertEquals('baseCodeRoute', $route->getDefault('_sonata_admin'));
-        $this->assertEquals('baseRouteName_view', $route->getDefault('_sonata_name'));
+        $this->assertSame('baseControllerServiceName:viewAction', $route->getDefault('_controller'));
+        $this->assertSame('baseCodeRoute', $route->getDefault('_sonata_admin'));
+        $this->assertSame('baseRouteName_view', $route->getDefault('_sonata_name'));
     }
 }

--- a/Tests/Security/Acl/Permission/MaskBuilderTest.php
+++ b/Tests/Security/Acl/Permission/MaskBuilderTest.php
@@ -18,21 +18,21 @@ class MaskBuilderTest extends \PHPUnit_Framework_TestCase
     public function testGetPattern()
     {
         $builder = new MaskBuilder();
-        $this->assertEquals(MaskBuilder::ALL_OFF, $builder->getPattern());
+        $this->assertSame(MaskBuilder::ALL_OFF, $builder->getPattern());
 
         $builder->add('view');
-        $this->assertEquals(str_repeat('.', 31).'V', $builder->getPattern());
+        $this->assertSame(str_repeat('.', 31).'V', $builder->getPattern());
 
         $builder->add('owner');
-        $this->assertEquals(str_repeat('.', 24).'N......V', $builder->getPattern());
+        $this->assertSame(str_repeat('.', 24).'N......V', $builder->getPattern());
 
         $builder->add('list');
-        $this->assertEquals(str_repeat('.', 19).'L....N......V', $builder->getPattern());
+        $this->assertSame(str_repeat('.', 19).'L....N......V', $builder->getPattern());
 
         $builder->add('export');
-        $this->assertEquals(str_repeat('.', 18).'EL....N......V', $builder->getPattern());
+        $this->assertSame(str_repeat('.', 18).'EL....N......V', $builder->getPattern());
 
         $builder->add(1 << 10);
-        $this->assertEquals(str_repeat('.', 18).'EL.'.MaskBuilder::ON.'..N......V', $builder->getPattern());
+        $this->assertSame(str_repeat('.', 18).'EL.'.MaskBuilder::ON.'..N......V', $builder->getPattern());
     }
 }

--- a/Tests/Security/Handler/NoopSecurityHandlerTest.php
+++ b/Tests/Security/Handler/NoopSecurityHandlerTest.php
@@ -34,7 +34,7 @@ class NoopSecurityHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildSecurityInformation()
     {
-        $this->assertEquals(array(), $this->handler->buildSecurityInformation($this->getSonataAdminObject()));
+        $this->assertSame(array(), $this->handler->buildSecurityInformation($this->getSonataAdminObject()));
     }
 
     public function testCreateObjectSecurity()
@@ -49,7 +49,7 @@ class NoopSecurityHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetBaseRole()
     {
-        $this->assertEquals('', $this->handler->getBaseRole($this->getSonataAdminObject()));
+        $this->assertSame('', $this->handler->getBaseRole($this->getSonataAdminObject()));
     }
 
     /**

--- a/Tests/Security/Handler/RoleSecurityHandlerTest.php
+++ b/Tests/Security/Handler/RoleSecurityHandlerTest.php
@@ -51,7 +51,7 @@ class RoleSecurityHandlerTest extends \PHPUnit_Framework_TestCase
             ->method('getCode')
             ->will($this->returnValue($code));
 
-        $this->assertEquals($expected, $handler->getBaseRole($this->admin));
+        $this->assertSame($expected, $handler->getBaseRole($this->admin));
     }
 
     public function getBaseRoleTests()
@@ -102,7 +102,7 @@ class RoleSecurityHandlerTest extends \PHPUnit_Framework_TestCase
                 return false;
             }));
 
-        $this->assertEquals($expected, $handler->isGranted($this->admin, $operation, $object));
+        $this->assertSame($expected, $handler->isGranted($this->admin, $operation, $object));
     }
 
     public function getIsGrantedTests()
@@ -204,7 +204,7 @@ class RoleSecurityHandlerTest extends \PHPUnit_Framework_TestCase
     public function testBuildSecurityInformation()
     {
         $handler = $this->getRoleSecurityHandler(array('ROLE_FOO'));
-        $this->assertEquals(array(), $handler->buildSecurityInformation($this->getSonataAdminObject()));
+        $this->assertSame(array(), $handler->buildSecurityInformation($this->getSonataAdminObject()));
     }
 
     /**

--- a/Tests/Show/ShowMapperTest.php
+++ b/Tests/Show/ShowMapperTest.php
@@ -130,9 +130,9 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
     {
         $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
 
-        $this->assertEquals($this->showMapper, $this->showMapper->add($fieldDescription));
-        $this->assertEquals($this->showMapper, $this->showMapper->remove('fooName'));
-        $this->assertEquals($this->showMapper, $this->showMapper->reorder(array()));
+        $this->assertSame($this->showMapper, $this->showMapper->add($fieldDescription));
+        $this->assertSame($this->showMapper, $this->showMapper->remove('fooName'));
+        $this->assertSame($this->showMapper, $this->showMapper->reorder(array()));
     }
 
     public function testGet()
@@ -142,7 +142,7 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
         $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
 
         $this->showMapper->add($fieldDescription);
-        $this->assertEquals($fieldDescription, $this->showMapper->get('fooName'));
+        $this->assertSame($fieldDescription, $this->showMapper->get('fooName'));
     }
 
     public function testAdd()
@@ -154,8 +154,8 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
         $fieldDescription = $this->showMapper->get('fooName');
 
         $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
-        $this->assertEquals('fooName', $fieldDescription->getName());
-        $this->assertEquals('fooName', $fieldDescription->getOption('label'));
+        $this->assertSame('fooName', $fieldDescription->getName());
+        $this->assertSame('fooName', $fieldDescription->getOption('label'));
     }
 
     public function testAddRemove()
@@ -186,7 +186,7 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
 
     public function testReorder()
     {
-        $this->assertEquals(array(), $this->admin->getShowGroups());
+        $this->assertSame(array(), $this->admin->getShowGroups());
 
         $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');
         $fieldDescription2 = $this->getFieldDescriptionMock('fooName2', 'fooLabel2');
@@ -199,20 +199,20 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
         $this->showMapper->add($fieldDescription3);
         $this->showMapper->add($fieldDescription4);
 
-        $this->assertEquals(array(
+        $this->assertSame(array(
             'Group1' => array(
                 'collapsed'          => false,
-                'fields'             => array('fooName1' => 'fooName1', 'fooName2' => 'fooName2', 'fooName3' => 'fooName3', 'fooName4' => 'fooName4'),
+                'class'              => false,
                 'description'        => false,
                 'translation_domain' => null,
-                'class'              => false,
                 'name'               => 'Group1',
+                'fields'             => array('fooName1' => 'fooName1', 'fooName2' => 'fooName2', 'fooName3' => 'fooName3', 'fooName4' => 'fooName4'),
             ), ), $this->admin->getShowGroups());
 
         $this->showMapper->reorder(array('fooName3', 'fooName2', 'fooName1', 'fooName4'));
 
         // print_r is used to compare order of items in associative arrays
-        $this->assertEquals(print_r(array(
+        $this->assertSame(print_r(array(
             'Group1' => array(
                 'collapsed'          => false,
                 'class'              => false,

--- a/Tests/Translator/BCLabelTranslatorStrategyTest.php
+++ b/Tests/Translator/BCLabelTranslatorStrategyTest.php
@@ -19,9 +19,9 @@ class BCLabelTranslatorStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new BCLabelTranslatorStrategy();
 
-        $this->assertEquals('Isvalid', $strategy->getLabel('isValid', 'form', 'label'));
-        $this->assertEquals('Plainpassword', $strategy->getLabel('plainPassword', 'form', 'label'));
+        $this->assertSame('Isvalid', $strategy->getLabel('isValid', 'form', 'label'));
+        $this->assertSame('Plainpassword', $strategy->getLabel('plainPassword', 'form', 'label'));
 
-        $this->assertEquals('breadcrumb.link_projectversion_list', $strategy->getLabel('ProjectVersion_list', 'breadcrumb', 'link'));
+        $this->assertSame('breadcrumb.link_projectversion_list', $strategy->getLabel('ProjectVersion_list', 'breadcrumb', 'link'));
     }
 }

--- a/Tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
+++ b/Tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
@@ -109,8 +109,8 @@ class AdminExtractorTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('JMS\TranslationBundle\Model\Message', $catalogue->get('foo', 'foo_admin_domain'));
 
         $message = $catalogue->get('foo', 'foo_admin_domain');
-        $this->assertEquals('foo', $message->getId());
-        $this->assertEquals('foo_admin_domain', $message->getDomain());
+        $this->assertSame('foo', $message->getId());
+        $this->assertSame('foo_admin_domain', $message->getDomain());
     }
 
     public function testExtractWithException()

--- a/Tests/Translator/FormLabelTranslatorStrategyTest.php
+++ b/Tests/Translator/FormLabelTranslatorStrategyTest.php
@@ -19,7 +19,7 @@ class FormLabelTranslatorStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new FormLabelTranslatorStrategy();
 
-        $this->assertEquals('Isvalid', $strategy->getLabel('isValid', 'form', 'label'));
-        $this->assertEquals('Plainpassword', $strategy->getLabel('plainPassword', 'form', 'label'));
+        $this->assertSame('Isvalid', $strategy->getLabel('isValid', 'form', 'label'));
+        $this->assertSame('Plainpassword', $strategy->getLabel('plainPassword', 'form', 'label'));
     }
 }

--- a/Tests/Translator/NativeLabelTranslatorStrategyTest.php
+++ b/Tests/Translator/NativeLabelTranslatorStrategyTest.php
@@ -22,7 +22,7 @@ class NativeLabelTranslatorStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new NativeLabelTranslatorStrategy();
 
-        $this->assertEquals($expectedLabel, $strategy->getLabel($label, 'form', 'label'));
+        $this->assertSame($expectedLabel, $strategy->getLabel($label, 'form', 'label'));
     }
 
     public function getLabelTests()

--- a/Tests/Translator/NoopLabelTranslatorStrategyTest.php
+++ b/Tests/Translator/NoopLabelTranslatorStrategyTest.php
@@ -19,7 +19,7 @@ class NoopLabelTranslatorStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new NoopLabelTranslatorStrategy();
 
-        $this->assertEquals('isValid', $strategy->getLabel('isValid', 'form', 'label'));
-        $this->assertEquals('isValid_SuperCool', $strategy->getLabel('isValid_SuperCool', 'form', 'label'));
+        $this->assertSame('isValid', $strategy->getLabel('isValid', 'form', 'label'));
+        $this->assertSame('isValid_SuperCool', $strategy->getLabel('isValid_SuperCool', 'form', 'label'));
     }
 }

--- a/Tests/Translator/UnderscoreLabelTranslatorStrategyTest.php
+++ b/Tests/Translator/UnderscoreLabelTranslatorStrategyTest.php
@@ -19,7 +19,7 @@ class UnderscoreLabelTranslatorStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new UnderscoreLabelTranslatorStrategy();
 
-        $this->assertEquals('datagrid.label_is_valid', $strategy->getLabel('isValid', 'datagrid', 'label'));
-        $this->assertEquals('breadcrumb.link_is0_valid', $strategy->getLabel('is0Valid', 'breadcrumb', 'link'));
+        $this->assertSame('datagrid.label_is_valid', $strategy->getLabel('isValid', 'datagrid', 'label'));
+        $this->assertSame('breadcrumb.link_is0_valid', $strategy->getLabel('is0Valid', 'breadcrumb', 'link'));
     }
 }

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -226,7 +226,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
                 }
             }));
 
-        $this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $this->twigExtension->renderListElement($this->object, $this->fieldDescription))));
+        $this->assertSame($expected, trim(preg_replace('/\s+/', ' ', $this->twigExtension->renderListElement($this->object, $this->fieldDescription))));
     }
 
     public function getRenderListElementTests()
@@ -459,7 +459,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
                 }
             }));
 
-        $this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $this->twigExtension->renderViewElement($this->fieldDescription, $this->object))));
+        $this->assertSame($expected, trim(preg_replace('/\s+/', ' ', $this->twigExtension->renderViewElement($this->fieldDescription, $this->object))));
     }
 
     public function getRenderViewElementTests()
@@ -593,7 +593,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
             ->method('getValue')
             ->will($this->returnValue('test123'));
 
-        $this->assertEquals('test123', $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
+        $this->assertSame('test123', $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
     }
 
     public function testGetValueFromFieldDescriptionWithRemoveLoopException()
@@ -602,7 +602,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
         $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
 
         try {
-            $this->assertEquals('anything', $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription, array('loop' => true)));
+            $this->assertSame('anything', $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription, array('loop' => true)));
         } catch (\RuntimeException $e) {
             $this->assertContains('remove the loop requirement', $e->getMessage());
 
@@ -627,7 +627,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
             ->method('getAssociationAdmin')
             ->will($this->returnValue(null));
 
-        $this->assertEquals(null, $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
+        $this->assertSame(null, $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
     }
 
     public function testGetValueFromFieldDescriptionWithNoValueExceptionNewAdminInstance()
@@ -649,7 +649,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
             ->method('getNewInstance')
             ->will($this->returnValue('foo'));
 
-        $this->assertEquals('foo', $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
+        $this->assertSame('foo', $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
     }
 
     public function testOutput()
@@ -673,17 +673,17 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
 
         $template = $this->environment->loadTemplate('SonataAdminBundle:CRUD:base_list_field.html.twig');
 
-        $this->assertEquals('<td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> foo </td>',
+        $this->assertSame('<td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> foo </td>',
                 trim(preg_replace('/\s+/', ' ', $this->twigExtension->output($this->fieldDescription, $template, $parameters))));
 
         $this->environment->enableDebug();
-        $this->assertEquals('<!-- START fieldName: fd_name template: SonataAdminBundle:CRUD:base_list_field.html.twig compiled template: SonataAdminBundle:CRUD:base_list_field.html.twig --> <td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> foo </td> <!-- END - fieldName: fd_name -->',
+        $this->assertSame('<!-- START fieldName: fd_name template: SonataAdminBundle:CRUD:base_list_field.html.twig compiled template: SonataAdminBundle:CRUD:base_list_field.html.twig --> <td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> foo </td> <!-- END - fieldName: fd_name -->',
                 trim(preg_replace('/\s+/', ' ', $this->twigExtension->output($this->fieldDescription, $template, $parameters))));
     }
 
     public function testRenderRelationElementNoObject()
     {
-        $this->assertEquals('foo', $this->twigExtension->renderRelationElement('foo', $this->fieldDescription));
+        $this->assertSame('foo', $this->twigExtension->renderRelationElement('foo', $this->fieldDescription));
     }
 
     public function testRenderRelationElementToString()
@@ -705,7 +705,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
             ->method('__toString')
             ->will($this->returnValue('bar'));
 
-        $this->assertEquals('bar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
+        $this->assertSame('bar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
     }
 
     public function testRenderRelationElementCustomToString()
@@ -727,7 +727,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
             ->method('customToString')
             ->will($this->returnValue('fooBar'));
 
-        $this->assertEquals('fooBar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
+        $this->assertSame('fooBar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
     }
 
     public function testRenderRelationElementMethodNotExist()
@@ -768,7 +768,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
         $element = new \stdClass();
         $element->foo = 'bar';
 
-        $this->assertEquals('bar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
+        $this->assertSame('bar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
     }
 
     public function testGetUrlsafeIdentifier()
@@ -784,6 +784,6 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo($entity))
             ->will($this->returnValue(1234567));
 
-        $this->assertEquals(1234567, $this->twigExtension->getUrlsafeIdentifier($entity));
+        $this->assertSame(1234567, $this->twigExtension->getUrlsafeIdentifier($entity));
     }
 }

--- a/Tests/Util/AdminObjectAclDataTest.php
+++ b/Tests/Util/AdminObjectAclDataTest.php
@@ -75,7 +75,7 @@ class AdminObjectAclDataTest extends \PHPUnit_Framework_TestCase
         $adminObjectAclData = $this->createAdminObjectAclData();
         $ret = $adminObjectAclData->setAcl($acl);
 
-        $this->assertEquals($adminObjectAclData, $ret);
+        $this->assertSame($adminObjectAclData, $ret);
 
         return $adminObjectAclData;
     }
@@ -105,7 +105,7 @@ class AdminObjectAclDataTest extends \PHPUnit_Framework_TestCase
         $adminObjectAclData = $this->createAdminObjectAclData();
         $ret = $adminObjectAclData->setForm($form);
 
-        $this->assertEquals($adminObjectAclData, $ret);
+        $this->assertSame($adminObjectAclData, $ret);
 
         return $adminObjectAclData;
     }

--- a/Tests/Util/AdminObjectAclManipulatorTest.php
+++ b/Tests/Util/AdminObjectAclManipulatorTest.php
@@ -28,6 +28,6 @@ class AdminObjectAclManipulatorTest extends \PHPUnit_Framework_TestCase
     public function testGetMaskBuilder()
     {
         $adminObjectAclManipulator = $this->createAdminObjectAclManipulator();
-        $this->assertEquals(self::MASK_BUILDER_CLASS, $adminObjectAclManipulator->getMaskBuilderClass());
+        $this->assertSame(self::MASK_BUILDER_CLASS, $adminObjectAclManipulator->getMaskBuilderClass());
     }
 }

--- a/Tests/Validator/Constraints/InlineConstraintTest.php
+++ b/Tests/Validator/Constraints/InlineConstraintTest.php
@@ -23,7 +23,7 @@ class InlineConstraintTest extends \PHPUnit_Framework_TestCase
     public function testValidatedBy()
     {
         $constraint = new InlineConstraint(array('service' => 'foo', 'method' => 'bar'));
-        $this->assertEquals('sonata.admin.validator.inline', $constraint->validatedBy());
+        $this->assertSame('sonata.admin.validator.inline', $constraint->validatedBy());
     }
 
     public function testIsClosure()
@@ -40,30 +40,30 @@ class InlineConstraintTest extends \PHPUnit_Framework_TestCase
         $closure = function () {return 'FOO';};
 
         $constraint = new InlineConstraint(array('service' => 'foo', 'method' => $closure));
-        $this->assertEquals($closure, $constraint->getClosure());
+        $this->assertSame($closure, $constraint->getClosure());
     }
 
     public function testGetTargets()
     {
         $constraint = new InlineConstraint(array('service' => 'foo', 'method' => 'bar'));
-        $this->assertEquals(InlineConstraint::CLASS_CONSTRAINT, $constraint->getTargets());
+        $this->assertSame(InlineConstraint::CLASS_CONSTRAINT, $constraint->getTargets());
     }
 
     public function testGetRequiredOptions()
     {
         $constraint = new InlineConstraint(array('service' => 'foo', 'method' => 'bar'));
-        $this->assertEquals(array('service', 'method'), $constraint->getRequiredOptions());
+        $this->assertSame(array('service', 'method'), $constraint->getRequiredOptions());
     }
 
     public function testGetMethod()
     {
         $constraint = new InlineConstraint(array('service' => 'foo', 'method' => 'bar'));
-        $this->assertEquals('bar', $constraint->getMethod());
+        $this->assertSame('bar', $constraint->getMethod());
     }
 
     public function testGetService()
     {
         $constraint = new InlineConstraint(array('service' => 'foo', 'method' => 'bar'));
-        $this->assertEquals('foo', $constraint->getService());
+        $this->assertSame('foo', $constraint->getService());
     }
 }

--- a/Tests/Validator/ErrorElementTest.php
+++ b/Tests/Validator/ErrorElementTest.php
@@ -42,24 +42,24 @@ class ErrorElementTest extends \PHPUnit_Framework_TestCase
 
     public function testGetSubject()
     {
-        $this->assertEquals($this->subject, $this->errorElement->getSubject());
+        $this->assertSame($this->subject, $this->errorElement->getSubject());
     }
 
     public function testGetErrorsEmpty()
     {
-        $this->assertEquals(array(), $this->errorElement->getErrors());
+        $this->assertSame(array(), $this->errorElement->getErrors());
     }
 
     public function testGetErrors()
     {
         $this->errorElement->addViolation('Foo error message', array('bar_param' => 'bar_param_lvalue'), 'BAR');
-        $this->assertEquals(array(array('Foo error message', array('bar_param' => 'bar_param_lvalue'), 'BAR')), $this->errorElement->getErrors());
+        $this->assertSame(array(array('Foo error message', array('bar_param' => 'bar_param_lvalue'), 'BAR')), $this->errorElement->getErrors());
     }
 
     public function testAddViolation()
     {
         $this->errorElement->addViolation(array('Foo error message', array('bar_param' => 'bar_param_lvalue'), 'BAR'));
-        $this->assertEquals(array(array('Foo error message', array('bar_param' => 'bar_param_lvalue'), 'BAR')), $this->errorElement->getErrors());
+        $this->assertSame(array(array('Foo error message', array('bar_param' => 'bar_param_lvalue'), 'BAR')), $this->errorElement->getErrors());
     }
 
     public function testAddConstraint()
@@ -113,10 +113,10 @@ class ErrorElementTest extends \PHPUnit_Framework_TestCase
     public function testGetFullPropertyPath()
     {
         $this->errorElement->with('baz');
-        $this->assertEquals('bar.baz', $this->errorElement->getFullPropertyPath());
+        $this->assertSame('bar.baz', $this->errorElement->getFullPropertyPath());
         $this->errorElement->end();
 
-        $this->assertEquals('bar', $this->errorElement->getFullPropertyPath());
+        $this->assertSame('bar', $this->errorElement->getFullPropertyPath());
     }
 
     public function testFluidInterface()
@@ -128,10 +128,10 @@ class ErrorElementTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo($this->subject), $this->equalTo($constraint), $this->equalTo(''), $this->equalTo('foo_admin'))
             ->will($this->returnValue(null));
 
-        $this->assertEquals($this->errorElement, $this->errorElement->with('baz'));
-        $this->assertEquals($this->errorElement, $this->errorElement->end());
-        $this->assertEquals($this->errorElement, $this->errorElement->addViolation('Foo error message', array('bar_param' => 'bar_param_lvalue'), 'BAR'));
-        $this->assertEquals($this->errorElement, $this->errorElement->addConstraint($constraint));
-        $this->assertEquals($this->errorElement, $this->errorElement->assertNotNull());
+        $this->assertSame($this->errorElement, $this->errorElement->with('baz'));
+        $this->assertSame($this->errorElement, $this->errorElement->end());
+        $this->assertSame($this->errorElement, $this->errorElement->addViolation('Foo error message', array('bar_param' => 'bar_param_lvalue'), 'BAR'));
+        $this->assertSame($this->errorElement, $this->errorElement->addConstraint($constraint));
+        $this->assertSame($this->errorElement, $this->errorElement->assertNotNull());
     }
 }


### PR DESCRIPTION
PHP CS fixer 1.10 is out with some [new fixers](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/1.10/CHANGELOG.md).

Two of them are interesting about PHPUnit: `php_unit_construct` and `php_unit_strict` for more reliable tests.

Some tests are failing. I'm working on it.

@rande What is your opinion about it?