### PR TITLE
choice options in advanced filters are flipped [sf3]

### DIFF
--- a/Form/Type/Filter/ChoiceType.php
+++ b/Form/Type/Filter/ChoiceType.php
@@ -72,6 +72,10 @@ class ChoiceType extends AbstractType
             self::TYPE_EQUAL        => $this->translator->trans('label_type_equals', array(), 'SonataAdminBundle'),
         );
 
+        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choices = array_flip($choices);
+        }
+
         $operatorChoices = $options['operator_type'] !== 'hidden' ? array('choices' => $choices) : array();
 
         $builder

--- a/Form/Type/Filter/DateRangeType.php
+++ b/Form/Type/Filter/DateRangeType.php
@@ -68,6 +68,10 @@ class DateRangeType extends AbstractType
             self::TYPE_NOT_BETWEEN => $this->translator->trans('label_date_type_not_between', array(), 'SonataAdminBundle'),
         );
 
+        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choices = array_flip($choices);
+        }
+
         $builder
             ->add('type', 'choice', array('choices' => $choices, 'required' => false))
             ->add('value', $options['field_type'], $options['field_options'])

--- a/Form/Type/Filter/DateTimeRangeType.php
+++ b/Form/Type/Filter/DateTimeRangeType.php
@@ -68,6 +68,10 @@ class DateTimeRangeType extends AbstractType
             self::TYPE_NOT_BETWEEN => $this->translator->trans('label_date_type_not_between', array(), 'SonataAdminBundle'),
         );
 
+        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choices = array_flip($choices);
+        }
+
         $builder
             ->add('type', 'choice', array('choices' => $choices, 'required' => false))
             ->add('value', $options['field_type'], $options['field_options'])

--- a/Form/Type/Filter/DateTimeType.php
+++ b/Form/Type/Filter/DateTimeType.php
@@ -84,6 +84,10 @@ class DateTimeType extends AbstractType
             self::TYPE_NOT_NULL      => $this->translator->trans('label_date_type_not_null', array(), 'SonataAdminBundle'),
         );
 
+        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choices = array_flip($choices);
+        }
+
         $builder
             ->add('type', 'choice', array('choices' => $choices, 'required' => false))
             ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))

--- a/Form/Type/Filter/DateType.php
+++ b/Form/Type/Filter/DateType.php
@@ -84,6 +84,10 @@ class DateType extends AbstractType
             self::TYPE_NOT_NULL      => $this->translator->trans('label_date_type_not_null', array(), 'SonataAdminBundle'),
         );
 
+        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choices = array_flip($choices);
+        }
+
         $builder
             ->add('type', 'choice', array('choices' => $choices, 'required' => false))
             ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))

--- a/Form/Type/Filter/NumberType.php
+++ b/Form/Type/Filter/NumberType.php
@@ -79,6 +79,10 @@ class NumberType extends AbstractType
             self::TYPE_LESS_THAN     => $this->translator->trans('label_type_less_than', array(), 'SonataAdminBundle'),
         );
 
+        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choices = array_flip($choices);
+        }
+
         $builder
             ->add('type', 'choice', array('choices' => $choices, 'required' => false))
             ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))

--- a/Tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
+++ b/Tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Widget;
+
+use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
+use Symfony\Component\Form\Tests\Fixtures\TestExtension;
+use Symfony\Component\HttpKernel\Kernel;
+
+class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
+{
+    protected $type = 'filter';
+
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    protected function cleanHtmlAttributeWhitespace($html)
+    {
+        $html = preg_replace_callback('~<([A-Z0-9]+) \K(.*?)>~i', function ($m) {
+            $replacement = preg_replace('~\s*~', '', $m[0]);
+
+            return $replacement;
+        }, $html);
+
+        return $html;
+    }
+
+    public function testDefaultValueRendering()
+    {
+        $choice = $this->factory->create(
+            $this->getParentClass(),
+            null,
+            $this->getDefaultOption()
+        );
+
+        $html = $this->cleanHtmlWhitespace($this->renderWidget($choice->createView()));
+        $html = $this->cleanHtmlAttributeWhitespace($html);
+
+        $this->assertContains(
+            '<option value="1">[trans]label_type_contains[/trans]</option>',
+           $html
+        );
+
+        $this->assertContains(
+            '<option value="2">[trans]label_type_not_contains[/trans]</option>',
+            $html
+        );
+
+        $this->assertContains(
+            '<option value="3">[trans]label_type_equals[/trans]</option></select>',
+            $html
+        );
+    }
+
+    protected function getParentClass()
+    {
+        if (version_compare(Kernel::VERSION, '2.8.0', '>=')) {
+            return 'Sonata\AdminBundle\Form\Type\Filter\ChoiceType';
+        } else {
+            return 'sonata_type_filter_choice';
+        }
+    }
+
+    protected function getChoiceClass()
+    {
+        if (version_compare(Kernel::VERSION, '2.8.0', '>=')) {
+            return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
+        } else {
+            return 'choice';
+        }
+    }
+
+    protected function getExtensions()
+    {
+        $mock = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
+
+        $mock->expects($this->exactly(3))
+            ->method('trans')
+            ->will($this->returnCallback(function ($arg) { return $arg;})
+            );
+
+        $extensions = parent::getExtensions();
+        $guesser = $this->getMock('Symfony\Component\Form\FormTypeGuesserInterface');
+        $extension = new TestExtension($guesser);
+        $type = new ChoiceType($mock);
+        $extension->addType($type);
+
+        if (!$extension->hasType($this->getParentClass())) {
+            $reflection = new \ReflectionClass($extension);
+            $property = $reflection->getProperty('types');
+            $property->setAccessible(true);
+            $property->setValue($extension, array(get_class($type) => current($property->getValue($extension))));
+        }
+
+        $extensions[] = $extension;
+
+        return $extensions;
+    }
+
+    protected function getDefaultOption()
+    {
+        return array('field_type' => $this->getChoiceClass(),
+             'field_options'      => array(),
+             'operator_type'      => $this->getChoiceClass(),
+             'operator_options'   => array(),
+        );
+    }
+}


### PR DESCRIPTION
Related to #3565 

Symfony 3.* remove choices_as_value = false 

> symfony/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php

```php
if (true !== $choicesAsValues) {
    throw new \RuntimeException(sprintf('The "choices_as_values" option of the %s should not be used. Remove it and flip the contents of the "choices" option instead.', get_class($this)));
}
```

[source code](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php#L269)