### PR TITLE
Remove method expectations

### DIFF
--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -313,8 +313,6 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $formExtension = $this->getMock('Twig_ExtensionInterface', array('renderListElement', 'initRuntime', 'getTokenParsers', 'getNodeVisitors', 'getFilters', 'getTests', 'getFunctions', 'getOperators', 'getGlobals', 'getName'));
 
         $formExtension->expects($this->once())->method('getName')->will($this->returnValue('form'));
-        $formExtension->expects($this->never())->method('searchAndRenderBlock');
-        $formExtension->expects($this->never())->method('setTheme');
         $formExtension->renderer = $mockRenderer;
 
         $twig = new Twig();
@@ -396,8 +394,6 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $formExtension = $this->getMock('Twig_ExtensionInterface', array('renderListElement', 'initRuntime', 'getTokenParsers', 'getNodeVisitors', 'getFilters', 'getTests', 'getFunctions', 'getOperators', 'getGlobals', 'getName'));
         $formExtension->expects($this->once())->method('getName')->will($this->returnValue('form'));
-        $formExtension->expects($this->never())->method('searchAndRenderBlock');
-        $formExtension->expects($this->never())->method('setTheme');
         $formExtension->renderer = $mockRenderer;
 
         $twig = new Twig();


### PR DESCRIPTION
These methods do not actually exist on the mock object, which means we will get
an error anyway if they are called. Recent versions of phpunit forbid
configuring inexistant methods in mocks, which makes tests fail.
See https://github.com/sebastianbergmann/phpunit-mock-objects/issues/299