### PR TITLE
Using form type names instead of FQCN to significantly reduce the change of getting an error while visiting the admin panel

### DIFF
--- a/Datagrid/Datagrid.php
+++ b/Datagrid/Datagrid.php
@@ -126,15 +126,15 @@ class Datagrid implements DatagridInterface
             $this->formBuilder->add($filter->getFormName(), $type, $options);
         }
 
-        $this->formBuilder->add('_sort_by', 'Symfony\Component\Form\Extension\Core\Type\HiddenType');
+        $this->formBuilder->add('_sort_by', 'hidden');
         $this->formBuilder->get('_sort_by')->addViewTransformer(new CallbackTransformer(
             function ($value) { return $value; },
             function ($value) { return $value instanceof FieldDescriptionInterface ? $value->getName() : $value; }
         ));
 
-        $this->formBuilder->add('_sort_order', 'Symfony\Component\Form\Extension\Core\Type\HiddenType');
-        $this->formBuilder->add('_page', 'Symfony\Component\Form\Extension\Core\Type\HiddenType');
-        $this->formBuilder->add('_per_page', 'Symfony\Component\Form\Extension\Core\Type\HiddenType');
+        $this->formBuilder->add('_sort_order', 'hidden');
+        $this->formBuilder->add('_page', 'hidden');
+        $this->formBuilder->add('_per_page', 'hidden');
 
         $this->form = $this->formBuilder->getForm();
         $this->form->submit($this->values);

--- a/Filter/Filter.php
+++ b/Filter/Filter.php
@@ -95,7 +95,7 @@ abstract class Filter implements FilterInterface
      */
     public function getFieldType()
     {
-        return $this->getOption('field_type', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        return $this->getOption('field_type', 'text');
     }
 
     /**

--- a/Tests/Datagrid/DatagridMapperTest.php
+++ b/Tests/Datagrid/DatagridMapperTest.php
@@ -104,7 +104,7 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Sonata\AdminBundle\Filter\FilterInterface', $filter);
         $this->assertSame('foo.name', $filter->getName());
         $this->assertSame('foo__name', $filter->getFormName());
-        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\TextType', $filter->getFieldType());
+        $this->assertSame('text', $filter->getFieldType());
         $this->assertSame('fooLabel', $filter->getLabel());
         $this->assertSame(array('required' => false), $filter->getFieldOptions());
         $this->assertSame(array(

--- a/Tests/Filter/FilterTest.php
+++ b/Tests/Filter/FilterTest.php
@@ -19,7 +19,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FooFilter();
 
-        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\TextType', $filter->getFieldType());
+        $this->assertSame('text', $filter->getFieldType());
         $this->assertSame(array('required' => false), $filter->getFieldOptions());
         $this->assertNull($filter->getLabel());
 


### PR DESCRIPTION
Revert #3709

Now I have to figure out why things don't work nice with the CMF on Symfony 3...