### PR TITLE
Set not required option for boolean fields

### DIFF
--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -117,6 +117,10 @@ class FormMapper extends BaseGroupedMapper
             // Note that the builder var is actually the formContractor:
             $options = array_replace_recursive($this->builder->getDefaultOptions($type, $fieldDescription), $options);
 
+            if (!isset($options['required']) && $fieldDescription->getType() == 'boolean') {
+                $options['required'] = $options['required'] || false;
+            }
+
             // be compatible with mopa if not installed, avoid generating an exception for invalid option
             // force the default to false ...
             if (!isset($options['label_render'])) {


### PR DESCRIPTION
When having a boolean database field, you have to set the required option to false manually.

**Foo.orm.yml**
```
acme\DemoBundle\Entity\Foo:
    type: entity
    fields:
        archived:
            type: boolean
```

**FooAdmin.php**
``` 
$formMapper
   ->add('archived', null, array('required' => false));
```

Now the option is automatically set to false.

**FooAdmin.php**
``` 
$formMapper
   ->add('archived');
```
![bildschirmfoto 2015-10-10 um 00 55 56](https://cloud.githubusercontent.com/assets/3440437/10407329/ba223e46-6ee9-11e5-8397-6a3bb0463dd4.PNG)
