### PR TITLE
Add possibility to append or remove assets based on defaults

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,6 +31,58 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
+        $defaultStylesheets = array(
+            'bundles/sonatacore/vendor/bootstrap/dist/css/bootstrap.min.css',
+            'bundles/sonatacore/vendor/components-font-awesome/css/font-awesome.min.css',
+            'bundles/sonatacore/vendor/ionicons/css/ionicons.min.css',
+            'bundles/sonataadmin/vendor/admin-lte/dist/css/AdminLTE.min.css',
+            'bundles/sonataadmin/vendor/admin-lte/dist/css/skins/skin-black.min.css',
+            'bundles/sonataadmin/vendor/iCheck/skins/square/blue.css',
+
+            'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css',
+
+            'bundles/sonataadmin/vendor/jqueryui/themes/base/jquery-ui.css',
+
+            'bundles/sonatacore/vendor/select2/select2.css',
+            'bundles/sonatacore/vendor/select2-bootstrap-css/select2-bootstrap.min.css',
+
+            'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/css/bootstrap-editable.css',
+
+            'bundles/sonataadmin/css/styles.css',
+            'bundles/sonataadmin/css/layout.css',
+            'bundles/sonataadmin/css/tree.css',
+        );
+
+        $defaultJavascripts = array(
+            'bundles/sonatacore/vendor/jquery/dist/jquery.min.js',
+            'bundles/sonataadmin/vendor/jquery.scrollTo/jquery.scrollTo.min.js',
+
+            'bundles/sonatacore/vendor/moment/min/moment.min.js',
+
+            'bundles/sonataadmin/vendor/jqueryui/ui/minified/jquery-ui.min.js',
+            'bundles/sonataadmin/vendor/jqueryui/ui/minified/i18n/jquery-ui-i18n.min.js',
+
+            'bundles/sonatacore/vendor/bootstrap/dist/js/bootstrap.min.js',
+
+            'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js',
+
+            'bundles/sonataadmin/vendor/jquery-form/jquery.form.js',
+            'bundles/sonataadmin/jquery/jquery.confirmExit.js',
+
+            'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/js/bootstrap-editable.min.js',
+
+            'bundles/sonatacore/vendor/select2/select2.min.js',
+
+            'bundles/sonataadmin/vendor/admin-lte/dist/js/app.min.js',
+            'bundles/sonataadmin/vendor/iCheck/icheck.min.js',
+            'bundles/sonataadmin/vendor/slimScroll/jquery.slimscroll.min.js',
+            'bundles/sonataadmin/vendor/waypoints/lib/jquery.waypoints.min.js',
+            'bundles/sonataadmin/vendor/waypoints/lib/shortcuts/sticky.min.js',
+
+            'bundles/sonataadmin/Admin.js',
+            'bundles/sonataadmin/treeview.js',
+        );
+
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('sonata_admin', 'array');
 
@@ -278,60 +330,52 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->arrayNode('stylesheets')
-                            ->defaultValue(array(
-                                'bundles/sonatacore/vendor/bootstrap/dist/css/bootstrap.min.css',
-                                'bundles/sonatacore/vendor/components-font-awesome/css/font-awesome.min.css',
-                                'bundles/sonatacore/vendor/ionicons/css/ionicons.min.css',
-                                'bundles/sonataadmin/vendor/admin-lte/dist/css/AdminLTE.min.css',
-                                'bundles/sonataadmin/vendor/admin-lte/dist/css/skins/skin-black.min.css',
-                                'bundles/sonataadmin/vendor/iCheck/skins/square/blue.css',
-
-                                'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css',
-
-                                'bundles/sonataadmin/vendor/jqueryui/themes/base/jquery-ui.css',
-
-                                'bundles/sonatacore/vendor/select2/select2.css',
-                                'bundles/sonatacore/vendor/select2-bootstrap-css/select2-bootstrap.min.css',
-
-                                'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/css/bootstrap-editable.css',
-
-                                'bundles/sonataadmin/css/styles.css',
-                                'bundles/sonataadmin/css/layout.css',
-                                'bundles/sonataadmin/css/tree.css',
-                            ))
+                            ->defaultValue($defaultStylesheets)
                             ->prototype('scalar')->end()
+                            ->beforeNormalization()
+                                ->always()
+                                ->then(function ($v) use ($defaultStylesheets) {
+                                    if (!isset($v['append']) & !isset($v['remove'])) {
+                                        return $v;
+                                    }
+
+                                    $stylesheets = $defaultStylesheets;
+
+                                    if (isset($v['append'])) {
+                                        $stylesheets = array_merge($stylesheets, $v['append']);
+                                    }
+
+                                    if (isset($v['remove'])) {
+                                        $stylesheets = array_diff($stylesheets, $v['remove']);
+                                    }
+
+                                    return $stylesheets;
+                                })
+                            ->end()
                         ->end()
                         ->arrayNode('javascripts')
-                            ->defaultValue(array(
-                                'bundles/sonatacore/vendor/jquery/dist/jquery.min.js',
-                                'bundles/sonataadmin/vendor/jquery.scrollTo/jquery.scrollTo.min.js',
-
-                                'bundles/sonatacore/vendor/moment/min/moment.min.js',
-
-                                'bundles/sonataadmin/vendor/jqueryui/ui/minified/jquery-ui.min.js',
-                                'bundles/sonataadmin/vendor/jqueryui/ui/minified/i18n/jquery-ui-i18n.min.js',
-
-                                'bundles/sonatacore/vendor/bootstrap/dist/js/bootstrap.min.js',
-
-                                'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js',
-
-                                'bundles/sonataadmin/vendor/jquery-form/jquery.form.js',
-                                'bundles/sonataadmin/jquery/jquery.confirmExit.js',
-
-                                'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/js/bootstrap-editable.min.js',
-
-                                'bundles/sonatacore/vendor/select2/select2.min.js',
-
-                                'bundles/sonataadmin/vendor/admin-lte/dist/js/app.min.js',
-                                'bundles/sonataadmin/vendor/iCheck/icheck.min.js',
-                                'bundles/sonataadmin/vendor/slimScroll/jquery.slimscroll.min.js',
-                                'bundles/sonataadmin/vendor/waypoints/lib/jquery.waypoints.min.js',
-                                'bundles/sonataadmin/vendor/waypoints/lib/shortcuts/sticky.min.js',
-
-                                'bundles/sonataadmin/Admin.js',
-                                'bundles/sonataadmin/treeview.js',
-                            ))
+                            ->defaultValue($defaultJavascripts)
                             ->prototype('scalar')->end()
+                            ->beforeNormalization()
+                                ->always()
+                                ->then(function ($v) use ($defaultJavascripts) {
+                                    if (!isset($v['append']) & !isset($v['remove'])) {
+                                        return $v;
+                                    }
+
+                                    $javascripts = $defaultJavascripts;
+
+                                    if (isset($v['append'])) {
+                                        $javascripts = array_merge($javascripts, $v['append']);
+                                    }
+
+                                    if (isset($v['remove'])) {
+                                        $javascripts = array_diff($javascripts, $v['remove']);
+                                    }
+
+                                    return $javascripts;
+                                })
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -204,4 +204,142 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             ),
         )));
     }
+
+    /**
+     * @dataProvider getAssetsTests
+     */
+    public function testAssets($configs, $expected)
+    {
+        $configuration = new Configuration();
+
+        $reflection = new \ReflectionClass($configuration);
+        $property = $reflection->getProperty('defaultAssets');
+        $property->setAccessible(true);
+        $property->setValue($configuration, array('javascripts' => array('default.js'), 'stylesheets' => array('default.css')));
+
+        $processor = new Processor();
+        $config = $processor->processConfiguration($configuration, array_map(function ($config) {return ['assets' => $config];}, $configs));
+
+        $this->assertEquals($expected, $config['assets']);
+    }
+
+    public function getAssetsTests()
+    {
+        return array(
+            array(// Defaults
+                array(),
+                array('javascripts' => array('default.js'), 'stylesheets' => array('default.css')),
+            ),
+            array(// Replace
+                array(
+                    array(
+                        'javascripts' => array(
+                            'someAsset.js',
+                            'someOtherAsset.js',
+                        ),
+                        'stylesheets' => array(
+                            'someAsset.css',
+                            'someOtherAsset.css',
+                        ),
+                    )
+                ),
+                array(
+                    'javascripts' => array(
+                        'someAsset.js',
+                        'someOtherAsset.js',
+                    ),
+                    'stylesheets' => array(
+                        'someAsset.css',
+                        'someOtherAsset.css',
+                    ),
+                ),
+            ),
+            array(// Append
+                array(
+                    array(
+                        'javascripts' => array(
+                            'append' => array(
+                                'appended.js',
+                            ),
+                        ),
+                        'stylesheets' => array(
+                            'append' => array(
+                                'appended.css',
+                            ),
+                        ),
+                    ),
+                ),
+                array(
+                    'javascripts' => array(
+                        'default.js',
+                        'appended.js',
+                    ),
+                    'stylesheets' => array(
+                        'default.css',
+                        'appended.css',
+                    ),
+                ),
+            ),
+            array(// Remove
+                array(
+                    array(
+                        'javascripts' => array(
+                            'remove' => array(
+                                'default.js',
+                            ),
+                        ),
+                        'stylesheets' => array(
+                            'remove' => array(
+                                'default.css',
+                            ),
+                        ),
+                    ),
+                ),
+                array(
+                    'javascripts' => array(),
+                    'stylesheets' => array(),
+                ),
+            ),
+            array(// Merging append
+                array(
+                    array(
+                        'javascripts' => array(
+                            'append' => array(
+                                'appended1.js',
+                            ),
+                        ),
+                        'stylesheets' => array(
+                            'append' => array(
+                                'appended1.css',
+                            ),
+                        ),
+                    ),
+                    array(
+                        'javascripts' => array(
+                            'append' => array(
+                                'appended2.js',
+                            ),
+                        ),
+                        'stylesheets' => array(
+                            'append' => array(
+                                'appended2.css',
+                            ),
+                        ),
+                    ),
+                ),
+                array(
+                    'javascripts' => array(
+                        'default.js',
+                        'appended1.js',
+                        'appended2.js',
+                    ),
+                    'stylesheets' => array(
+                        'default.css',
+                        'appended1.css',
+                        'appended2.css',
+                    ),
+                ),
+            ),
+        );
+    }
 }


### PR DESCRIPTION
Alternative approach to #2425

The idea is to be able to do both:
```yaml
javascripts:
    append:
        - new.js
    remove:
        - existing.js
```
That would allow to manipulate the defaults.

And
```yaml
javascripts:
    - someJs.js
```
That allow to completely redefine the used assets.

The problem it have is that it will currently broke if assets are defined in multiple config files (the default assets will be included multiple times). I will try to find a solution to this problem when i have more time.