### PR TITLE
[AdminPoolLoader] Extend Loader instead of FileLoader to avoid deprecation message

### DIFF
--- a/Route/AdminPoolLoader.php
+++ b/Route/AdminPoolLoader.php
@@ -12,7 +12,7 @@
 namespace Sonata\AdminBundle\Route;
 
 use Sonata\AdminBundle\Admin\Pool;
-use Symfony\Component\Config\Loader\FileLoader;
+use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\RouteCollection as SymfonyRouteCollection;
@@ -22,7 +22,7 @@ use Symfony\Component\Routing\RouteCollection as SymfonyRouteCollection;
  *
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AdminPoolLoader extends FileLoader
+class AdminPoolLoader extends Loader
 {
     const ROUTE_TYPE_NAME = 'sonata_admin';
 


### PR DESCRIPTION
Ref. https://github.com/sonata-project/SonataAdminBundle/issues/3091#issuecomment-147698804