### PR TITLE
Fix for #3763

### DIFF
--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -284,13 +284,11 @@ class AdminHelper
                     $partReturnValue .= $dot.$id;
                     $dot = '.';
                     $id = '';
-                } else {
-                    $dot = '';
                 }
             }
 
-            if ($dot !== '.') {
-                throw new \Exception(sprintf('Could not get element id from %s Failing part: %s', $elementId, $subValue));
+            if (!empty($id)) {
+                throw new \Exception(sprintf('Could not get element id from %s Failing part: %s', $elementId, $id));
             }
 
             //check if array access was in this location originally

--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Util\FormViewIterator;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
@@ -332,6 +333,8 @@ class AdminHelper
 
             return true;
         } catch (NoSuchPropertyException $e) {
+            return false;
+        } catch (UnexpectedTypeException $e) {
             return false;
         }
     }

--- a/Tests/Admin/AdminHelperTest.php
+++ b/Tests/Admin/AdminHelperTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\Form\FormView;
 
 class AdminHelperTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var AdminHelper
+     */
     protected $helper;
 
     public function setUp()


### PR DESCRIPTION
Issue: https://github.com/sonata-project/SonataAdminBundle/issues/3763

With this fix, getElementAccessPath now detects better when a property is accesible and shows better exception message when it's not.

I added more test to be sure it's working.