### PR TITLE
Array support for property transformer when using $multiple = true

### DIFF
--- a/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -83,10 +83,12 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
         if (!$entityOrCollection) {
             return $result;
         }
+
         if ($this->multiple) {
-            if (substr(get_class($entityOrCollection), -1 * strlen($this->className)) == $this->className) {
+            $isArray = is_array($entityOrCollection);
+            if (!$isArray && substr(get_class($entityOrCollection), -1 * strlen($this->className)) == $this->className) {
                 throw new \InvalidArgumentException('A multiple selection must be passed a collection not a single value. Make sure that form option "multiple=false" is set for many-to-one relation and "multiple=true" is set for many-to-many or one-to-many relations.');
-            } elseif ($entityOrCollection instanceof \ArrayAccess) {
+            } elseif ($isArray || ($entityOrCollection instanceof \ArrayAccess)) {
                 $collection = $entityOrCollection;
             } else {
                 throw new \InvalidArgumentException('A multiple selection must be passed a collection not a single value. Make sure that form option "multiple=false" is set for many-to-one relation and "multiple=true" is set for many-to-many or one-to-many relations.');

--- a/Tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
@@ -195,7 +195,7 @@ class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
         $collection[] = $entity2;
         $collection[] = $entity3;
 
-        $this->modelManager->expects($this->exactly(3))
+        $this->modelManager->expects($this->exactly(6))
             ->method('getIdentifierValues')
             ->will($this->returnCallback(function ($value) use ($entity1, $entity2, $entity3) {
                 if ($value == $entity1) {
@@ -220,7 +220,9 @@ class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array('identifiers' => array(), 'labels' => array()), $transformer->transform(0));
         $this->assertSame(array('identifiers' => array(), 'labels' => array()), $transformer->transform('0'));
 
-        $this->assertSame(array('identifiers' => array(123, 456, 789), 'labels' => array('foo', 'bar', 'baz')), $transformer->transform($collection));
+        $expected = array('identifiers' => array(123, 456, 789), 'labels' => array('foo', 'bar', 'baz'));
+        $this->assertSame($expected, $transformer->transform($collection));
+        $this->assertSame($expected, $transformer->transform($collection->toArray()));
     }
 
     /**


### PR DESCRIPTION
When using `OneToMany` collections in a form field with `'multiple' => true` the `ModelToIdPropertyTransformer` expects an `ArrayCollection` and throws an exception if the supplied value is an `array`.

Example: A `User` entity which implements the `UserInterface` has to return an `array` for `getRoles` even though the property `roles` (might be /) is an `ArrayCollection`; hence the getter will return `$this->roles->toArray()`.

- Check if $entityOrCollection is array
- Add test case for transforming an array
