### PR TITLE
explicit reference to symfony/security-acl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "symfony/http-foundation": "~2.3",
         "symfony/form": "~2.3",
         "symfony/validator": "~2.3",
+        "symfony/security-acl": "~2.3",
         "symfony/security-bundle": "~2.3",
         "symfony/routing": "~2.3",
         "symfony/config": "~2.3",


### PR DESCRIPTION
with symfony 2.8, symfony/symfony no longer provides symfony/security-acl but provides the security-bundle (which in its composer.json does depend on symfony/security-acl). this means that as soon as we install symfony/symfony 2.8, we are missing security-acl which is used by this bundle.

i am not exactly sure if this is a mistake on symfony side but making the requirement explicit here does solve the issue.