### PR TITLE
Make dashboard breadcrumb translation independant of translator strategy

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -2125,7 +2125,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
             $menu = $this->menuFactory->createItem('root');
 
             $menu = $menu->addChild(
-                $this->trans($this->getLabelTranslatorStrategy()->getLabel('dashboard', 'breadcrumb', 'link'), array(), 'SonataAdminBundle'),
+                $this->trans('breadcrumb.link_dashboard', array(), 'SonataAdminBundle'),
                 array('uri' => $this->routeGenerator->generate('sonata_admin_dashboard'))
             );
         }

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -155,53 +155,43 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->with('sonata_admin_dashboard')
             ->will($this->returnValue('http://somehost.com'));
 
-        $translatorStrategy->expects($this->exactly(18))
+        $translatorStrategy->expects($this->exactly(13))
             ->method('getLabel')
             ->withConsecutive(
-                array('dashboard'),
                 array('Post_list'),
                 array('Comment_list'),
                 array('Comment_repost'),
 
-                array('dashboard'),
                 array('Post_list'),
                 array('Comment_list'),
                 array('Comment_flag'),
 
-                array('dashboard'),
                 array('Post_list'),
                 array('Comment_list'),
                 array('Comment_edit'),
 
-                array('dashboard'),
                 array('Post_list'),
                 array('Comment_list'),
 
-                array('dashboard'),
                 array('Post_list'),
                 array('Comment_list')
             )
             ->will($this->onConsecutiveCalls(
-                'someLabel',
                 'someOtherLabel',
                 'someInterestingLabel',
                 'someFancyLabel',
 
-                'someCoolLabel',
                 'someTipTopLabel',
                 'someFunkyLabel',
                 'someAwesomeLabel',
 
-                'someLikeableLabel',
                 'someMildlyInterestingLabel',
                 'someWTFLabel',
                 'someBadLabel',
 
-                'someBoringLabel',
                 'someLongLabel',
                 'someEndlessLabel',
 
-                'someAlmostThereLabel',
                 'someOriginalLabel',
                 'someOkayishLabel'
             ));
@@ -209,30 +199,30 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $menu->expects($this->exactly(24))
             ->method('addChild')
             ->withConsecutive(
-                array('someLabel'),
+                array('breadcrumb.link_dashboard'),
                 array('someOtherLabel'),
                 array('dummy subject representation'),
                 array('someInterestingLabel'),
                 array('someFancyLabel'),
 
-                array('someCoolLabel'),
+                array('breadcrumb.link_dashboard'),
                 array('someTipTopLabel'),
                 array('dummy subject representation'),
                 array('someFunkyLabel'),
                 array('someAwesomeLabel'),
 
-                array('someLikeableLabel'),
+                array('breadcrumb.link_dashboard'),
                 array('someMildlyInterestingLabel'),
                 array('dummy subject representation'),
                 array('someWTFLabel'),
                 array('someBadLabel'),
 
-                array('someBoringLabel'),
+                array('breadcrumb.link_dashboard'),
                 array('someLongLabel'),
                 array('dummy subject representation'),
                 array('someEndlessLabel'),
 
-                array('someAlmostThereLabel'),
+                array('breadcrumb.link_dashboard'),
                 array('someOriginalLabel'),
                 array('dummy subject representation'),
                 array('someOkayishLabel'),
@@ -286,32 +276,29 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->with('root')
             ->will($this->returnValue($menu));
 
-        $translatorStrategy->expects($this->exactly(5))
+        $translatorStrategy->expects($this->exactly(3))
             ->method('getLabel')
             ->withConsecutive(
-                array('dashboard'),
                 array('Post_list'),
                 array('Post_repost'),
 
-                array('dashboard'),
                 array('Post_list')
             )
             ->will($this->onConsecutiveCalls(
-                'someLabel',
                 'someOtherLabel',
                 'someInterestingLabel',
-                'someFancyLabel',
+
                 'someCoolLabel'
             ));
 
         $menu->expects($this->exactly(6))
             ->method('addChild')
             ->withConsecutive(
-                array('someLabel'),
+                array('breadcrumb.link_dashboard'),
                 array('someOtherLabel'),
                 array('someInterestingLabel'),
-                array('someFancyLabel'),
 
+                array('breadcrumb.link_dashboard'),
                 array('someCoolLabel'),
                 array('dummy subject representation')
             )


### PR DESCRIPTION
Since the dashboard link in the generated breadcrumbs is translated with the SonataAdminBundle domain, the translation key shouldn't depend on the translation strategy.

Without this fix the translation present in the translation files only works with the underscore strategy.