### PR TITLE
Revert "Make symfony/security-acl as a suggestion"

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -21,10 +21,6 @@ for older versions:
 
     Please provide a version constraint for the sonata-project/admin-bundle requirement: dev-master
 
-.. note::
-
-    If you are using Symfony 2.8 and upper, you need to require :code:`symfony/security-acl` to make it working.
-
 Selecting and downloading a storage bundle
 ------------------------------------------
 

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "symfony/translation":"~2.3|~3.0",
         "symfony/dependency-injection": "~2.3,>=2.3.3|~3.0",
         "symfony/property-access": "~2.3|~3.0",
+        "symfony/security-acl": "~2.3|~3.0",
         "twig/twig": "~1.23",
         "twig/extensions": "~1.0",
         "sonata-project/exporter": "~1.0",
@@ -42,15 +43,13 @@
     "require-dev": {
         "sensio/generator-bundle": "~2.3|~3.0",
         "symfony/yaml": "~2.3|~3.0",
-        "symfony/security-acl": "~2.4|~3.0",
         "sonata-project/intl-bundle": "dev-master",
         "symfony/phpunit-bridge": "~2.7|~3.0"
     },
     "suggest": {
         "jms/translation-bundle": "Extract message keys from Admins",
         "sensio/generator-bundle": "Add sonata:admin:generate command",
-        "sonata-project/intl-bundle": "Add localized date and number into the list",
-        "symfony/security-acl": "To make sonata working with Symfony >=2.8"
+        "sonata-project/intl-bundle": "Add localized date and number into the list"
     },
     "autoload": {
         "psr-4": { "Sonata\\AdminBundle\\": "" }


### PR DESCRIPTION
This reverts commit a0a3157a34e49e4f32069b9343bb61ead5ab42ff.
Do not pretend ACLs are optional when they are really not. The admin
class implements an interface from the ACL package. This means that
anyone that uses an admin (so any user of the package, really), needs
to have that interface (and the ACL package).
Fixes #3511