### PR TITLE
Allow using overriden layout template in empty_layout

### DIFF
--- a/Resources/views/empty_layout.html.twig
+++ b/Resources/views/empty_layout.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle::standard_layout.html.twig' %}
+{% extends admin_pool.getTemplate('layout') %}
 
 {% block sonata_header %}{% endblock %}
 {% block sonata_left_side %}{% endblock %}


### PR DESCRIPTION
We have overriden layout template using bundle configuration, but our layout not applied