### PR TITLE
Fix #2630 : "Delete" label rendering on embedded collection + add space between checkbox and label when using icheck

### DIFF
--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -351,6 +351,50 @@ td.sonata-ba-list-field .editable-empty:not(.editable-open) {
     width: auto; /* See https://github.com/sonata-project/SonataAdminBundle/issues/2950 */
 }
 
+/**
+ * Make checkbox / radio label consistant with other labels
+ */
+.checkbox label,
+.radio label {
+    font-weight: 700;
+}
+
+/**
+ * The iCheck checkboxes & radios have 0 margin by default,
+ * add some space for the label text.
+ */
+.checkbox div[class^="icheckbox"],
+.checkbox-inline div[class^="icheckbox"],
+.radio div[class^="iradio"],
+.radio-inline div[class^="iradio"] {
+    position: relative;
+    margin-top: 4px \9;
+    margin-left: -20px;
+    margin-right: 5px;
+    margin-top: -3px;
+}
+.form-inline .checkbox div[class^="icheckbox"],
+.form-inline .checkbox-inline div[class^="icheckbox"],
+.form-inline .radio div[class^="iradio"],
+.form-inline .radio-inline div[class^="iradio"] {
+    position: relative;
+    margin-top: 4px \9;
+    margin-left: 0;
+    margin-right: 5px;
+    margin-top: -3px;
+}
+/* Hide Delete checkbox on sonata_type_collection tables */
+.sonata-ba-field-inline-table td > div.checkbox > label > .control-label__text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    border: 0;
+}
+
 /* select2 */
 .select2-choice, .select2-choices, .select2-drop {
     border-radius: 0 !important;

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -80,7 +80,7 @@ file that was distributed with this source code.
 
 {% block checkbox_widget -%}
     {% set parent_label_class = parent_label_class|default('') -%}
-    {% if 'checkbox-inline' in parent_label_class or sonata_admin.options['use_icheck'] %}
+    {% if 'checkbox-inline' in parent_label_class %}
         {{- form_label(form, null, { widget: parent() }) -}}
     {% else -%}
         <div class="checkbox">
@@ -91,7 +91,7 @@ file that was distributed with this source code.
 
 {% block radio_widget -%}
     {%- set parent_label_class = parent_label_class|default('') -%}
-    {% if 'radio-inline' in parent_label_class or sonata_admin.options['use_icheck'] %}
+    {% if 'radio-inline' in parent_label_class %}
         {{- form_label(form, null, { widget: parent() }) -}}
     {% else -%}
         <div class="radio">
@@ -166,7 +166,11 @@ file that was distributed with this source code.
         {% endif %}
         <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
             {{- widget|raw -}}
-            {{- label is not same as(false) ? label|trans({}, translation_domain) -}}
+            {%- if label is not same as(false) -%}
+                <span class="control-label__text">
+                    {{- label|trans({}, translation_domain) -}}
+                </span>
+            {%- endif -%}
         </label>
     {% endif %}
 {% endblock checkbox_radio_label %}

--- a/Tests/Form/Widget/FormChoiceWidgetTest.php
+++ b/Tests/Form/Widget/FormChoiceWidgetTest.php
@@ -39,35 +39,7 @@ class FormChoiceWidgetTest extends BaseWidgetTest
         $html = $this->renderWidget($choice->createView());
 
         $this->assertContains(
-            '<li><label><input type="checkbox" id="choice_0" name="choice[]" value="0" />[trans]some[/trans]</label></li>',
-            $this->cleanHtmlWhitespace($html)
-        );
-    }
-
-    public function testBootstrapLabelRendering()
-    {
-        $sonataAdmin = $this->getSonataAdmin();
-        $sonataAdmin['options']['use_icheck'] = false;
-        $this->environment->addGlobal('sonata_admin', $sonataAdmin);
-
-        $choices = array('some', 'choices');
-        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-            $choices = array_flip($choices);
-        }
-
-        $choice = $this->factory->create(
-            $this->getChoiceClass(),
-            null,
-            $this->getDefaultOption() + array(
-                'multiple' => true,
-                'expanded' => true,
-            ) + compact('choices')
-        );
-
-        $html = $this->renderWidget($choice->createView());
-
-        $this->assertContains(
-            '<li><div class="checkbox"><label><input type="checkbox" id="choice_0" name="choice[]" value="0" />[trans]some[/trans]</label></div></li>',
+            '<li><div class="checkbox"><label><input type="checkbox" id="choice_0" name="choice[]" value="0" /><span class="control-label__text">[trans]some[/trans]</span></label></div></li>',
             $this->cleanHtmlWhitespace($html)
         );
     }


### PR DESCRIPTION
As asked here : https://github.com/sonata-project/SonataAdminBundle/issues/2630#issuecomment-196755129

* Add space between checkbox and label when using icheck
* Hide checkbox label on embedded collection tables

When using `sonata_type_collection` with `['edit' => 'inline', 'inline => 'table']`. The label of boolean fields are not visible (as they're already in the table heading). For expanded choices the label is still visible.
![capture](https://cloud.githubusercontent.com/assets/2057992/14043085/c840c432-f280-11e5-8a9b-d021393e3651.PNG)
