### PR TITLE
Removed duplicated Fixed section on CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added AbstractAdmin, replacing Admin
 
-### Fixed
-- Fix detection of path when using nested properties with underscores in `AdminHelper:getElementAccessPath` method
-
 ### Changed
 - Updated AdminLTE theme to version 2.3.3
 
@@ -18,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Deprecated `Admin` class
 
 ### Fixed
+- Fix detection of path when using nested properties with underscores in `AdminHelper:getElementAccessPath` method
 - Fixed bad rendering on datetime field with `single_text` widget for date and time
 
 ## [3.0.0](https://github.com/sonata-project/SonataAdminBundle/compare/2.3.10...3.0.0) - 2016-05-08


### PR DESCRIPTION
With the last two PR we introduced duplicated Fixed section on the CHANGELOG.md