### PR TITLE
Remove setRequest

### DIFF
--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -10,7 +10,6 @@
             <argument type="service" id="knp_menu.factory" />
             <argument type="service" id="knp_menu.menu_provider" />
             <argument type="service" id="event_dispatcher" />
-            <call method="setRequest"><argument type="service" id="request" on-invalid="null" strict="false" /></call>
         </service>
 
         <service id="sonata.admin.sidebar_menu" class="Knp\Menu\MenuItem">


### PR DESCRIPTION
setRequest was removed in this change: 

https://github.com/sonata-project/SonataAdminBundle/commit/51c517f46724aacbb5499fca5224e3459e649ad2
This fires an error:

```
FatalThrowableError in appDevDebugProjectContainer.php line 5642: Fatal error: Call to undefined method Sonata\AdminBundle\Menu\MenuBuilder::setRequest()
```