### PR TITLE
Handle separated date and time single_text widget from datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Deprecated `AdminHelper::camelize()`
 - Deprecated `Admin` class
 
+### Fixed
+- Fixed bad rendering on datetime field with `single_text` widget for date and time
+
 ## [3.0.0](https://github.com/sonata-project/SonataAdminBundle/compare/2.3.10...3.0.0) - 2016-05-08
 ### Added
 - Add missing Route constructor parameters to `RouteCollection:add` method

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -289,8 +289,22 @@ file that was distributed with this source code.
         <div {{ block('widget_container_attributes') }}>
             {{ form_errors(form.date) }}
             {{ form_errors(form.time) }}
-            {{ form_widget(form.date, {'row': false, 'input_wrapper_class': 'col-sm-2'}) }}
-            {{ form_widget(form.time, {'row': false, 'input_wrapper_class': 'col-sm-2'}) }}
+
+            {% if form.date.vars.widget == 'single_text' %}
+                <div class="col-sm-2">
+                    {{ form_widget(form.date) }}
+                </div>
+            {% else %}
+                {{ form_widget(form.date, {'row': false, 'input_wrapper_class': 'col-sm-2'}) }}
+            {% endif %}
+
+            {% if form.time.vars.widget == 'single_text' %}
+                <div class="col-sm-2">
+                    {{ form_widget(form.time) }}
+                </div>
+            {% else %}
+                {{ form_widget(form.time, {'row': false, 'input_wrapper_class': 'col-sm-2'}) }}
+            {% endif %}
         </div>
     {% endif %}
 {% endspaceless %}


### PR DESCRIPTION
Fixes #3812.

When you choose `single_text` for date and time fields from a datetime one, you have to do a special case on twig rendering.

Before:

![selection_847](https://cloud.githubusercontent.com/assets/1698357/15253824/3918458e-1934-11e6-9a20-3964dd234cc4.png)

After:

![selection_846](https://cloud.githubusercontent.com/assets/1698357/15253832/3d259b86-1934-11e6-85f4-6df111afeb90.png)

