### PR TITLE
Fix getSubject() when ID is null

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1598,7 +1598,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     {
         if ($this->subject === null && $this->request) {
             $id = $this->request->get($this->getIdParameter());
-            if (!preg_match('#^[0-9A-Fa-f\-]+$#', $id)) {
+            if (($id === null) || !preg_match('#^[0-9A-Fa-f\-]+$#', $id)) {
                 $this->subject = false;
             } else {
                 $this->subject = $this->getModelManager()->find($this->class, $id);


### PR DESCRIPTION
In Symfony 3.0.6, `$this->request->get('id')` returns null when no ID is set (new entity).
This was seen in `configureFormFields()` method.