### PR TITLE
[Form] [ChoiceList] Symfony3.0 Support

### DIFF
--- a/Form/ChoiceList/ModelChoiceList.php
+++ b/Form/ChoiceList/ModelChoiceList.php
@@ -13,9 +13,9 @@ namespace Sonata\AdminBundle\Form\ChoiceList;
 
 use Doctrine\Common\Util\ClassUtils;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\Exception\RuntimeException;
-use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
 
@@ -24,7 +24,7 @@ use Symfony\Component\PropertyAccess\PropertyPath;
  *
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class ModelChoiceList extends SimpleChoiceList
+class ModelChoiceList extends ArrayChoiceList
 {
     /**
      * @var ModelManagerInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3492
| License       | MIT
| Doc PR        | 

Since Symfony 3.0 the `Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList` class has been removed in favor of `Symfony\Component\Form\ChoiceList\ArrayChoiceList`.

So ModelChoiceList class should now extends ArrayChoiceList instead.