### PR TITLE
Property access reuse

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -39,7 +39,6 @@ use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
@@ -974,7 +973,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         if ($this->isChild() && $this->getParentAssociationMapping()) {
             $parent = $this->getParent()->getObject($this->request->get($this->getParent()->getIdParameter()));
 
-            $propertyAccessor = PropertyAccess::createPropertyAccessor();
+            $propertyAccessor = $this->getConfigurationPool()->getPropertyAccessor();
             $propertyPath = new PropertyPath($this->getParentAssociationMapping());
 
             $object = $this->getSubject();
@@ -1367,8 +1366,6 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         if (isset($this->templates[$name])) {
             return $this->templates[$name];
         }
-
-        return;
     }
 
     /**

--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -19,7 +19,7 @@ use Sonata\AdminBundle\Util\FormViewIterator;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
-use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
  * Class AdminHelper.
@@ -118,7 +118,7 @@ class AdminHelper
         //Child form not found (probably nested one)
         //if childFormBuilder was not found resulted in fatal error getName() method call on non object
         if (!$childFormBuilder) {
-            $propertyAccessor = new PropertyAccessor();
+            $propertyAccessor = $this->pool->getPropertyAccessor();
             $entity = $admin->getSubject();
 
             $path = $this->getElementAccessPath($elementId, $entity);
@@ -249,7 +249,7 @@ class AdminHelper
     }
 
     /**
-     * get access path to element which works with PropertyAccessor.
+     * Get access path to element which works with PropertyAccessor.
      *
      * @param string $elementId expects string in format used in form id field. (uniqueIdentifier_model_sub_model or uniqueIdentifier_model_1_sub_model etc.)
      * @param mixed  $entity
@@ -260,7 +260,7 @@ class AdminHelper
      */
     public function getElementAccessPath($elementId, $entity)
     {
-        $propertyAccessor = new PropertyAccessor();
+        $propertyAccessor = $this->pool->getPropertyAccessor();
 
         $idWithoutUniqueIdentifier = implode('_', explode('_', substr($elementId, strpos($elementId, '_') + 1)));
 
@@ -312,29 +312,29 @@ class AdminHelper
     }
 
     /**
-     * check if given path exists in $entity.
+     * Check if given path exists in $entity.
      *
-     * @param PropertyAccessor $propertyAccessor
-     * @param mixed            $entity
-     * @param string           $path
+     * @param PropertyAccessorInterface $propertyAccessor
+     * @param mixed                     $entity
+     * @param string                    $path
      *
      * @return bool
      *
      * @throws \RuntimeException
      */
-    private function pathExists(PropertyAccessor $propertyAccessor, $entity, $path)
+    private function pathExists(PropertyAccessorInterface $propertyAccessor, $entity, $path)
     {
-        //sf2 <= 2.3 did not have isReadable method for PropertyAccessor
+        // Symfony <= 2.3 did not have isReadable method for PropertyAccessor
         if (method_exists($propertyAccessor, 'isReadable')) {
             return $propertyAccessor->isReadable($entity, $path);
-        } else {
-            try {
-                $propertyAccessor->getValue($entity, $path);
+        }
 
-                return true;
-            } catch (NoSuchPropertyException $e) {
-                return false;
-            }
+        try {
+            $propertyAccessor->getValue($entity, $path);
+
+            return true;
+        } catch (NoSuchPropertyException $e) {
+            return false;
         }
     }
 }

--- a/Admin/Pool.php
+++ b/Admin/Pool.php
@@ -12,6 +12,8 @@
 namespace Sonata\AdminBundle\Admin;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
  * Class Pool.
@@ -23,7 +25,7 @@ class Pool
     /**
      * @var ContainerInterface|null
      */
-    protected $container = null;
+    protected $container;
 
     /**
      * @var string[]
@@ -66,17 +68,23 @@ class Pool
     protected $options;
 
     /**
+     * @var PropertyAccessorInterface
+     */
+    protected $propertyAccessor;
+
+    /**
      * @param ContainerInterface $container
      * @param string             $title
      * @param string             $logoTitle
      * @param array              $options
      */
-    public function __construct(ContainerInterface $container, $title, $logoTitle, $options = array())
+    public function __construct(ContainerInterface $container, $title, $logoTitle, $options = array(), PropertyAccessorInterface $propertyAccessor = null)
     {
         $this->container = $container;
         $this->title     = $title;
         $this->titleLogo = $logoTitle;
         $this->options   = $options;
+        $this->propertyAccessor = $propertyAccessor;
     }
 
     /**
@@ -325,8 +333,6 @@ class Pool
         if (isset($this->templates[$name])) {
             return $this->templates[$name];
         }
-
-        return;
     }
 
     /**
@@ -358,5 +364,14 @@ class Pool
         }
 
         return $default;
+    }
+
+    public function getPropertyAccessor()
+    {
+        if (null === $this->propertyAccessor) {
+            $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+        }
+
+        return $this->propertyAccessor;
     }
 }

--- a/Admin/Pool.php
+++ b/Admin/Pool.php
@@ -23,7 +23,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 class Pool
 {
     /**
-     * @var ContainerInterface|null
+     * @var ContainerInterface
      */
     protected $container;
 

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -20,7 +20,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -269,12 +268,11 @@ class HelperController
             return new JsonResponse(array('status' => 'KO', 'message' => 'The field cannot be edit, editable option must be set to true'));
         }
 
-        $propertyAccessor = PropertyAccess::createPropertyAccessor();
-        $propertyPath     = new PropertyPath($field);
+        $propertyPath = new PropertyPath($field);
 
         // If property path has more than 1 element, take the last object in order to validate it
         if ($propertyPath->getLength() > 1) {
-            $object = $propertyAccessor->getValue($object, $propertyPath->getParent());
+            $object = $this->pool->getPropertyAccessor()->getValue($object, $propertyPath->getParent());
 
             $elements     = $propertyPath->getElements();
             $field        = end($elements);
@@ -286,7 +284,7 @@ class HelperController
             $value = new \DateTime($value);
         }
 
-        $propertyAccessor->setValue($object, $propertyPath, '' !== $value ? $value : null);
+        $this->pool->getPropertyAccessor()->setValue($object, $propertyPath, '' !== $value ? $value : null);
 
         $violations = $this->validator->validate($object);
 

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -203,6 +203,8 @@ BOOM
         $container->setParameter('sonata.admin.configuration.filters.persist', $config['persist_filters']);
 
         $this->configureClassesToCompile();
+
+        $this->replacePropertyAccessor($container);
     }
 
     public function configureClassesToCompile()
@@ -296,5 +298,18 @@ BOOM
     public function getNamespace()
     {
         return 'https://sonata-project.org/schema/dic/admin';
+    }
+
+    private function replacePropertyAccessor(ContainerBuilder $container)
+    {
+        if (!$container->has('form.property_accessor')) {
+            return;
+        }
+
+        $pool = $container->getDefinition('sonata.admin.pool');
+        $pool->replaceArgument(4, new Reference('form.property_accessor'));
+
+        $modelChoice = $container->getDefinition('sonata.admin.form.type.model_choice');
+        $modelChoice->replaceArgument(0, new Reference('form.property_accessor'));
     }
 }

--- a/Form/ChoiceList/ModelChoiceList.php
+++ b/Form/ChoiceList/ModelChoiceList.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\Exception\RuntimeException;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPath;
 
 /**
@@ -83,13 +84,18 @@ class ModelChoiceList extends SimpleChoiceList
     private $propertyPath;
 
     /**
+     * @var PropertyAccessorInterface
+     */
+    private $propertyAccessor;
+
+    /**
      * @param ModelManagerInterface $modelManager
      * @param string                $class
      * @param null                  $property
      * @param null                  $query
      * @param array                 $choices
      */
-    public function __construct(ModelManagerInterface $modelManager, $class, $property = null, $query = null, $choices = array())
+    public function __construct(ModelManagerInterface $modelManager, $class, $property = null, $query = null, $choices = array(), PropertyAccessorInterface $propertyAccessor = null)
     {
         $this->modelManager   = $modelManager;
         $this->class          = $class;
@@ -100,6 +106,7 @@ class ModelChoiceList extends SimpleChoiceList
         // displaying entities as strings
         if ($property) {
             $this->propertyPath = new PropertyPath($property);
+            $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
         }
 
         parent::__construct($this->load($choices));
@@ -146,8 +153,7 @@ class ModelChoiceList extends SimpleChoiceList
         foreach ($entities as $key => $entity) {
             if ($this->propertyPath) {
                 // If the property option was given, use it
-                $propertyAccessor = PropertyAccess::createPropertyAccessor();
-                $value = $propertyAccessor->getValue($entity, $this->propertyPath);
+                $value = $this->propertyAccessor->getValue($entity, $this->propertyPath);
             } else {
                 // Otherwise expect a __toString() method in the entity
                 try {

--- a/Form/ChoiceList/ModelChoiceList.php
+++ b/Form/ChoiceList/ModelChoiceList.php
@@ -153,7 +153,7 @@ class ModelChoiceList extends SimpleChoiceList
                 try {
                     $value = (string) $entity;
                 } catch (\Exception $e) {
-                    throw new RuntimeException(sprintf("Unable to convert the entity %s to String, entity must have a '__toString()' method defined", ClassUtils::getClass($entity)), 0, $e);
+                    throw new RuntimeException(sprintf('Unable to convert the entity "%s" to string, provide "property" option or implement "__toString()" method in your entity.', ClassUtils::getClass($entity)), 0, $e);
                 }
             }
 

--- a/Form/ChoiceList/ModelChoiceList.php
+++ b/Form/ChoiceList/ModelChoiceList.php
@@ -159,7 +159,8 @@ class ModelChoiceList extends SimpleChoiceList
                 try {
                     $value = (string) $entity;
                 } catch (\Exception $e) {
-                    throw new RuntimeException(sprintf('Unable to convert the entity "%s" to string, provide "property" option or implement "__toString()" method in your entity.', ClassUtils::getClass($entity)), 0, $e);
+                    throw new RuntimeException(sprintf('Unable to convert the entity "%s" to string, provide '
+                        .'"property" option or implement "__toString()" method in your entity.', ClassUtils::getClass($entity)), 0, $e);
                 }
             }
 

--- a/Form/ChoiceList/ModelChoiceLoader.php
+++ b/Form/ChoiceList/ModelChoiceLoader.php
@@ -96,7 +96,7 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
                     try {
                         $valueObject = (string) $entity;
                     } catch (\Exception $e) {
-                        throw new RuntimeException(sprintf("Unable to convert the entity %s to String, entity must have a '__toString()' method defined", ClassUtils::getClass($entity)), 0, $e);
+                        throw new RuntimeException(sprintf('Unable to convert the entity "%s" to string, provide "property" option or implement "__toString()" method in your entity.', ClassUtils::getClass($entity)), 0, $e);
                     }
                 }
 

--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -24,6 +24,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
  * Class ModelType
@@ -33,6 +34,16 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  */
 class ModelType extends AbstractType
 {
+    /**
+     * @var PropertyAccessorInterface
+     */
+    protected $propertyAccessor;
+
+    public function __construct(PropertyAccessorInterface $propertyAccessor)
+    {
+        $this->propertyAccessor = $propertyAccessor;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -82,8 +93,9 @@ class ModelType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $options = array();
+        $propertyAccessor = $this->propertyAccessor;
         if (interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) { // SF2.7+
-            $options['choice_loader'] = function (Options $options, $previousValue) {
+            $options['choice_loader'] = function (Options $options, $previousValue) use ($propertyAccessor) {
                 if ($previousValue && count($choices = $previousValue->getChoices())) {
                     return $choices;
                 }
@@ -93,12 +105,13 @@ class ModelType extends AbstractType
                     $options['class'],
                     $options['property'],
                     $options['query'],
-                    $options['choices']
+                    $options['choices'],
+                    $propertyAccessor
                 );
 
             };
         } else {
-            $options['choice_list'] = function (Options $options, $previousValue) {
+            $options['choice_list'] = function (Options $options, $previousValue) use ($propertyAccessor) {
                 if ($previousValue && count($choices = $previousValue->getChoices())) {
                     return $choices;
                 }
@@ -108,7 +121,8 @@ class ModelType extends AbstractType
                     $options['class'],
                     $options['property'],
                     $options['query'],
-                    $options['choices']
+                    $options['choices'],
+                    $propertyAccessor
                 );
             };
         }

--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -10,7 +10,7 @@
             <argument />
             <argument />
             <argument type="collection" />
-            <argument type="collection" />
+            <argument type="service" id="property_accessor" />
 
             <call method="setTemplates">
                 <argument>%sonata.admin.configuration.templates%</argument>

--- a/Resources/config/form_types.xml
+++ b/Resources/config/form_types.xml
@@ -12,6 +12,7 @@
         </service>
 
         <service id="sonata.admin.form.type.model_choice" class="Sonata\AdminBundle\Form\Type\ModelType">
+            <argument type="service" id="property_accessor" />
             <tag name="form.type" alias="sonata_type_model" />
         </service>
 

--- a/Resources/doc/reference/action_list.rst
+++ b/Resources/doc/reference/action_list.rst
@@ -41,7 +41,7 @@ Customizing the fields displayed on the list page
 -------------------------------------------------
 
 You can customize the columns displayed on the list through the ``configureListFields`` method.
-Here is an example:
+Here is an example from Sonata E-Commerce Product Admin:
 
 .. code-block:: php
 
@@ -71,10 +71,13 @@ Here is an example:
                 'currency' => $this->currencyDetector->getCurrency()->getLabel()
             ))
 
-            // Here we specify which property is used to render the label of each entity in the list
+            // here we specify which method is used to render the label
             ->add('productCategories', null, array(
-                'associated_property' => 'name')
-            )
+                'associated_property' => 'category'
+            ))
+            ->add('productCollections', null, array(
+                'associated_property' => 'collection'
+            ))
 
             // you may also use dotted-notation to access
             // specific properties of a relation to the entity
@@ -104,10 +107,8 @@ Options
 - ``template`` (o): the template used to render the field
 - ``label`` (o): the name used for the column's title
 - ``link_parameters`` (o): add link parameter to the related Admin class when the ``Admin::generateUrl`` is called
-- ``code`` (o): the method name to retrieve the related value (for example,
-  if you have an `array` type field, you would like to show info prettier
-  than `[0] => 'Value'`; useful when simple getter is not enough).
-  Notice: works with string-like types (string, text, html)
+- ``code`` (o): the method name to retrieve the related value
+- ``associated_tostring`` (o): (deprecated, use ``associated_property`` option) the method to retrieve the "string" representation of the collection element.
 - ``associated_property`` (o): property path to retrieve the "string" representation of the collection element, or a closure with the element as argument and return a string.
 - ``identifier`` (o): if set to true a link appears on the value to edit the element
 
@@ -150,10 +151,6 @@ Available types and associated options
 | percent   |                | Renders value as a percentage.                                        |
 +-----------+----------------+-----------------------------------------------------------------------+
 | string    |                | Renders a simple string.                                              |
-+-----------+----------------+-----------------------------------------------------------------------+
-| text      |                | See 'string'                                                          |
-+-----------+----------------+-----------------------------------------------------------------------+
-| html      |                | Renders string as html                                                |
 +-----------+----------------+-----------------------------------------------------------------------+
 | time      |                | Renders a datetime's time with format ``H:i:s``.                      |
 +-----------+----------------+-----------------------------------------------------------------------+
@@ -513,7 +510,7 @@ To do:
 Visual configuration
 --------------------
 
-You have the possibility to configure your List View to customize the render without overriding to whole template.
+You have the possibility to configure your List View to customize the render without overring to whole template.
 You can :
 
 - `header_style`: Customize the style of header (width, color, background, align...)

--- a/Resources/doc/reference/action_list.rst
+++ b/Resources/doc/reference/action_list.rst
@@ -41,7 +41,7 @@ Customizing the fields displayed on the list page
 -------------------------------------------------
 
 You can customize the columns displayed on the list through the ``configureListFields`` method.
-Here is an example from Sonata E-Commerce Product Admin:
+Here is an example:
 
 .. code-block:: php
 
@@ -71,13 +71,10 @@ Here is an example from Sonata E-Commerce Product Admin:
                 'currency' => $this->currencyDetector->getCurrency()->getLabel()
             ))
 
-            // here we specify which method is used to render the label
+            // Here we specify which property is used to render the label of each entity in the list
             ->add('productCategories', null, array(
-                'associated_property' => 'category'
-            ))
-            ->add('productCollections', null, array(
-                'associated_property' => 'collection'
-            ))
+                'associated_property' => 'name')
+            )
 
             // you may also use dotted-notation to access
             // specific properties of a relation to the entity
@@ -107,8 +104,10 @@ Options
 - ``template`` (o): the template used to render the field
 - ``label`` (o): the name used for the column's title
 - ``link_parameters`` (o): add link parameter to the related Admin class when the ``Admin::generateUrl`` is called
-- ``code`` (o): the method name to retrieve the related value
-- ``associated_tostring`` (o): (deprecated, use ``associated_property`` option) the method to retrieve the "string" representation of the collection element.
+- ``code`` (o): the method name to retrieve the related value (for example,
+  if you have an `array` type field, you would like to show info prettier
+  than `[0] => 'Value'`; useful when simple getter is not enough).
+  Notice: works with string-like types (string, text, html)
 - ``associated_property`` (o): property path to retrieve the "string" representation of the collection element, or a closure with the element as argument and return a string.
 - ``identifier`` (o): if set to true a link appears on the value to edit the element
 
@@ -151,6 +150,10 @@ Available types and associated options
 | percent   |                | Renders value as a percentage.                                        |
 +-----------+----------------+-----------------------------------------------------------------------+
 | string    |                | Renders a simple string.                                              |
++-----------+----------------+-----------------------------------------------------------------------+
+| text      |                | See 'string'                                                          |
++-----------+----------------+-----------------------------------------------------------------------+
+| html      |                | Renders string as html                                                |
 +-----------+----------------+-----------------------------------------------------------------------+
 | time      |                | Renders a datetime's time with format ``H:i:s``.                      |
 +-----------+----------------+-----------------------------------------------------------------------+
@@ -510,7 +513,7 @@ To do:
 Visual configuration
 --------------------
 
-You have the possibility to configure your List View to customize the render without overring to whole template.
+You have the possibility to configure your List View to customize the render without overriding to whole template.
 You can :
 
 - `header_style`: Customize the style of header (width, color, background, align...)

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -26,6 +26,7 @@ use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Tag;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToStringNull;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class AdminTest extends \PHPUnit_Framework_TestCase
 {
@@ -1476,6 +1477,14 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
         $tagAdmin->setRequest($request);
+
+        $configurationPool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $configurationPool->expects($this->any())->method('getPropertyAccessor')->will($this->returnValue(PropertyAccess::createPropertyAccessor()));
+
+        $tagAdmin->setConfigurationPool($configurationPool);
 
         return $tagAdmin;
     }

--- a/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -366,6 +366,9 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->register('router')
             ->setClass('Symfony\Component\Routing\RouterInterface');
         $container
+            ->register('property_accessor')
+            ->setClass('Symfony\Component\PropertyAccess\PropertyAccessor');
+        $container
             ->register('form.factory')
             ->setClass('Symfony\Component\Form\FormFactoryInterface');
         foreach (array(

--- a/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -350,6 +350,9 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->register('router')
             ->setClass('Symfony\Component\Routing\RouterInterface');
         $container
+            ->register('property_accessor')
+            ->setClass('Symfony\Component\PropertyAccess\PropertyAccessor');
+        $container
             ->register('form.factory')
             ->setClass('Symfony\Component\Form\FormFactoryInterface');
         $container

--- a/Tests/Form/Type/ModelTypeTest.php
+++ b/Tests/Form/Type/ModelTypeTest.php
@@ -14,20 +14,29 @@ namespace Sonata\AdminBundle\Tests\Form\Type;
 use Sonata\AdminBundle\Form\Type\ModelType;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class ModelTypeTest extends TypeTestCase
 {
+    protected $type;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->type = new ModelType(PropertyAccess::createPropertyAccessor());
+    }
+
     public function testGetDefaultOptions()
     {
-        $type = new ModelType();
         $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $optionResolver = new OptionsResolver();
 
         if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $type->setDefaultOptions($optionResolver);
+            $this->type->setDefaultOptions($optionResolver);
         } else {
-            $type->configureOptions($optionResolver);
+            $this->type->configureOptions($optionResolver);
         }
 
         $options = $optionResolver->resolve(array('model_manager' => $modelManager, 'choices' => array()));
@@ -58,14 +67,13 @@ class ModelTypeTest extends TypeTestCase
      */
     public function testCompoundOption($expectedCompound, $multiple, $expanded)
     {
-        $type = new ModelType();
         $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $optionResolver = new OptionsResolver();
 
         if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $type->setDefaultOptions($optionResolver);
+            $this->type->setDefaultOptions($optionResolver);
         } else {
-            $type->configureOptions($optionResolver);
+            $this->type->configureOptions($optionResolver);
         }
 
         $options = $optionResolver->resolve(array('model_manager' => $modelManager, 'choices' => array(), 'multiple' => $multiple, 'expanded' => $expanded));

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -274,7 +274,13 @@ class SonataAdminExtension extends \Twig_Extension implements \Twig_Extension_In
 
         if (null === $propertyPath) {
             // For BC kept associated_tostring option behavior
-            $method = $fieldDescription->getOption('associated_tostring', '__toString');
+            $method = $fieldDescription->getOption('associated_tostring');
+
+            if ($method) {
+                @trigger_error('Option "associated_tostring" is deprecated since version 2.3. Use "associated_property" instead.', E_USER_DEPRECATED);
+            } else {
+                $method = '__toString';
+            }
 
             if (!method_exists($element, $method)) {
                 throw new \RuntimeException(sprintf(

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -17,7 +17,6 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Exception\NoValueException;
-use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
  * Class SonataAdminExtension.
@@ -293,7 +292,7 @@ class SonataAdminExtension extends \Twig_Extension implements \Twig_Extension_In
             return $propertyPath($element);
         }
 
-        return PropertyAccess::createPropertyAccessor()->getValue($element, $propertyPath);
+        return $this->pool->getPropertyAccessor()->getValue($element, $propertyPath);
     }
 
     /**


### PR DESCRIPTION
Reuse existing property access instance for performance improvement.

Reasons:
1. starting from Symfony v2.3.35 there is internal cache for this component (cache inside request) https://github.com/symfony/symfony/commit/284dc75796b693562e2c091fd770c4a04c179a2b . Cache working using class property and we should use same instance to get it works properly.
2. there is unmerged yet PR that adds cache outside request https://github.com/symfony/symfony/pull/16838 . For getting it working we should use configured instance with passed cache layer inside it instead of creating new one.
3. in two classes you instanciate property accessor inside foreach.