### PR TITLE
Load jquery ui before the boostrap js to fix tooltip conflict

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -302,12 +302,12 @@ class Configuration implements ConfigurationInterface
 
                                 'bundles/sonatacore/vendor/moment/min/moment.min.js',
 
+                                'bundles/sonataadmin/vendor/jqueryui/ui/minified/jquery-ui.min.js',
+                                'bundles/sonataadmin/vendor/jqueryui/ui/minified/i18n/jquery-ui-i18n.min.js',
+
                                 'bundles/sonatacore/vendor/bootstrap/dist/js/bootstrap.min.js',
 
                                 'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js',
-
-                                'bundles/sonataadmin/vendor/jqueryui/ui/minified/jquery-ui.min.js',
-                                'bundles/sonataadmin/vendor/jqueryui/ui/minified/i18n/jquery-ui-i18n.min.js',
 
                                 'bundles/sonataadmin/vendor/jquery-form/jquery.form.js',
                                 'bundles/sonataadmin/jquery/jquery.confirmExit.js',


### PR DESCRIPTION
Admin LTE enables the [bootstrap tooltip by default](https://github.com/almasaeed2010/AdminLTE/blob/master/dist/js/app.js#L59). But if the jquery ui is loaded after the bootstrap js, the bootstrap tooltip plugin is replaced by jquery's tooltip plugin. Because of different parameters (jQuery doesn't have the `selector` parameter) of the plugins it's wrongly enabled [on all items in `body`](https://github.com/almasaeed2010/AdminLTE/blob/master/dist/js/app.js#L183-L185) - see screenshot of button in LIst view below. This commit fixes the tooltip conflict, the bootstrap tooltip plugin is prefered.
![tooltip_on_hover](https://cloud.githubusercontent.com/assets/960844/9059641/f8bf85c2-3aab-11e5-9dfa-d13dec0e69b9.jpg)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes, if user uses the jquery tooltip plugin. He has to modify the order of the files to prefer the jquery Ui tooltip and also disable tooltip support in Admin LTE to not enable the bootstrap tooltip.
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT