### PR TITLE
Multiple admin parent

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -302,7 +302,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     protected $baseCodeRoute = '';
 
     /**
-     * @var string
+     * @var mixed string|array<string>
      */
     protected $parentAssociationMapping = null;
 
@@ -948,11 +948,37 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
      * Returns the name of the parent related field, so the field can be use to set the default
      * value (ie the parent object) or to filter the object.
      *
-     * @return string the name of the parent related field
+     * @return null|string
+     *
+     * @throws \InvalidArgumentException
      */
     public function getParentAssociationMapping()
     {
+        if (is_array($this->parentAssociationMapping) && $this->getParent()) {
+            $parent = $this->getParent()->getCode();
+            if (array_key_exists($parent, $this->parentAssociationMapping)) {
+                return $this->parentAssociationMapping[$parent];
+            }
+            throw new \InvalidArgumentException(sprintf(
+                "There's no association between %s and %s.",
+                $this->getCode(),
+                $this->getParent()->getCode()
+            ));
+        }
+
         return $this->parentAssociationMapping;
+    }
+
+    /**
+     * @param string $code
+     * @param string $value
+     */
+    public function addParentAssociationMapping($code, $value)
+    {
+        if ($this->parentAssociationMapping === null) {
+            $this->parentAssociationMapping = array();
+        }
+        $this->parentAssociationMapping[$code] = $value;
     }
 
     /**
@@ -2026,12 +2052,15 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function addChild(AdminInterface $child)
+    public function addChild(AdminInterface $child, $field = null)
     {
         $this->children[$child->getCode()] = $child;
 
         $child->setBaseCodeRoute($this->getCode().'|'.$child->getCode());
         $child->setParent($this);
+        if ($field) {
+            $child->addParentAssociationMapping($this->getCode(), $field);
+        }
     }
 
     /**

--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -302,11 +302,7 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     protected $baseCodeRoute = '';
 
     /**
-     * The related field reflection, ie if OrderElement is linked to Order,
-     * then the $parentReflectionProperty must be the ReflectionProperty of
-     * the order (OrderElement::$order).
-     *
-     * @var \ReflectionProperty
+     * @var string
      */
     protected $parentAssociationMapping = null;
 

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -528,11 +528,12 @@ interface AdminInterface
     public function supportsPreviewMode();
 
     /**
-     * add an Admin child to the current one.
+     * add an Admin child to the current one linked to child's field.
      *
      * @param AdminInterface $child
+     * @param null|string    $field
      */
-    public function addChild(AdminInterface $child);
+    public function addChild(AdminInterface $child, $field = null);
 
     /**
      * Returns true or false if an Admin child exists for the given $code.

--- a/Resources/doc/reference/architecture.rst
+++ b/Resources/doc/reference/architecture.rst
@@ -318,7 +318,9 @@ Let us say you have a ``PostAdmin`` and a ``CommentAdmin``. You can optionally d
 to be a child of the ``PostAdmin``. This will create new routes like, for example, ``/post/{id}/comment/list``,
 where the comments will automatically be filtered by post.
 
-To do this, you first need to call the ``addChild`` method in your PostAdmin service configuration :
+To do this, you first need to call the ``addChild`` method in your ``PostAdmin`` service configuration with two arguments,
+the child admin name (in this case ``CommentAdmin`` service) and the Entity field that relates our child Entity with 
+its parent :
 
 .. configuration-block::
 
@@ -330,29 +332,9 @@ To do this, you first need to call the ``addChild`` method in your PostAdmin ser
 
             <call method="addChild">
                 <argument type="service" id="sonata.news.admin.comment" />
+                <argument>post</argument>
             </call>
         </service>
-
-Then, you have to set the CommentAdmin ``parentAssociationMapping`` attribute to ``post`` :
-
-.. code-block:: php
-
-    <?php
-    namespace Sonata\NewsBundle\Admin;
-
-    // ...
-
-    class CommentAdmin extends Admin
-    {
-        protected $parentAssociationMapping = 'post';
-
-        // OR
-
-        public function getParentAssociationMapping()
-        {
-            return 'post';
-        }
-    }
 
 It also possible to set a dot-separated value, like ``post.author``, if your parent and child admins are not directly related.
 

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -108,7 +108,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             'Application\Sonata\NewsBundle\Entity\Comment',
             'SonataNewsBundle:CommentAdmin'
         );
-        $admin->addChild($commentAdmin);
+        $admin->addChild($commentAdmin, 'post');
         $admin->setRequest(new Request(array('id' => 42)));
         $commentAdmin->setRequest(new Request());
         $commentAdmin->initialize();
@@ -265,7 +265,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             'Application\Sonata\NewsBundle\Entity\Comment',
             'SonataNewsBundle:CommentAdmin'
         );
-        $admin->addChild($commentAdmin);
+        $admin->addChild($commentAdmin, 'post');
         $admin->setRequest(new Request(array('id' => 42)));
         $commentAdmin->setRequest(new Request());
         $commentAdmin->initialize();
@@ -341,7 +341,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($postAdmin->hasChild('comment'));
 
         $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
-        $postAdmin->addChild($commentAdmin);
+        $postAdmin->addChild($commentAdmin, 'post');
         $this->assertTrue($postAdmin->hasChildren());
         $this->assertTrue($postAdmin->hasChild('sonata.post.admin.comment'));
 
@@ -592,7 +592,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $commentAdmin->setRouteGenerator($routeGenerator);
         $commentAdmin->initialize();
 
-        $postAdmin->addChild($commentAdmin);
+        $postAdmin->addChild($commentAdmin, 'post');
 
         $this->assertSame($expected.'_comment', $commentAdmin->getBaseRouteName());
 


### PR DESCRIPTION
Right now, the workaround is to extend a base admin and the children classes have different parentAssociationMappings