### PR TITLE
Configure search result link in admin

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -246,6 +246,13 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     protected $pagerType = Pager::TYPE_DEFAULT;
 
     /**
+     * Action list for the search result.
+     * 
+     * @var string[]
+     */
+    protected $searchResultActions = array('edit', 'show');
+
+    /**
      * The code related to the admin.
      *
      * @var string
@@ -3025,5 +3032,21 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
         }
 
         return $list;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchResultLink($object)
+    {
+        if (is_array($this->searchResultActions)) {
+            foreach ($this->searchResultActions as $action) {
+                if ($this->hasRoute($action) && $this->isGranted(strtoupper($action), $object)) {
+                    return $this->generateObjectUrl($action, $object);
+                }
+            }
+        }
+
+        return;
     }
 }

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -1024,4 +1024,14 @@ interface AdminInterface
      *
      */
     // public function configureActionButtons($action, $object = null);
+
+    //TODO: uncomment this method for 4.0
+    /*
+     * Returns the result link for an object.
+     * 
+     * @param mixed $object
+     *
+     * @return string|null
+     */
+    //public function getSearchResultLink($object)
 }

--- a/Resources/doc/reference/search.rst
+++ b/Resources/doc/reference/search.rst
@@ -55,6 +55,30 @@ You can also configure the block template per admin while defining the admin:
               </call>
           </service>
 
+
+
+Configure the default search result action.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In general the search result generates a link to the edit action of an item or is using the show action, if the edit
+route is disabled or you haven't the required permission. You can change this behaviour by overriding the
+``searchResultActions`` property. The defined action list will we checked successive until a route with the required
+permissions exists. If no route is found, the item will be displayed as a text.
+
+.. code-block:: php
+
+    <?php
+    // src/AppBundle/Admin/PersonAdmin.php
+
+    class PersonAdmin extends Admin
+    {
+        // ...
+
+        protected $searchResultActions = array('edit', 'show');
+
+        // ...
+    }
+
 Performance
 -----------
 

--- a/Resources/views/Block/block_search_result.html.twig
+++ b/Resources/views/Block/block_search_result.html.twig
@@ -40,8 +40,9 @@ file that was distributed with this source code.
                 <div class="box-body no-padding">
                     <ul class="nav nav-stacked sonata-search-result-list">
                         {% for result in pager.getResults() %}
-                            {% if admin.hasRoute('edit') and admin.isGranted('EDIT', result) %}
-                                <li><a href="{{ admin.generateObjectUrl('edit', result) }}">{{ admin.toString(result) }}</a></li>
+                            {% set link = admin.getSearchResultLink(result) %}
+                            {% if link %}
+                                <li><a href="{{ link }}">{{ admin.toString(result) }}</a></li>
                             {% else %}
                                 <li><a>{{ admin.toString(result) }}</a></li>
                             {% endif %}

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1671,6 +1671,45 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $admin->getActionButtons('list', null));
     }
+
+    public function testGetSearchResultLink()
+    {
+        $entity = new \stdClass();
+
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+
+        $routeGenerator = $this->getMock('Sonata\AdminBundle\Route\RouteGeneratorInterface');
+        $routeGenerator->expects($this->once())
+            ->method('hasAdminRoute')
+            ->with($admin, 'edit')
+            ->will($this->returnValue(true));
+        $routeGenerator->expects($this->once())
+            ->method('generateUrl')
+            ->will($this->returnValue('edit/123'));
+        $admin->setRouteGenerator($routeGenerator);
+
+        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager->expects($this->once())
+            ->method('getUrlsafeIdentifier')
+            ->with($this->equalTo($entity))
+            ->will($this->returnValue('foo'));
+        $admin->setModelManager($modelManager);
+
+        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface');
+        $securityHandler->expects($this->any())
+            ->method('isGranted')
+            ->will($this->returnCallback(function (AdminInterface $adminIn, $attributes, $object = null) use ($admin) {
+                if ($admin == $adminIn && $attributes == 'EDIT' && $testObject = $object) {
+                    return true;
+                }
+
+                return false;
+            }));
+
+        $admin->setSecurityHandler($securityHandler);
+
+        $this->assertSame('edit/123', $admin->getSearchResultLink($entity));
+    }
 }
 
 class DummySubject


### PR DESCRIPTION
This commit allows you to configure the search result link for each admin separately

Fixes (partial) https://github.com/sonata-project/SonataAdminBundle/issues/2581, https://github.com/sonata-project/SonataAdminBundle/issues/3092

It's kind of hard where to configure the default ``action`` for the link. Should the **\*\*Admin** class define the final action or should a global config value override it.