### PR TITLE
Add symfony/security-acl requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "symfony/form": "~2.3",
         "symfony/validator": "~2.3",
         "symfony/security-bundle": "~2.3",
+        "symfony/security-acl": "~2.3",
         "symfony/routing": "~2.3",
         "symfony/config": "~2.3",
         "symfony/console": "~2.3",


### PR DESCRIPTION
This is needed since this package is not part of SF 2.8 anymore

Issue #3150 (do not closed, another re flexion in progress).