### PR TITLE
show a default value if revision has no username set

### DIFF
--- a/Resources/translations/SonataAdminBundle.ar.xliff
+++ b/Resources/translations/SonataAdminBundle.ar.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.bg.xliff
+++ b/Resources/translations/SonataAdminBundle.bg.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/Resources/translations/SonataAdminBundle.ca.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>No hi ha tipus d'objecte disponibles</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/Resources/translations/SonataAdminBundle.cs.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>Keine Typen verfügbar.</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>unbekannt</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>No object types available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>unknown</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.es.xliff
+++ b/Resources/translations/SonataAdminBundle.es.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.eu.xliff
+++ b/Resources/translations/SonataAdminBundle.eu.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.fa.xliff
+++ b/Resources/translations/SonataAdminBundle.fa.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.hu.xliff
+++ b/Resources/translations/SonataAdminBundle.hu.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>Nem található objektum típus</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>Nessun tipo disponibile</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/Resources/translations/SonataAdminBundle.ja.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/Resources/translations/SonataAdminBundle.lb.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.lt.xliff
+++ b/Resources/translations/SonataAdminBundle.lt.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.no.xliff
+++ b/Resources/translations/SonataAdminBundle.no.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>Ingen objektttyper er tilgjengelige</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pt.xliff
+++ b/Resources/translations/SonataAdminBundle.pt.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>Nenhum tipo de objeto disponível</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ro.xliff
+++ b/Resources/translations/SonataAdminBundle.ro.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/Resources/translations/SonataAdminBundle.sk.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/Resources/translations/SonataAdminBundle.sl.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.sv_SE.xliff
+++ b/Resources/translations/SonataAdminBundle.sv_SE.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/Resources/translations/SonataAdminBundle.uk.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -462,6 +462,10 @@
                 <source>no_subclass_available</source>
                 <target>no_subclass_available</target>
             </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>label_unknown_user</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/views/CRUD/base_history.html.twig
+++ b/Resources/views/CRUD/base_history.html.twig
@@ -36,10 +36,8 @@ file that was distributed with this source code.
                             <tr class="{% if (currentRevision != false and revision.rev == currentRevision.rev) %}current-revision{% endif %}">
                                 <td>{{ revision.rev }}</td>
                                 <td>{% include admin.getTemplate('history_revision_timestamp') %}</td>
-                                <td>{{ revision.username }}</td>
-                                <td>
-                                    <a href="{{ admin.generateObjectUrl('history_view_revision', object, {'revision': revision.rev }) }}" class="revision-link" rel="{{ revision.rev }}">{{ 'label_view_revision'|trans({}, 'SonataAdminBundle') }}</a>
-                                </td>
+                                <td>{{ revision.username|default('label_unknown_user'|trans({}, 'SonataAdminBundle')) }}</td>
+                                <td><a href="{{ admin.generateObjectUrl('history_view_revision', object, {'revision': revision.rev }) }}" class="revision-link" rel="{{ revision.rev }}">{{ "label_view_revision"|trans({}, 'SonataAdminBundle') }}</a></td>
                                 <td>
                                     {% if (currentRevision == false or revision.rev == currentRevision.rev) %}
                                         /


### PR DESCRIPTION
before:
![bildschirmfoto 2015-10-22 um 12 50 14](https://cloud.githubusercontent.com/assets/995707/10663420/8faaef7e-78bb-11e5-95ed-94f7e9558baf.png)

after:
![bildschirmfoto 2015-10-22 um 12 50 46](https://cloud.githubusercontent.com/assets/995707/10663426/94372468-78bb-11e5-946b-5bb3cc990ea2.png)

The simplethings guys do the same here:
https://github.com/simplethings/EntityAudit/blob/master/src/SimpleThings/EntityAudit/Resources/views/Audit/view_entity.html.twig#L29