### PR TITLE
Catchable Fatal Error

### DIFF
--- a/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Form\DataTransformer;
 
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
+use Symfony\Component\Form\ChoiceList\LazyChoiceList;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
@@ -42,11 +43,11 @@ class ModelsToArrayTransformer implements DataTransformerInterface
     /**
      * ModelsToArrayTransformer constructor.
      *
-     * @param ModelChoiceList       $choiceList
+     * @param LazyChoiceList       $choiceList
      * @param ModelManagerInterface $modelManager
      * @param                       $class
      */
-    public function __construct(ModelChoiceList $choiceList, ModelManagerInterface $modelManager, $class)
+    public function __construct(LazyChoiceList $choiceList, ModelManagerInterface $modelManager, $class)
     {
         $this->choiceList   = $choiceList;
         $this->modelManager = $modelManager;


### PR DESCRIPTION
```
Catchable Fatal Error: Argument 1 passed to Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer::__construct() must be an instance of Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList, instance of Symfony\Component\Form\ChoiceList\LazyChoiceList given, called in /media/raidone/workspace/insaini/Karmany/vendor/sonata-project/admin-bundle/Form/Type/ModelType.php on line 43 and defined
```