### PR TITLE
Empty groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fix detection of path when using nested properties with underscores in `AdminHelper:getElementAccessPath` method
 - Fixed bad rendering on datetime field with `single_text` widget for date and time
+- Fixed rendering of empty form groups
 
 ## [3.0.0](https://github.com/sonata-project/SonataAdminBundle/compare/2.3.10...3.0.0) - 2016-05-08
 ### Added

--- a/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -1,7 +1,7 @@
 {% macro render_groups(admin, form, groups, has_tab) %}
     <div class="row">
 
-    {% for code in groups %}
+    {% for code in groups if admin.formgroups[code] is defined %}
         {% set form_group = admin.formgroups[code] %}
 
         <div class="{{ form_group.class|default('col-md-12') }}">


### PR DESCRIPTION
If you remove fields that are in a tab, you got a template error. This isn't the best solution, but it will fix: https://github.com/sonata-project/SonataUserBundle/issues/503

Refs https://github.com/sonata-project/SonataAdminBundle/pull/3447 https://github.com/sonata-project/SonataAdminBundle/pull/3661