### PR TITLE
Properly initialize the admin subject in retrieveAutocompleteItemsAction

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -333,8 +333,7 @@ class HelperController
             throw new AccessDeniedException();
         }
 
-        // subject will be empty to avoid unnecessary database requests and keep autocomplete function fast
-        $admin->setSubject($admin->getNewInstance());
+        $admin->setSubject($request->query->has('id') ? $admin->getObject($request->query->get('id')) : $admin->getNewInstance());
 
         if ($context === 'filter') {
             // filter

--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -61,6 +61,9 @@ file that was distributed with this source code.
                                 {% if sonata_admin.admin is not null %}
                                     'uniqid': '{{ sonata_admin.admin.uniqid }}',
                                     'admin_code': '{{ sonata_admin.admin.code }}',
+                                    {% if sonata_admin.admin.id(sonata_admin.admin.subject) %}
+                                        'id': '{{ sonata_admin.admin.id(sonata_admin.admin.subject) }}',
+                                    {% endif %}
                                 {% elseif admin_code %}
                                     'admin_code':  '{{ admin_code }}',
                                 {% endif %}


### PR DESCRIPTION
If you conditional add or enable a sonata_type_model_autocomplete field based on the admin subject the ajax query will fail because it initialize the admin instance with an new subject instead of the current one.

This PR make the auto-complete field pass the id of the current subject allowing the the retrieveAutocompleteItemsAction to retrieve the correct subject. This means the auto-complete feature will do one more query to the database making it a bit slower.

If the performance change is really a problem, this could be made configurable with an option on the form type.