### PR TITLE
Ability to add custom dashboard actions

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -3026,4 +3026,35 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
 
         return $list;
     }
+
+    /**
+     * Get the list of actions that can be accessed directly from the dashboard.
+     * 
+     * @return array
+     */
+    public function getDashboardActions()
+    {
+        $actions = array();
+
+        if ($this->hasRoute('create') && $this->isGranted('CREATE')) {
+            $actions['create'] = array(
+                'label'              => 'link_add',
+                'translation_domain' => 'SonataAdminBundle',
+                'template'           => 'SonataAdminBundle:CRUD:dashboard__action_create.html.twig',
+                'url'                => $this->generateUrl('create'),
+                'icon'               => 'plus-circle',
+            );
+        }
+
+        if ($this->hasRoute('list') && $this->isGranted('LIST')) {
+            $actions['list'] = array(
+                'label'              => 'link_list',
+                'translation_domain' => 'SonataAdminBundle',
+                'url'                => $this->generateUrl('list'),
+                'icon'               => 'list',
+            );
+        }
+
+        return $actions;
+    }
 }

--- a/Resources/doc/reference/dashboard.rst
+++ b/Resources/doc/reference/dashboard.rst
@@ -356,3 +356,63 @@ On ``top`` and ``bottom`` positions, you can also specify an optional ``class`` 
                         position: top
                         class: col-md-6
                         type: sonata.admin.block.admin_list
+
+Configuring what actions are available for each item on the dashboard
+---------------------------------------------------------------------
+
+By default. A "list" and a "create" option are available for each item on the
+dashboard. If you created a custom action and want to display it along the
+other two on the dashboard, you can do so by overriding the
+``getDashboardActions()`` method of your admin class:
+
+.. code-block:: php
+
+    <?php
+    // src/AppBundle/Admin/PostAdmin.php
+
+    class PostAdmin extends Admin
+    {
+        // ...
+
+        public function getDashboardActions()
+        {
+            $actions = parent::getDashboardActions();
+
+            $actions['import'] = array(
+                'label'              => 'Import',
+                'url'                => $this->generateUrl('import'),
+                'icon'               => 'import',
+                'translation_domain' => 'SonataAdminBundle', // optional
+                'template'           => 'SonataAdminBundle:CRUD:dashboard__action.html.twig', // optional
+            );
+
+            return $actions;
+        }
+
+    }
+
+You can also hide an action from the dashboard by unsetting it:
+
+.. code-block:: php
+
+    <?php
+    // src/AppBundle/Admin/PostAdmin.php
+
+    class PostAdmin extends Admin
+    {
+        // ...
+
+        public function getDashboardActions()
+        {
+            $actions = parent::getDashboardActions();
+
+            unset($actions['list']);
+
+            return $actions;
+        }
+
+    }
+
+If you do this, you need to be aware that the action is only hidden. it will
+still be available by directly calling its URL, unless you prevent that using
+proper security measures (e.g. ACL or role based).

--- a/Resources/views/Block/block_admin_list.html.twig
+++ b/Resources/views/Block/block_admin_list.html.twig
@@ -27,40 +27,16 @@ file that was distributed with this source code.
                     <table class="table table-hover">
                         <tbody>
                             {% for admin in group.items %}
-                                {% if admin.hasRoute('create') and admin.isGranted('CREATE') or admin.hasroute('list') and admin.isGranted('LIST') %}
+                                {% if admin.dashboardActions|length > 0 %}
                                             <tr>
                                                 <td class="sonata-ba-list-label" width="40%">
                                                     {{ admin.label|trans({}, admin.translationdomain) }}
                                                 </td>
                                                 <td>
                                                     <div class="btn-group">
-                                                        {% if admin.hasroute('create') and admin.isGranted('CREATE') %}
-                                                            {% if admin.subClasses is empty %}
-                                                                <a class="btn btn-link btn-flat" href="{{ admin.generateUrl('create')}}">
-                                                                    <i class="fa fa-plus-circle"></i>
-                                                                    {% trans from 'SonataAdminBundle' %}link_add{% endtrans %}
-                                                                </a>
-                                                            {% else %}
-                                                                <a class="btn btn-link btn-flat dropdown-toggle" data-toggle="dropdown" href="#">
-                                                                    <i class="fa fa-plus-circle"></i>
-                                                                    {% trans from 'SonataAdminBundle' %}link_add{% endtrans %}
-                                                                    <span class="caret"></span>
-                                                                </a>
-                                                                <ul class="dropdown-menu">
-                                                                    {% for subclass in admin.subclasses|keys %}
-                                                                        <li>
-                                                                            <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">{{ subclass|trans({}, admin.translationdomain) }}</a>
-                                                                        </li>
-                                                                    {% endfor %}
-                                                                </ul>
-                                                            {% endif %}
-                                                        {% endif %}
-                                                        {% if admin.hasroute('list') and admin.isGranted('LIST') %}
-                                                            <a class="btn btn-link btn-flat" href="{{ admin.generateUrl('list')}}">
-                                                                <i class="fa fa-list"></i>
-                                                                {% trans from 'SonataAdminBundle' %}link_list{% endtrans -%}
-                                                            </a>
-                                                        {% endif %}
+                                                        {% for action in admin.dashboardActions %}
+                                                            {% include action.template|default('SonataAdminBundle:CRUD:dashboard__action.html.twig') with {'action': action} %}
+                                                        {% endfor %}
                                                     </div>
                                                 </td>
                                             </tr>

--- a/Resources/views/CRUD/dashboard__action.html.twig
+++ b/Resources/views/CRUD/dashboard__action.html.twig
@@ -1,0 +1,4 @@
+<a class="btn btn-link btn-flat" href="{{ action.url }}">
+    <i class="fa fa-{{ action.icon }}"></i>
+    {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
+</a>

--- a/Resources/views/CRUD/dashboard__action_create.html.twig
+++ b/Resources/views/CRUD/dashboard__action_create.html.twig
@@ -1,0 +1,19 @@
+{% if admin.subClasses is empty %}
+    <a class="btn btn-link btn-flat" href="{{ action.url }}">
+        <i class="fa fa-{{ action.icon }}"></i>
+        {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
+    </a>
+{% else %}
+    <a class="btn btn-link btn-flat dropdown-toggle" data-toggle="dropdown" href="#">
+        <i class="fa fa-{{ action.icon }}"></i>
+        {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
+        <span class="caret"></span>
+    </a>
+    <ul class="dropdown-menu">
+        {% for subclass in admin.subclasses|keys %}
+            <li>
+                <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">{{ subclass|trans({}, action.translation_domain|default('SonataAdminBundle')) }}</a>
+            </li>
+        {% endfor %}
+    </ul>
+{% endif %}


### PR DESCRIPTION
The actions displayed on the dashboard for each admin type are hard-coded: only "create" and "list" are available. I wanted to customize them to add direct links to special views. Unfortunately, that was not possible yet, so I came up with a solution. The templates for the two existing actions are moved into individual templates: "dashboard__action_list.html.twig" and "dashboard__action_create.html.twig". What remains is a "for" loop that retrieves the necessary configuration from the getDashboardActions methon in the admin class. This method can then be overwritten for individual types.

This is not a finished patch yet, as I first wanted to gather feedback: Would this patch be accepted if I finish it? Is this something other people would find useful as well?