### PR TITLE
replace glyphicons with font-awesome

### DIFF
--- a/Resources/views/Block/block_admin_list.html.twig
+++ b/Resources/views/Block/block_admin_list.html.twig
@@ -57,7 +57,7 @@ file that was distributed with this source code.
                                                         {% endif %}
                                                         {% if admin.hasroute('list') and admin.isGranted('LIST') %}
                                                             <a class="btn btn-link btn-flat" href="{{ admin.generateUrl('list')}}">
-                                                                <i class="glyphicon glyphicon-list"></i>
+                                                                <i class="fa fa-list"></i>
                                                                 {% trans from 'SonataAdminBundle' %}link_list{% endtrans -%}
                                                             </a>
                                                         {% endif %}

--- a/Resources/views/CRUD/base_edit_form.html.twig
+++ b/Resources/views/CRUD/base_edit_form.html.twig
@@ -33,7 +33,7 @@
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">
                                 {% for name, form_tab in admin.formtabs %}
-                                    <li{% if loop.index == 1 %} class="active"{% endif %}><a href="#tab_{{ admin.uniqid }}_{{ loop.index }}" data-toggle="tab"><span class="glyphicon glyphicon-exclamation-sign has-errors hide"></span> {{ admin.trans(name, {}, form_tab.translation_domain) }}</a></li>
+                                    <li{% if loop.index == 1 %} class="active"{% endif %}><a href="#tab_{{ admin.uniqid }}_{{ loop.index }}" data-toggle="tab"><i class="fa fa-exclamation-circle"></i> {{ admin.trans(name, {}, form_tab.translation_domain) }}</a></li>
                                 {% endfor %}
                             </ul>
                             <div class="tab-content">

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -159,7 +159,7 @@ file that was distributed with this source code.
                                     {% if admin.hasRoute('export') and admin.isGranted("EXPORT") and admin.getExportFormats()|length %}
                                         <div class="btn-group">
                                             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-                                                <i class="glyphicon glyphicon-export"></i>
+                                                <i class="fa fa-share-square-o"></i>
                                                 {{ "label_export_download"|trans({}, "SonataAdminBundle") }}
                                                 <span class="caret"></span>
                                             </button>
@@ -167,7 +167,7 @@ file that was distributed with this source code.
                                                 {% for format in admin.getExportFormats() %}
                                                 <li>
                                                     <a href="{{ admin.generateUrl('export', admin.modelmanager.paginationparameters(admin.datagrid, 0) + {'format' : format}) }}">
-                                                        <i class="glyphicon glyphicon-download"></i>
+                                                        <i class="fa fa-arrow-circle-o-down"></i>
                                                         {{ ("export_format_" ~ format)|trans({}, 'SonataAdminBundle') }}
                                                     </a>
                                                 <li>

--- a/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/Resources/views/CRUD/batch_confirmation.html.twig
@@ -44,7 +44,7 @@ file that was distributed with this source code.
                     {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
 
                     <a class="btn btn-success" href="{{ admin.generateUrl('list') }}">
-                        <i class="glyphicon glyphicon-th-list"></i> {{ 'link_action_list'|trans({}, 'SonataAdminBundle') }}
+                        <i class="fa fa-th-list"></i> {{ 'link_action_list'|trans({}, 'SonataAdminBundle') }}
                     </a>
                 {% endif %}
             </form>

--- a/Resources/views/CRUD/delete.html.twig
+++ b/Resources/views/CRUD/delete.html.twig
@@ -34,12 +34,12 @@ file that was distributed with this source code.
                     <input type="hidden" name="_method" value="DELETE">
                     <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
 
-                    <button type="submit" class="btn btn-danger"><i class="glyphicon glyphicon-trash"></i> {{ 'btn_delete'|trans({}, 'SonataAdminBundle') }}</button>
+                    <button type="submit" class="btn btn-danger"><i class="fa fa-trash"></i> {{ 'btn_delete'|trans({}, 'SonataAdminBundle') }}</button>
                     {% if admin.hasRoute('edit') and admin.isGranted('EDIT', object) %}
                         {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
 
                         <a class="btn btn-success" href="{{ admin.generateObjectUrl('edit', object) }}">
-                            <i class="glyphicon glyphicon-edit"></i>
+                            <i class="fa fa-pencil"></i>
                             {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}</a>
                     {% endif %}
                 </form>

--- a/Resources/views/CRUD/list__select.html.twig
+++ b/Resources/views/CRUD/list__select.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 
 {% block field %}
     <a class="btn btn-default" href="{{ admin.generateObjectUrl('edit', object) }}">
-        <i class="glyphicon glyphicon-arrow-right"></i>
+        <i class="fa fa-arrow-right"></i>
         {{ 'list_select'|trans({}, 'SonataAdminBundle') }}
     </a>
 {% endblock %}

--- a/Resources/views/CRUD/preview.html.twig
+++ b/Resources/views/CRUD/preview.html.twig
@@ -19,11 +19,11 @@ file that was distributed with this source code.
 
 {% block formactions %}
     <button class="btn btn-success" type="submit" name="btn_preview_approve">
-        <i class="glyphicon glyphicon-ok"></i>
+        <i class="fa fa-check"></i>
         {{ 'btn_preview_approve'|trans({}, 'SonataAdminBundle') }}
     </button>
     <button class="btn btn-danger" type="submit" name="btn_preview_decline">
-        <i class="glyphicon glyphicon-remove"></i>
+        <i class="fa fa-times"></i>
         {{ 'btn_preview_decline'|trans({}, 'SonataAdminBundle') }}
     </button>
 {% endblock %}

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
         {% if not form.parent %}<div class="alert alert-danger">{% endif %}
             <ul class="list-unstyled">
                 {% for error in errors %}
-                    <li><i class="glyphicon glyphicon-exclamation-sign"></i> {{ error.message }}</li>
+                    <li><i class="fa fa-exclamation-circle"></i> {{ error.message }}</li>
                 {% endfor %}
             </ul>
         {% if not form.parent %}</div>{% endif %}


### PR DESCRIPTION
Some icons are missing in #3291 

Preview (before/after)
![bildschirmfoto 2015-09-28 um 19 05 14](https://cloud.githubusercontent.com/assets/3440437/10142577/e3d7ce92-6613-11e5-82f7-b6e20a07322a.PNG)

Delete (before/after)
![bildschirmfoto 2015-09-28 um 19 02 32](https://cloud.githubusercontent.com/assets/3440437/10142581/e3fdce12-6613-11e5-95b4-505dd5e6f211.PNG)

Batch (before/after)
![bildschirmfoto 2015-09-28 um 19 01 17](https://cloud.githubusercontent.com/assets/3440437/10142580/e3fcd8ea-6613-11e5-989e-2c04c46e77cb.PNG)

Edit error tabs (before/after)
![bildschirmfoto 2015-09-28 um 19 00 03](https://cloud.githubusercontent.com/assets/3440437/10142578/e3f9e19e-6613-11e5-88e5-978ef48d7004.PNG)

List export (before/after)
![bildschirmfoto 2015-09-28 um 18 56 42](https://cloud.githubusercontent.com/assets/3440437/10142579/e3fcb2b6-6613-11e5-8aff-a51b8a1f6bd4.PNG)

Modal select (before/after)
![bildschirmfoto 2015-09-28 um 19 06 09](https://cloud.githubusercontent.com/assets/3440437/10142604/01c652c0-6614-11e5-880f-1807676b1503.PNG)
