### PR TITLE
Remove the add_pretty_errors feature. Fixes #1076.

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -26,7 +26,6 @@ var Admin = {
         Admin.setup_select2(subject);
         Admin.setup_icheck(subject);
         Admin.setup_xeditable(subject);
-        Admin.add_pretty_errors(subject);
         Admin.setup_form_tabs_for_errors(subject);
         Admin.setup_inline_form_errors(subject);
         Admin.setup_tree_view(subject);
@@ -139,47 +138,11 @@ var Admin = {
     },
 
     /**
-     * display related errors messages
-     *
-     * @param subject
+     * @deprecated in version 2.4
      */
-    add_pretty_errors: function(subject) {
-        Admin.log('[core|add_pretty_errors] configure pretty errors on', subject);
-        jQuery('div.sonata-ba-field-error', subject).each(function(index, element) {
-            var input = jQuery(':input', element);
-
-            if (!input.length) {
-                return;
-            }
-
-            var message = jQuery('div.sonata-ba-field-error-messages', element).html();
-            jQuery('div.sonata-ba-field-error-messages', element).remove();
-
-            if (!message || message.length == 0) {
-                return;
-            }
-
-            var target = input,
-                fieldShortDescription = input.closest('.field-container').find('.field-short-description'),
-                select2 = input.closest('.select2-container')
-                ;
-
-            if (fieldShortDescription.length) {
-                target = fieldShortDescription;
-            } else if (select2.length) {
-                target= select2;
-            }
-
-            target.popover({
-                content: message,
-                trigger: 'hover',
-                html: true,
-                placement: 'top',
-                template: '<div class="popover"><div class="arrow"></div><div class="popover-inner"><div class="popover-content alert-error"><p></p></div></div></div>'
-            });
-
-        });
-    },
+    add_pretty_errors: function() {
+        console.warn('Admin.add_pretty_errors() was deprecated in version 2.4');
+    }
 
     stopEvent: function(event) {
         // https://github.com/sonata-project/SonataAdminBundle/issues/151


### PR DESCRIPTION
This commit removes the javascript function that hides form errors only to show them in a popover.

This feature had a number of serious issues.

1. Instead of drawing attention to the errors, it hides them. Consider **this**:
  ![sonata_pretty_errors_on-fs8](https://cloud.githubusercontent.com/assets/218404/13505935/d0c03842-e17b-11e5-8d15-7367e166ae2b.png)
  **Versus**:
  ![sonata_pretty_errors_off-fs8](https://cloud.githubusercontent.com/assets/218404/13505953/d700fbce-e17b-11e5-9db7-e200d853df05.png)
   And this is a very simple example. It tends to get exponentially more confusing as the number of fields increase.
2. Showing tooltips oh hover doesn't work for touch devices.
3. Relying only on color is an obvious accessibility issue.

So I propose to remove it entirely because this feature actually does more harm than good.
I'll work on solutions to improve the situation regarding the client-side error feedback.
Notably trying to fix [#522](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/522) which is a major issue.
But this is for another PR.

Thanks.