### PR TITLE
Correct issue 3467

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "symfony/translation":"~2.3|~3.0",
         "symfony/dependency-injection": "~2.3,>=2.3.3|~3.0",
         "symfony/property-access": "~2.3|~3.0",
+        "symfony/security-acl": "~2.3|~3.0",
         "twig/twig": "~1.23",
         "twig/extensions": "~1.0",
         "sonata-project/exporter": "~1.0",


### PR DESCRIPTION
https://github.com/sonata-project/SonataAdminBundle/issues/3467

To prevent this bug with DomainObjectInterface missing, you need ACL to be installed... so it must be required by Sonata.