### PR TITLE
Fixed x-editable datepicker

### DIFF
--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -445,3 +445,11 @@ div.sonata-filters-box div.form-group span.input-group-addon {
     padding: 3px 10px;
     font-size: 13px;
 }
+
+.editable-container .prev:before {
+    content: "\2190 ";
+}
+
+.editable-container .next:before {
+    content: "\2192 ";
+}


### PR DESCRIPTION
The next and prev buttons on the datepicker are broken, but the x-editable script is frozen and not maintained anymore. I think we should fix it ourselves.

Before
![bildschirmfoto 2015-10-09 um 23 01 59](https://cloud.githubusercontent.com/assets/3440437/10405591/2e5b5c26-6eda-11e5-9ef3-67220356456b.PNG)
After
![bildschirmfoto 2015-10-09 um 23 04 51](https://cloud.githubusercontent.com/assets/3440437/10405590/2e5a03e4-6eda-11e5-9979-c5483b49bf09.PNG)

