### PR TITLE
Add new trigger after ".sonata-collection-row" successfully removed.

### DIFF
--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -517,7 +517,9 @@ This bundle handle the native Symfony ``collection`` form type by adding:
 .. tip::
 
     A jQuery event is fired after a row has been added (``sonata-collection-item-added``)
-    or deleted (``sonata-collection-item-deleted``). You can listen to these events to trigger custom JavaScript.
+    or before deleted (``sonata-collection-item-deleted``).
+    A jQuery event is fired after a row has been deleted successfully (``sonata-collection-item-deleted-successful``)
+    You can listen to these events to trigger custom JavaScript.
 
 FieldDescription options
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -358,6 +358,8 @@ var Admin = {
             jQuery(this).trigger('sonata-collection-item-deleted');
 
             jQuery(this).closest('.sonata-collection-row').remove();
+
+            jQuery(this).trigger('sonata-collection-item-deleted-successful');
         });
     },
 


### PR DESCRIPTION
Add new trigger event, when ".sonata-collection-row" successfully removed. Issue #3442 
