### PR TITLE
Fixed possible security issue on list action with parent association

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -234,7 +234,7 @@ class CRUDController extends Controller
     {
         $request = $this->resolveRequest($request);
 
-        $this->admin->checkAccess('list');
+        $this->admin->checkAccess('list', $this->admin->getParent() ? $this->admin->getParent()->getSubject() : null);
 
         $preResponse = $this->preList($request);
         if ($preResponse !== null) {


### PR DESCRIPTION
When you have a child admin, access to the parent object is not checked in the list action. 