### PR TITLE
allow version 3.0 of the generator bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/class-loader":"~2.3",
         "symfony/expression-language": "~2.4",
         "symfony/property-access": "~2.3",
-        "sensio/generator-bundle": "~2.3",
+        "sensio/generator-bundle": "~2.3|^3.0",
         "twig/twig": "~1.15",
         "twig/extensions": "~1.0",
         "sonata-project/exporter": "~1.0",


### PR DESCRIPTION
It is the version required by default when installing a brand new sf 2.8
project. See symfony/symfony-standard

Fixes #3596