### PR TITLE
Add support for SF3.0

### DIFF
--- a/Form/Type/Filter/ChoiceType.php
+++ b/Form/Type/Filter/ChoiceType.php
@@ -67,12 +67,12 @@ class ChoiceType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_CONTAINS     => $this->translator->trans('label_type_contains', array(), 'SonataAdminBundle'),
-            self::TYPE_NOT_CONTAINS => $this->translator->trans('label_type_not_contains', array(), 'SonataAdminBundle'),
-            self::TYPE_EQUAL        => $this->translator->trans('label_type_equals', array(), 'SonataAdminBundle'),
+            $this->translator->trans('label_type_contains', array(), 'SonataAdminBundle')     => self::TYPE_CONTAINS,
+            $this->translator->trans('label_type_not_contains', array(), 'SonataAdminBundle') => self::TYPE_NOT_CONTAINS,
+            $this->translator->trans('label_type_equals', array(), 'SonataAdminBundle')       => self::TYPE_EQUAL,
         );
 
-        $operatorChoices = $options['operator_type'] !== 'hidden' ? array('choices' => $choices) : array();
+        $operatorChoices = $options['operator_type'] !== 'hidden' ? array('choices' => $choices, 'choices_as_values' => true) : array();
 
         $builder
             ->add('type', $options['operator_type'], array_merge(array('required' => false), $options['operator_options'], $operatorChoices))

--- a/Form/Type/Filter/DateRangeType.php
+++ b/Form/Type/Filter/DateRangeType.php
@@ -64,12 +64,12 @@ class DateRangeType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_BETWEEN     => $this->translator->trans('label_date_type_between', array(), 'SonataAdminBundle'),
-            self::TYPE_NOT_BETWEEN => $this->translator->trans('label_date_type_not_between', array(), 'SonataAdminBundle'),
+            $this->translator->trans('label_date_type_between', array(), 'SonataAdminBundle')     => self::TYPE_BETWEEN,
+            $this->translator->trans('label_date_type_not_between', array(), 'SonataAdminBundle') => self::TYPE_NOT_BETWEEN,
         );
 
         $builder
-            ->add('type', 'choice', array('choices' => $choices, 'required' => false))
+            ->add('type', 'choice', array('choices' => $choices, 'choices_as_values' => true, 'required' => false))
             ->add('value', $options['field_type'], $options['field_options'])
         ;
     }

--- a/Form/Type/Filter/DateTimeRangeType.php
+++ b/Form/Type/Filter/DateTimeRangeType.php
@@ -64,12 +64,12 @@ class DateTimeRangeType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_BETWEEN     => $this->translator->trans('label_date_type_between', array(), 'SonataAdminBundle'),
-            self::TYPE_NOT_BETWEEN => $this->translator->trans('label_date_type_not_between', array(), 'SonataAdminBundle'),
+            $this->translator->trans('label_date_type_between', array(), 'SonataAdminBundle')     => self::TYPE_BETWEEN,
+            $this->translator->trans('label_date_type_not_between', array(), 'SonataAdminBundle') => self::TYPE_NOT_BETWEEN,
         );
 
         $builder
-            ->add('type', 'choice', array('choices' => $choices, 'required' => false))
+            ->add('type', 'choice', array('choices' => $choices, 'choices_as_values' => true, 'required' => false))
             ->add('value', $options['field_type'], $options['field_options'])
         ;
     }

--- a/Form/Type/Filter/DateTimeType.php
+++ b/Form/Type/Filter/DateTimeType.php
@@ -75,17 +75,17 @@ class DateTimeType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_EQUAL         => $this->translator->trans('label_date_type_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_GREATER_EQUAL => $this->translator->trans('label_date_type_greater_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_GREATER_THAN  => $this->translator->trans('label_date_type_greater_than', array(), 'SonataAdminBundle'),
-            self::TYPE_LESS_EQUAL    => $this->translator->trans('label_date_type_less_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_LESS_THAN     => $this->translator->trans('label_date_type_less_than', array(), 'SonataAdminBundle'),
-            self::TYPE_NULL          => $this->translator->trans('label_date_type_null', array(), 'SonataAdminBundle'),
-            self::TYPE_NOT_NULL      => $this->translator->trans('label_date_type_not_null', array(), 'SonataAdminBundle'),
+            $this->translator->trans('label_date_type_equal', array(), 'SonataAdminBundle')         => self::TYPE_EQUAL,
+            $this->translator->trans('label_date_type_greater_equal', array(), 'SonataAdminBundle') => self::TYPE_GREATER_EQUAL,
+            $this->translator->trans('label_date_type_greater_than', array(), 'SonataAdminBundle')  => self::TYPE_GREATER_THAN,
+            $this->translator->trans('label_date_type_less_equal', array(), 'SonataAdminBundle')    => self::TYPE_LESS_EQUAL,
+            $this->translator->trans('label_date_type_less_than', array(), 'SonataAdminBundle')     => self::TYPE_LESS_THAN,
+            $this->translator->trans('label_date_type_null', array(), 'SonataAdminBundle')          => self::TYPE_NULL,
+            $this->translator->trans('label_date_type_not_null', array(), 'SonataAdminBundle')      => self::TYPE_NOT_NULL,
         );
 
         $builder
-            ->add('type', 'choice', array('choices' => $choices, 'required' => false))
+            ->add('type', 'choice', array('choices' => $choices, 'choices_as_values' => true, 'required' => false))
             ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))
         ;
     }

--- a/Form/Type/Filter/DateType.php
+++ b/Form/Type/Filter/DateType.php
@@ -75,17 +75,17 @@ class DateType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_EQUAL         => $this->translator->trans('label_date_type_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_GREATER_EQUAL => $this->translator->trans('label_date_type_greater_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_GREATER_THAN  => $this->translator->trans('label_date_type_greater_than', array(), 'SonataAdminBundle'),
-            self::TYPE_LESS_EQUAL    => $this->translator->trans('label_date_type_less_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_LESS_THAN     => $this->translator->trans('label_date_type_less_than', array(), 'SonataAdminBundle'),
-            self::TYPE_NULL          => $this->translator->trans('label_date_type_null', array(), 'SonataAdminBundle'),
-            self::TYPE_NOT_NULL      => $this->translator->trans('label_date_type_not_null', array(), 'SonataAdminBundle'),
+            $this->translator->trans('label_date_type_equal', array(), 'SonataAdminBundle')         => self::TYPE_EQUAL,
+            $this->translator->trans('label_date_type_greater_equal', array(), 'SonataAdminBundle') => self::TYPE_GREATER_EQUAL,
+            $this->translator->trans('label_date_type_greater_than', array(), 'SonataAdminBundle')  => self::TYPE_GREATER_THAN,
+            $this->translator->trans('label_date_type_less_equal', array(), 'SonataAdminBundle')    => self::TYPE_LESS_EQUAL,
+            $this->translator->trans('label_date_type_less_than', array(), 'SonataAdminBundle')     => self::TYPE_LESS_THAN,
+            $this->translator->trans('label_date_type_null', array(), 'SonataAdminBundle')          => self::TYPE_NULL,
+            $this->translator->trans('label_date_type_not_null', array(), 'SonataAdminBundle')      => self::TYPE_NOT_NULL,
         );
 
         $builder
-            ->add('type', 'choice', array('choices' => $choices, 'required' => false))
+            ->add('type', 'choice', array('choices' => $choices, 'choices_as_values' => true, 'required' => false))
             ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))
         ;
     }

--- a/Form/Type/Filter/NumberType.php
+++ b/Form/Type/Filter/NumberType.php
@@ -72,15 +72,15 @@ class NumberType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_EQUAL         => $this->translator->trans('label_type_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_GREATER_EQUAL => $this->translator->trans('label_type_greater_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_GREATER_THAN  => $this->translator->trans('label_type_greater_than', array(), 'SonataAdminBundle'),
-            self::TYPE_LESS_EQUAL    => $this->translator->trans('label_type_less_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_LESS_THAN     => $this->translator->trans('label_type_less_than', array(), 'SonataAdminBundle'),
+            $this->translator->trans('label_type_equal', array(), 'SonataAdminBundle')         => self::TYPE_EQUAL,
+            $this->translator->trans('label_type_greater_equal', array(), 'SonataAdminBundle') => self::TYPE_GREATER_EQUAL,
+            $this->translator->trans('label_type_greater_than', array(), 'SonataAdminBundle')  => self::TYPE_GREATER_THAN,
+            $this->translator->trans('label_type_less_equal', array(), 'SonataAdminBundle')    => self::TYPE_LESS_EQUAL,
+            $this->translator->trans('label_type_less_than', array(), 'SonataAdminBundle')     => self::TYPE_LESS_THAN,
         );
 
         $builder
-            ->add('type', 'choice', array('choices' => $choices, 'required' => false))
+            ->add('type', 'choice', array('choices' => $choices, 'choices_as_values' => true, 'required' => false))
             ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))
         ;
     }


### PR DESCRIPTION
In Symfony 3.0, the choices_as_values option doesn't exist, but the choice type behaves as if it were set to true