### PR TITLE
Require at least CoreBundle 2.2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "sonata-project/jquery-bundle": "1.8.*",
         "sonata-project/exporter": "~1.0,<1.2",
         "sonata-project/block-bundle": "~2.2,>=2.2.7",
-        "sonata-project/core-bundle": "~2.2,<2.3",
+        "sonata-project/core-bundle": "~2.2,<2.3,>=2.2.3",
         "doctrine/common": "~2.2",
         "knplabs/knp-menu-bundle": ">=1.1.0,<3.0.0",
         "knplabs/knp-menu": ">=1.1.0,<3.0.0"


### PR DESCRIPTION
The bundle depends on `SonataCoreBundle:FlashMessage:render.html.twig`, which was introduced in version 2.2.3