### PR TITLE
Added translation domain to batchActions

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1158,8 +1158,9 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
 
         if ($this->hasRoute('delete') && $this->isGranted('DELETE')) {
             $actions['delete'] = array(
-                'label'            => $this->trans('action_delete', array(), 'SonataAdminBundle'),
-                'ask_confirmation' => true, // by default always true
+                'label'              => 'action_delete',
+                'translation_domain' => 'SonataAdminBundle',
+                'ask_confirmation'   => true, // by default always true
             );
         }
 

--- a/Resources/doc/reference/batch_actions.rst
+++ b/Resources/doc/reference/batch_actions.rst
@@ -37,7 +37,8 @@ merges them onto a single target item. It should only be available when two cond
           $this->hasRoute('delete') && $this->isGranted('DELETE')
         ) {
             $actions['merge'] = array(
-                'label' => $this->trans('action_merge', array(), 'SonataAdminBundle'),
+                'label' => 'action_merge',
+                'translation_domain' => 'SonataAdminBundle'
                 'ask_confirmation' => true
             );
 

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -144,7 +144,7 @@ file that was distributed with this source code.
 
                                             <select name="action" style="width: auto; height: auto" class="form-control">
                                                 {% for action, options in batchactions %}
-                                                    <option value="{{ action }}">{{ options.label }}</option>
+                                                    <option value="{{ action }}">{{ options.label|trans({}, options.translation_domain|default(admin.translationDomain)) }}</option>
                                                 {% endfor %}
                                             </select>
                                         {% endblock %}


### PR DESCRIPTION
With this PR you don't have to translate the batchAction label manually. Now the domain comes from the admin translation domain or can be set a via ``translation_domain`` in the action.