### PR TITLE
move the breadcrumb build in a separate component

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -518,6 +518,13 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     private $managerType;
 
     /**
+     * The breadcrumbsBuilder component.
+     *
+     * @var BreadcrumbsBuilderInterface
+     */
+    private $breadcrumbsBuilder;
+
+    /**
      * @param string $code
      * @param string $class
      * @param string $baseControllerName
@@ -1949,20 +1956,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      */
     public function getBreadcrumbs($action)
     {
-        if ($this->isChild()) {
-            return $this->getParent()->getBreadcrumbs($action);
-        }
-
-        $menu = $this->buildBreadcrumbs($action);
-
-        do {
-            $breadcrumbs[] = $menu;
-        } while ($menu = $menu->getParent());
-
-        $breadcrumbs = array_reverse($breadcrumbs);
-        array_shift($breadcrumbs);
-
-        return $breadcrumbs;
+        return $this->getBreadcrumbsBuilder()->getBreadcrumbs($this, $action);
     }
 
     /**
@@ -1981,50 +1975,32 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
             return $this->breadcrumbs[$action];
         }
 
-        if (!$menu) {
-            $menu = $this->menuFactory->createItem('root');
+        return $this->breadcrumbs[$action] = $this->getBreadcrumbsBuilder()
+            ->buildBreadcrumbs($this, $action, $menu);
+    }
 
-            $menu = $menu->addChild(
-                $this->trans($this->getLabelTranslatorStrategy()->getLabel('dashboard', 'breadcrumb', 'link'), array(), 'SonataAdminBundle'),
-                array('uri' => $this->routeGenerator->generate('sonata_admin_dashboard'))
-            );
+    /**
+     * @return BreadcrumbsBuilderInterface
+     */
+    final public function getBreadcrumbsBuilder()
+    {
+        if ($this->breadcrumbsBuilder === null) {
+            $this->breadcrumbsBuilder = new BreadcrumbsBuilder();
         }
 
-        $menu = $menu->addChild(
-            $this->trans($this->getLabelTranslatorStrategy()->getLabel(sprintf('%s_list', $this->getClassnameLabel()), 'breadcrumb', 'link')),
-            array('uri' => $this->hasRoute('list') && $this->isGranted('LIST') ? $this->generateUrl('list') : null)
-        );
+        return $this->breadcrumbsBuilder;
+    }
 
-        $childAdmin = $this->getCurrentChildAdmin();
+    /**
+     * @param BreadcrumbsBuilderInterface
+     *
+     * @return AbstractAdmin
+     */
+    final public function setBreadcrumbsBuilder(BreadcrumbsBuilderInterface $value)
+    {
+        $this->breadcrumbsBuilder = $value;
 
-        if ($childAdmin) {
-            $id = $this->request->get($this->getIdParameter());
-
-            $menu = $menu->addChild(
-                $this->toString($this->getSubject()),
-                array('uri' => $this->hasRoute('edit') && $this->isGranted('EDIT') ? $this->generateUrl('edit', array('id' => $id)) : null)
-            );
-
-            return $childAdmin->buildBreadcrumbs($action, $menu);
-        }
-
-        if ($action === 'list' && $this->isChild()) {
-            $menu->setUri(false);
-        } elseif ($action !== 'create' && $this->hasSubject()) {
-            $menu = $menu->addChild($this->toString($this->getSubject()));
-        } else {
-            $menu = $menu->addChild(
-                $this->trans(
-                    $this->getLabelTranslatorStrategy()->getLabel(
-                        sprintf('%s_%s', $this->getClassnameLabel(), $action),
-                        'breadcrumb',
-                        'link'
-                    )
-                )
-            );
-        }
-
-        return $this->breadcrumbs[$action] = $menu;
+        return $this;
     }
 
     /**

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -941,7 +941,7 @@ interface AdminInterface
      *
      * @param string $action
      *
-     * @return array
+     * @return mixed array|Traversable
      */
     public function getBreadcrumbs($action);
 

--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+use Knp\Menu\ItemInterface;
+
+/**
+ * Stateless breadcrumbs builder (each method needs an Admin object).
+ *
+ * @author Grégoire Paris <postmaster@greg0ire.fr>
+ */
+final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getBreadcrumbs(AdminInterface $admin, $action)
+    {
+        $breadcrumbs = array();
+        if ($admin->isChild()) {
+            return $admin->getParent()->getBreadcrumbs($action);
+        }
+
+        $menu = $admin->buildBreadcrumbs($action);
+
+        do {
+            $breadcrumbs[] = $menu;
+        } while ($menu = $menu->getParent());
+
+        $breadcrumbs = array_reverse($breadcrumbs);
+        array_shift($breadcrumbs);
+
+        return $breadcrumbs;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildBreadcrumbs(AdminInterface $admin, $action, ItemInterface $menu = null)
+    {
+        if (!$menu) {
+            $menu = $admin->getMenuFactory()->createItem('root');
+
+            $menu = $menu->addChild(
+                $admin->trans(
+                    $admin->getLabelTranslatorStrategy()->getLabel(
+                        'dashboard',
+                        'breadcrumb',
+                        'link'
+                    ),
+                    array(),
+                    'SonataAdminBundle'
+                ),
+                array('uri' => $admin->getRouteGenerator()->generate(
+                    'sonata_admin_dashboard'
+                ))
+            );
+        }
+
+        $menu = $menu->addChild(
+            $admin->trans(
+                $admin->getLabelTranslatorStrategy()->getLabel(sprintf(
+                    '%s_list',
+                    $admin->getClassnameLabel()
+                ), 'breadcrumb', 'link')
+            ),
+            array(
+                'uri' => $admin->hasRoute('list') && $admin->isGranted('LIST') ?
+                $admin->generateUrl('list') :
+                null,
+            )
+        );
+
+        $childAdmin = $admin->getCurrentChildAdmin();
+
+        if ($childAdmin) {
+            $id = $admin->getRequest()->get($admin->getIdParameter());
+
+            $menu = $menu->addChild(
+                $admin->toString($admin->getSubject()),
+                array(
+                    'uri' => $admin->hasRoute('edit') && $admin->isGranted('EDIT') ?
+                    $admin->generateUrl('edit', array('id' => $id)) :
+                    null,
+                )
+            );
+
+            return $childAdmin->buildBreadcrumbs($action, $menu);
+        }
+
+        if ('list' === $action && $admin->isChild()) {
+            $menu->setUri(false);
+        } elseif ('create' !== $action && $admin->hasSubject()) {
+            $menu = $menu->addChild($admin->toString($admin->getSubject()));
+        } else {
+            $menu = $menu->addChild(
+                $admin->trans(
+                    $admin->getLabelTranslatorStrategy()->getLabel(
+                        sprintf('%s_%s', $admin->getClassnameLabel(), $action),
+                        'breadcrumb',
+                        'link'
+                    )
+                )
+            );
+        }
+
+        return $menu;
+    }
+}

--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -50,29 +50,22 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
         if (!$menu) {
             $menu = $admin->getMenuFactory()->createItem('root');
 
-            $menu = $menu->addChild(
-                $admin->trans(
-                    $admin->getLabelTranslatorStrategy()->getLabel(
-                        'dashboard',
-                        'breadcrumb',
-                        'link'
-                    ),
-                    array(),
-                    'SonataAdminBundle'
-                ),
+            $menu = $this->createMenuItem(
+                $admin,
+                $menu,
+                'dashboard',
+                'SonataAdminBundle',
                 array('uri' => $admin->getRouteGenerator()->generate(
                     'sonata_admin_dashboard'
                 ))
             );
         }
 
-        $menu = $menu->addChild(
-            $admin->trans(
-                $admin->getLabelTranslatorStrategy()->getLabel(sprintf(
-                    '%s_list',
-                    $admin->getClassnameLabel()
-                ), 'breadcrumb', 'link')
-            ),
+        $menu = $this->createMenuItem(
+            $admin,
+            $menu,
+            sprintf('%s_list', $admin->getClassnameLabel()),
+            null,
             array(
                 'uri' => $admin->hasRoute('list') && $admin->isGranted('LIST') ?
                 $admin->generateUrl('list') :
@@ -102,17 +95,46 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
         } elseif ('create' !== $action && $admin->hasSubject()) {
             $menu = $menu->addChild($admin->toString($admin->getSubject()));
         } else {
-            $menu = $menu->addChild(
-                $admin->trans(
-                    $admin->getLabelTranslatorStrategy()->getLabel(
-                        sprintf('%s_%s', $admin->getClassnameLabel(), $action),
-                        'breadcrumb',
-                        'link'
-                    )
-                )
+            $menu = $this->createMenuItem(
+                $admin,
+                $menu,
+                sprintf('%s_%s', $admin->getClassnameLabel(), $action)
             );
         }
 
         return $menu;
+    }
+
+    /**
+     * Creates a new menu item from a simple name. The name is normalized and
+     * translated with the specified translation domain.
+     *
+     * @param AdminInterface $admin             used for translation
+     * @param ItemInterface  $menu              will be modified and returned
+     * @param string         $name              the source of the final label
+     * @param string         $translationDomain for label translation
+     * @param array          $options           menu item options
+     *
+     * @return ItemInterface
+     */
+    private function createMenuItem(
+        AdminInterface $admin,
+        ItemInterface $menu,
+        $name,
+        $translationDomain = null,
+        $options = array()
+    ) {
+        return $menu->addChild(
+            $admin->trans(
+                $admin->getLabelTranslatorStrategy()->getLabel(
+                    $name,
+                    'breadcrumb',
+                    'link'
+                ),
+                array(),
+                $translationDomain
+            ),
+            $options
+        );
     }
 }

--- a/Admin/BreadcrumbsBuilderInterface.php
+++ b/Admin/BreadcrumbsBuilderInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+use Knp\Menu\ItemInterface;
+
+/**
+ * Builds a breacrumbs. There is a dependency on the AdminInterface because
+ * this object holds useful object to deal with this task, but there is
+ * probably a better design.
+ *
+ * @author Grégoire Paris <postmaster@greg0ire.fr>
+ */
+interface BreadcrumbsBuilderInterface
+{
+    /**
+     * Get breadcrumbs for $action.
+     *
+     * @param AdminInterface $admin
+     * @param string         $action the name of the action we want to get a
+     *                               breadcrumbs for
+     *
+     * @return mixed array|Traversable the breadcrumbs
+     */
+    public function getBreadcrumbs(AdminInterface $admin, $action);
+
+    /**
+     * Builds breadcrumbs for $action, starting from $menu.
+     *
+     * Note: the method will be called by the top admin instance (parent => child)
+     *
+     * @param AdminInterface     $admin
+     * @param string             $action
+     * @param ItemInterface|null $menu
+     */
+    public function buildBreadcrumbs(
+        AdminInterface $admin,
+        $action,
+        ItemInterface $menu = null
+    );
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.x]
+### Added
+- Extract the breadcrumbs building part of the `AbstractAdmin` to a separate class
 
 ## [3.1.0](https://github.com/sonata-project/SonataAdminBundle/compare/3.0.0...3.1.0) - 2016-05-17
 ### Added

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -217,7 +217,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($admin->hasAccess('edit_action'));
     }
 
-    public function testGetBreadCrumbs()
+    public function testGetBreadcrumbs()
     {
         $class = 'Application\Sonata\NewsBundle\Entity\Post';
         $baseControllerName = 'SonataNewsBundle:PostAdmin';
@@ -379,7 +379,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $commentAdmin->getBreadcrumbs('reply');
     }
 
-    public function testGetBreadCrumbsWithNoCurrentAdmin()
+    public function testGetBreadcrumbsWithNoCurrentAdmin()
     {
         $class = 'Application\Sonata\NewsBundle\Entity\Post';
         $baseControllerName = 'SonataNewsBundle:PostAdmin';

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -217,240 +217,6 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($admin->hasAccess('edit_action'));
     }
 
-    public function testGetBreadcrumbs()
-    {
-        $class = 'Application\Sonata\NewsBundle\Entity\Post';
-        $baseControllerName = 'SonataNewsBundle:PostAdmin';
-
-        $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
-        $commentAdmin = new CommentAdmin(
-            'sonata.post.admin.comment',
-            'Application\Sonata\NewsBundle\Entity\Comment',
-            'SonataNewsBundle:CommentAdmin'
-        );
-        $subCommentAdmin = new CommentAdmin(
-            'sonata.post.admin.comment',
-            'Application\Sonata\NewsBundle\Entity\Comment',
-            'SonataNewsBundle:CommentAdmin'
-        );
-        $admin->addChild($commentAdmin);
-        $admin->setRequest(new Request(array('id' => 42)));
-        $commentAdmin->setRequest(new Request());
-        $commentAdmin->initialize();
-        $admin->initialize();
-        $commentAdmin->setCurrentChild($subCommentAdmin);
-
-        $menuFactory = $this->getMock('Knp\Menu\FactoryInterface');
-        $menu = $this->getMock('Knp\Menu\ItemInterface');
-        $translatorStrategy = $this->getMock(
-            'Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface'
-        );
-        $routeGenerator = $this->getMock(
-            'Sonata\AdminBundle\Route\RouteGeneratorInterface'
-        );
-        $modelManager = $this->getMock(
-            'Sonata\AdminBundle\Model\ModelManagerInterface'
-        );
-
-        $admin->setMenuFactory($menuFactory);
-        $admin->setLabelTranslatorStrategy($translatorStrategy);
-        $admin->setRouteGenerator($routeGenerator);
-        $admin->setModelManager($modelManager);
-
-        $commentAdmin->setLabelTranslatorStrategy($translatorStrategy);
-        $commentAdmin->setRouteGenerator($routeGenerator);
-
-        $modelManager->expects($this->exactly(1))
-            ->method('find')
-            ->with('Application\Sonata\NewsBundle\Entity\Post', 42)
-            ->will($this->returnValue(new DummySubject()));
-
-        $menuFactory->expects($this->exactly(5))
-            ->method('createItem')
-            ->with('root')
-            ->will($this->returnValue($menu));
-
-        $menu->expects($this->once())
-            ->method('setUri')
-            ->with($this->identicalTo(false));
-
-        $menu->expects($this->exactly(5))
-            ->method('getParent')
-            ->will($this->returnValue(false));
-
-        $routeGenerator->expects($this->exactly(5))
-            ->method('generate')
-            ->with('sonata_admin_dashboard')
-            ->will($this->returnValue('http://somehost.com'));
-
-        $translatorStrategy->expects($this->exactly(18))
-            ->method('getLabel')
-            ->withConsecutive(
-                array('dashboard'),
-                array('Post_list'),
-                array('Comment_list'),
-                array('Comment_repost'),
-
-                array('dashboard'),
-                array('Post_list'),
-                array('Comment_list'),
-                array('Comment_flag'),
-
-                array('dashboard'),
-                array('Post_list'),
-                array('Comment_list'),
-                array('Comment_edit'),
-
-                array('dashboard'),
-                array('Post_list'),
-                array('Comment_list'),
-
-                array('dashboard'),
-                array('Post_list'),
-                array('Comment_list')
-            )
-            ->will($this->onConsecutiveCalls(
-                'someLabel',
-                'someOtherLabel',
-                'someInterestingLabel',
-                'someFancyLabel',
-
-                'someCoolLabel',
-                'someTipTopLabel',
-                'someFunkyLabel',
-                'someAwesomeLabel',
-
-                'someLikeableLabel',
-                'someMildlyInterestingLabel',
-                'someWTFLabel',
-                'someBadLabel',
-
-                'someBoringLabel',
-                'someLongLabel',
-                'someEndlessLabel',
-
-                'someAlmostThereLabel',
-                'someOriginalLabel',
-                'someOkayishLabel'
-            ));
-
-        $menu->expects($this->exactly(24))
-            ->method('addChild')
-            ->withConsecutive(
-                array('someLabel'),
-                array('someOtherLabel'),
-                array('dummy subject representation'),
-                array('someInterestingLabel'),
-                array('someFancyLabel'),
-
-                array('someCoolLabel'),
-                array('someTipTopLabel'),
-                array('dummy subject representation'),
-                array('someFunkyLabel'),
-                array('someAwesomeLabel'),
-
-                array('someLikeableLabel'),
-                array('someMildlyInterestingLabel'),
-                array('dummy subject representation'),
-                array('someWTFLabel'),
-                array('someBadLabel'),
-
-                array('someBoringLabel'),
-                array('someLongLabel'),
-                array('dummy subject representation'),
-                array('someEndlessLabel'),
-
-                array('someAlmostThereLabel'),
-                array('someOriginalLabel'),
-                array('dummy subject representation'),
-                array('someOkayishLabel'),
-                array('dummy subject representation')
-            )
-            ->will($this->returnValue($menu));
-
-        $admin->getBreadcrumbs('repost');
-        $admin->setSubject(new DummySubject());
-        $admin->getBreadcrumbs('flag');
-
-        $commentAdmin->getBreadcrumbs('edit');
-
-        $commentAdmin->getBreadcrumbs('list');
-        $commentAdmin->setSubject(new DummySubject());
-        $commentAdmin->getBreadcrumbs('reply');
-    }
-
-    public function testGetBreadcrumbsWithNoCurrentAdmin()
-    {
-        $class = 'Application\Sonata\NewsBundle\Entity\Post';
-        $baseControllerName = 'SonataNewsBundle:PostAdmin';
-
-        $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
-        $commentAdmin = new CommentAdmin(
-            'sonata.post.admin.comment',
-            'Application\Sonata\NewsBundle\Entity\Comment',
-            'SonataNewsBundle:CommentAdmin'
-        );
-        $admin->addChild($commentAdmin);
-        $admin->setRequest(new Request(array('id' => 42)));
-        $commentAdmin->setRequest(new Request());
-        $commentAdmin->initialize();
-        $admin->initialize();
-
-        $menuFactory = $this->getMock('Knp\Menu\FactoryInterface');
-        $menu = $this->getMock('Knp\Menu\ItemInterface');
-        $translatorStrategy = $this->getMock(
-            'Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface'
-        );
-        $routeGenerator = $this->getMock(
-            'Sonata\AdminBundle\Route\RouteGeneratorInterface'
-        );
-
-        $admin->setMenuFactory($menuFactory);
-        $admin->setLabelTranslatorStrategy($translatorStrategy);
-        $admin->setRouteGenerator($routeGenerator);
-
-        $menuFactory->expects($this->exactly(2))
-            ->method('createItem')
-            ->with('root')
-            ->will($this->returnValue($menu));
-
-        $translatorStrategy->expects($this->exactly(5))
-            ->method('getLabel')
-            ->withConsecutive(
-                array('dashboard'),
-                array('Post_list'),
-                array('Post_repost'),
-
-                array('dashboard'),
-                array('Post_list')
-            )
-            ->will($this->onConsecutiveCalls(
-                'someLabel',
-                'someOtherLabel',
-                'someInterestingLabel',
-                'someFancyLabel',
-                'someCoolLabel'
-            ));
-
-        $menu->expects($this->exactly(6))
-            ->method('addChild')
-            ->withConsecutive(
-                array('someLabel'),
-                array('someOtherLabel'),
-                array('someInterestingLabel'),
-                array('someFancyLabel'),
-
-                array('someCoolLabel'),
-                array('dummy subject representation')
-            )
-            ->will($this->returnValue($menu));
-
-        $admin->getBreadcrumbs('repost');
-        $admin->setSubject(new DummySubject());
-        $flagBreadcrumb = $admin->getBreadcrumbs('flag');
-        $this->assertSame($flagBreadcrumb, $admin->getBreadcrumbs('flag'));
-    }
-
     /**
      * @covers Sonata\AdminBundle\Admin\AbstractAdmin::hasChild
      * @covers Sonata\AdminBundle\Admin\AbstractAdmin::addChild
@@ -1845,6 +1611,61 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('create', $admin->getDashboardActions());
     }
 
+    public function testDefaultBreadcrumbsBuilder()
+    {
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AbstractAdmin', array(
+            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin',
+        ));
+        $this->assertInstanceOf(
+            'Sonata\AdminBundle\Admin\BreadcrumbsBuilder',
+            $admin->getBreadcrumbsBuilder()
+        );
+    }
+
+    public function testBreadcrumbsBuilderSetter()
+    {
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AbstractAdmin', array(
+            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin',
+        ));
+        $this->assertSame($admin, $admin->setBreadcrumbsBuilder($builder = $this->getMock(
+            'Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface'
+        )));
+        $this->assertSame($builder, $admin->getBreadcrumbsBuilder());
+    }
+
+    public function testGetBreadcrumbs()
+    {
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AbstractAdmin', array(
+            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin',
+        ));
+        $builder = $this->prophesize(
+            'Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface'
+        );
+        $action = 'myaction';
+        $builder->getBreadcrumbs($admin, $action)->shouldBeCalled();
+        $admin->setBreadcrumbsBuilder($builder->reveal())->getBreadcrumbs($action);
+    }
+
+    public function testBuildBreadcrumbs()
+    {
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AbstractAdmin', array(
+            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin',
+        ));
+        $builder = $this->prophesize(
+            'Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface'
+        );
+        $action = 'myaction';
+        $menu = $this->getMock('Knp\Menu\ItemInterface');
+        $builder->buildBreadcrumbs($admin, $action, $menu)
+            ->shouldBeCalledTimes(1)
+            ->willReturn($menu);
+        $admin->setBreadcrumbsBuilder($builder->reveal());
+
+        /* check the called is proxied only once */
+        $this->assertSame($menu, $admin->buildBreadcrumbs($action, $menu));
+        $this->assertSame($menu, $admin->buildBreadcrumbs($action, $menu));
+    }
+
     private function createTagAdmin(Post $post)
     {
         $postAdmin = $this->getMockBuilder('Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin')
@@ -1879,13 +1700,5 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $tagAdmin->setConfigurationPool($configurationPool);
 
         return $tagAdmin;
-    }
-}
-
-class DummySubject
-{
-    public function __toString()
-    {
-        return 'dummy subject representation';
     }
 }

--- a/Tests/Admin/BreadcrumbsBuilderTest.php
+++ b/Tests/Admin/BreadcrumbsBuilderTest.php
@@ -345,12 +345,12 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
                 'breadcrumb',
                 'link'
             )->willReturn('create my object');
-            $admin->trans('create my object')->willReturn('Créer mon objet')->shouldBeCalled();
-            $menu->addChild('Créer mon objet')->willReturn($menu);
+            $admin->trans('create my object', array(), null)->willReturn('Créer mon objet')->shouldBeCalled();
+            $menu->addChild('Créer mon objet', array())->willReturn($menu);
         }
         $childAdmin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
 
-        $admin->trans('My class')->willReturn('Ma classe');
+        $admin->trans('My class', array(), null)->willReturn('Ma classe');
         $admin->hasRoute('list')->willReturn(true);
         $admin->isGranted('LIST')->willReturn(true);
         $admin->generateUrl('list')->willReturn('/myadmin/list');

--- a/Tests/Admin/BreadcrumbsBuilderTest.php
+++ b/Tests/Admin/BreadcrumbsBuilderTest.php
@@ -1,0 +1,386 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Admin;
+
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilder;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentAdmin;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin;
+use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\DummySubject;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * This test class contains unit and integration tests. Maybe it could be
+ * separated into two classes.
+ *
+ * @author Grégoire Paris <postmaster@greg0ire.fr>
+ */
+class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetBreadcrumbs()
+    {
+        $class = 'Application\Sonata\NewsBundle\Entity\Post';
+        $baseControllerName = 'SonataNewsBundle:PostAdmin';
+
+        $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
+        $commentAdmin = new CommentAdmin(
+            'sonata.post.admin.comment',
+            'Application\Sonata\NewsBundle\Entity\Comment',
+            'SonataNewsBundle:CommentAdmin'
+        );
+        $subCommentAdmin = new CommentAdmin(
+            'sonata.post.admin.comment',
+            'Application\Sonata\NewsBundle\Entity\Comment',
+            'SonataNewsBundle:CommentAdmin'
+        );
+        $admin->addChild($commentAdmin);
+        $admin->setRequest(new Request(array('id' => 42)));
+        $commentAdmin->setRequest(new Request());
+        $commentAdmin->initialize();
+        $admin->initialize();
+        $commentAdmin->setCurrentChild($subCommentAdmin);
+
+        $menuFactory = $this->getMock('Knp\Menu\FactoryInterface');
+        $menu = $this->getMock('Knp\Menu\ItemInterface');
+        $translatorStrategy = $this->getMock(
+            'Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface'
+        );
+        $routeGenerator = $this->getMock(
+            'Sonata\AdminBundle\Route\RouteGeneratorInterface'
+        );
+        $modelManager = $this->getMock(
+            'Sonata\AdminBundle\Model\ModelManagerInterface'
+        );
+
+        $admin->setMenuFactory($menuFactory);
+        $admin->setLabelTranslatorStrategy($translatorStrategy);
+        $admin->setRouteGenerator($routeGenerator);
+        $admin->setModelManager($modelManager);
+
+        $commentAdmin->setLabelTranslatorStrategy($translatorStrategy);
+        $commentAdmin->setRouteGenerator($routeGenerator);
+
+        $modelManager->expects($this->exactly(1))
+            ->method('find')
+            ->with('Application\Sonata\NewsBundle\Entity\Post', 42)
+            ->will($this->returnValue(new DummySubject()));
+
+        $menuFactory->expects($this->exactly(5))
+            ->method('createItem')
+            ->with('root')
+            ->will($this->returnValue($menu));
+
+        $menu->expects($this->once())
+            ->method('setUri')
+            ->with($this->identicalTo(false));
+
+        $menu->expects($this->exactly(5))
+            ->method('getParent')
+            ->will($this->returnValue(false));
+
+        $routeGenerator->expects($this->exactly(5))
+            ->method('generate')
+            ->with('sonata_admin_dashboard')
+            ->will($this->returnValue('http://somehost.com'));
+
+        $translatorStrategy->expects($this->exactly(18))
+            ->method('getLabel')
+            ->withConsecutive(
+                array('dashboard'),
+                array('Post_list'),
+                array('Comment_list'),
+                array('Comment_repost'),
+
+                array('dashboard'),
+                array('Post_list'),
+                array('Comment_list'),
+                array('Comment_flag'),
+
+                array('dashboard'),
+                array('Post_list'),
+                array('Comment_list'),
+                array('Comment_edit'),
+
+                array('dashboard'),
+                array('Post_list'),
+                array('Comment_list'),
+
+                array('dashboard'),
+                array('Post_list'),
+                array('Comment_list')
+            )
+            ->will($this->onConsecutiveCalls(
+                'someLabel',
+                'someOtherLabel',
+                'someInterestingLabel',
+                'someFancyLabel',
+
+                'someCoolLabel',
+                'someTipTopLabel',
+                'someFunkyLabel',
+                'someAwesomeLabel',
+
+                'someLikeableLabel',
+                'someMildlyInterestingLabel',
+                'someWTFLabel',
+                'someBadLabel',
+
+                'someBoringLabel',
+                'someLongLabel',
+                'someEndlessLabel',
+
+                'someAlmostThereLabel',
+                'someOriginalLabel',
+                'someOkayishLabel'
+            ));
+
+        $menu->expects($this->exactly(24))
+            ->method('addChild')
+            ->withConsecutive(
+                array('someLabel'),
+                array('someOtherLabel'),
+                array('dummy subject representation'),
+                array('someInterestingLabel'),
+                array('someFancyLabel'),
+
+                array('someCoolLabel'),
+                array('someTipTopLabel'),
+                array('dummy subject representation'),
+                array('someFunkyLabel'),
+                array('someAwesomeLabel'),
+
+                array('someLikeableLabel'),
+                array('someMildlyInterestingLabel'),
+                array('dummy subject representation'),
+                array('someWTFLabel'),
+                array('someBadLabel'),
+
+                array('someBoringLabel'),
+                array('someLongLabel'),
+                array('dummy subject representation'),
+                array('someEndlessLabel'),
+
+                array('someAlmostThereLabel'),
+                array('someOriginalLabel'),
+                array('dummy subject representation'),
+                array('someOkayishLabel'),
+                array('dummy subject representation')
+            )
+            ->will($this->returnValue($menu));
+
+        $admin->getBreadcrumbs('repost');
+        $admin->setSubject(new DummySubject());
+        $admin->getBreadcrumbs('flag');
+
+        $commentAdmin->getBreadcrumbs('edit');
+
+        $commentAdmin->getBreadcrumbs('list');
+        $commentAdmin->setSubject(new DummySubject());
+        $commentAdmin->getBreadcrumbs('reply');
+    }
+
+    public function testGetBreadcrumbsWithNoCurrentAdmin()
+    {
+        $class = 'Application\Sonata\NewsBundle\Entity\Post';
+        $baseControllerName = 'SonataNewsBundle:PostAdmin';
+
+        $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
+        $commentAdmin = new CommentAdmin(
+            'sonata.post.admin.comment',
+            'Application\Sonata\NewsBundle\Entity\Comment',
+            'SonataNewsBundle:CommentAdmin'
+        );
+        $admin->addChild($commentAdmin);
+        $admin->setRequest(new Request(array('id' => 42)));
+        $commentAdmin->setRequest(new Request());
+        $commentAdmin->initialize();
+        $admin->initialize();
+
+        $menuFactory = $this->getMock('Knp\Menu\FactoryInterface');
+        $menu = $this->getMock('Knp\Menu\ItemInterface');
+        $translatorStrategy = $this->getMock(
+            'Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface'
+        );
+        $routeGenerator = $this->getMock(
+            'Sonata\AdminBundle\Route\RouteGeneratorInterface'
+        );
+
+        $admin->setMenuFactory($menuFactory);
+        $admin->setLabelTranslatorStrategy($translatorStrategy);
+        $admin->setRouteGenerator($routeGenerator);
+
+        $menuFactory->expects($this->exactly(2))
+            ->method('createItem')
+            ->with('root')
+            ->will($this->returnValue($menu));
+
+        $translatorStrategy->expects($this->exactly(5))
+            ->method('getLabel')
+            ->withConsecutive(
+                array('dashboard'),
+                array('Post_list'),
+                array('Post_repost'),
+
+                array('dashboard'),
+                array('Post_list')
+            )
+            ->will($this->onConsecutiveCalls(
+                'someLabel',
+                'someOtherLabel',
+                'someInterestingLabel',
+                'someFancyLabel',
+                'someCoolLabel'
+            ));
+
+        $menu->expects($this->exactly(6))
+            ->method('addChild')
+            ->withConsecutive(
+                array('someLabel'),
+                array('someOtherLabel'),
+                array('someInterestingLabel'),
+                array('someFancyLabel'),
+
+                array('someCoolLabel'),
+                array('dummy subject representation')
+            )
+            ->will($this->returnValue($menu));
+
+        $admin->getBreadcrumbs('repost');
+        $admin->setSubject(new DummySubject());
+        $flagBreadcrumb = $admin->getBreadcrumbs('flag');
+        $this->assertSame($flagBreadcrumb, $admin->getBreadcrumbs('flag'));
+    }
+
+    public function testUnitGetBreadCrumbs()
+    {
+        $root = $this->prophesize('Knp\Menu\ItemInterface');
+        $breadcrumbs = $this->prophesize('Knp\Menu\ItemInterface');
+        $breadcrumbs->getParent()->willreturn($root);
+        $breadcrumbs = $breadcrumbs->reveal();
+        $action = 'my_action';
+        $breadcrumbsBuilder = new BreadcrumbsBuilder();
+        $admin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $admin->isChild()->willReturn(false);
+        $admin->buildBreadcrumbs($action)->willReturn($breadcrumbs);
+        $this->assertSame(array($breadcrumbs), $breadcrumbsBuilder->getBreadcrumbs(
+            $admin->reveal(),
+            $action
+        ));
+    }
+
+    public function testUnitChildGetBreadCrumbs()
+    {
+        $parentMenu = 'parent menu';
+
+        $action = 'my_action';
+        $breadcrumbsBuilder = new BreadcrumbsBuilder();
+        $parentAdmin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $parentAdmin->getBreadcrumbs($action)->willReturn($parentMenu);
+        $admin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $admin->isChild()->willReturn(true);
+        $admin->getParent()->willReturn($parentAdmin->reveal());
+
+        $this->assertSame(
+            'parent menu',
+            $breadcrumbsBuilder->getBreadcrumbs($admin->reveal(), $action)
+        );
+    }
+
+    public function actionProvider()
+    {
+        return array(
+            array('my_action'),
+            array('list'),
+            array('edit'),
+            array('create'),
+        );
+    }
+
+    /**
+     * @dataProvider actionProvider
+     */
+    public function testUnitBuildBreadcrumbs($action)
+    {
+        $breadcrumbsBuilder = new BreadcrumbsBuilder();
+
+        $menu = $this->prophesize('Knp\Menu\ItemInterface');
+        $menuFactory = $this->prophesize('Knp\Menu\MenuFactory');
+        $menuFactory->createItem('root')->willReturn($menu);
+        $admin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $admin->getMenuFactory()->willReturn($menuFactory);
+        $labelTranslatorStrategy = $this->prophesize(
+            'Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface'
+        );
+        $labelTranslatorStrategy->getLabel(
+            'dashboard',
+            'breadcrumb',
+            'link'
+        )->willReturn('Dashboard');
+        $admin->trans('Dashboard', array(), 'SonataAdminBundle')->willReturn(
+            'Tableau de bord'
+        );
+
+        $routeGenerator = $this->prophesize('Sonata\AdminBundle\Route\RouteGeneratorInterface');
+        $routeGenerator->generate('sonata_admin_dashboard')->willReturn('/dashboard');
+        $admin->getRouteGenerator()->willReturn($routeGenerator->reveal());
+        $menu->addChild('Tableau de bord', array('uri' => '/dashboard'))->willReturn(
+            $menu->reveal()
+        );
+        $labelTranslatorStrategy->getLabel(
+            'my_class_name_list',
+            'breadcrumb',
+            'link'
+        )->willReturn('My class');
+        if ($action == 'create') {
+            $labelTranslatorStrategy->getLabel(
+                'my_class_name_create',
+                'breadcrumb',
+                'link'
+            )->willReturn('create my object');
+            $admin->trans('create my object')->willReturn('Créer mon objet')->shouldBeCalled();
+            $menu->addChild('Créer mon objet')->willReturn($menu);
+        }
+        $childAdmin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
+
+        $admin->trans('My class')->willReturn('Ma classe');
+        $admin->hasRoute('list')->willReturn(true);
+        $admin->isGranted('LIST')->willReturn(true);
+        $admin->generateUrl('list')->willReturn('/myadmin/list');
+        $admin->getCurrentChildAdmin()->willReturn(
+            $action == 'my_action' ? $childAdmin->reveal() : false
+        );
+        if ($action == 'list') {
+            $admin->isChild()->willReturn(true);
+            $menu->setUri(false)->shouldBeCalled();
+        }
+        $request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
+        $request->get('slug')->willReturn('my-object');
+
+        $admin->getIdParameter()->willReturn('slug');
+        $admin->hasRoute('edit')->willReturn(false);
+        $admin->getRequest()->willReturn($request->reveal());
+        $admin->hasSubject()->willReturn(true);
+        $admin->getSubject()->willReturn('my subject');
+        $admin->toString('my subject')->willReturn('My subject');
+        $admin->getLabelTranslatorStrategy()->willReturn(
+            $labelTranslatorStrategy->reveal()
+        );
+        $admin->getClassnameLabel()->willReturn('my_class_name');
+
+        $menu->addChild('Ma classe', array(
+            'uri' => '/myadmin/list',
+        ))->willReturn($menu->reveal());
+        $menu->addChild('My subject')->willReturn($menu);
+        $menu->addChild('My subject', array('uri' => null))->willReturn($menu);
+
+        $breadcrumbsBuilder->buildBreadCrumbs($admin->reveal(), $action);
+    }
+}

--- a/Tests/Fixtures/Bundle/Entity/DummySubject.php
+++ b/Tests/Fixtures/Bundle/Entity/DummySubject.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity;
+
+class DummySubject
+{
+    public function __toString()
+    {
+        return 'dummy subject representation';
+    }
+}


### PR DESCRIPTION
The Admin class is huge (~ 3000 lines), and it handles many unrelated
things. Let's move out what we can, starting with the breadcrumb
generation code.