### PR TITLE
Translate export fields by default

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -607,7 +607,18 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         $datagrid = $this->getDatagrid();
         $datagrid->buildPager();
 
-        return $this->getModelManager()->getDataSourceIterator($datagrid, $this->getExportFields());
+        $fields = array();
+        foreach ($this->getExportFields() as $key => $field) {
+            $label = $this->getTranslationLabel($field, 'export', 'label');
+
+            if ($key != $field) {
+                $label = $key;
+            }
+
+            $fields[$label] =  $field;
+        }
+
+        return $this->getModelManager()->getDataSourceIterator($datagrid, $fields);
     }
 
     /**


### PR DESCRIPTION
Today the exported fields use the internal field name as a label. With this PR the label is changed to the defined translator strategy.