### PR TITLE
make the code samples syntactically correct

### DIFF
--- a/Resources/doc/cookbook/recipe_sortable_listing.rst
+++ b/Resources/doc/cookbook/recipe_sortable_listing.rst
@@ -133,8 +133,8 @@ And in  the admin.yml add the following call
 
 .. code-block:: yaml
     
-	- [ setContainer, [ @service_container ] ]
-	- [ setPositionService, [@pix_sortable_behavior.position]]
+	- [ setContainer, [ "@service_container" ] ]
+	- [ setPositionService, ["@pix_sortable_behavior.position"]]
 
 
 You should now have in your listing a new action column with 4 arrows to sort your records.

--- a/Resources/doc/reference/advanced.rst
+++ b/Resources/doc/reference/advanced.rst
@@ -106,8 +106,8 @@ You have 2 ways of defining the dependencies inside ``services.xml``:
                 - Acme\ProjectBundle\Entity\Project
                 - ~
             calls:
-                - [ setLabelTranslatorStrategy, [ @sonata.admin.label.strategy.native ]]
-                - [ setRouteBuilder, [ @sonata.admin.route.path_info ]]
+                - [ setLabelTranslatorStrategy, [ "@sonata.admin.label.strategy.native" ]]
+                - [ setRouteBuilder, [ "@sonata.admin.route.path_info" ]]
 
 If you want to modify the service that is going to be injected, add the following code to your
 application's config file:
@@ -179,9 +179,9 @@ To create your own RouteBuilder create the PHP class and register it as a servic
 
         services:
             acme.admin.entity_route_builder:
-                class: %acme.admin.entity_route_builder.class%
+                class: "%acme.admin.entity_route_builder.class%"
                 arguments:
-                    - @sonata.admin.audit.manager
+                    - "@sonata.admin.audit.manager"
 
 
 Inherited classes

--- a/Resources/doc/reference/getting_started.rst
+++ b/Resources/doc/reference/getting_started.rst
@@ -189,7 +189,7 @@ use the correct file extension):
 
         # app/config/config.yml
         imports:
-            - { resource: @AcmeDemoBundle/Resources/config/admin.xml }
+            - { resource: "@AcmeDemoBundle/Resources/config/admin.xml" }
 
 2 - Have your bundle load it
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Resources/doc/reference/preview_mode.rst
+++ b/Resources/doc/reference/preview_mode.rst
@@ -124,7 +124,7 @@ Hiding the fieldset tags with css (display:none) will be enough to only show the
 
 Or if you prefer less:
 
-.. code-block:: sass
+.. code-block:: scss
 
     div.sonata-preview-form {
       .row {


### PR DESCRIPTION
see https://github.com/sphinx-doc/sphinx/issues/2264
Should fix the build.

Conflicts:
	Resources/doc/cookbook/recipe_sortable_listing.rst
	Resources/doc/reference/architecture.rst
	Resources/doc/reference/getting_started.rst