### PR TITLE
Configure search result link in admin

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -416,6 +416,13 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
 
     protected $cacheIsGranted = array();
 
+    /**
+     * Action list for the search result.
+     *
+     * @var string[]
+     */
+    protected $searchResultActions = array('edit', 'show');
+
     protected $listModes = array(
         'list' => array(
             'class' => 'fa fa-list fa-fw',
@@ -2822,6 +2829,20 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
 
     /**
      * @param FormMapper $form
+     */
+    final public function getSearchResultLink($object)
+    {
+        foreach ($this->searchResultActions as $action) {
+            if ($this->hasRoute($action) && $this->isGranted(strtoupper($action), $object)) {
+                return $this->generateObjectUrl($action, $object);
+            }
+        }
+
+        return;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     protected function configureFormFields(FormMapper $form)
     {

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -1050,4 +1050,14 @@ interface AdminInterface
 //     * @return bool
 //     */
 //    public function hasAccess($action, $object = null);
+
+    //TODO: uncomment this method for 4.0
+    /*
+     * Returns the result link for an object.
+     *
+     * @param mixed $object
+     *
+     * @return string|null
+     */
+    //public function getSearchResultLink($object)
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.x]
 ### Added
 - Extract the breadcrumbs building part of the `AbstractAdmin` to a separate class
+- Added `AbstractAdmin::getSearchResultLink` method
 
 ## [3.1.0](https://github.com/sonata-project/SonataAdminBundle/compare/3.0.0...3.1.0) - 2016-05-17
 ### Added

--- a/Resources/doc/reference/search.rst
+++ b/Resources/doc/reference/search.rst
@@ -55,6 +55,28 @@ You can also configure the block template per admin while defining the admin:
               </call>
           </service>
 
+Configure the default search result action
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In general the search result generates a link to the edit action of an item or is using the show action, if the edit
+route is disabled or you haven't the required permission. You can change this behaviour by overriding the
+``searchResultActions`` property. The defined action list will we checked successive until a route with the required
+permissions exists. If no route is found, the item will be displayed as a text.
+
+.. code-block:: php
+
+    <?php
+    // src/AppBundle/Admin/PersonAdmin.php
+
+    class PersonAdmin extends AbstractAdmin
+    {
+        // ...
+
+        protected $searchResultActions = array('edit', 'show');
+
+        // ...
+    }
+
 Performance
 -----------
 

--- a/Resources/views/Block/block_search_result.html.twig
+++ b/Resources/views/Block/block_search_result.html.twig
@@ -40,8 +40,9 @@ file that was distributed with this source code.
                 <div class="box-body no-padding">
                     <ul class="nav nav-stacked sonata-search-result-list">
                         {% for result in pager.getResults() %}
-                            {% if admin.hasRoute('edit') and admin.isGranted('EDIT', result) %}
-                                <li><a href="{{ admin.generateObjectUrl('edit', result) }}">{{ admin.toString(result) }}</a></li>
+                            {% set link = admin.getSearchResultLink(result) %}
+                            {% if link %}
+                                <li><a href="{{ link }}">{{ admin.toString(result) }}</a></li>
                             {% else %}
                                 <li><a>{{ admin.toString(result) }}</a></li>
                             {% endif %}


### PR DESCRIPTION
This commit allows you to configure the search result link for each admin separately

Fixes (partial) #2581, #3092

It's kind of hard where to configure the default action for the link. Should the **Admin class define the final action or should a global config value override it.