### PR TITLE
Add preValidate method.

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -711,6 +711,13 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
+    public function preValidate($object)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function preUpdate($object)
     {
     }

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -657,6 +657,14 @@ interface AdminInterface
      */
     public function delete($object);
 
+//TODO: uncomment this method for 3.0
+//    /**
+//     * @param mixed $object
+//     *
+//     * @return mixed
+//     */
+//    public function preValidate($object);
+
     /**
      * @param mixed $object
      *

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -405,6 +405,10 @@ class CRUDController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
+            //TODO: remove this check for 3.0
+            if (method_exists($this->admin, 'preValidate')) {
+                $this->admin->preValidate($object);
+            }
             $isFormValid = $form->isValid();
 
             // persist if the form was valid and if in preview mode the preview was approved
@@ -686,6 +690,10 @@ class CRUDController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
+            //TODO: remove this check for 3.0
+            if (method_exists($this->admin, 'preValidate')) {
+                $this->admin->preValidate($object);
+            }
             $isFormValid = $form->isValid();
 
             // persist if the form was valid and if in preview mode the preview was approved

--- a/Resources/doc/reference/saving_hooks.rst
+++ b/Resources/doc/reference/saving_hooks.rst
@@ -1,17 +1,18 @@
 Saving hooks
 ============
 
-When a SonataAdmin is submitted for processing, two events are always called. One
-is before any persistence layer interaction and the other is afterwards, the
+When a SonataAdmin is submitted for processing, there are some events called. One
+is before any persistence layer interaction and the other is afterward. Also between submitting
+and validating for edit and create actions ``preValidate`` event called. The
 events are named as follows:
 
-- new object : ``prePersist($object)`` / ``postPersist($object)``
-- edited object : ``preUpdate($object)`` / ``postUpdate($object)``
+- new object : ``preValidate($object)`` / ``prePersist($object)`` / ``postPersist($object)``
+- edited object : ``preValidate($object)`` / ``preUpdate($object)`` / ``postUpdate($object)``
 - deleted object : ``preRemove($object)`` / ``postRemove($object)``
 
 It is worth noting that the update events are called whenever the Admin is successfully
 submitted, regardless of whether there are any actual persistence layer events. This
-differs from the use of preUpdate and postUpdate events in DoctrineORM and perhaps some
+differs from the use of ``preUpdate`` and ``postUpdate`` events in DoctrineORM and perhaps some
 other persistence layers.
 
 For example: if you submit an edit form without changing any of the values on the form


### PR DESCRIPTION
Use cases for this: slug/sku generation. Slug and sku cannot be empty and should be unique. We cann't generate they in `preUpdate` methods because validation not pass and `preUpdate` not calls. So I've added method which triggered after bind sumbitted data from user and before it will validated.