### PR TITLE
Make the admin accept both the old and the new validator

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -198,7 +198,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             'translator'                => 'translator',
             'configuration_pool'        => 'sonata.admin.pool',
             'route_generator'           => 'sonata.admin.route.default_generator',
-            'validator'                 => 'validator',
+            'validator'                 => 'sonata_admin.validator.validator_wrapper',
             'security_handler'          => 'sonata.admin.security.handler',
             'menu_factory'              => 'knp_menu.factory',
             'route_builder'             => 'sonata.admin.route.path_info'.

--- a/Resources/config/validator.xml
+++ b/Resources/config/validator.xml
@@ -11,6 +11,11 @@
 
             <tag name="validator.constraint_validator" alias="sonata.admin.validator.inline" />
         </service>
+
+        <service id="sonata_admin.validator.validator_wrapper" class="Sonata\AdminBundle\Validator\ValidatorWrapper"
+                 public="false">
+            <argument type="service" id="validator" />
+        </service>
     </services>
 
 </container>

--- a/Tests/Validator/ValidatorWrapperTest.php
+++ b/Tests/Validator/ValidatorWrapperTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Validator;
+
+use Sonata\AdminBundle\Validator\ValidatorWrapper;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * Test for ValidatorWrapper.
+ *
+ * @author Alfonso Machado <email@alfonsomachado.com>
+ *
+ * @group validator-wrapper
+ */
+class ValidatorWrapperTest extends \PHPUnit_Framework_TestCase
+{
+    const RECURSIVE_VALIDATOR = 'Symfony\Component\Validator\Validator\RecursiveValidator';
+    const VALIDATOR_INTERFACE = 'Symfony\Component\Validator\ValidatorInterface';
+
+    public function testConstructor()
+    {
+        $wrappedValidator = $this->prophesize('OtherInterface');
+
+        $this->setExpectedException('\InvalidArgumentException');
+
+        $validator = new ValidatorWrapper($wrappedValidator->reveal());
+    }
+
+    /**
+     * @dataProvider validatorProvider
+     */
+    public function testValidate($validatorInterface)
+    {
+        $value = 'string_to_validate';
+        $violations = new ConstraintViolationList();
+        $wrappedValidator = $this->prophesize($validatorInterface);
+        $wrappedValidator->validate($value, null, false, false)->willReturn($violations);
+        $validator = new ValidatorWrapper($wrappedValidator->reveal());
+
+        $this->assertSame(0, count($validator->validate($value)));
+    }
+
+    /**
+     * @dataProvider validatorProvider
+     */
+    public function testValidateProperty($validatorInterface)
+    {
+        $value = 'string_to_validate';
+        $property = 'property';
+        $violations = new ConstraintViolationList();
+        $wrappedValidator = $this->prophesize($validatorInterface);
+        $wrappedValidator->validateProperty($value, $property, null)->willReturn($violations);
+        $validator = new ValidatorWrapper($wrappedValidator->reveal());
+
+        $this->assertSame(0, count($validator->validateProperty($value, $property)));
+    }
+
+    /**
+     * @dataProvider validatorProvider
+     */
+    public function testValidatePropertyValue($validatorInterface)
+    {
+        $value = 'string_to_validate';
+        $property = 'property';
+        $violations = new ConstraintViolationList();
+        $wrappedValidator = $this->prophesize($validatorInterface);
+        $wrappedValidator->validatePropertyValue($value, $property, $value, null)->willReturn($violations);
+        $validator = new ValidatorWrapper($wrappedValidator->reveal());
+
+        $this->assertSame(0, count($validator->validatePropertyValue($value, $property, $value)));
+    }
+
+    /**
+     * @dataProvider validatorProvider
+     */
+    public function testValidateValue($validatorInterface)
+    {
+        $value = 'string_to_validate';
+        $constraint = $this->prophesize('Symfony\Component\Validator\Constraint')->reveal();
+        $violations = new ConstraintViolationList();
+        $wrappedValidator = $this->prophesize($validatorInterface);
+        if (
+            $validatorInterface === self::RECURSIVE_VALIDATOR &&
+            !method_exists(self::RECURSIVE_VALIDATOR, 'validateValue')
+        ) {
+            $wrappedValidator->validate($value, $constraint, $value, null)->willReturn($violations);
+        } else {
+            $wrappedValidator->validateValue($value, $constraint, $value, null)->willReturn($violations);
+        }
+        $validator = new ValidatorWrapper($wrappedValidator->reveal());
+
+        $this->assertSame(0, count($validator->validateValue($value, $constraint, $value)));
+    }
+
+    /**
+     * @dataProvider validatorProvider
+     */
+    public function testGetMetadataFactory($validatorInterface)
+    {
+        if (
+            $validatorInterface === self::RECURSIVE_VALIDATOR &&
+            !method_exists(self::RECURSIVE_VALIDATOR, 'getMetadataFactory')
+        ) {
+            $this->markTestSkipped(
+                'You are testing Symfony 2.5 and 2.6 that not have support for LegacyValidator'
+            );
+        }
+
+        $metadataFactory = $this->prophesize('Symfony\Component\Validato\MetadataFactoryInterface')->reveal();
+        $wrappedValidator = $this->prophesize($validatorInterface);
+        $wrappedValidator->getMetadataFactory()->willReturn($metadataFactory);
+        $validator = new ValidatorWrapper($wrappedValidator->reveal());
+
+        $this->assertSame($metadataFactory, $validator->getMetadataFactory());
+    }
+
+    public function validatorProvider()
+    {
+        if (class_exists(self::RECURSIVE_VALIDATOR)) {
+            return array(
+                array(self::VALIDATOR_INTERFACE),
+                array(self::RECURSIVE_VALIDATOR),
+            );
+        } else {
+            return array(
+                array(self::VALIDATOR_INTERFACE),
+            );
+        }
+    }
+}

--- a/Validator/ValidatorWrapper.php
+++ b/Validator/ValidatorWrapper.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Validator;
+
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
+
+class ValidatorWrapper implements LegacyValidatorInterface
+{
+    /* @var mixed ValidatorInterface|LegacyValidatorInterface $validator */
+    private $validator;
+
+    /**
+     * ValidatorWrapper constructor.
+     *
+     * @param mixed ValidatorInterface|LegacyValidatorInterface $validator
+     */
+    public function __construct($validator)
+    {
+        if (!$validator instanceof ValidatorInterface && !$validator instanceof LegacyValidatorInterface) {
+            $message = 'Argument 1 must be an instance of '.
+                'Symfony\Component\Validator\Validator\ValidatorInterface '.
+                'or Symfony\Component\Validator\ValidatorInterface';
+
+            throw new \InvalidArgumentException($message);
+        }
+
+        $this->validator = $validator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, $groups = null, $traverse = false, $deep = false)
+    {
+        return $this->validator->validate($value, $groups, $traverse, $deep);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateProperty($containingValue, $property, $groups = null)
+    {
+        return $this->validator->validateProperty($containingValue, $property, $groups);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatePropertyValue($containingValue, $property, $value, $groups = null)
+    {
+        return $this->validator->validatePropertyValue($containingValue, $property, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateValue($value, $constraints, $groups = null)
+    {
+        if ($this->validator instanceof LegacyValidatorInterface) {
+            return $this->validator->validateValue($value, $constraints, $groups);
+        } else {
+            return $this->validator->validate($value, $constraints, $groups);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataFactory()
+    {
+        return $this->validator->getMetadataFactory();
+    }
+}


### PR DESCRIPTION
There is some problems when try to use other bundles (https://github.com/liip/LiipFunctionalTestBundle/issues/178) with this one due to SonataAdmin use in this branch the old validator. Although it is fixed in master and just bring the changes to 2.3 branch because I have to do a lot of work to migrate to next version of sonata admin and I think it is easier bring the changes to this branch.

I don't know if it is the right way to do it, but I propose the PR.

