### PR TITLE
Fix collection counter when we have more than 10 elements

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -312,7 +312,7 @@ var Admin = {
         Admin.log('[core|setup_collection_counter] setup collection counter', subject);
 
         // Count and save element of each collection
-        var highestCounterRegexp = new RegExp('_([0-9])+$');
+        var highestCounterRegexp = new RegExp('_([0-9]+)[^0-9]*$');
         jQuery(subject).find('[data-prototype]').each(function() {
             var collection = jQuery(this);
             var counter = 0;


### PR DESCRIPTION
When a collection is populated with more than 10 elements, the regexp ``_([0-9])+$`` only matches the last digit. The last element is always "9" and the new one "10".