### PR TITLE
Update AdminType.php (fix error subject)

### DIFF
--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -65,6 +65,8 @@ class AdminType extends AbstractType
                         );
                         if ($subjectCollection instanceof Collection) {
                             $subject = $subjectCollection->get(trim($options['property_path'], '[]'));
+                        } else {
+                            $subject = $subjectCollection;
                         }
                     } else {
                         // for PropertyAccessor >= 2.5


### PR DESCRIPTION
When you use sonata_type_admin into Admin class, an error can appear :
Undefined variable: subject in admin-bundle/Form/Type/AdminType.php line 74
Because an "else" is missing. (to prevent this error)