### PR TITLE
[WIP] Always show the button `Select` in `sonata_type_model_list`.

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -107,10 +107,6 @@ div.sonata-actions {
     font-weight: bold;
 }
 
-.sonata-ba-list tr:hover td.sonata-ba-list-field.sonata-ba-list-field-select a {
-    visibility: visible;
-}
-
 td.sonata-ba-list-field.sonata-ba-list-field-boolean i {
     margin-right: 1ex;
 }
@@ -126,9 +122,6 @@ td.sonata-ba-list-field.sonata-ba-list-field-integer {
 
 td.sonata-ba-list-field.sonata-ba-list-field-select {
     text-align: center;
-}
-td.sonata-ba-list-field.sonata-ba-list-field-select a {
-    visibility: hidden;
 }
 
 div.sonata-ba-modal-edit-one-to-one td.sonata-ba-list-field-batch,


### PR DESCRIPTION
Before this commit the button `Select` in popup of `sonata_type_model_list` was hidden by default but it was unusable on touch devices.

| Q             | A
| ------------- | ---
| Bug fix?      | yes (on touch devices)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

![sonata_list_remove_hover](https://cloud.githubusercontent.com/assets/960844/9893261/0c0898f8-5c17-11e5-8df5-eb17ab6cbed4.png)
