### PR TITLE
Fixed wrongly managed collection of collections

### DIFF
--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -53,6 +53,7 @@ class AdminType extends AbstractType
 
         // hack to make sure the subject is correctly set
         // https://github.com/sonata-project/SonataAdminBundle/pull/2076
+        $subject = null;
         if ($builder->getData() === null) {
             $p = new PropertyAccessor(false, true);
             try {
@@ -75,14 +76,17 @@ class AdminType extends AbstractType
                             $this->getFieldDescription($options)->getFieldName().$options['property_path']
                         );
                     }
-                    $builder->setData($subject);
                 }
             } catch (NoSuchIndexException $e) {
                 // no object here
             }
         }
 
-        $admin->setSubject($builder->getData());
+        if (null !== $subject) {
+            $admin->setSubject($subject);
+        } else {
+            $admin->setSubject($builder->getData());
+        }
 
         $admin->defineFormBuilder($builder);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3094
| License       | MIT

Related to #2076, #3128.

I have to remove the `$builder->setData($subject);` because it caused problems with collections in collections (first level of collection was ok). The newly added items in subcollections breaks already created collection (entity was inserted as a child to a different entity, that it should be).
cc @rande 