### PR TITLE
Fix action translations, translate remaining strings

### DIFF
--- a/Resources/translations/SonataAdminBundle.hu.xliff
+++ b/Resources/translations/SonataAdminBundle.hu.xliff
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="" >
+<?xml version="1.0" standalone="yes"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="hu" datatype="plaintext" original="SonataAdminBundle.en.xliff">
         <body>
             <trans-unit id="sonata_administration">
                 <source>sonata_administration</source>
@@ -8,7 +8,7 @@
             </trans-unit>
             <trans-unit id="action_delete">
                 <source>action_delete</source>
-                <target>Töröl</target>
+                <target>Törlés</target>
             </trans-unit>
             <trans-unit id="btn_batch">
                 <source>btn_batch</source>
@@ -16,19 +16,19 @@
             </trans-unit>
             <trans-unit id="btn_create">
                 <source>btn_create</source>
-                <target>Elkészít</target>
+                <target>Létrehozás</target>
             </trans-unit>
             <trans-unit id="btn_create_and_edit_again">
                 <source>btn_create_and_edit_again</source>
-                <target>Elkészít</target>
+                <target>Létrehozás</target>
             </trans-unit>
             <trans-unit id="btn_create_and_create_a_new_one">
                 <source>btn_create_and_create_a_new_one</source>
-                <target>Elkészít és hozzáad</target>
+                <target>Létrehozás és új hozzáadása</target>
             </trans-unit>
             <trans-unit id="btn_create_and_return_to_list">
                 <source>btn_create_and_return_to_list</source>
-                <target>Elkészít és vissza a listára</target>
+                <target>Létrehozás és visszalépés a listára</target>
             </trans-unit>
             <trans-unit id="btn_filter">
                 <source>btn_filter</source>
@@ -36,23 +36,23 @@
             </trans-unit>
             <trans-unit id="btn_advanced_filters">
                 <source>btn_advanced_filters</source>
-                <target>btn_advanced_filters</target>
+                <target>Fejlett szűrés</target>
             </trans-unit>
             <trans-unit id="btn_update">
                 <source>btn_update</source>
-                <target>Frissít</target>
+                <target>Frissítés</target>
             </trans-unit>
             <trans-unit id="btn_update_and_edit_again">
                 <source>btn_update_and_edit_again</source>
-                <target>Frissít</target>
+                <target>Frissítés</target>
             </trans-unit>
             <trans-unit id="btn_update_and_return_to_list">
                 <source>btn_update_and_return_to_list</source>
-                <target>Frissít és bezár</target>
+                <target>Frissítés és bezárás</target>
             </trans-unit>
             <trans-unit id="link_delete">
                 <source>link_delete</source>
-                <target>Töröl</target>
+                <target>Törlés</target>
             </trans-unit>
             <trans-unit id="link_action_create">
                 <source>link_action_create</source>
@@ -64,11 +64,11 @@
             </trans-unit>
             <trans-unit id="link_action_show">
                 <source>link_action_show</source>
-                <target>Mutat</target>
+                <target>Megjelenítés</target>
             </trans-unit>
             <trans-unit id="link_action_edit">
                 <source>link_action_edit</source>
-                <target>Szerkeszt</target>
+                <target>Szerkesztés</target>
             </trans-unit>
             <trans-unit id="link_add">
                 <source>link_add</source>
@@ -80,7 +80,7 @@
             </trans-unit>
             <trans-unit id="link_reset_filter">
                 <source>link_reset_filter</source>
-                <target>Visszaállít</target>
+                <target>Visszaállítás</target>
             </trans-unit>
             <trans-unit id="title_create">
                 <source>title_create</source>
@@ -120,7 +120,7 @@
             </trans-unit>
             <trans-unit id="link_expand">
                 <source>link_expand</source>
-                <target>szétnyit/összecsuk</target>
+                <target>kinyit/összecsuk</target>
             </trans-unit>
             <trans-unit id="no_result">
                 <source>no_result</source>
@@ -136,59 +136,59 @@
             </trans-unit>
             <trans-unit id="action_show">
                 <source>action_show</source>
-                <target>Megmutat</target>
+                <target>Megjelenítés</target>
             </trans-unit>
             <trans-unit id="all_elements">
                 <source>all_elements</source>
                 <target>Minden elem</target>
             </trans-unit>
-            <trans-unit id='flash_batch_empty'>
+            <trans-unit id="flash_batch_empty">
                 <source>flash_batch_empty</source>
                 <target>Megszakítva. Nincs kijelölt elem.</target>
             </trans-unit>
-            <trans-unit id='flash_create_success'>
+            <trans-unit id="flash_create_success">
                 <source>flash_create_success</source>
                 <target>Elem sikeresen hozzáadva.</target>
             </trans-unit>
-            <trans-unit id='flash_create_error'>
+            <trans-unit id="flash_create_error">
                 <source>flash_create_error</source>
                 <target>Hiba történt az elem hozzáadásakor.</target>
             </trans-unit>
-            <trans-unit id='flash_edit_success'>
+            <trans-unit id="flash_edit_success">
                 <source>flash_edit_success</source>
                 <target>Az elem sikeresen frissült.</target>
             </trans-unit>
-            <trans-unit id='flash_edit_error'>
+            <trans-unit id="flash_edit_error">
                 <source>flash_edit_error</source>
                 <target>Hiba történt az elem frissítésekor.</target>
             </trans-unit>
             <trans-unit id="flash_lock_error">
                 <source>flash_lock_error</source>
-                <target>flash_lock_error</target>
+                <target>Egy másik felhasználó módosította a(z) "%name%" elemet. %link_start%Ide%link_end% kattintva a változtatások betöltésre kerülnek.</target>
             </trans-unit>
-            <trans-unit id='flash_batch_delete_success'>
+            <trans-unit id="flash_batch_delete_success">
                 <source>flash_batch_delete_success</source>
                 <target>A kijelölt elemek sikeresen törölve lettek.</target>
             </trans-unit>
-            <trans-unit id='flash_batch_delete_error'>
+            <trans-unit id="flash_batch_delete_error">
                 <source>flash_batch_delete_error</source>
                 <target>Hiba történt a kijelölt elemek törlésekor.</target>
             </trans-unit>
-            <trans-unit id='flash_delete_error'>
+            <trans-unit id="flash_delete_error">
                 <source>flash_delete_error</source>
                 <target>Hiba történt az elem törlésekor.</target>
             </trans-unit>
-            <trans-unit id='flash_delete_success'>
+            <trans-unit id="flash_delete_success">
                 <source>flash_delete_success</source>
                 <target>Az elem sikeresen törölve lett.</target>
             </trans-unit>
             <trans-unit id="form_not_available">
                 <source>form_not_available</source>
-                <target>form_not_available</target>
+                <target>Az űrlap nem elérhető.</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
                 <source>breadcrumb.link_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+                <target>&lt;i class="fa fa-home"&gt;&lt;/i&gt;</target>
             </trans-unit>
             <trans-unit id="title_delete">
                 <source>title_delete</source>
@@ -212,7 +212,7 @@
             </trans-unit>
             <trans-unit id="message_batch_all_confirmation">
                 <source>message_batch_all_confirmation</source>
-                <target>message_batch_all_confirmation</target>
+                <target>Biztosan végre akarja hajtani a műveletet az összes elemen?</target>
             </trans-unit>
             <trans-unit id="btn_execute_batch_action">
                 <source>btn_execute_batch_action</source>
@@ -332,7 +332,7 @@
             </trans-unit>
             <trans-unit id="td_role">
                 <source>td_role</source>
-                <target>td_role</target>
+                <target>Szerepkör</target>
             </trans-unit>
             <trans-unit id="label_view_revision">
                 <source>label_view_revision</source>
@@ -344,7 +344,7 @@
             </trans-unit>
             <trans-unit id="list_results_count_prefix">
                 <source>list_results_count_prefix</source>
-                <target>list_results_count_prefix</target>
+                <target>legalább</target>
             </trans-unit>
             <trans-unit id="list_results_count">
                 <source>list_results_count</source>
@@ -384,7 +384,7 @@
             </trans-unit>
             <trans-unit id="btn_preview_decline">
                 <source>btn_preview_decline</source>
-                <target>Elutasítom</target>
+                <target>Elutasítás</target>
             </trans-unit>
             <trans-unit id="label_per_page">
                 <source>label_per_page</source>
@@ -392,7 +392,7 @@
             </trans-unit>
             <trans-unit id="list_select">
                 <source>list_select</source>
-                <target>Kijelöl</target>
+                <target>Kijelölés</target>
             </trans-unit>
             <trans-unit id="confirm_exit">
                 <source>confirm_exit</source>
@@ -452,15 +452,15 @@
             </trans-unit>
             <trans-unit id="stats_view_more">
                 <source>stats_view_more</source>
-                <target>stats_view_more</target>
+                <target>Több megjelenítése</target>
             </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
-                <target>Select object type</target>
+                <target>Objektum típus kiválasztása</target>
             </trans-unit>
             <trans-unit id="no_subclass_available">
                 <source>no_subclass_available</source>
-                <target>No object types available</target>
+                <target>Nem található objektum típus</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
I fixed some translations based on how they are generally translated on websites. I also translated some unstranslated strings.