### PR TITLE
Fix overflow on big tables / small screens

### DIFF
--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -445,3 +445,15 @@ div.sonata-filters-box div.form-group span.input-group-addon {
     padding: 3px 10px;
     font-size: 13px;
 }
+
+/* table list scrollbar */
+.box .box-body {
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+.sonata-ba-list .pull-right.fix-overflow {
+    position: absolute;
+    right: 10px;
+    bottom: 10px;
+}

--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -457,3 +457,4 @@ div.sonata-filters-box div.form-group span.input-group-addon {
     right: 10px;
     bottom: 10px;
 }
+

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -155,7 +155,7 @@ file that was distributed with this source code.
                                 </div>
 
 
-                                <div class="pull-right">
+                                <div class="pull-right fix-overflow">
                                     {% if admin.hasRoute('export') and admin.isGranted('EXPORT') and admin.getExportFormats()|length %}
                                         <div class="btn-group">
                                             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">


### PR DESCRIPTION
Hello,

This PR is related to a previous one : https://github.com/sonata-project/SonataAdminBundle/pull/2169, the issue is you can't scroll on the right side of a table list on small screen. With the previous PR you couldn't access the different type of exports. I added a position absolute on this list and some markup (class fix-overflow) to apply the css and avoid wrong behaviour (display is a bit broken on IE9, IE10+, Firefox, Chrome is OK).

There is still one little remaining issue with this fix, on really small screen (~ 500px) the actions on the right (export, items per page) are on top of the actions of the left.

Related issue: https://github.com/sonata-project/SonataAdminBundle/issues/3362

Here are some screenshots : 

Without the PR
![big table no scroll](https://cloud.githubusercontent.com/assets/520893/10431230/51ec83dc-7104-11e5-8f99-8651b0107d87.png)

With the PR
![big table scroll](https://cloud.githubusercontent.com/assets/520893/10431235/5598ab64-7104-11e5-861f-d513d5f6df8e.png)

WIth PR and opened export
![opened export](https://cloud.githubusercontent.com/assets/520893/10431273/7ca11e76-7104-11e5-8af0-c74f6ffa1af5.png)

Issue on small device (500px)
![overflow right buttons](https://cloud.githubusercontent.com/assets/520893/10431239/5e29ac56-7104-11e5-8041-0249c0b291a4.png)

Issue on IE9 with absolute positioning
<img width="444" alt="ie9" src="https://cloud.githubusercontent.com/assets/520893/10431835/b28f0b80-7107-11e5-82a9-98f64ca8ca15.png">

Could add some IE9 specific css to fix this if needed.


