### PR TITLE
Added "getAccessMapping" method to AdminExtensionInterface

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -3077,10 +3077,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
         ), $this->getAccessMapping());
 
         foreach ($this->extensions as $extension) {
-            // TODO: remove method check in next major release
-            if (method_exists($extension, 'getAccessMapping')) {
-                $access = array_merge($access, $extension->getAccessMapping($this));
-            }
+            $access = array_merge($access, $extension->getAccessMapping($this));
         }
 
         return $access;

--- a/Admin/AdminExtensionInterface.php
+++ b/Admin/AdminExtensionInterface.php
@@ -114,15 +114,14 @@ interface AdminExtensionInterface
      */
     public function getPersistentParameters(AdminInterface $admin);
 
-    /**
-     * Return the controller access mapping.
-     *
-     * @param AdminInterface $admin
-     *
-     * @return array
-     */
-    // TODO: Uncomment in next major release
-    // public function getAccessMapping(AdminInterface $admin);
+     /**
+      * Return the controller access mapping.
+      *
+      * @param AdminInterface $admin
+      *
+      * @return array
+      */
+     public function getAccessMapping(AdminInterface $admin);
 
     /**
      * Returns the list of batch actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add the ``configureActionButtons`` method to the AdminInterface
 - Add the ``configureActionButtons`` method to the AdminExtensionInterface
 - Add the ``configureBatchActions`` method to the AdminExtensionInterface
+- Added the `getAccessMapping` method to the AdminExtensionInterface
 
 ## [3.x]
 ### Added

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -17,3 +17,4 @@ If you have implemented a custom admin, you must adapt the signature of the foll
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:
  * `configureActionButtons`
  * `configureBatchActions`
+ * `getAccessMapping`


### PR DESCRIPTION
Added missing method to interface (See https://github.com/sonata-project/SonataAdminBundle/pull/3297)
This should be scheduled for the next major.