### PR TITLE
Fixing incorrect extended type

### DIFF
--- a/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -196,7 +196,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return 'field';
+        return 'form';
     }
 
     /**


### PR DESCRIPTION
This pull request fixes the error: The extended type specified for the service "sonata.admin.form.extension.field" does not match the actual extended type. Expected "form", given "field".