### PR TITLE
Add one subclass to admin

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1078,6 +1078,16 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
+    public function addSubClass($subClass)
+    {
+        if (!in_array($subClass, $this->subClasses)) {
+            $this->subClasses[] = $subClass;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setSubClasses(array $subClasses)
     {
         $this->subClasses = $subClasses;


### PR DESCRIPTION
Would be great if you can add one simple subclass to an admin instead of replacing the whole subclasses by using ``setSubClasses``. 