### PR TITLE
Fixes typo introduced in 95d9d6c. Closes #3684

### DIFF
--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% extends base_template %}
 
-{% import "@Admin/CRUD/base_show_macro.html.twig" as show_helper %}
+{% import 'SonataAdminBundle:CRUD:base_show_macro.html.twig' as show_helper %}
 
 {% block actions %}
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}


### PR DESCRIPTION
Commit 95d9d6c contained a typo in a template path, causing the following Twig exception:
```
Unable to find template "@Admin/CRUD/base_show_macro.html.twig" in SonataAdminBundle:CRUD:base_show.html.twig at line 14.
```