### PR TITLE
Allows Symfony Validation API 2.5 in ControllerHelper

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -22,7 +22,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
 /**
  * Class HelperController.
@@ -47,18 +48,22 @@ class HelperController
     protected $pool;
 
     /**
-     * @var \Symfony\Component\Validator\ValidatorInterface
+     * @var \Symfony\Component\Validator\Validator\ValidatorInterface|\Symfony\Component\Validator\ValidatorInterface
      */
     protected $validator;
 
     /**
-     * @param \Twig_Environment                               $twig
-     * @param \Sonata\AdminBundle\Admin\Pool                  $pool
-     * @param \Sonata\AdminBundle\Admin\AdminHelper           $helper
-     * @param \Symfony\Component\Validator\ValidatorInterface $validator
+     * @param \Twig_Environment                                         $twig
+     * @param \Sonata\AdminBundle\Admin\Pool                            $pool
+     * @param \Sonata\AdminBundle\Admin\AdminHelper                     $helper
+     * @param \Symfony\Component\Validator\Validator\ValidatorInterface $validator
      */
-    public function __construct(\Twig_Environment $twig, Pool $pool, AdminHelper $helper, ValidatorInterface $validator)
+    public function __construct(\Twig_Environment $twig, Pool $pool, AdminHelper $helper, $validator)
     {
+        if (!($validator instanceof ValidatorInterface) && !($validator instanceof LegacyValidatorInterface)) {
+            throw new \InvalidArgumentException('Argument 4 is an instance of '.get_class($validator).', expecting an instance of \Symfony\Component\Validator\Validator\ValidatorInterface or \Symfony\Component\Validator\ValidatorInterface');
+        }
+
         $this->twig      = $twig;
         $this->pool      = $pool;
         $this->helper    = $helper;

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -20,7 +20,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
-use Symfony\Component\HttpKernel\Kernel;
 
 class AdminControllerHelper_Foo
 {
@@ -741,5 +740,4 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         return $data;
     }
-
 }

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -729,9 +729,12 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
     {
         $data = array();
 
-        $data['2.4'] = array('Symfony\Component\Validator\ValidatorInterface');
+        // For Symfony <= 2.8
+        if (interface_exists('Symfony\Component\Validator\ValidatorInterface')) {
+            $data['2.4'] = array('Symfony\Component\Validator\ValidatorInterface');
+        }
 
-        // For Symfony 2.5+
+        // For Symfony >= 2.5
         if (interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
             $data['2.5'] = array('Symfony\Component\Validator\Validator\ValidatorInterface');
         }

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\HttpKernel\Kernel;
 
 class AdminControllerHelper_Foo
 {
@@ -86,7 +87,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $twig = new \Twig_Environment($this->getMock('\Twig_LoaderInterface'));
         $helper = new AdminHelper($pool);
-        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+        $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
         $this->controller = new HelperController($twig, $pool, $helper, $validator);
 
         // php 5.3 BC
@@ -108,8 +109,9 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @dataProvider getValidatorInterfaces
      */
-    public function testgetShortObjectDescriptionActionInvalidAdmin()
+    public function testgetShortObjectDescriptionActionInvalidAdmin($validatorInterface)
     {
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $twig = new \Twig_Environment($this->getMock('\Twig_LoaderInterface'));
@@ -121,7 +123,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(array('sonata.post.admin'));
         $helper = new AdminHelper($pool);
-        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+        $validator = $this->getMock($validatorInterface);
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
         $controller->getShortObjectDescriptionAction($request);
@@ -130,8 +132,10 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \RuntimeException
      * @exceptionMessage Invalid format
+     *
+     * @dataProvider getValidatorInterfaces
      */
-    public function testgetShortObjectDescriptionActionObjectDoesNotExist()
+    public function testgetShortObjectDescriptionActionObjectDoesNotExist($validatorInterface)
     {
         $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('setUniqid');
@@ -152,13 +156,16 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+        $validator = $this->getMock($validatorInterface);
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
         $controller->getShortObjectDescriptionAction($request);
     }
 
-    public function testgetShortObjectDescriptionActionEmptyObjectId()
+    /**
+     * @dataProvider getValidatorInterfaces
+     */
+    public function testgetShortObjectDescriptionActionEmptyObjectId($validatorInterface)
     {
         $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('setUniqid');
@@ -180,13 +187,16 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+        $validator = $this->getMock($validatorInterface);
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
         $controller->getShortObjectDescriptionAction($request);
     }
 
-    public function testgetShortObjectDescriptionActionObject()
+    /**
+     * @dataProvider getValidatorInterfaces
+     */
+    public function testgetShortObjectDescriptionActionObject($validatorInterface)
     {
         $mockTemplate = 'AdminHelperTest:mock-short-object-description.html.twig';
 
@@ -226,7 +236,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+        $validator = $this->getMock($validatorInterface);
 
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
@@ -236,7 +246,10 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $response->getContent());
     }
 
-    public function testsetObjectFieldValueAction()
+    /**
+     * @dataProvider getValidatorInterfaces
+     */
+    public function testsetObjectFieldValueAction($validatorInterface)
     {
         $object = new AdminControllerHelper_Foo();
 
@@ -270,7 +283,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+        $validator = $this->getMock($validatorInterface);
 
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
@@ -279,7 +292,10 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('{"status":"OK","content":"\u003Cfoo \/\u003E"}', $response->getContent());
     }
 
-    public function testappendFormFieldElementAction()
+    /**
+     * @dataProvider getValidatorInterfaces
+     */
+    public function testappendFormFieldElementAction($validatorInterface)
     {
         $object = new AdminControllerHelper_Foo();
 
@@ -327,7 +343,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(array('sonata.post.admin'));
 
-        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+        $validator = $this->getMock($validatorInterface);
 
         $mockView = $this->getMockBuilder('Symfony\Component\Form\FormView')
             ->disableOriginalConstructor()
@@ -353,7 +369,10 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
     }
 
-    public function testretrieveFormFieldElementAction()
+    /**
+     * @dataProvider getValidatorInterfaces
+     */
+    public function testretrieveFormFieldElementAction($validatorInterface)
     {
         $object = new AdminControllerHelper_Foo();
 
@@ -410,7 +429,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(array('sonata.post.admin'));
 
-        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+        $validator = $this->getMock($validatorInterface);
 
         $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
 
@@ -423,7 +442,10 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
     }
 
-    public function testSetObjectFieldValueActionWithViolations()
+    /**
+     * @dataProvider getValidatorInterfaces
+     */
+    public function testSetObjectFieldValueActionWithViolations($validatorInterface)
     {
         $bar = new AdminControllerHelper_Bar();
 
@@ -460,7 +482,8 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
             new ConstraintViolation('error2', null, array(), null, 'enabled', null),
         ));
 
-        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+        $validator = $this->getMock($validatorInterface);
+
         $validator
             ->expects($this->once())
             ->method('validate')
@@ -697,4 +720,23 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->controller->retrieveAutocompleteItemsAction($request);
     }
+
+    /**
+     * Symfony Validator has 2 API version (2.4 and 2.5)
+     * This data provider ensure tests pass on each one.
+     */
+    public function getValidatorInterfaces()
+    {
+        $data = array();
+
+        $data['2.4'] = array('Symfony\Component\Validator\ValidatorInterface');
+
+        // For Symfony 2.5+
+        if (interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
+            $data['2.5'] = array('Symfony\Component\Validator\Validator\ValidatorInterface');
+        }
+
+        return $data;
+    }
+
 }


### PR DESCRIPTION
Hello,

The Symfony Validator API [changed between 2.4 and 2.5](https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.5.md#validator) but the SonataAdminBundle is compatible with API 2.4 only. 
After upgrading the project configuration in `framework: validation: api: 2.5`, the `Sonata\AdminBundle\Controller\HelperController` can't be used (for autocomplete):

```
Catchable Fatal Error: Argument 4 passed to
Sonata\AdminBundle\Controller\HelperController::__construct() 
must be an instance of Symfony\Component\Validator\ValidatorInterface,
instance of Symfony\Component\Validator\Validator\RecursiveValidator given
```

The compatibility was partially fixed fixed by the PR #2961.
The PR #2176 tried to make the `HelperController` compatible with validation 2.5, but this PR was abandoned. 
