### PR TITLE
remove default template loading on exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 - Removed BC handler for deprecated `view` `_action`
 
+### Removed
+- The fallback mechanism that loads a default template when the template
+specified in a field description cannot be found was removed.
+
 ## [3.x]
 ### Added
 - Added AbstractAdmin, replacing Admin

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -275,9 +275,6 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
                         return 'SonataAdminBundle:CRUD:list_url.html.twig';
                     case 'html':
                         return 'SonataAdminBundle:CRUD:list_html.html.twig';
-                    case 'nonexistent':
-                        // template doesn`t exist
-                        return 'SonataAdminBundle:CRUD:list_nonexistent_template.html.twig';
                     default:
                         return false;
                 }
@@ -290,69 +287,6 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
                 $this->object,
                 $this->fieldDescription
             ))
-        );
-    }
-
-    /**
-     * @dataProvider getDeprecatedRenderListElementTests
-     * @group legacy
-     */
-    public function testDeprecatedRenderListElement($expected, $value, array $options)
-    {
-        $this->admin->expects($this->any())
-            ->method('isGranted')
-            ->will($this->returnValue(true));
-
-        $this->admin->expects($this->any())
-            ->method('getTemplate')
-            ->with($this->equalTo('base_list_field'))
-            ->will($this->returnValue('SonataAdminBundle:CRUD:base_list_field.html.twig'));
-
-        $this->fieldDescription->expects($this->any())
-            ->method('getValue')
-            ->will($this->returnValue($value));
-
-        $this->fieldDescription->expects($this->any())
-            ->method('getType')
-            ->will($this->returnValue('nonexistent'));
-
-        $this->fieldDescription->expects($this->any())
-            ->method('getOptions')
-            ->will($this->returnValue($options));
-
-        $this->fieldDescription->expects($this->any())
-            ->method('getOption')
-            ->will($this->returnCallback(function ($name, $default = null) use ($options) {
-                return isset($options[$name]) ? $options[$name] : $default;
-            }));
-
-        $this->fieldDescription->expects($this->any())
-            ->method('getTemplate')
-            ->will($this->returnValue('SonataAdminBundle:CRUD:list_nonexistent_template.html.twig'));
-
-        $this->assertSame(
-            $this->removeExtraWhitespace($expected),
-            $this->removeExtraWhitespace($this->twigExtension->renderListElement(
-                $this->environment,
-                $this->object,
-                $this->fieldDescription
-            ))
-        );
-    }
-
-    public function getDeprecatedRenderListElementTests()
-    {
-        return array(
-            array(
-                '<td class="sonata-ba-list-field sonata-ba-list-field-nonexistent" objectId="12345"> Example </td>',
-                'Example',
-                array(),
-            ),
-            array(
-                '<td class="sonata-ba-list-field sonata-ba-list-field-nonexistent" objectId="12345"> </td>',
-                null,
-                array(),
-            ),
         );
     }
 
@@ -1145,56 +1079,11 @@ EOT
     }
 
     /**
-     * @group legacy
-     */
-    public function testRenderListElementNonExistentTemplate()
-    {
-        $this->admin->expects($this->once())
-            ->method('getTemplate')
-            ->with($this->equalTo('base_list_field'))
-            ->will($this->returnValue('SonataAdminBundle:CRUD:base_list_field.html.twig'));
-
-        $this->fieldDescription->expects($this->once())
-            ->method('getValue')
-            ->will($this->returnValue('Foo'));
-
-        $this->fieldDescription->expects($this->once())
-            ->method('getFieldName')
-            ->will($this->returnValue('Foo_name'));
-
-        $this->fieldDescription->expects($this->exactly(2))
-            ->method('getType')
-            ->will($this->returnValue('nonexistent'));
-
-        $this->fieldDescription->expects($this->once())
-            ->method('getTemplate')
-            ->will($this->returnValue('SonataAdminBundle:CRUD:list_nonexistent_template.html.twig'));
-
-        $this->logger->expects($this->once())
-            ->method('warning')
-            ->with(($this->stringStartsWith($this->removeExtraWhitespace(
-                'An error occured trying to load the template
-                "SonataAdminBundle:CRUD:list_nonexistent_template.html.twig"
-                for the field "Foo_name", the default template
-                    "SonataAdminBundle:CRUD:base_list_field.html.twig" was used
-                    instead.'
-            ))));
-
-        $this->twigExtension->renderListElement($this->environment, $this->object, $this->fieldDescription);
-    }
-
-    /**
      * @expectedException        Twig_Error_Loader
-     * @expectedExceptionMessage Unable to find template "base_list_nonexistent_field.html.twig"
-     * @group                    legacy
+     * @expectedExceptionMessage Unable to find template "list_nonexistent_template.html.twig"
      */
     public function testRenderListElementErrorLoadingTemplate()
     {
-        $this->admin->expects($this->once())
-            ->method('getTemplate')
-            ->with($this->equalTo('base_list_field'))
-            ->will($this->returnValue('SonataAdminBundle:CRUD:base_list_nonexistent_field.html.twig'));
-
         $this->fieldDescription->expects($this->once())
             ->method('getTemplate')
             ->will($this->returnValue('SonataAdminBundle:CRUD:list_nonexistent_template.html.twig'));

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -434,28 +434,6 @@ EOT;
     ) {
         $templateName = $fieldDescription->getTemplate() ?: $defaultTemplate;
 
-        try {
-            $template = $environment->loadTemplate($templateName);
-        } catch (\Twig_Error_Loader $e) {
-            @trigger_error(
-                'Relying on default template loading on field template loading exception '.
-                'is deprecated since 3.x and will be removed in 4.0. '.
-                'A \Twig_Error_Loader exception will be thrown instead',
-                E_USER_DEPRECATED
-            );
-            $template = $environment->loadTemplate($defaultTemplate);
-
-            if (null !== $this->logger) {
-                $this->logger->warning(sprintf(
-                    'An error occured trying to load the template "%s" for the field "%s", '.
-                    'the default template "%s" was used instead.',
-                    $templateName,
-                    $fieldDescription->getFieldName(),
-                    $defaultTemplate
-                ), array('exception' => $e));
-            }
-        }
-
-        return $template;
+        return $environment->loadTemplate($templateName);
     }
 }

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -18,3 +18,6 @@ If you have implemented a custom admin extension, you must adapt the signature o
  * `configureActionButtons`
  * `configureBatchActions`
  * `getAccessMapping`
+
+## SonataAdminExtension
+The Twig filters that come with the bundle will no longer load a default template when used with a missing template.


### PR DESCRIPTION
Why would anyone want to rely on that? Maybe there is a valid reason,
but it does not appear in the comments or in the commit history. The
best way to find out is to remove the "feature". If anyone reverts this
commit, please make sure to add a comment to explain this.