### PR TITLE
Allow Admin to have multiple parents

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -234,7 +234,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      * then the $parentReflectionProperty must be the ReflectionProperty of
      * the order (OrderElement::$order).
      *
-     * @var \ReflectionProperty
+     * @var \ReflectionProperty|mixed
      */
     protected $parentAssociationMapping = null;
 
@@ -822,11 +822,38 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      * Returns the name of the parent related field, so the field can be use to set the default
      * value (ie the parent object) or to filter the object.
      *
-     * @return string the name of the parent related field
+     * @return null|string
+     *
+     * @throws \InvalidArgumentException
      */
     public function getParentAssociationMapping()
     {
+        if (is_array($this->parentAssociationMapping) && $this->getParent()) {
+            $parent = $this->getParent()->getCode();
+            if (array_key_exists($parent, $this->parentAssociationMapping)) {
+                return $this->parentAssociationMapping[$parent];
+            }
+            throw new \InvalidArgumentException(sprintf(
+                "There's no association between %s and %s.",
+                $this->getCode(),
+                $this->getParent()->getCode()
+            ));
+        }
+
         return $this->parentAssociationMapping;
+    }
+
+    /**
+     * @param string $code
+     * @param string $value
+     *
+     * @return $this
+     */
+    final public function addParentAssociationMapping($code, $value)
+    {
+        $this->parentAssociationMapping[$code] = $value;
+
+        return $this;
     }
 
     /**
@@ -1811,12 +1838,15 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function addChild(AdminInterface $child)
+    public function addChild(AdminInterface $child, $field = null)
     {
         $this->children[$child->getCode()] = $child;
 
         $child->setBaseCodeRoute($this->getCode().'|'.$child->getCode());
         $child->setParent($this);
+        if ($field) {
+            $child->addParentAssociationMapping($this->getCode(), $field);
+        }
     }
 
     /**

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -545,11 +545,12 @@ interface AdminInterface
     public function supportsPreviewMode();
 
     /**
-     * add an Admin child to the current one.
+     * add an Admin child to the current one linked to child's field.
      *
      * @param AdminInterface $child
+     * @param null|string    $field
      */
-    public function addChild(AdminInterface $child);
+    public function addChild(AdminInterface $child, $field = null);
 
     /**
      * Returns true or false if an Admin child exists for the given $code.

--- a/Resources/doc/reference/architecture.rst
+++ b/Resources/doc/reference/architecture.rst
@@ -318,7 +318,9 @@ Let us say you have a ``PostAdmin`` and a ``CommentAdmin``. You can optionally d
 to be a child of the ``PostAdmin``. This will create new routes like, for example, ``/post/{id}/comment/list``,
 where the comments will automatically be filtered by post.
 
-To do this, you first need to call the ``addChild`` method in your PostAdmin service configuration :
+To do this, you first need to call the ``addChild`` method in your ``PostAdmin`` service configuration with two arguments,
+the child admin name (in this case ``CommentAdmin`` service) and the Entity field that relates our child Entity with
+its parent :
 
 .. configuration-block::
 
@@ -330,6 +332,7 @@ To do this, you first need to call the ``addChild`` method in your PostAdmin ser
 
             <call method="addChild">
                 <argument type="service" id="sonata.news.admin.comment" />
+                <argument>post</<argument>
             </call>
         </service>
 

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -233,7 +233,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             'Application\Sonata\NewsBundle\Entity\Comment',
             'SonataNewsBundle:CommentAdmin'
         );
-        $admin->addChild($commentAdmin);
+        $admin->addChild($commentAdmin, 'post');
         $admin->setRequest(new Request(array('id' => 42)));
         $commentAdmin->setRequest(new Request());
         $commentAdmin->initialize();
@@ -390,7 +390,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             'Application\Sonata\NewsBundle\Entity\Comment',
             'SonataNewsBundle:CommentAdmin'
         );
-        $admin->addChild($commentAdmin);
+        $admin->addChild($commentAdmin, 'post');
         $admin->setRequest(new Request(array('id' => 42)));
         $commentAdmin->setRequest(new Request());
         $commentAdmin->initialize();
@@ -466,7 +466,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($postAdmin->hasChild('comment'));
 
         $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
-        $postAdmin->addChild($commentAdmin);
+        $postAdmin->addChild($commentAdmin, 'post');
         $this->assertTrue($postAdmin->hasChildren());
         $this->assertTrue($postAdmin->hasChild('sonata.post.admin.comment'));
 
@@ -724,7 +724,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $commentAdmin->setRouteGenerator($routeGenerator);
         $commentAdmin->initialize();
 
-        $postAdmin->addChild($commentAdmin);
+        $postAdmin->addChild($commentAdmin, 'post');
         $pool->setAdminServiceIds(array('sonata.post.admin.post', 'sonata.post.admin.comment'));
 
         $this->assertSame($expected.'_comment', $commentAdmin->getBaseRouteName());


### PR DESCRIPTION
I've found that our project required Admin to have multiple parent Admins, but sonata couldn't handle that, as it was only possible to have one parent at a time.

With this, we allow an Admin to use multiple parents, it is working in our project, I've changed the tests file but i don't know if I've edited good, because I don't know about theese Tests...

How does it works?

Well, `$parentAssociationMapping` is now an Array which contains a key based on an admin's code and a value which is the entity mapped field.

For example

`Post` has `Comments`
`Page` has `Comments`
`Comment` can be from `Post` or `Page`.

`Post` = `admin.post`
`Page` = `admin.page`
`Comment` = `admin.comment`

Our Yaml file would be

``` yaml
  admin.post:
      class: AdminBundle\Admin\Post
      arguments: [~, AdminBundle\Entity\Post, ~]
      tags:
          - {name: sonata.admin, manager_type: orm, group: admin, label: post}
      calls:
          - [addChild, [@admin.comment, "post"]]

  admin.page:
      class: AdminBundle\Admin\Page
      arguments: [~, AdminBundle\Entity\Page, ~]
      tags:
          - {name: sonata.admin, manager_type: orm, group: admin, label: page}
      calls:
          - [addChild, [@admin.comment, "page"]]

  admin.comment:
      class: AdminBundle\Admin\Comment
      arguments: [~, AdminBundle\Entity\Comment, ~]
      tags:
          - {name: sonata.admin, manager_type: orm, group: admin, label: comment}
```

As you can see, instead of declaring `$parentAssociationMapping` field inside `Admin` class, we declare the linked field inside our admin's config, this would add an array to `Comment` that would be

``` php
array('admin.post' => 'post', 'admin.page' => 'page');
```

`post` and `page` are `manyToOne` relationships between `Comment` and `Post`/`Page` so, it's the field name as always have been used in Sonata.

It will call `setParent()` as usual. So when retrieving `getParentAssociationMapping()` we check if we have a parent, if we do, we will get it's admin's code, and check against the array, return the value (the field) or throw an exception if the key was not found.

Maybe it can be improved, but I think this is something needed and I've searched it everywhere but people was doing ugly things like getting the class name on a switch-case that of course is not automatic and need writing on every admin and every situation.
