### PR TITLE
Update getting_started.rst

### DIFF
--- a/Resources/doc/reference/getting_started.rst
+++ b/Resources/doc/reference/getting_started.rst
@@ -208,6 +208,8 @@ For ``admin.xml`` use:
 
     namespace AppBundle\DependencyInjection;
 
+    use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+    use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Loader;
     use Symfony\Component\Config\FileLocator;
 


### PR DESCRIPTION
We have an errors without this two additional strings. 
"AppBundle\DependencyInjection".
These strings from Symfony Coockbook (http://symfony.com/doc/current/cookbook/bundles/extension.html)
Errors like this one "Attempted to load class "Extension" from namespace 