### PR TITLE
add back missing wrapper divs

### DIFF
--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -25,45 +25,50 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block show %}
-    {{ sonata_block_render_event('sonata.admin.show.top', { 'admin': admin, 'object': object }) }}
+    <div class="sonata-ba-view">
 
-    {% set has_tab = (admin.showtabs|length == 1 and admin.showtabs|keys[0] != 'default') or admin.showtabs|length > 1 %}
+        {{ sonata_block_render_event('sonata.admin.show.top', { 'admin': admin, 'object': object }) }}
 
-    {% if has_tab %}
-        <div class="nav-tabs-custom">
-            <ul class="nav nav-tabs" role="tablist">
-                {% for name, show_tab in admin.showtabs %}
-                    <li{% if loop.first %} class="active"{% endif %}>
-                        <a href="#tab_{{ admin.uniqid }}_{{ loop.index }}" data-toggle="tab">
-                            <i class="fa fa-exclamation-circle has-errors hide"></i>
-                            {{ admin.trans(name, {}, show_tab.translation_domain) }}
-                        </a>
-                    </li>
-                {% endfor %}
-            </ul>
+        {% set has_tab = (admin.showtabs|length == 1 and admin.showtabs|keys[0] != 'default') or admin.showtabs|length > 1 %}
 
-            <div class="tab-content">
-                {% for code, show_tab in admin.showtabs %}
-                    <div
-                            class="tab-pane fade{% if loop.first %} in active{% endif %}"
-                            id="tab_{{ admin.uniqid }}_{{ loop.index }}"
-                    >
-                        <div class="box-body  container-fluid">
-                            <div class="sonata-ba-collapsed-fields">
-                                {% if show_tab.description != false %}
-                                    <p>{{ show_tab.description|raw }}</p>
-                                {% endif %}
+        {% if has_tab %}
+            <div class="nav-tabs-custom">
+                <ul class="nav nav-tabs" role="tablist">
+                    {% for name, show_tab in admin.showtabs %}
+                        <li{% if loop.first %} class="active"{% endif %}>
+                            <a href="#tab_{{ admin.uniqid }}_{{ loop.index }}" data-toggle="tab">
+                                <i class="fa fa-exclamation-circle has-errors hide"></i>
+                                {{ admin.trans(name, {}, show_tab.translation_domain) }}
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
 
-                                {{ show_helper.render_groups(admin, object, elements, show_tab.groups, has_tab) }}
+                <div class="tab-content">
+                    {% for code, show_tab in admin.showtabs %}
+                        <div
+                                class="tab-pane fade{% if loop.first %} in active{% endif %}"
+                                id="tab_{{ admin.uniqid }}_{{ loop.index }}"
+                        >
+                            <div class="box-body  container-fluid">
+                                <div class="sonata-ba-collapsed-fields">
+                                    {% if show_tab.description != false %}
+                                        <p>{{ show_tab.description|raw }}</p>
+                                    {% endif %}
+
+                                    {{ show_helper.render_groups(admin, object, elements, show_tab.groups, has_tab) }}
+                                </div>
                             </div>
                         </div>
-                    </div>
-                {% endfor %}
+                    {% endfor %}
+                </div>
             </div>
-        </div>
-    {% elseif admin.showtabs is iterable %}
-        {{ show_helper.render_groups(admin, object, elements, admin.showtabs.default.groups, has_tab) }}
-    {% endif %}
+        {% elseif admin.showtabs is iterable %}
+            {{ show_helper.render_groups(admin, object, elements, admin.showtabs.default.groups, has_tab) }}
+        {% endif %}
+
+    </div>
 
     {{ sonata_block_render_event('sonata.admin.show.bottom', { 'admin': admin, 'object': object }) }}
 {% endblock %}
+

--- a/Resources/views/CRUD/base_show_macro.html.twig
+++ b/Resources/views/CRUD/base_show_macro.html.twig
@@ -1,11 +1,7 @@
 {% macro render_groups(admin, object, elements, groups, has_tab, no_padding = false) %}
-    {% if has_tab %}
-        <div class="row">
-            {{ block('field_row') }}
-        </div>
-    {% else %}
+    <div class="row">
         {{ block('field_row') }}
-    {% endif %}
+    </div>
 {% endmacro %}
 
 {% block field_row %}


### PR DESCRIPTION
Commit fd1a159 removed two wrapper divs that shouldn't have been removed, one of these being a BC break (see first commit).
The other is closely related to issue #3729 and PR #3730 (I should have done it there, but it is merged already, see second commit)