### PR TITLE
Instanciate a new class for each Filter, fix #3475

### DIFF
--- a/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
+++ b/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
@@ -14,7 +14,6 @@ namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Class AddFilterTypeCompilerPass.
@@ -29,7 +28,7 @@ class AddFilterTypeCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $definition = $container->getDefinition('sonata.admin.builder.filter.factory');
-        $types      = array();
+        $types = array();
 
         foreach ($container->findTaggedServiceIds('sonata.admin.filter.type') as $id => $attributes) {
             if (method_exists($definition, 'setShared')) { // Symfony 2.8+

--- a/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
+++ b/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
@@ -33,9 +33,9 @@ class AddFilterTypeCompilerPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('sonata.admin.filter.type') as $id => $attributes) {
             if (method_exists($definition, 'setShared')) { // Symfony 2.8+
-                $definition->setShared(false);
+                $container->getDefinition($id)->setShared(false);
             } else { // For Symfony <2.8 compatibility
-                $definition->setScope(ContainerInterface::SCOPE_PROTOTYPE);
+                $container->getDefinition($id)->setScope(ContainerInterface::SCOPE_PROTOTYPE);
             }
 
             foreach ($attributes as $eachTag) {

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -115,24 +115,24 @@ BOOM
             case 'sonata.admin.security.handler.role':
                 if (count($config['security']['information']) === 0) {
                     $config['security']['information'] = array(
-                        'EDIT'      => array('EDIT'),
-                        'LIST'      => array('LIST'),
-                        'CREATE'    => array('CREATE'),
-                        'VIEW'      => array('VIEW'),
-                        'DELETE'    => array('DELETE'),
-                        'EXPORT'    => array('EXPORT'),
-                        'OPERATOR'  => array('OPERATOR'),
-                        'MASTER'    => array('MASTER'),
+                        'EDIT'     => array('EDIT'),
+                        'LIST'     => array('LIST'),
+                        'CREATE'   => array('CREATE'),
+                        'VIEW'     => array('VIEW'),
+                        'DELETE'   => array('DELETE'),
+                        'EXPORT'   => array('EXPORT'),
+                        'OPERATOR' => array('OPERATOR'),
+                        'MASTER'   => array('MASTER'),
                     );
                 }
                 break;
             case 'sonata.admin.security.handler.acl':
                 if (count($config['security']['information']) === 0) {
                     $config['security']['information'] = array(
-                        'GUEST'    => array('VIEW', 'LIST'),
-                        'STAFF'    => array('EDIT', 'LIST', 'CREATE'),
-                        'EDITOR'   => array('OPERATOR', 'EXPORT'),
-                        'ADMIN'    => array('MASTER'),
+                        'GUEST'  => array('VIEW', 'LIST'),
+                        'STAFF'  => array('EDIT', 'LIST', 'CREATE'),
+                        'EDITOR' => array('OPERATOR', 'EXPORT'),
+                        'ADMIN'  => array('MASTER'),
                     );
                 }
                 break;
@@ -178,13 +178,13 @@ BOOM
             'date'     => 'sonata-medium-date',
 
             // SF3+
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' => '',
-            'Symfony\Component\Form\Extension\Core\Type\DateType' => 'sonata-medium-date',
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType'   => '',
+            'Symfony\Component\Form\Extension\Core\Type\DateType'     => 'sonata-medium-date',
             'Symfony\Component\Form\Extension\Core\Type\DateTimeType' => 'sonata-medium-date',
-            'Symfony\Component\Form\Extension\Core\Type\EmailType' => '',
-            'Symfony\Component\Form\Extension\Core\Type\IntegerType' => '',
+            'Symfony\Component\Form\Extension\Core\Type\EmailType'    => '',
+            'Symfony\Component\Form\Extension\Core\Type\IntegerType'  => '',
             'Symfony\Component\Form\Extension\Core\Type\TextareaType' => '',
-            'Symfony\Component\Form\Extension\Core\Type\TextType' => '',
+            'Symfony\Component\Form\Extension\Core\Type\TextType'     => '',
         );
 
         $container->getDefinition('sonata.admin.form.extension.field')

--- a/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -69,13 +69,13 @@ class FormTypeFieldExtension extends AbstractTypeExtension
         if ($options['sonata_field_description'] instanceof FieldDescriptionInterface) {
             $fieldDescription = $options['sonata_field_description'];
 
-            $sonataAdmin['admin']             = $fieldDescription->getAdmin();
+            $sonataAdmin['admin'] = $fieldDescription->getAdmin();
             $sonataAdmin['field_description'] = $fieldDescription;
-            $sonataAdmin['name']              = $fieldDescription->getName();
-            $sonataAdmin['edit']              = $fieldDescription->getOption('edit', 'standard');
-            $sonataAdmin['inline']            = $fieldDescription->getOption('inline', 'natural');
-            $sonataAdmin['block_name']        = $fieldDescription->getOption('block_name', false);
-            $sonataAdmin['class']             = $this->getClass($builder);
+            $sonataAdmin['name'] = $fieldDescription->getName();
+            $sonataAdmin['edit'] = $fieldDescription->getOption('edit', 'standard');
+            $sonataAdmin['inline'] = $fieldDescription->getOption('inline', 'natural');
+            $sonataAdmin['block_name'] = $fieldDescription->getOption('block_name', false);
+            $sonataAdmin['class'] = $this->getClass($builder);
 
             $builder->setAttribute('sonata_admin_enabled', true);
         }
@@ -91,7 +91,6 @@ class FormTypeFieldExtension extends AbstractTypeExtension
     protected function getClass(FormBuilderInterface $formBuilder)
     {
         foreach ($this->getTypes($formBuilder) as $type) {
-
             if (!method_exists($type, 'getName')) { // SF3.0+
                 $name = get_class($type);
             } else {
@@ -133,7 +132,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
          * We have a child, so we need to upgrade block prefix
          */
         if ($view->parent && $view->parent->vars['sonata_admin_enabled'] && !$sonataAdmin['admin']) {
-            $blockPrefixes    = $view->vars['block_prefixes'];
+            $blockPrefixes = $view->vars['block_prefixes'];
 
             $baseName = str_replace('.', '_', $view->parent->vars['sonata_admin_code']);
 
@@ -144,9 +143,9 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             $blockPrefixes[] = sprintf('%s_%s_%s_%s', $baseName, $baseType, $view->parent->vars['name'], $view->vars['name']);
             $blockPrefixes[] = sprintf('%s_%s_%s_%s', $baseName, $baseType, $view->parent->vars['name'], $blockSuffix);
 
-            $view->vars['block_prefixes']       = $blockPrefixes;
+            $view->vars['block_prefixes'] = $blockPrefixes;
             $view->vars['sonata_admin_enabled'] = true;
-            $view->vars['sonata_admin']         = array(
+            $view->vars['sonata_admin'] = array(
                 'admin'             => false,
                 'field_description' => false,
                 'name'              => false,
@@ -156,7 +155,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
                 'class'             => false,
                 'options'           => $this->options,
             );
-            $view->vars['sonata_admin_code']    = $view->parent->vars['sonata_admin_code'];
+            $view->vars['sonata_admin_code'] = $view->parent->vars['sonata_admin_code'];
 
             return;
         }
@@ -168,7 +167,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             $sonataAdmin['value'] = $form->getData();
 
             // add a new block types, so the Admin Form element can be tweaked based on the admin code
-            $blockPrefixes    = $view->vars['block_prefixes'];
+            $blockPrefixes = $view->vars['block_prefixes'];
             $baseName = str_replace('.', '_', $sonataAdmin['admin']->getCode());
             $baseType = $blockPrefixes[count($blockPrefixes) - 2];
             $blockSuffix = preg_replace('#^_([a-z0-9]{14})_(.++)$#', '$2', array_pop($blockPrefixes));
@@ -181,10 +180,10 @@ class FormTypeFieldExtension extends AbstractTypeExtension
                 $blockPrefixes[] = $sonataAdmin['block_name'];
             }
 
-            $view->vars['block_prefixes']       = $blockPrefixes;
+            $view->vars['block_prefixes'] = $blockPrefixes;
             $view->vars['sonata_admin_enabled'] = true;
-            $view->vars['sonata_admin']         = $sonataAdmin;
-            $view->vars['sonata_admin_code']    = $sonataAdmin['admin']->getCode();
+            $view->vars['sonata_admin'] = $sonataAdmin;
+            $view->vars['sonata_admin_code'] = $sonataAdmin['admin']->getCode();
 
             $attr = $view->vars['attr'];
 
@@ -197,7 +196,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             $view->vars['sonata_admin_enabled'] = false;
         }
 
-        $view->vars['sonata_help']  = $sonataAdminHelp;
+        $view->vars['sonata_help'] = $sonataAdminHelp;
         $view->vars['sonata_admin'] = $sonataAdmin;
     }
 
@@ -229,8 +228,8 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             'sonata_field_description' => null,
 
             // be compatible with mopa if not installed, avoid generating an exception for invalid option
-            'label_render'             => true,
-            'sonata_help'              => null,
+            'label_render' => true,
+            'sonata_help'  => null,
         ));
     }
 


### PR DESCRIPTION
Since commit 5443959ecea1b77fb6b0e053f49a1f657d76c70c, the filter list form is broken.

Filters of the **same** type are displayed multiple times.
This is because the same instance of the filter is given for every filters of the same type (`stringFilter` for instance).
![image](https://cloud.githubusercontent.com/assets/2278002/11660925/aa09f084-9dcf-11e5-976e-5d83d91f2a78.png)

Before : 
![image](https://cloud.githubusercontent.com/assets/2278002/11660939/c3cfc7f0-9dcf-11e5-96d3-5719176238b3.png)

After :
![capture d ecran 2015-12-08 a 17 08 12](https://cloud.githubusercontent.com/assets/2278002/11660980/e842bd18-9dcf-11e5-904d-7c3c08077213.png)

In this example, `remoteId` and `name` are both filters of the type `string`

Linked issue : https://github.com/sonata-project/SonataAdminBundle/issues/3475