### PR TITLE
always include delete button in option prototype

### DIFF
--- a/Form/Type/CollectionType.php
+++ b/Form/Type/CollectionType.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * This type wrap native `collection` form type and render `add` and `delete`
@@ -26,7 +27,11 @@ class CollectionType extends AbstractType
      */
     public function getParent()
     {
-        return 'collection';
+        if (version_compare(Kernel::VERSION, '2.8.0', '>=')) {
+            return 'Symfony\Component\Form\Extension\Core\Type\CollectionType';
+        } else {
+            return 'collection';
+        }
     }
 
     /**

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -268,7 +268,7 @@ file that was distributed with this source code.
             {% set div_class = div_class ~ ' sonata-collection-row-without-label' %}
         {% endif %}
 
-        {% if sonata_admin.options['form_type'] == 'horizontal' %}
+        {% if sonata_admin is defined and sonata_admin.options['form_type'] == 'horizontal' %}
             {% if label is same as(false) %}
                 {% if 'collection' in form.parent.vars.block_prefixes %}
                     {% set div_class = div_class ~ ' col-sm-12' %}
@@ -331,7 +331,10 @@ file that was distributed with this source code.
 {% spaceless %}
     {% if prototype is defined %}
         {% set child = prototype %}
+        {% set allow_delete_backup = allow_delete %}
+        {% set allow_delete = true %}
         {% set attr = attr|merge({'data-prototype': block('sonata_type_native_collection_widget_row'), 'data-prototype-name': prototype.vars.name, 'class': attr.class|default('') }) %}
+        {% set allow_delete = allow_delete_backup %}
     {% endif %}
     <div {{ block('widget_container_attributes') }}>
         {{ form_errors(form) }}

--- a/Tests/Form/Widget/BaseWidgetTest.php
+++ b/Tests/Form/Widget/BaseWidgetTest.php
@@ -57,7 +57,7 @@ abstract class BaseWidgetTest extends TypeTestCase
             $this->type.'_admin_fields.html.twig',
         ));
 
-        if (version_compare(Kernel::VERSION, '3.0.0', '>=')) {
+        if (version_compare(Kernel::VERSION, '2.8.0', '>=')) {
             $csrfManagerClass = 'Symfony\Component\Security\Csrf\CsrfTokenManagerInterface';
         } else {
             $csrfManagerClass = 'Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface';

--- a/Tests/Form/Widget/FormSonataNativeCollectionWidgetTest.php
+++ b/Tests/Form/Widget/FormSonataNativeCollectionWidgetTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Widget;
+
+use Sonata\AdminBundle\Form\Type\CollectionType;
+use Symfony\Component\Form\Tests\Fixtures\TestExtension;
+use Symfony\Component\HttpKernel\Kernel;
+
+class FormSonataNativeCollectionWidgetTest extends BaseWidgetTest
+{
+    protected $type = 'form';
+
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    public function prototypeRenderingProvider()
+    {
+        return array(
+            'shrinkable collection'   => array(array('allow_delete' => true)),
+            'unshrinkable collection' => array(array('allow_delete' => false)),
+        );
+    }
+
+    /**
+     * @dataProvider prototypeRenderingProvider
+     */
+    public function testPrototypeIsDeletableNoMatterTheShrinkability(array $options)
+    {
+        $choice = $this->factory->create(
+            $this->getChoiceClass(),
+            null,
+            array('allow_add' => true) + $options
+        );
+
+        $html = $this->renderWidget($choice->createView());
+
+        $this->assertContains(
+            'sonata-collection-delete',
+            $this->cleanHtmlWhitespace($html)
+        );
+    }
+
+    protected function getExtensions()
+    {
+        $extensions = parent::getExtensions();
+        if (!version_compare(Kernel::VERSION, '2.8.0', '>=')) {
+            $guesser = $this->getMock('Symfony\Component\Form\FormTypeGuesserInterface');
+            $extension = new TestExtension($guesser);
+            $extension->addType(new CollectionType());
+
+            $extensions[] = $extension;
+        }
+
+        return $extensions;
+    }
+
+    protected function getChoiceClass()
+    {
+        if (version_compare(Kernel::VERSION, '2.8.0', '>=')) {
+            return 'Sonata\AdminBundle\Form\Type\CollectionType';
+        } else {
+            return 'sonata_type_native_collection';
+        }
+    }
+}


### PR DESCRIPTION
It makes no sense to prevent people from deleting things that are not
yet persisted.