### PR TITLE
Check if subject is available to avoid error in PropertyAccessor

### DIFF
--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -54,24 +54,27 @@ class AdminType extends AbstractType
         if ($builder->getData() === null) {
             $p = new PropertyAccessor(false, true);
             try {
-                // for PropertyAccessor < 2.5
-                // @todo remove this code for old PropertyAccessor after dropping support for Symfony 2.3
-                if (!method_exists($p, 'isReadable')) {
-                    $subjectCollection = $p->getValue(
-                        $admin->getParentFieldDescription()->getAdmin()->getSubject(),
-                        $this->getFieldDescription($options)->getFieldName()
-                    );
-                    if ($subjectCollection instanceof Collection) {
-                        $subject = $subjectCollection->get(trim($options['property_path'], '[]'));
+                $parentSubject = $admin->getParentFieldDescription()->getAdmin()->getSubject();
+                if ($parentSubject !== null && $parentSubject !== false) {
+                    // for PropertyAccessor < 2.5
+                    // @todo remove this code for old PropertyAccessor after dropping support for Symfony 2.3
+                    if (!method_exists($p, 'isReadable')) {
+                        $subjectCollection = $p->getValue(
+                            $parentSubject,
+                            $this->getFieldDescription($options)->getFieldName()
+                        );
+                        if ($subjectCollection instanceof Collection) {
+                            $subject = $subjectCollection->get(trim($options['property_path'], '[]'));
+                        }
+                    } else {
+                        // for PropertyAccessor >= 2.5
+                        $subject = $p->getValue(
+                            $parentSubject,
+                            $this->getFieldDescription($options)->getFieldName().$options['property_path']
+                        );
                     }
-                } else {
-                    // for PropertyAccessor >= 2.5
-                    $subject = $p->getValue(
-                        $admin->getParentFieldDescription()->getAdmin()->getSubject(),
-                        $this->getFieldDescription($options)->getFieldName().$options['property_path']
-                    );
+                    $builder->setData($subject);
                 }
-                $builder->setData($subject);
             } catch (NoSuchIndexException $e) {
                 // no object here
             }


### PR DESCRIPTION
Whithout checking the subject value, PropertyAccessor throws error: `PropertyAccessor requires a graph of objects or arrays to operate on, but it found type "boolean" while trying to traverse path "examples[0]" at property "examples".` (PropertyAccessor 2.7) or `Expected argument of type "object or array", "boolean" given ` (old PropertyAccessor 2.3) when creating new item with collection.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
