### PR TITLE
Fix BlockBundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "twig/extensions": "~1.0",
         "sonata-project/jquery-bundle": "1.8.*",
         "sonata-project/exporter": "~1.0,<1.2",
-        "sonata-project/block-bundle": "~2.2,>=2.2.7",
+        "sonata-project/block-bundle": "~2.2,>=2.2.8",
         "sonata-project/core-bundle": "~2.2,<2.3",
         "doctrine/common": "~2.2",
         "knplabs/knp-menu-bundle": ">=1.1.0,<3.0.0",


### PR DESCRIPTION
Templates are using `sonata_block_render_event`, which exists only since 2.2.8