### PR TITLE
Fix for #2504 

### DIFF
--- a/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -1,7 +1,7 @@
 {% macro render_groups(admin, form, groups, has_tab) %}
     <div class="row">
 
-    {% for code in groups %}
+    {% for code in groups if admin.formgroups[code] is defined %}
         {% set form_group = admin.formgroups[code] %}
 
         <div class="{{ form_group.class | default('col-md-12') }}">


### PR DESCRIPTION
I encountered issue #2504 when trying to remove elements from the FOS User form. The removal was copy pasted from a working 2.3 install, so I was reasonably sure my code was not at fault. I dug around a little and found that by adding a safety check in the form macro then the issue is resolved.

I don't know much about the root cause, I am guessing it is to do with inherited properties but it is just that - a guess. Maybe someone who knows more about the project can come up with a more eloquent solution?

