### PR TITLE
Bugfix base_edit_form_macro.html.twig

### DIFF
--- a/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -18,7 +18,7 @@
 
                         {% for field_name in form_group.fields %}
                             {% if admin.formfielddescriptions[field_name] is defined %}
-                                {% if form[field_name].vars.sonata_admin.field_description.type == 'sonata_type_admin' %}
+                                {% if form[field_name].vars.sonata_admin.field_description and form[field_name].vars.sonata_admin.field_description.type == 'sonata_type_admin' %}
                                     {% set inline_admin = form[field_name].vars.sonata_admin.field_description.associationAdmin %}
                                     {% set inline_form = form[field_name].vars.form %}
                                     {% set inline_groups = [] %}


### PR DESCRIPTION
- bugfix of commit:
https://github.com/sonata-project/SonataAdminBundle/commit/292215822b41d9f497012e1c4aa44d6d97311d83
- fixed error code: 
```
Impossible to access an attribute ("type") on a null variable in SonataAdminBundle:CRUD:base_edit_form_macro.html.twig at line 22
```