### PR TITLE
Fix namespace for ErrorElement

### DIFF
--- a/Resources/doc/reference/conditional_validation.rst
+++ b/Resources/doc/reference/conditional_validation.rst
@@ -9,7 +9,7 @@ the ``Admin`` class itself contains an empty ``validate`` method. This is automa
 .. code-block:: php
 
     // add this to your existing use statements
-    use Sonata\CoreBundle\Validator\ErrorElement;
+    use Sonata\AdminBundle\Validator\ErrorElement;
 
     class MyAdmin extends Admin
     {


### PR DESCRIPTION
Found the solution in this issue, but the documentation wasn't updated. 
https://github.com/sonata-project/SonataAdminBundle/issues/2796