### PR TITLE
Make the table in edition forms responsive

### DIFF
--- a/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -10,7 +10,7 @@
                     </h4>
                 </div>
                 {#<div class="box{% if loop.first %} in{% endif %}" id="{{ admin.uniqid }}_{{ loop.index }}">#}
-                <div class="box-body">
+                <div class="box-body table-responsive">
                     <div class="sonata-ba-collapsed-fields">
                         {% if form_group.description != false %}
                             <p>{{ form_group.description|raw }}</p>


### PR DESCRIPTION
On small devices, this class makes a scrollbar appear so that tables can be scrolled independently from the whole page.
See http://jasonbradley.me/bootstrap-responsive-tables/