### PR TITLE
Fix count on actions

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -262,7 +262,7 @@ file that was distributed with this source code.
 
                                                 {% if _actions|replace({ '<li>': '', '</li>': '' })|trim is not empty %}
                                                     <ul class="nav navbar-nav navbar-right">
-                                                    {% if _actions|split('<li>')|length > 2 %}
+                                                    {% if _actions|split('</a>')|length > 2 %}
                                                         <li class="dropdown sonata-actions">
                                                             <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ 'link_actions'|trans({}, 'SonataAdminBundle') }} <b class="caret"></b></a>
                                                             <ul class="dropdown-menu" role="menu">


### PR DESCRIPTION
There is an issue with this count, because sometimes we got empty li or an li with a class and this doesn't match.
The goal of this dropdown is to provide links to with this we count only links tags

![capture d ecran 2015-08-27 a 11 20 09](https://cloud.githubusercontent.com/assets/1943676/9517128/d90a4ffa-4cad-11e5-8a9d-0f170dea48f5.png)
![capture d ecran 2015-08-27 a 11 20 19](https://cloud.githubusercontent.com/assets/1943676/9517133/dcb33e64-4cad-11e5-80bd-49c80ed13ea9.png)
