### PR TITLE
Remove previously attached event(s) to "sonata-collection-add"

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -329,6 +329,11 @@ var Admin = {
 
     setup_collection_buttons: function(subject) {
 
+        // Remove previously attached event(s) which causing function to be called multiple times
+        jQuery(subject).on('click', '.sonata-collection-add', function(event){
+            return false;
+        });
+
         jQuery(subject).on('click', '.sonata-collection-add', function(event) {
             Admin.stopEvent(event);
 


### PR DESCRIPTION
Remove previously attached event(s) which cause function to be called multiple times.
For some reason, unbind wont work with jQuery 1.11.1 which I am using. So this solution should work with it and later versions as well.

I already filed issue with this https://github.com/sonata-project/SonataAdminBundle/issues/3533