### PR TITLE
Fixed Scope Crossing Injection

### DIFF
--- a/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
+++ b/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
@@ -32,10 +32,11 @@ class AddFilterTypeCompilerPass implements CompilerPassInterface
         $types      = array();
 
         foreach ($container->findTaggedServiceIds('sonata.admin.filter.type') as $id => $attributes) {
-            if (method_exists($definition, 'setShared')) { // Symfony 2.8+
-                $definition->setShared(false);
+            $typeDefinition = $container->getDefinition($id);
+            if (method_exists($typeDefinition, 'setShared')) { // Symfony 2.8+
+                $typeDefinition->setShared(false);
             } else { // For Symfony <2.8 compatibility
-                $definition->setScope(ContainerInterface::SCOPE_PROTOTYPE);
+                $typeDefinition->setScope(ContainerInterface::SCOPE_PROTOTYPE);
             }
 
             foreach ($attributes as $eachTag) {


### PR DESCRIPTION
Fixed error

```
Scope Crossing Injection detected: The definition "sonata.admin.builder.orm_datagrid" references the service "sonata.admin.builder.filter.factory" which belongs to another scope hierarchy. This service might not be available consistently. Generally, it is safer to either move the definition "sonata.admin.builder.orm_datagrid" to scope "prototype", or declare "container" as a child scope of "prototype". If you can be sure that the other scope is always active, you can set the reference to strict=false to get rid of this error.
```