### PR TITLE
Remove wells from form actions bar

### DIFF
--- a/Resources/views/CRUD/base_edit_form.html.twig
+++ b/Resources/views/CRUD/base_edit_form.html.twig
@@ -65,7 +65,7 @@
             {{ form_rest(form) }}
 
             {% block formactions %}
-                <div class="sonata-ba-form-actions well well-small form-actions">
+                <div class="sonata-ba-form-actions form-actions">
                 {% block sonata_form_actions %}
                     {% if app.request.isxmlhttprequest %}
                         {% if admin.id(object) is not null %}


### PR DESCRIPTION
I think that here we can remove well & well-small CSS classes to clean up form acions bar.

<img width="525" alt="captura de pantalla 2015-09-09 a les 16 50 26" src="https://cloud.githubusercontent.com/assets/698779/9765828/67f6b222-5716-11e5-8c8d-27d57a63a8d6.png">


