### PR TITLE
StyleCI integration

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,5 +1,10 @@
 <?php
 
+require_once __DIR__.'/vendor/sllh/php-cs-fixer-styleci-bridge/autoload.php';
+
+use SLLH\StyleCIBridge\ConfigBridge;
+use Symfony\CS\Fixer\Contrib\HeaderCommentFixer;
+
 $header = <<<EOF
 This file is part of the Sonata Project package.
 
@@ -9,26 +14,8 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 EOF;
 
-Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
+HeaderCommentFixer::setHeader($header);
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()
-    ->in(array(__DIR__))
-    ->exclude(array('Tests/Fixtures'))
-;
-
-return Symfony\CS\Config\Config::create()
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers(array(
-        'header_comment',
-        '-unalign_double_arrow',
-        '-unalign_equals',
-        'align_double_arrow',
-        'newline_after_open_tag',
-        'ordered_use',
-        'long_array_syntax',
-        'php_unit_construct',
-        'php_unit_strict',
-    ))
+return ConfigBridge::create()
     ->setUsingCache(true)
-    ->finder($finder)
 ;

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,17 @@
+preset: symfony
+
+enabled:
+  - align_double_arrow
+  - newline_after_open_tag
+  - ordered_use
+  - long_array_syntax
+  - php_unit_construct
+  - php_unit_strict
+
+disabled:
+  - unalign_double_arrow
+  - unalign_equals
+
+finder:
+  exclude:
+    - Tests/Fixtures

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env: CS_FIXER=run
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
@@ -48,7 +46,7 @@ before_script:
   - mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d && echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer selfupdate
   - composer config -q -g github-oauth.github.com $GITHUB_OAUTH_TOKEN
-  - composer global require phpunit/phpunit:@stable fabpot/php-cs-fixer --no-update
+  - composer global require phpunit/phpunit:@stable --no-update
   - composer global update --prefer-dist --no-interaction
   - if [ "$SYMFONY_VERSION" = "2.8.*" ]; then SYMFONY_DEPRECATIONS_HELPER=strict; fi;
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
@@ -56,9 +54,7 @@ before_script:
   - export PATH=$HOME/.local/bin:$PATH
   - pip install -r Resources/doc/requirements.txt --user `whoami`
 
-script:
- - if [ "$CS_FIXER" = "run" ]; then make cs_dry_run ; fi;
- - make test
+script: make test
 
 notifications:
   webhooks: https://sonata-project.org/bundles/admin/master/travis

--- a/Admin/AdminExtensionInterface.php
+++ b/Admin/AdminExtensionInterface.php
@@ -20,9 +20,6 @@ use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Validator\ErrorElement;
 
-/**
- *
- */
 interface AdminExtensionInterface
 {
     /**

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -604,8 +604,6 @@ interface AdminInterface
      */
     public function getDataSourceIterator();
 
-    /**
-     */
     public function configure();
 
     /**

--- a/Builder/DatagridBuilderInterface.php
+++ b/Builder/DatagridBuilderInterface.php
@@ -25,7 +25,7 @@ interface DatagridBuilderInterface extends BuilderInterface
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $fieldDescription
      * @param \Sonata\AdminBundle\Admin\AdminInterface            $admin
      */
-    public function addFilter(DatagridInterface $datagrid, $type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin);
+    public function addFilter(DatagridInterface $datagrid, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin);
 
     /**
      * @param \Sonata\AdminBundle\Admin\AdminInterface $admin

--- a/Builder/ListBuilderInterface.php
+++ b/Builder/ListBuilderInterface.php
@@ -31,7 +31,7 @@ interface ListBuilderInterface extends BuilderInterface
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $fieldDescription
      * @param \Sonata\AdminBundle\Admin\AdminInterface            $admin
      */
-    public function buildField($type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin);
+    public function buildField($type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin);
 
     /**
      * Modify a field description and add it to the displayed columns.
@@ -41,5 +41,5 @@ interface ListBuilderInterface extends BuilderInterface
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface  $fieldDescription
      * @param \Sonata\AdminBundle\Admin\AdminInterface             $admin
      */
-    public function addField(FieldDescriptionCollection $list, $type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin);
+    public function addField(FieldDescriptionCollection $list, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin);
 }

--- a/Builder/ShowBuilderInterface.php
+++ b/Builder/ShowBuilderInterface.php
@@ -32,5 +32,5 @@ interface ShowBuilderInterface extends BuilderInterface
      * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface  $fieldDescription
      * @param \Sonata\AdminBundle\Admin\AdminInterface             $admin
      */
-    public function addField(FieldDescriptionCollection $list, $type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin);
+    public function addField(FieldDescriptionCollection $list, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin);
 }

--- a/Command/GenerateAdminCommand.php
+++ b/Command/GenerateAdminCommand.php
@@ -240,7 +240,7 @@ class GenerateAdminCommand extends ContainerAwareCommand
         foreach ($application->getKernel()->getBundles() as $bundle) {
             if (strpos($class, $bundle->getNamespace().'\\') === 0) {
                 return $bundle->getName();
-            };
+            }
         }
 
         return;

--- a/Datagrid/DatagridInterface.php
+++ b/Datagrid/DatagridInterface.php
@@ -30,8 +30,6 @@ interface DatagridInterface
      */
     public function getResults();
 
-    /**
-     */
     public function buildPager();
 
     /**

--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -63,7 +63,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
                 $classes[$arguments[1]][] = $id;
 
-                $showInDashboard = (boolean) (isset($attributes['show_in_dashboard']) ?  $parameterBag->resolveValue($attributes['show_in_dashboard']) : true);
+                $showInDashboard = (bool) (isset($attributes['show_in_dashboard']) ?  $parameterBag->resolveValue($attributes['show_in_dashboard']) : true);
                 if (!$showInDashboard) {
                     continue;
                 }

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -36,7 +36,7 @@ class SonataAdminExtension extends Extension
         $bundles = $container->getParameter('kernel.bundles');
 
         if (!isset($bundles['SonataCoreBundle'])) {
-            throw new \RuntimeException(<<<BOOM
+            throw new \RuntimeException(<<<'BOOM'
 Boom! you are living on the edge ;) The AdminBundle requires the CoreBundle!
 Please add ``"sonata-project/core-bundle": "~2.2"`` into your composer.json file and add the SonataCoreBundle into the AppKernel');
 BOOM

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,3 @@
-cs:
-	php-cs-fixer fix --verbose
-
-cs_dry_run:
-	php-cs-fixer fix --verbose --dry-run
-
 test:
 	phpunit
 	cd Resources/doc && sphinx-build -W -b html -d _build/doctrees . _build/html

--- a/Manipulator/ServicesManipulator.php
+++ b/Manipulator/ServicesManipulator.php
@@ -93,6 +93,6 @@ class ServicesManipulator
                 $serviceId,
                 $this->file
             ));
-        };
+        }
     }
 }

--- a/Mapper/BaseGroupedMapper.php
+++ b/Mapper/BaseGroupedMapper.php
@@ -20,9 +20,11 @@ abstract class BaseGroupedMapper extends BaseMapper
     protected $currentTab;
 
     abstract protected function getGroups();
+
     abstract protected function getTabs();
 
     abstract protected function setGroups(array $groups);
+
     abstract protected function setTabs(array $tabs);
 
     /**

--- a/Tests/Validator/Constraints/InlineConstraintTest.php
+++ b/Tests/Validator/Constraints/InlineConstraintTest.php
@@ -37,7 +37,7 @@ class InlineConstraintTest extends \PHPUnit_Framework_TestCase
 
     public function testGetClosure()
     {
-        $closure = function () {return 'FOO';};
+        $closure = function () {return 'FOO'; };
 
         $constraint = new InlineConstraint(array('service' => 'foo', 'method' => $closure));
         $this->assertSame($closure, $constraint->getClosure());

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -117,7 +117,7 @@ class SonataAdminExtension extends \Twig_Extension
      *
      * @return string
      */
-    public function output(FieldDescriptionInterface $fieldDescription, \Twig_Template $template, array $parameters = array(), Twig_Environment $environment)
+    public function output(FieldDescriptionInterface $fieldDescription, \Twig_Template $template, array $parameters, Twig_Environment $environment)
     {
         $content = $template->render($parameters);
 

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
         "jms/translation-bundle": "~1.1",
         "symfony/yaml": "~2.3",
         "sonata-project/intl-bundle": "~2.1",
-        "symfony/phpunit-bridge": "~2.7|~3.0"
+        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "suggest": {
         "jms/translation-bundle": "Extract message keys from Admins",


### PR DESCRIPTION
@rande I assigned you for this.

StyleCI is a php-cs-fixer interface that make CS lint quicker and proper than Travis.

I propose to integrate it: https://styleci.io/

You need to link this project. The only config that must be done on interface is for header comment.

If possible, could you give me access to StyleCI management? With that, I could set up this tools quiclky on each sonata project.

Regards.