### PR TITLE
Remove method version_compare used on Form component integration tests

### DIFF
--- a/Tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
+++ b/Tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
@@ -13,7 +13,6 @@ namespace Sonata\AdminBundle\Tests\Form\Widget;
 
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
 use Symfony\Component\Form\Tests\Fixtures\TestExtension;
-use Symfony\Component\HttpKernel\Kernel;
 
 class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
 {
@@ -64,7 +63,7 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
 
     protected function getParentClass()
     {
-        if (version_compare(Kernel::VERSION, '2.8.0', '>=')) {
+        if (class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType')) {
             return 'Sonata\AdminBundle\Form\Type\Filter\ChoiceType';
         } else {
             return 'sonata_type_filter_choice';
@@ -73,7 +72,7 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
 
     protected function getChoiceClass()
     {
-        if (version_compare(Kernel::VERSION, '2.8.0', '>=')) {
+        if (class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType')) {
             return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
         } else {
             return 'choice';


### PR DESCRIPTION
Related to a [comment](https://github.com/sonata-project/SonataAdminBundle/pull/3585#issuecomment-184741402) on #3585 

> This PR is not valid, version_compare should not be used even if on tests.

@Soullivaneuh  it's ok?