### PR TITLE
Fix show tabs when embedded as sonata_type_admin

### DIFF
--- a/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -39,5 +39,5 @@
             </div>
         </div>
     {% endfor %}
-    </div>
+    {% if has_tab %}<div class="row">{% endif %}
 {% endmacro %}


### PR DESCRIPTION
Fix for show tabs when embedded as sonata_type_admin
Currently if no tabs exists results in messed Html tree, because of this ```<div>``` without checking  "has_tab".