### PR TITLE
Remove default menu creation logic from MenuBuilder

### DIFF
--- a/Menu/Provider/GroupMenuProvider.php
+++ b/Menu/Provider/GroupMenuProvider.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Menu\Provider;
+
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\Provider\MenuProviderInterface;
+use Sonata\AdminBundle\Admin\Pool;
+
+/**
+ * Menu provider based on group options.
+ *
+ * @author Alexandru Furculita <alex@furculita.net>
+ */
+class GroupMenuProvider implements MenuProviderInterface
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $menuFactory;
+
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @param FactoryInterface $menuFactory
+     * @param Pool             $pool
+     */
+    public function __construct(FactoryInterface $menuFactory, Pool $pool)
+    {
+        $this->menuFactory = $menuFactory;
+        $this->pool = $pool;
+    }
+
+    /**
+     * Retrieves the menu based on the group options.
+     *
+     * @param string $name
+     * @param array  $options
+     *
+     * @return \Knp\Menu\ItemInterface
+     *
+     * @throws \InvalidArgumentException if the menu does not exists
+     */
+    public function get($name, array $options = array())
+    {
+        $group = $options['group'];
+
+        $menuItem = $this->menuFactory->createItem(
+            $options['name'],
+            array(
+                'label' => $group['label'],
+            )
+        );
+
+        foreach ($group['items'] as $item) {
+            if (isset($item['admin']) && !empty($item['admin'])) {
+                $admin = $this->pool->getInstance($item['admin']);
+
+                // skip menu item if no `list` url is available or user doesn't have the LIST access rights
+                if (!$admin->hasRoute('list') || !$admin->isGranted('LIST')) {
+                    continue;
+                }
+
+                $label = $admin->getLabel();
+                $options = $admin->generateMenuUrl('list');
+                $options['extras'] = array(
+                    'translation_domain' => $admin->getTranslationDomain(),
+                    'admin'              => $admin,
+                );
+            } else {
+                $label = $item['label'];
+                $options = array(
+                    'route'           => $item['route'],
+                    'routeParameters' => $item['route_params'],
+                    'extras'          => array(
+                        'translation_domain' => $group['label_catalogue'],
+                    ),
+                );
+            }
+
+            $menuItem->addChild($label, $options);
+        }
+
+        if (false === $menuItem->hasChildren()) {
+            $menuItem->setDisplay(false);
+        }
+
+        return $menuItem;
+    }
+
+    /**
+     * Checks whether a menu exists in this provider.
+     *
+     * @param string $name
+     * @param array  $options
+     *
+     * @return bool
+     */
+    public function has($name, array $options = array())
+    {
+        return 'sonata_group_menu' === $name;
+    }
+}

--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -16,5 +16,11 @@
         <service id="sonata.admin.sidebar_menu" class="Knp\Menu\MenuItem">
             <tag name="knp_menu.menu" alias="sonata_admin_sidebar" />
         </service>
+
+        <service id="sonata.admin.menu.group_provider" class="Sonata\AdminBundle\Menu\Provider\GroupMenuProvider" public="false">
+            <argument type="service" id="knp_menu.factory" />
+            <argument type="service" id="sonata.admin.pool" />
+            <tag name="knp_menu.provider" />
+        </service>
     </services>
 </container>

--- a/Tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/Tests/Menu/Provider/GroupMenuProviderTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Menu\Provider;
+
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\MenuFactory;
+use Knp\Menu\Provider\MenuProviderInterface;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Menu\Provider\GroupMenuProvider;
+
+class GroupMenuProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MockObject|Pool
+     */
+    private $pool;
+    /**
+     * @var MockObject|MenuProviderInterface
+     */
+    private $provider;
+    /**
+     * @var MockObject|FactoryInterface
+     */
+    private $factory;
+
+    protected function setUp()
+    {
+        $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
+        $this->factory = new MenuFactory();
+
+        $this->provider = new GroupMenuProvider($this->factory, $this->pool);
+    }
+
+    /**
+     * @param bool $hasRoute
+     * @param bool $isGranted
+     *
+     * @return MockObject|AdminInterface
+     */
+    private function getAdminMock($hasRoute = true, $isGranted = true)
+    {
+        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin->expects($this->once())
+            ->method('hasRoute')
+            ->with($this->equalTo('list'))
+            ->will($this->returnValue($hasRoute));
+
+        $admin->expects($this->any())
+            ->method('isGranted')
+            ->with($this->equalTo('LIST'))
+            ->will($this->returnValue($isGranted));
+
+        $admin->expects($this->any())
+            ->method('getLabel')
+            ->will($this->returnValue('foo_admin_label'));
+
+        $admin->expects($this->any())
+            ->method('generateMenuUrl')
+            ->will($this->returnValue(array()));
+
+        return $admin;
+    }
+
+    public function testGroupMenuProviderName()
+    {
+        $this->assertTrue($this->provider->has('sonata_group_menu'));
+    }
+
+    /**
+     * @param array $adminGroups
+     *
+     * @dataProvider getAdminGroups
+     */
+    public function testGetMenuProviderWithAdmin(array $adminGroups)
+    {
+        $this->pool->expects($this->once())
+            ->method('getInstance')
+            ->with($this->equalTo('sonata_admin_foo_service'))
+            ->will($this->returnValue($this->getAdminMock()));
+
+        $menu = $this->provider->get(
+            'providerFoo',
+            array(
+                'name'  => 'foo',
+                'group' => $adminGroups,
+            )
+        );
+
+        $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
+        $this->assertSame('foo', $menu->getName());
+
+        $children = $menu->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertArrayHasKey('foo_admin_label', $children);
+        $this->assertInstanceOf('Knp\Menu\MenuItem', $menu['foo_admin_label']);
+        $this->assertSame('foo_admin_label', $menu['foo_admin_label']->getLabel());
+    }
+
+    /**
+     * @param array $adminGroups
+     *
+     * @dataProvider getAdminGroups
+     */
+    public function testGetKnpMenuWithNoListRoute(array $adminGroups)
+    {
+        $this->pool->expects($this->once())
+            ->method('getInstance')
+            ->with($this->equalTo('sonata_admin_foo_service'))
+            ->will($this->returnValue($this->getAdminMock(false)));
+
+        $menu = $this->provider->get(
+            'providerFoo',
+            array(
+                'name'  => 'foo',
+                'group' => $adminGroups,
+            )
+        );
+
+        $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
+        $this->assertArrayNotHasKey('foo_admin_label', $menu->getChildren());
+        $this->assertCount(0, $menu->getChildren());
+    }
+
+    /**
+     * @param array $adminGroups
+     *
+     * @dataProvider getAdminGroups
+     */
+    public function testGetKnpMenuWithNotGrantedList(array $adminGroups)
+    {
+        $this->pool->expects($this->once())
+            ->method('getInstance')
+            ->with($this->equalTo('sonata_admin_foo_service'))
+            ->will($this->returnValue($this->getAdminMock(true, false)));
+
+        $menu = $this->provider->get(
+            'providerFoo',
+            array(
+                'name'  => 'foo',
+                'group' => $adminGroups,
+            )
+        );
+
+        $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
+        $this->assertArrayNotHasKey('foo_admin_label', $menu->getChildren());
+        $this->assertCount(0, $menu->getChildren());
+    }
+
+    /**
+     * @return array
+     */
+    public function getAdminGroups()
+    {
+        return array(
+            array(
+                'bar' => array(
+                    'label'           => 'foo',
+                    'icon'            => '<i class="fa fa-edit"></i>',
+                    'label_catalogue' => 'SonataAdminBundle',
+                    'items'           => array(
+                        array(
+                            'admin' => 'sonata_admin_foo_service',
+                            'label' => 'fooLabel',
+                        ),
+                    ),
+                    'item_adds'       => array(),
+                    'roles'           => array(),
+                ),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a few changes that make the MenuBuilder class more flexible, easier to test and more complaint to SRP:

1. The request is added to the root menu options through an extension: `RequestExtension`
2. The logic of the creation process for the default menu items is moved to the menu provider `GroupMenuProvider`