### PR TITLE
Move Security ACL dependency to required again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "symfony/config": "~2.3",
         "symfony/console": "~2.3",
         "symfony/twig-bridge": "~2.3",
+        "symfony/twig-bundle": "~2.3",
         "symfony/class-loader":"~2.3",
         "symfony/expression-language": "~2.4",
         "symfony/property-access": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "symfony/form": "~2.3",
         "symfony/validator": "~2.3",
         "symfony/security-bundle": "~2.3",
+        "symfony/security-acl": "~2.4",
         "symfony/routing": "~2.3",
         "symfony/config": "~2.3",
         "symfony/console": "~2.3",
@@ -42,14 +43,12 @@
     "require-dev": {
         "jms/translation-bundle": "~1.1",
         "symfony/yaml": "~2.3",
-        "symfony/security-acl": "~2.4",
         "sonata-project/intl-bundle": "~2.1",
         "symfony/phpunit-bridge": "~2.7|~3.0"
     },
     "suggest": {
         "jms/translation-bundle": "Extract message keys from Admins",
-        "sonata-project/intl-bundle": "Add localized date and number into the list",
-        "symfony/security-acl": "To make sonata working with Symfony >=2.8"
+        "sonata-project/intl-bundle": "Add localized date and number into the list"
     },
     "autoload": {
         "psr-4": { "Sonata\\AdminBundle\\": "" }


### PR DESCRIPTION
It's strange to say "you have to require `symfony/security-acl` in order to use this bundle in Symfony >2.8", as making sure packages are usuable is exactly the task of Composer.

The bug (ref https://github.com/sonata-project/SonataAdminBundle/issues/3152) that was causing problems when this was added as a requirement a half year ago has been fixed on Symfony's side (ref https://github.com/symfony/symfony/pull/16144) and is included in all latest releases of the maintained versions (2.3.25, 2.7.7, 2.8.0 and 3.0.0). So it should not cause any troubles again.