### PR TITLE
Embeddable support for Datagrid

### DIFF
--- a/Datagrid/Datagrid.php
+++ b/Datagrid/Datagrid.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Datagrid;
 
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Filter\Filter;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
@@ -137,12 +138,24 @@ class Datagrid implements DatagridInterface
         $this->formBuilder->add('_per_page', 'hidden');
 
         $this->form = $this->formBuilder->getForm();
-        $this->form->submit($this->values);
+
+        $values = array();
+        foreach ($this->values as $name => $value) {
+            $name = str_replace('.', '__', $name);
+            $values[$name] = $value;
+        }
+        $this->form->submit($values);
+
 
         $data = $this->form->getData();
 
+        /**
+         * @var string $name
+         * @var Filter $filter
+         */
         foreach ($this->getFilters() as $name => $filter) {
             $this->values[$name] = isset($this->values[$name]) ? $this->values[$name] : null;
+
             $filter->apply($this->query, $data[$filter->getFormName()]);
         }
 


### PR DESCRIPTION
In the enclosed example trying to use the `GroupAdmin` to autocomplete the `person` property  will not work because the `HelperController` will receive a filter query for the property `address.street` and initialize the `PersonAdmin` datagrid with a value of:
```
'address.street' => [
    'type' => null,
    'value' => $_GET['q']
]
```
...the datagrid will initialize a form and submit the datagrid values to it and try to apply all valid filters.

The problem is that it initializes the form without sanitizing the names but it will look into the form data using `getFormName` (which replaces dots with `__` in the filter names) and the filter won't be applied.

```php
/**
 * @ORM\Entity
 */
class Group
{
    /**
     * @ORM\ManyToOne(targetEntity=Person::class)
     */
    protected $person;
}

/**
 * @ORM\Entity
 */
class Person
{
    /**
     * @ORM\Embedded(class=Address::class)
     */
    protected $address;
}

class GroupAdmin extends Admin
{
    /**
     * @param FormMapper $formMapper
     */
    protected function configureFormFields(FormMapper $formMapper)
    {
        $formMapper
                ->add(
                    'person',
                    'sonata_type_model_autocomplete',
                    [
                        'property' => 'address.street',
                    ]
                );
}

class PersonAdmin extends Admin
{
    /**
     * @param DatagridMapper $datagridMapper
     */
    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
    {
        $datagridMapper
            ->add('address.street', null, ['field_name' => 'address.street'])
    }
}
```