### PR TITLE
COPY of fixed nested child association in forms #3056

### DIFF
--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -164,9 +164,9 @@ class AdminHelper
     /**
      * Add a new instance to the related FieldDescriptionInterface value.
      *
-     * @param object                                              $object
+     * @param object                    $object
      * @param FieldDescriptionInterface $fieldDescription
-     * @param array                                               $fieldPath
+     * @param array                     $fieldPath
      *
      * @throws \RuntimeException
      */

--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -49,7 +49,7 @@ class AdminHelper
      */
     public function getChildFormBuilder(FormBuilderInterface $formBuilder, $elementId)
     {
-        foreach (new FormBuilderIterator($formBuilder) as $name => $formBuilder) {
+        foreach (new \RecursiveIteratorIterator(new FormBuilderIterator($formBuilder), \RecursiveIteratorIterator::SELF_FIRST) as $name => $formBuilder) {
             if ($name == $elementId) {
                 return $formBuilder;
             }
@@ -88,11 +88,6 @@ class AdminHelper
     }
 
     /**
-     * Note:
-     *   This code is ugly, but there is no better way of doing it.
-     *   For now the append form element action used to add a new row works
-     *   only for direct FieldDescription (not nested one).
-     *
      * @throws \RuntimeException
      *
      * @param AdminInterface $admin
@@ -116,6 +111,14 @@ class AdminHelper
         // retrieve the FieldDescription
         $fieldDescription = $admin->getFormFieldDescription($childFormBuilder->getName());
 
+        if (null === $fieldDescription) {
+            //its null because the form field couldnt be found in the main form, so search the childs with the fieldpath
+            $fieldPath = explode('_', $elementId);
+            array_shift($fieldPath);
+
+            $fieldDescription = $this->getChildFieldDescription($admin, $childFormBuilder, $fieldPath);
+        }
+
         try {
             $value = $fieldDescription->getValue($form->getData());
         } catch (NoValueException $e) {
@@ -130,7 +133,7 @@ class AdminHelper
         }
 
         $objectCount = count($value);
-        $postCount   = count($data[$childFormBuilder->getName()]);
+        $postCount = count($data[$childFormBuilder->getName()]);
 
         $fields = array_keys($fieldDescription->getAssociationAdmin()->getFormFieldDescriptions());
 
@@ -143,11 +146,11 @@ class AdminHelper
         // add new elements to the subject
         while ($objectCount < $postCount) {
             // append a new instance into the object
-            $this->addNewInstance($form->getData(), $fieldDescription);
+            $this->addNewInstance($form->getData(), $fieldDescription, isset($fieldPath) ? $fieldPath : array());
             ++$objectCount;
         }
 
-        $this->addNewInstance($form->getData(), $fieldDescription);
+        $this->addNewInstance($form->getData(), $fieldDescription, isset($fieldPath) ? $fieldPath : array());
 
         $finalForm = $admin->getFormBuilder()->getForm();
         $finalForm->setData($subject);
@@ -161,15 +164,20 @@ class AdminHelper
     /**
      * Add a new instance to the related FieldDescriptionInterface value.
      *
-     * @param object                    $object
+     * @param object                                              $object
      * @param FieldDescriptionInterface $fieldDescription
+     * @param array                                               $fieldPath
      *
      * @throws \RuntimeException
      */
-    public function addNewInstance($object, FieldDescriptionInterface $fieldDescription)
+    public function addNewInstance($object, FieldDescriptionInterface $fieldDescription, $fieldPath = array())
     {
+        if ($fieldPath) {
+            $object = $this->getChildObject($object, $fieldPath);
+        }
+
         $instance = $fieldDescription->getAssociationAdmin()->getNewInstance();
-        $mapping  = $fieldDescription->getAssociationMapping();
+        $mapping = $fieldDescription->getAssociationMapping();
 
         $method = sprintf('add%s', $this->camelize($mapping['fieldName']));
 
@@ -180,7 +188,7 @@ class AdminHelper
                 $method = sprintf('add%s', $this->camelize(Inflector::singularize($mapping['fieldName'])));
 
                 if (!method_exists($object, $method)) {
-                    throw new \RuntimeException(sprintf('Please add a method %s in the %s class!', $method, ClassUtils::getClass($object)));
+                    throw new \RuntimeException(sprintf('Please add a %s method in the %s class!', $method, ClassUtils::getClass($object)));
                 }
             }
         }
@@ -200,5 +208,45 @@ class AdminHelper
     public function camelize($property)
     {
         return BaseFieldDescription::camelize($property);
+    }
+
+    /**
+     * Recursively iterate through all child associations to find the correct FieldDescription.
+     *
+     * @param AdminInterface       $admin
+     * @param FormBuilderInterface $childFormBuilder
+     * @param array                $fieldPath
+     *
+     * @return FieldDescriptionInterface
+     */
+    private function getChildFieldDescription(AdminInterface $admin, FormBuilderInterface $childFormBuilder, array $fieldPath)
+    {
+        $formFieldDescription = $admin->getFormFieldDescription(array_shift($fieldPath));
+
+        if ($childField = $formFieldDescription->getAssociationAdmin()->getFormFieldDescription($childFormBuilder->getName())) {
+            return $childField;
+        }
+
+        return $this->getChildFieldDescription($formFieldDescription->getAssociationAdmin(), $childFormBuilder, $fieldPath);
+    }
+
+    /**
+     * Recursively iterate through all child associations to find the correct entity.
+     *
+     * @param object $object
+     * @param array  $fieldPath
+     *
+     * @return object
+     */
+    private function getChildObject($object, array $fieldPath)
+    {
+        $current = array_shift($fieldPath);
+        $method = sprintf('get%s', $this->camelize($current));
+
+        if (1 === count($fieldPath)) { //only 1 entry left means we reached the correct
+            return $object->$method();
+        }
+
+        return $this->getChildObject($object->$method(), $fieldPath);
     }
 }

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -761,7 +761,7 @@ class CRUDController extends Controller
     {
         $request = $this->resolveRequest($request);
 
-        return ($request->get('btn_preview') !== null);
+        return $request->get('btn_preview') !== null;
     }
 
     /**
@@ -775,7 +775,7 @@ class CRUDController extends Controller
     {
         $request = $this->resolveRequest($request);
 
-        return ($request->get('btn_preview_approve') !== null);
+        return $request->get('btn_preview_approve') !== null;
     }
 
     /**
@@ -809,7 +809,7 @@ class CRUDController extends Controller
     {
         $request = $this->resolveRequest($request);
 
-        return ($request->get('btn_preview_decline') !== null);
+        return $request->get('btn_preview_decline') !== null;
     }
 
     /**

--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -117,7 +117,7 @@ class AdminType extends AbstractType
     {
         $resolver->setDefaults(array(
             'delete'          => function (Options $options) {
-                return ($options['btn_delete'] !== false);
+                return $options['btn_delete'] !== false;
             },
             'delete_options'  => array(
                 'type'         => 'checkbox',

--- a/Tests/Admin/AdminHelperTest.php
+++ b/Tests/Admin/AdminHelperTest.php
@@ -112,4 +112,30 @@ class AdminHelperTest extends \PHPUnit_Framework_TestCase
 
         $helper->addNewInstance($object, $fieldDescription);
     }
+
+    public function testAddNewInstanceInAssociation()
+    {
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $pool = new Pool($container, 'title', 'logo.png');
+        $helper = new AdminHelper($pool);
+
+        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin->expects($this->once())->method('getNewInstance')->will($this->returnValue(new \stdClass()));
+
+        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription->expects($this->once())->method('getAssociationAdmin')->will($this->returnValue($admin));
+        $fieldDescription->expects($this->once())->method('getAssociationMapping')->will($this->returnValue(array('fieldName' => 'entries')));
+
+        $grandChild = $this->getMock('sdtClass', array('addEntry'), array(), 'GrandChild');
+        $grandChild->expects($this->once())->method('addEntry');
+
+        $child = $this->getMock('sdtClass', array('getBar'), array(), 'Child');
+        $child->expects($this->once())->method('getBar')->will($this->returnValue($grandChild));
+
+        $object = $this->getMock('sdtClass', array('getFoo'), array(), 'Actual');
+        $object->expects($this->once())->method('getFoo')->will($this->returnValue($child));
+
+        $helper->addNewInstance($object, $fieldDescription, array('foo', 'bar', 'entries'));
+    }
 }

--- a/Tests/Admin/BaseFieldDescriptionTest.php
+++ b/Tests/Admin/BaseFieldDescriptionTest.php
@@ -125,7 +125,7 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
          * Test with Two parameters int
          */
         $arg2 = 4;
-        $twoParameters = array($arg1,$arg2);
+        $twoParameters = array($arg1, $arg2);
         $description2 = new FieldDescription();
         $description2->setOption('code', 'getWithTwoParameters');
         $description2->setOption('parameters', $twoParameters);

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -1980,7 +1980,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
                     return true;
                 }
 
-                return ($objectIn === $object);
+                return $objectIn === $object;
             }));
 
         $this->admin->expects($this->once())
@@ -2232,7 +2232,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
                     return true;
                 }
 
-                return ($objectIn === $object);
+                return $objectIn === $object;
             }));
 
         $this->admin->expects($this->once())

--- a/Util/FormBuilderIterator.php
+++ b/Util/FormBuilderIterator.php
@@ -120,7 +120,7 @@ class FormBuilderIterator extends \RecursiveArrayIterator
      */
     public function getChildren()
     {
-        return new self($this->formBuilder->get($this->iterator->current()), $this->current());
+        return new self($this->formBuilder->get($this->iterator->current()), $this->prefix.'_'.$this->current()->getName());
     }
 
     /**


### PR DESCRIPTION
Original:
adding relations in (deeply) nested admins failed because the AdminHelper only searched for Fields in the Main-Admin and did not respect the field path to the Embedded Admin (or even Embedded in Embedded and so forth). This PR respected the Field-Path and traverses the (Grand)Childs to the correct Field and adds a Relation there.

Edited: I rebased this onto current master, so it might finally be merged.