### PR TITLE
Missing coma

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -69,7 +69,7 @@ var Admin = {
         jQuery('.modal-body', modal).css({
             width:    'auto',
             height:   '90%',
-            padding: 15
+            padding: 15,
             overflow: 'auto'
         });
     },


### PR DESCRIPTION
Missing coma triggers "Admin.js:73 Uncaught SyntaxError: Unexpected identifier" at least on admin dashboard