### PR TITLE
Removed type check of sonata_type_model_autocomplete to allow extending the form type.

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -462,10 +462,6 @@ class HelperController
             throw new \RuntimeException(sprintf('The field "%s" does not exist.', $field));
         }
 
-        if ($fieldDescription->getType() !== 'sonata_type_model_autocomplete') {
-            throw new \RuntimeException(sprintf('Unsupported form type "%s" for field "%s".', $fieldDescription->getType(), $field));
-        }
-
         if (null === $fieldDescription->getTargetEntity()) {
             throw new \RuntimeException(sprintf('No associated entity with field "%s".', $field));
         }

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -538,10 +538,6 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
 
         $fieldDescription->expects($this->once())
-            ->method('getType')
-            ->will($this->returnValue('sonata_type_model_autocomplete'));
-
-        $fieldDescription->expects($this->once())
             ->method('getTargetEntity')
             ->will($this->returnValue('Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo'));
 
@@ -609,10 +605,6 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $entity = new Foo();
 
         $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
-
-        $fieldDescription->expects($this->once())
-            ->method('getType')
-            ->will($this->returnValue('sonata_type_model_autocomplete'));
 
         $fieldDescription->expects($this->once())
             ->method('getTargetEntity')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3164, #3406
| License       | MIT
