### PR TITLE
Pager was not initialised

### DIFF
--- a/Search/SearchHandler.php
+++ b/Search/SearchHandler.php
@@ -65,6 +65,7 @@ class SearchHandler
         $pager = $datagrid->getPager();
         $pager->setPage($page);
         $pager->setMaxPerPage($offset);
+        $pager->init();
 
         return $pager;
     }


### PR DESCRIPTION
The pager on the search page is not initalised, so the parameters in `search.html.twig` would be ignored.

This can be tested in the sonata demo environment. The template limits the results to 10 hits, but 25 will be displayed.