### PR TITLE
Added new Twig block sonata_form_attributes into base_edit_form.html.twig

### DIFF
--- a/Resources/views/CRUD/base_edit_form.html.twig
+++ b/Resources/views/CRUD/base_edit_form.html.twig
@@ -15,6 +15,7 @@
               {% if form.vars.multipart %} enctype="multipart/form-data"{% endif %}
               method="POST"
               {% if not sonata_admin.adminPool.getOption('html5_validate') %}novalidate="novalidate"{% endif %}
+              {% block sonata_form_attributes %}{% endblock %}
               >
             {% if form.vars.errors|length > 0 %}
                 <div class="sonata-ba-form-error">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

Use case: we need to set `autocomplete="off"` to the whole `form`, but not as a global option, just to a few edit pages.
