### PR TITLE
Symfony 2.8 & 3.0 test fixes

### DIFF
--- a/Tests/Command/ExplainAdminCommandTest.php
+++ b/Tests/Command/ExplainAdminCommandTest.php
@@ -121,10 +121,18 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
                 return $adminParent;
             }));
 
-        $this->validatorFactory = $this->getMock('Symfony\Component\Validator\MetadataFactoryInterface');
+        // Prefer Symfony 2.x interfaces
+        if (interface_exists('Symfony\Component\Validator\MetadataFactoryInterface')) {
+            $this->validatorFactory = $this->getMock('Symfony\Component\Validator\MetadataFactoryInterface');
 
-        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
-        $validator->expects($this->any())->method('getMetadataFactory')->will($this->returnValue($this->validatorFactory));
+            $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+            $validator->expects($this->any())->method('getMetadataFactory')->will($this->returnValue($this->validatorFactory));
+        } else {
+            $this->validatorFactory = $this->getMock('Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface');
+
+            $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+            $validator->expects($this->any())->method('getMetadataFor')->will($this->returnValue($this->validatorFactory));
+        }
 
         // php 5.3 BC
         $admin = $this->admin;

--- a/Tests/Controller/CoreControllerTest.php
+++ b/Tests/Controller/CoreControllerTest.php
@@ -51,6 +51,13 @@ class CoreControllerTest extends \PHPUnit_Framework_TestCase
                 return array();
             }
         }));
+        $container->expects($this->any())->method('has')->will($this->returnCallback(function ($id) {
+            if ($id == 'templating') {
+                return true;
+            }
+
+            return false;
+        }));
 
         $controller = new CoreController();
         $controller->setContainer($container);
@@ -93,6 +100,13 @@ class CoreControllerTest extends \PHPUnit_Framework_TestCase
             if ($name == 'sonata.admin.configuration.dashboard_blocks') {
                 return array();
             }
+        }));
+        $container->expects($this->any())->method('has')->will($this->returnCallback(function ($id) {
+            if ($id == 'templating') {
+                return true;
+            }
+
+            return false;
         }));
 
         $controller = new CoreController();


### PR DESCRIPTION
This pull request contains some miscellaneous test fixes for the Symfony 2.8 and 3.0 branches, specifically:

- In `FrameworkBundle:Controller:render()` a check is added for the presence of either the `templating` or `twig` services as of Symfony 2.8
- Configuring the RequestStack in CRUDControllerTest for Symfony 3.0
- BC checks for interfaces that are removed in Symfony 3.0