### PR TITLE
Handle permissions in admin extension

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -2865,6 +2865,13 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
             'list'                    => 'LIST',
         ), $this->getAccessMapping());
 
+        foreach ($this->extensions as $extension) {
+            // TODO: remove method check in next major release
+            if (method_exists($extension, 'getAccessMapping')) {
+                $access = array_merge($access, $extension->getAccessMapping($this));
+            }
+        }
+
         if (!array_key_exists($action, $access)) {
             throw new \InvalidArgumentException(sprintf('Action "%s" could not be found in access mapping. Please make sure your action is defined into your admin class accessMapping property.', $action));
         }

--- a/Admin/AdminExtension.php
+++ b/Admin/AdminExtension.php
@@ -118,6 +118,14 @@ abstract class AdminExtension implements AdminExtensionInterface
     /**
      * {@inheritdoc}
      */
+    public function getAccessMapping(AdminInterface $admin)
+    {
+        return array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function preUpdate(AdminInterface $admin, $object)
     {
     }

--- a/Admin/AdminExtensionInterface.php
+++ b/Admin/AdminExtensionInterface.php
@@ -123,6 +123,16 @@ interface AdminExtensionInterface
     public function getPersistentParameters(AdminInterface $admin);
 
     /**
+     * Return the controller access mapping.
+     *
+     * @param AdminInterface $admin
+     *
+     * @return array
+     */
+    // TODO: Uncomment in next major release
+    // public function getAccessMapping(AdminInterface $admin);
+
+    /**
      * @param AdminInterface $admin
      * @param mixed          $object
      */


### PR DESCRIPTION
When adding some routes with `configureRoutes`, there should be a way to add the corresponding access mappings.