### PR TITLE
Add support for child base route pattern and name in admin class

### DIFF
--- a/Resources/doc/reference/routing.rst
+++ b/Resources/doc/reference/routing.rst
@@ -46,6 +46,30 @@ route names for your actions like 'admin_vendor_bundlename_entityname_list'.
 If the Admin fails to find a baseRouteName for your Admin class a ``RuntimeException``
 will be thrown with a related message.
 
+If the admin class is a child of another admin class the route name will be prefixed by the parent route name, example :
+
+.. code-block:: php
+
+    <?php
+    // The parent admin class
+    class PostAdmin extends Admin
+    {
+        protected $baseRouteName = 'sonata_post';
+        // ...
+    }
+
+    // The child admin class
+    class CommentAdmin extends Admin
+    {
+        protected $baseRouteName = 'comment'
+        // will result in routes named :
+        //   sonata_post_comment_list
+        //   sonata_post_comment_create
+        //   etc..
+
+        // ...
+    }
+
 Route patterns (URLs)
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -67,6 +91,28 @@ use the following code:
 
 You will then have route URLs like ``http://yourdomain.com/admin/foo/list`` and
 ``http://yourdomain.com/admin/foo/1/edit``
+
+If the admin class is a child of another admin class the route pattern will be prefixed by the parent route pattern, example :
+
+.. code-block:: php
+
+    <?php
+    // The parent admin class
+    class PostAdmin extends Admin
+    {
+        protected $baseRoutePattern = 'post';
+        // ...
+    }
+
+    // The child admin class
+    class CommentAdmin extends Admin
+    {
+        protected $baseRoutePattern = 'comment'
+        // ...
+    }
+
+For comment you will then have route URLs like ``http://yourdomain.com/admin/post/{postId}/comment/list`` and
+``http://yourdomain.com/admin/post/{postId}/comment/{commentId}/edit``
 
 Routing usage
 -------------

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -16,9 +16,11 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Route\DefaultRouteGenerator;
 use Sonata\AdminBundle\Route\RoutesCache;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentAdmin;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentWithCustomRouteAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\FieldDescription;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\ModelAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\PostWithCustomRouteAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Tag;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
@@ -460,6 +462,22 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('/sonata/news/post/{id}/comment', $commentAdmin->getBaseRoutePattern());
     }
 
+    public function testGetBaseRoutePatternWithSpecifedPattern()
+    {
+        $postAdmin = new PostWithCustomRouteAdmin('sonata.post.admin.post_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostWithCustomRouteAdmin');
+
+        $this->assertSame('/post-custom', $postAdmin->getBaseRoutePattern());
+    }
+
+    public function testGetBaseRoutePatternWithChildAdminAndWithSpecifedPattern()
+    {
+        $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $commentAdmin = new CommentWithCustomRouteAdmin('sonata.post.admin.comment_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentWithCustomRouteAdmin');
+        $commentAdmin->setParent($postAdmin);
+
+        $this->assertSame('/sonata/news/post/{id}/comment-custom', $commentAdmin->getBaseRoutePattern());
+    }
+
     /**
      * @expectedException RuntimeException
      */
@@ -578,6 +596,22 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'News\Entity\Post', 'SonataNewsBundle:PostAdmin');
         $admin->getBaseRouteName();
+    }
+
+    public function testGetBaseRouteNameWithSpecifiedName()
+    {
+        $postAdmin = new PostWithCustomRouteAdmin('sonata.post.admin.post_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+
+        $this->assertSame('post_custom', $postAdmin->getBaseRouteName());
+    }
+
+    public function testGetBaseRouteNameWithChildAdminAndWithSpecifiedName()
+    {
+        $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $commentAdmin = new CommentWithCustomRouteAdmin('sonata.post.admin.comment_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentWithCustomRouteAdmin');
+        $commentAdmin->setParent($postAdmin);
+
+        $this->assertSame('admin_sonata_news_post_comment_custom', $commentAdmin->getBaseRouteName());
     }
 
     /**

--- a/Tests/Fixtures/Admin/CommentWithCustomRouteAdmin.php
+++ b/Tests/Fixtures/Admin/CommentWithCustomRouteAdmin.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Admin;
+
+use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Route\RouteCollection;
+
+class CommentWithCustomRouteAdmin extends CommentAdmin
+{
+    protected $baseRoutePattern = 'comment-custom';
+    protected $baseRouteName = 'comment_custom';
+}

--- a/Tests/Fixtures/Admin/PostWithCustomRouteAdmin.php
+++ b/Tests/Fixtures/Admin/PostWithCustomRouteAdmin.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Admin;
+
+class PostWithCustomRouteAdmin extends PostAdmin
+{
+    protected $baseRoutePattern = '/post-custom';
+    protected $baseRouteName = 'post_custom';
+}


### PR DESCRIPTION
Hello,

This is a rebase of PR #3095 from 2.3 to master.
https://github.com/sonata-project/SonataAdminBundle/pull/3095

Copy of previous PR documentation :
------------------------------------------

I have tried to set the `$baseRoutePattern` in a child admin class and the behavior is that the parent base route pattern prefix is overridden by the child base route pattern.

Example:
```php
// ParentAdmin.php
protected $baseRoutePattern = 'my-parent';

// ChildAdmin.php
protected $baseRoutePattern = 'my-child';
```

So currently the generated route is : `/admin/my-child/list` (which is generated twice: once for the generic admin and once for the child (parent specific) admin)

This prevents filtering the children of my `Parent` instance.

With this pull request the generated route will be : `/admin/my-parent/{id}/my-child/list`

I did the same behavior with base route name.

I didn't found any tests that check the behavior when a custom base route name or a custom baseRoutePattern.

There is no setter to set the baseRoutePattern or the baseRouteName so it's hard to test, and, I think, out of the scope of this PR.

Do you accept this merge request as-is and after I do a new merge request for tests ?
Would you consider this PR acceptable as-is and I could, write comprehensive tests for explicitly specifying them, later on.

Thanks with advance.

Virgile