### PR TITLE
Update colon spacing in french translation

### DIFF
--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -204,7 +204,7 @@
             </trans-unit>
             <trans-unit id="title_batch_confirmation">
                 <source>title_batch_confirmation</source>
-                <target>Confirmation d'un traitement par lots: '%action%'</target>
+                <target>Confirmation d'un traitement par lots : '%action%'</target>
             </trans-unit>
             <trans-unit id="message_batch_confirmation">
                 <source>message_batch_confirmation</source>
@@ -420,7 +420,7 @@
             </trans-unit>
             <trans-unit id="title_search_results">
                 <source>title_search_results</source>
-                <target>Résultats de recherche: %query%</target>
+                <target>Résultats de recherche : %query%</target>
             </trans-unit>
             <trans-unit id="search_placeholder">
                 <source>search_placeholder</source>


### PR DESCRIPTION
French typography requires a space before a colon.