### PR TITLE
Detect long lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
   fast_finish: true
   include:
     - php: 7.0
-      env: TARGET=cs_dry_run
+      env: TARGET=test_cs
     - php: 7.0
       env: TARGET=docs
     - php: 5.3

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,22 @@
+detect_long_lines_in_diff:
+	@# Check Added, Copied, Modified or Renamed files only \
+	if git diff --cached --diff-filter=ACMR 'HEAD^' | \
+		# Check added lines only \
+		grep --extended-regexp '^\+' | \
+		# Remove file header \
+		grep --invert-match --extended-regexp '^\+\+\+' | \
+		# Find lines longer than 120 characters \
+		grep --extended-regexp '.{121}'; \
+	then echo 'long lines detected'; exit 1; \
+	else exit 0; \
+	fi
 cs:
 	php-cs-fixer fix --verbose
 
 cs_dry_run:
 	php-cs-fixer fix --verbose --dry-run
+
+test_cs: detect_long_lines_in_diff cs_dry_run
 
 test:
 	phpunit

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+this should pass

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,2 @@
 this should pass
+This should not pass at all because this line is waaaay to long. Have you ever seen such a long line? I haven't. Why would anyone commit that?


### PR DESCRIPTION
This PR add long lines detection during the CI build. The build will fail if the diff contains a line longer than 120 characters in any line. 