### PR TITLE
Update the_form_view.rst

### DIFF
--- a/Resources/doc/getting_started/the_form_view.rst
+++ b/Resources/doc/getting_started/the_form_view.rst
@@ -110,7 +110,7 @@ as choice.
     }
 .. note::
 
-    'property' field is not supported from Symfony2.7. You should use `choice_label`_ instead.
+    '`property`_' field is not supported by Symfony >= 2.7. You should use `choice_label`_ instead.
     
 As each blog post will only have one category, it renders as a select list:
 
@@ -274,3 +274,4 @@ and datagrid actions.
 .. _`field type reference`: http://symfony.com/doc/current/reference/forms/types.html
 .. _`entity field type`: http://symfony.com/doc/current/reference/forms/types/entity.html
 .. _`choice_label`: http://symfony.com/doc/current/reference/forms/types/entity.html#choice-label
+.. _`property`: http://symfony.com/doc/2.6/reference/forms/types/entity.html#property

--- a/Resources/doc/getting_started/the_form_view.rst
+++ b/Resources/doc/getting_started/the_form_view.rst
@@ -108,7 +108,10 @@ as choice.
             ))
         ;
     }
+.. note::
 
+    'property' field is not supported from Symfony2.7. You should use `choice_label`_ instead.
+    
 As each blog post will only have one category, it renders as a select list:
 
 .. image:: ../images/getting_started_entity_type.png
@@ -270,3 +273,4 @@ and datagrid actions.
 .. _`Symfony Form component`: http://symfony.com/doc/current/book/forms.html
 .. _`field type reference`: http://symfony.com/doc/current/reference/forms/types.html
 .. _`entity field type`: http://symfony.com/doc/current/reference/forms/types/entity.html
+.. _`choice_label`: http://symfony.com/doc/current/reference/forms/types/entity.html#choice-label


### PR DESCRIPTION
Lost about an hour trying to figure out why new symfony3 is yelling on 'property' option on entity when tried to complete tutorial. Figured out that it is deprecated but it took some time that now we should use 'choice_label'. Hope this note will help to other who try to learn Sonata on new symfony3.
'sonata_type_model' has this option on FormMapper, but not on DatagridMapper as I understood.