### PR TITLE
Hide the search panel if the search block is not enabled

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -192,7 +192,7 @@ file that was distributed with this source code.
                     <section class="sidebar">
                         {% block sonata_side_nav %}
                             {% block sonata_sidebar_search %}
-                                {% if app.user and is_granted('ROLE_SONATA_ADMIN') %}
+                                {% if app.user and is_granted('ROLE_SONATA_ADMIN') and sonata_block_exists('sonata.admin.block.search_result') %}
                                     <form action="{{ path('sonata_admin_search') }}" method="GET" class="sidebar-form" role="search">
                                         <div class="input-group custom-search-form">
                                             <input type="text" name="q" value="{{ app.request.get('q') }}" class="form-control" placeholder="{{ 'search_placeholder'|trans({}, 'SonataAdminBundle') }}">


### PR DESCRIPTION
SonataAdminBundle - hide-search-if-disabled
This adds as small check to see if the "search result" block is enabled or not and only displays the search field if the block is enabled.

Depends on https://github.com/sonata-project/SonataBlockBundle/pull/249

The PR conflicts with #3465, but as soon as either one is merged, I'll update the other one.