### PR TITLE
Catchable Fatal Error on Update security.rst

### DIFF
--- a/Resources/doc/reference/security.rst
+++ b/Resources/doc/reference/security.rst
@@ -692,7 +692,7 @@ return an iterable collection of users.
         $kevin = $userManager->findUserByUsername('kevin');
         $anne = $userManager->findUserByUsername('anne');
 
-        return array($kevin, $anne);
+        return new \ArrayIterator(array($kevin, $anne));
     }
 
 Custom user manager


### PR DESCRIPTION
For 

return array($kevin, $anne);

you receive ContextErrorException:

Catchable Fatal Error: Argument 3 passed to Sonata\AdminBundle\Util\AdminObjectAclData::__construct() must implement interface Traversable, array given, called in C:\_\xampp\htdocs\_projects\laas\git\vendor\sonata-project\admin-bundle\Controller\CRUDController.php on line 1027 and defined
500 Internal Server Error - ContextErrorException

Also maybe $container can be replaced by $this->container on line 689?

Thanks!