### PR TITLE
Tree style issue

### DIFF
--- a/Resources/public/css/tree.css
+++ b/Resources/public/css/tree.css
@@ -21,6 +21,7 @@
     border-radius: 2px;
     position: relative;
     margin-bottom: 5px;
+    margin-right: 10px;
     color: #444;
     background: #fff;
 }


### PR DESCRIPTION
This should fix a styling issue in the tree list. 
Before:
![bildschirmfoto 2015-08-10 um 17 47 50](https://cloud.githubusercontent.com/assets/3440437/9175834/f3c25ce4-3f87-11e5-89fc-4ab2c435bb5c.PNG)
After:
![bildschirmfoto 2015-08-10 um 17 47 39](https://cloud.githubusercontent.com/assets/3440437/9175835/f3c3bfa8-3f87-11e5-8538-143e4c3f8250.PNG)
You can see this at the media tree view in the MediaBundle.