### PR TITLE
Event on "this" can't triggered on deleted element

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -359,7 +359,7 @@ var Admin = {
 
             jQuery(this).closest('.sonata-collection-row').remove();
 
-            jQuery(this).trigger('sonata-collection-item-deleted-successful');
+            jQuery(document).trigger('sonata-collection-item-deleted-successful');
         });
     },
 


### PR DESCRIPTION
Once the collection items has been removed we can't trigger event on it.

We need to use document instead of this to make it work.
fix issue introduced in #3473 