### PR TITLE
[FIX] Height on images in the table of media

### DIFF
--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -264,6 +264,7 @@ table.sonata-ba-list {
 
 table.sonata-ba-list img {
     max-width: 100%;
+    height: auto;
 }
 
 table.sonata-ba-list td {


### PR DESCRIPTION
Fix the height of images when the max-width is reached.

### Before
<img width="200" alt="capture d ecran 2016-03-17 a 15 31 32" src="https://cloud.githubusercontent.com/assets/5006899/13849436/72f7cadc-ec56-11e5-8729-1265e33bcb88.png">

### After
<img width="200" alt="capture d ecran 2016-03-17 a 15 31 41" src="https://cloud.githubusercontent.com/assets/5006899/13849439/748cb3e4-ec56-11e5-81f4-7557dcd9cfb7.png">
