### PR TITLE
Fix visual regression in base_show_macro.html.twig. Closes #3729.

### DIFF
--- a/Resources/views/CRUD/base_show_macro.html.twig
+++ b/Resources/views/CRUD/base_show_macro.html.twig
@@ -12,7 +12,7 @@
     {% for code in groups %}
         {% set show_group = admin.showgroups[code] %}
 
-        <div class="{{ show_group.class }} {{ no_padding ? "nopadding" }}">
+        <div class="{{ show_group.class|default('col-md-12') }} {{ no_padding ? 'nopadding' }}">
             <div class="{{ show_group.box_class }}">
                 <div class="box-header">
                     <h4 class="box-title">


### PR DESCRIPTION
Commit fd1a1596f86bfb4afdafe9767efaa4c787bba6a5 introduced a visual bug by forgetting to add a default css class.
This commits fixes the issue.
See github issue #3729 for more details.