### PR TITLE
Removed unnecessary security checks

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -192,25 +192,21 @@ file that was distributed with this source code.
                     <section class="sidebar">
                         {% block sonata_side_nav %}
                             {% block sonata_sidebar_search %}
-                                {% if app.user and is_granted('ROLE_SONATA_ADMIN') %}
-                                    <form action="{{ path('sonata_admin_search') }}" method="GET" class="sidebar-form" role="search">
-                                        <div class="input-group custom-search-form">
-                                            <input type="text" name="q" value="{{ app.request.get('q') }}" class="form-control" placeholder="{{ 'search_placeholder'|trans({}, 'SonataAdminBundle') }}">
-                                                <span class="input-group-btn">
-                                                    <button class="btn btn-flat" type="submit">
-                                                        <i class="fa fa-search"></i>
-                                                    </button>
-                                                </span>
-                                        </div>
-                                    </form>
-                                {% endif %}
+                                <form action="{{ path('sonata_admin_search') }}" method="GET" class="sidebar-form" role="search">
+                                    <div class="input-group custom-search-form">
+                                        <input type="text" name="q" value="{{ app.request.get('q') }}" class="form-control" placeholder="{{ 'search_placeholder'|trans({}, 'SonataAdminBundle') }}">
+                                            <span class="input-group-btn">
+                                                <button class="btn btn-flat" type="submit">
+                                                    <i class="fa fa-search"></i>
+                                                </button>
+                                            </span>
+                                    </div>
+                                </form>
                             {% endblock sonata_sidebar_search %}
 
                             {% block side_bar_before_nav %} {% endblock %}
                             {% block side_bar_nav %}
-                                {% if app.user and is_granted('ROLE_SONATA_ADMIN') %}
-                                    {{ knp_menu_render('sonata_admin_sidebar', {template: sonata_admin.adminPool.getTemplate('knp_menu_template')}) }}
-                                {% endif %}
+                                {{ knp_menu_render('sonata_admin_sidebar', {template: sonata_admin.adminPool.getTemplate('knp_menu_template')}) }}
                             {% endblock side_bar_nav %}
                             {% block side_bar_after_nav %}
                                 <p class="text-center small" style="border-top: 1px solid #444444; padding-top: 10px">


### PR DESCRIPTION
This PR removes two security checks that have at some point become unnecessary.

* If you use a specific security handler ("acl" or "role" based), you already have ROLE_SONATA_ADMIN, so no need to check for this.

* If you use the default "noop" security handler and manage security through the Symfony firewall, any user authorized to access the admin path basically has access to everything even without any specific role. The two checks I removed only hide the sidebar menu and the search. The list on the dashboard as well as access to everything else is still available, so hiding the sidebar menu doesn't make much sense in this case.