### PR TITLE
Add some precisions on documentation and composer

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -11,6 +11,13 @@ Admin Bundle
 
 The demo website can be found in http://demo.sonata-project.org (``admin`` as user and password).
 
+**Usage examples:**
+
+* `SonataMediaBundle <https://github.com/sonata-project/SonataMediaBundle>`_: a media manager bundle
+* `SonataNewsBundle <https://github.com/sonata-project/SonataNewsBundle>`_: a news/blog bundle
+* `SonataPageBundle <https://github.com/sonata-project/SonataPageBundle>`_: a page (CMS like) bundle
+* `SonataUserBundle <https://github.com/sonata-project/SonataUserBundle>`_: integration of FOSUserBundle and SonataAdminBundle
+
 Getting Started
 ---------------
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "sonata-project/admin-bundle",
     "type": "symfony-bundle",
-    "description": "Symfony SonataAdminBundle",
+    "description": "The missing Symfony Admin Generator",
     "keywords": ["Admin Generator", "admin", "sonata", "bootstrap"],
     "homepage": "https://sonata-project.org/bundles/admin",
     "license": "MIT",


### PR DESCRIPTION
The goal is to permit to apply the generic readme on this bundle/

Ref: https://github.com/sonata-project/dev-kit/blob/4ff0f529c6f5e80203478bf769096ad964f0b322/project/README.md