### PR TITLE
Update admin service definition XML

### DIFF
--- a/Resources/doc/reference/architecture.rst
+++ b/Resources/doc/reference/architecture.rst
@@ -75,7 +75,7 @@ your ``Admin`` services. This is done using a ``call`` to the matching ``setter`
               <argument>AppBundle\Entity\Post</argument>
               <argument />
               <call method="setLabelTranslatorStrategy">
-                  <argument>sonata.admin.label.strategy.underscore</argument>
+                  <argument type="service" id="sonata.admin.label.strategy.underscore" />
               </call>
           </service>
 


### PR DESCRIPTION
Previous XML results in error:

```[Symfony\Component\Debug\Exception\ContextErrorException]
  Catchable Fatal Error: Argument 1 passed to Sonata\AdminBundle\Admin\Admin::setLabelTranslatorStrategy() must implement interface Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface, string given```