### PR TITLE
Add methods DatagridMapper::getDatagrid and ListMapper::getList

### DIFF
--- a/Datagrid/DatagridMapper.php
+++ b/Datagrid/DatagridMapper.php
@@ -41,6 +41,14 @@ class DatagridMapper extends BaseMapper
     }
 
     /**
+     * @return DatagridInterface
+     */
+    public function getDatagrid()
+    {
+        return $this->datagrid;
+    }
+
+    /**
      * @throws \RuntimeException
      *
      * @param string $name

--- a/Datagrid/ListMapper.php
+++ b/Datagrid/ListMapper.php
@@ -42,6 +42,14 @@ class ListMapper extends BaseMapper
     }
 
     /**
+     * @return FieldDescriptionCollection
+     */
+    public function getList()
+    {
+        return $this->list;
+    }
+
+    /**
      * @param string $name
      * @param null   $type
      * @param array  $fieldDescriptionOptions


### PR DESCRIPTION
I want to reorder columns in admin extension, but a mapper doesn't have a method to obtain columns from list.

```php
    public function configureListFields(ListMapper $listMapper)
    {
        $list = $listMapper->getList();
        $keys = array_keys($list->getElements());
        // ...
        $listMapper->reorder($keys);
    }
```