### PR TITLE
Support form with option `by_reference` to be `false`

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -405,6 +405,8 @@ class CRUDController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
+            $object = $form->getData();
+
             //TODO: remove this check for 3.0
             if (method_exists($this->admin, 'preValidate')) {
                 $this->admin->preValidate($object);
@@ -690,6 +692,8 @@ class CRUDController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
+            $object = $form->getData();
+
             //TODO: remove this check for 3.0
             if (method_exists($this->admin, 'preValidate')) {
                 $this->admin->preValidate($object);

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -1505,6 +1505,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
+
+        $form->expects($this->once())
             ->method('isValid')
             ->will($this->returnValue(true));
 
@@ -1551,6 +1555,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())
             ->method('isSubmitted')
             ->will($this->returnValue(true));
+
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
 
         $form->expects($this->once())
             ->method('isValid')
@@ -1615,6 +1623,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
+
+        $form->expects($this->once())
             ->method('isValid')
             ->will($this->returnValue(true));
 
@@ -1661,6 +1673,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())
             ->method('isSubmitted')
             ->will($this->returnValue(true));
+
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
 
         $form->expects($this->once())
             ->method('isValid')
@@ -1716,6 +1732,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
+
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
 
         $form->expects($this->once())
             ->method('isValid')
@@ -1790,6 +1810,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
+
+        $form->expects($this->once())
             ->method('isValid')
             ->will($this->returnValue(true));
 
@@ -1831,6 +1855,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
 
         $form->expects($this->any())
             ->method('isValid')
@@ -2012,6 +2040,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
+
+        $form->expects($this->once())
             ->method('isValid')
             ->will($this->returnValue(true));
 
@@ -2071,6 +2103,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
+
+        $form->expects($this->once())
             ->method('isValid')
             ->will($this->returnValue(true));
 
@@ -2110,6 +2146,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())
             ->method('isSubmitted')
             ->will($this->returnValue(true));
+
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
 
         $form->expects($this->once())
             ->method('isValid')
@@ -2187,6 +2227,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('isSubmitted')
             ->will($this->returnValue(true));
 
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
+
         $this->request->setMethod('POST');
 
         $formView = $this->getMock('Symfony\Component\Form\FormView');
@@ -2250,6 +2294,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
+
+        $form->expects($this->once())
             ->method('isValid')
             ->will($this->returnValue(true));
 
@@ -2300,6 +2348,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())
             ->method('isSubmitted')
             ->will($this->returnValue(true));
+
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
 
         $form->expects($this->once())
             ->method('isValid')
@@ -2366,6 +2418,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())
             ->method('isSubmitted')
             ->will($this->returnValue(true));
+
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
 
         $form->expects($this->once())
             ->method('isValid')


### PR DESCRIPTION
This PR allows for a DataMapper or DataTransformer or by using the [formOptions](https://github.com/sonata-project/SonataAdminBundle/blob/master/Admin/Admin.php#L223) in the Admin to be set to [`'by_reference' => false`](http://symfony.com/doc/current/reference/forms/types/form.html#by-reference) to have the form change the data and will not force the instance within the form to be used.

The current implementation will always use the data object returned by `Admin::getObject` or `Admin::getNewInstance` and put that into  `Admin::preValidate`, `Admin::update` or `Admin::create`. 

This PR changes this behaviour to use the data actually transformed from the request. 
The most basic example that will work after applying this PR is that `getNewInstance` will return `null` and that the form will transform this into a Entity instance and store it. This will not work currently.

Also this should not introduce a BC break because every thing that currently works will still work because getData will return the same instance as (for example) `getNewInstance` created.

