### PR TITLE
add AdminInterface::isCurrentRoute method

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1307,6 +1307,31 @@ abstract class Admin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
+    public function isCurrentRoute($name, $adminCode = null)
+    {
+        if (!$this->hasRequest()) {
+            return false;
+        }
+
+        $request = $this->getRequest();
+        $route = $request->get('_route');
+
+        if ($adminCode) {
+            $admin = $this->getConfigurationPool()->getAdminByAdminCode($adminCode);
+        } else {
+            $admin = $this;
+        }
+
+        if (!$admin) {
+            return false;
+        }
+
+        return ($admin->getBaseRouteName().'_'.$name) == $route;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function generateObjectUrl($name, $object, array $parameters = array(), $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
         $parameters['id'] = $this->getUrlsafeIdentifier($object);

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -308,6 +308,23 @@ interface AdminInterface
     public function hasRoute($name);
 
     /**
+     * Check the current request is given route or not.
+     *
+     * TODO: uncomment this method before releasing 4.0
+     *
+     * ```
+     * $this->isCurrentRoute('create'); // is create page?
+     * $this->isCurrentRoute('edit', 'some.admin.code'); // is some.admin.code admin's edit page?
+     * ```
+     *
+     * @param string $name
+     * @param string $adminCode
+     *
+     * @return bool
+     */
+    // public function isCurrentRoute($name, $adminCode = null);
+
+    /**
      * Returns true if the admin has a FieldDescription with the given $name.
      *
      * @param string $name

--- a/Resources/doc/cookbook/recipe_dynamic_form_modification.rst
+++ b/Resources/doc/cookbook/recipe_dynamic_form_modification.rst
@@ -10,7 +10,8 @@ This is a way for you to accomplish this.
 
 In your ``Admin`` class' ``configureFormFields`` method you are able to get the
 current object by calling ``$this->getSubject()``. The value returned will be your
-linked model. Then, you should be able to dynamically add needed fields to the form:
+linked model. And another method ``isCurrentRoute`` for check the current request's route.
+Then, you should be able to dynamically add needed fields to the form:
 
 .. code-block:: php
 
@@ -22,7 +23,7 @@ linked model. Then, you should be able to dynamically add needed fields to the f
     use Sonata\AdminBundle\Admin\Admin;
     use Sonata\AdminBundle\Form\FormMapper;
 
-    classPostAdmin extends Admin
+    class PostAdmin extends Admin
     {
         // ...
 
@@ -38,6 +39,11 @@ linked model. Then, you should be able to dynamically add needed fields to the f
             if ($subject->isNew()) {
                 // The thumbnail field will only be added when the edited item is created
                 $formMapper->add('thumbnail', 'file');
+            }
+
+            // Name field will be added only when create an item
+            if ($this->isCurrentRoute('create')) {
+                $formMapper->add('name', 'text');
             }
         }
     }


### PR DESCRIPTION
Check the current request's name, if matched with given admin's route, will return true. This is useful when share configureFormFields method's result between create/edit/custom action, you can build different rule form for different pages.