### PR TITLE
Collection form type add button fix

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -313,7 +313,7 @@ var Admin = {
         Admin.log('[core|setup_collection_counter] setup collection counter', subject);
 
         // Count and save element of each collection
-        var highestCounterRegexp = new RegExp('_([0-9])+$');
+        var highestCounterRegexp = new RegExp('_([0-9]+)$');
         jQuery(subject).find('[data-prototype]').each(function() {
             var collection = jQuery(this);
             var counter = 0;


### PR DESCRIPTION
Updated regexp is used when collection max index being defined.

Old version of regexp matched only first digit of element id => `counter` could not be greater than 9 => it was not possible to properly add item to collection with more than 10 elements - it just replaced 10'th element which supposed to be added.

This patch fixes the issue.