### PR TITLE
restore the signature for exportAction

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -965,14 +965,15 @@ class CRUDController extends Controller
     /**
      * Export data to specified format.
      *
+     * @param Request $reques
+     *
      * @return Response
      *
      * @throws AccessDeniedException If access is not granted
      * @throws \RuntimeException     If the export format is invalid
      */
-    public function exportAction()
+    public function exportAction(Request $request)
     {
-        $request = $this->getRequest();
         if (false === $this->admin->isGranted('EXPORT')) {
             throw new AccessDeniedException();
         }


### PR DESCRIPTION
It was like that from the beginning, removing the request parameter was
a BC-break in this case.