### PR TITLE
Fix too generic class selector for sticky footer

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -537,7 +537,7 @@ var Admin = {
 
             var wrapper = jQuery(subject).find('.content-wrapper');
             var navbar  = jQuery(wrapper).find('nav.navbar');
-            var footer  = jQuery(wrapper).find('.form-actions');
+            var footer  = jQuery(wrapper).find('.sonata-ba-form-actions');
 
             if (navbar.length) {
                 new Waypoint.Sticky({

--- a/Resources/views/CRUD/base_edit_form.html.twig
+++ b/Resources/views/CRUD/base_edit_form.html.twig
@@ -65,7 +65,7 @@
             {{ form_rest(form) }}
 
             {% block formactions %}
-                <div class="well well-small form-actions">
+                <div class="sonata-ba-form-actions well well-small form-actions">
                 {% block sonata_form_actions %}
                     {% if app.request.isxmlhttprequest %}
                         {% if admin.id(object) is not null %}


### PR DESCRIPTION
Sticky form introduced on #3194 by @qsomazzi use a too generic class selector for footer.

This introduced issues with another unrelated `.form-actions` on the view being stuck for no reason.