### PR TITLE
Fix empty form groups

### DIFF
--- a/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -5,30 +5,26 @@
         {% if admin.formgroups[code] is defined %}
             {% set form_group = admin.formgroups[code] %}
 
-            <div class="{{ form_group.class | default('col-md-12') }}">
+            <div class="{{ form_group.class|default('col-md-12') }}">
                 <div class="{{ form_group.box_class }}">
                     <div class="box-header">
                         <h4 class="box-title">
                             {{ admin.trans(form_group.name, {}, form_group.translation_domain) }}
                         </h4>
                     </div>
-                    {#<div class="box{% if loop.first %} in{% endif %}" id="{{ admin.uniqid }}_{{ loop.index }}">#}
                     <div class="box-body">
                         <div class="sonata-ba-collapsed-fields">
-                            {% if form_group.description != false %}
+                            {% if form_group.description %}
                                 <p>{{ form_group.description|raw }}</p>
                             {% endif %}
 
-                            {% for field_name in form_group.fields %}
-                                {% if admin.formfielddescriptions[field_name] is defined %}
-                                    {{ form_row(form[field_name])}}
-                                {% endif %}
+                            {% for field_name in form_group.fields if admin.formfielddescriptions[field_name] is defined %}
+                                {{ form_row(form[field_name])}}
                             {% else %}
                                 <em>{{ 'message_form_group_empty'|trans({}, 'SonataAdminBundle') }}</em>
                             {% endfor %}
                         </div>
                     </div>
-                    {#</div>#}
                 </div>
             </div>
         {% endif %}

--- a/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -2,34 +2,36 @@
     <div class="row">
 
     {% for code in groups %}
-        {% set form_group = admin.formgroups[code] %}
+        {% if admin.formgroups[code] is defined %}
+            {% set form_group = admin.formgroups[code] %}
 
-        <div class="{{ form_group.class | default('col-md-12') }}">
-            <div class="{{ form_group.box_class }}">
-                <div class="box-header">
-                    <h4 class="box-title">
-                        {{ admin.trans(form_group.name, {}, form_group.translation_domain) }}
-                    </h4>
-                </div>
-                {#<div class="box{% if loop.first %} in{% endif %}" id="{{ admin.uniqid }}_{{ loop.index }}">#}
-                <div class="box-body">
-                    <div class="sonata-ba-collapsed-fields">
-                        {% if form_group.description != false %}
-                            <p>{{ form_group.description|raw }}</p>
-                        {% endif %}
-
-                        {% for field_name in form_group.fields %}
-                            {% if admin.formfielddescriptions[field_name] is defined %}
-                                {{ form_row(form[field_name])}}
-                            {% endif %}
-                        {% else %}
-                            <em>{{ 'message_form_group_empty'|trans({}, 'SonataAdminBundle') }}</em>
-                        {% endfor %}
+            <div class="{{ form_group.class | default('col-md-12') }}">
+                <div class="{{ form_group.box_class }}">
+                    <div class="box-header">
+                        <h4 class="box-title">
+                            {{ admin.trans(form_group.name, {}, form_group.translation_domain) }}
+                        </h4>
                     </div>
+                    {#<div class="box{% if loop.first %} in{% endif %}" id="{{ admin.uniqid }}_{{ loop.index }}">#}
+                    <div class="box-body">
+                        <div class="sonata-ba-collapsed-fields">
+                            {% if form_group.description != false %}
+                                <p>{{ form_group.description|raw }}</p>
+                            {% endif %}
+
+                            {% for field_name in form_group.fields %}
+                                {% if admin.formfielddescriptions[field_name] is defined %}
+                                    {{ form_row(form[field_name])}}
+                                {% endif %}
+                            {% else %}
+                                <em>{{ 'message_form_group_empty'|trans({}, 'SonataAdminBundle') }}</em>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    {#</div>#}
                 </div>
-                {#</div>#}
             </div>
-        </div>
+        {% endif %}
     {% endfor %}
     </div>
 {% endmacro %}


### PR DESCRIPTION
This would fix https://github.com/sonata-project/SonataUserBundle/issues/503

If you remove fields that are in a tab, you got a template error. This bug also occurred when showing a user in the ``UserAdmin`` with ``ROLE_SUPER_ADMIN`` permissions.