### PR TITLE
Rename AdminExtension to AbstractAdminExtension

### DIFF
--- a/Admin/AbstractAdminExtension.php
+++ b/Admin/AbstractAdminExtension.php
@@ -21,11 +21,9 @@ use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\CoreBundle\Validator\ErrorElement;
 
 /**
- * Class AdminExtension.
- *
- * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-abstract class AdminExtension implements AdminExtensionInterface
+abstract class AbstractAdminExtension implements AdminExtensionInterface
 {
     /**
      * {@inheritdoc}

--- a/Admin/AdminExtension.php
+++ b/Admin/AdminExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+@trigger_error(
+    'The '.__NAMESPACE__.'\AdminExtension class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use '.__NAMESPACE__.'\AbstractAdminExtension instead.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated since version 3.x, to be removed in 4.0. Use Sonata\AdminBundle\AbstractAdminExtension instead.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+abstract class AdminExtension extends AbstractAdminExtension
+{
+}

--- a/Admin/Extension/LockExtension.php
+++ b/Admin/Extension/LockExtension.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\AdminBundle\Admin\Extension;
 
-use Sonata\AdminBundle\Admin\AdminExtension;
+use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Model\LockInterface;
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormEvents;
 /**
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
  */
-class LockExtension extends AdminExtension
+class LockExtension extends AbstractAdminExtension
 {
     /**
      * @var string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Deprecated `BaseFieldDescription::camelize()`
 - Deprecated `AdminHelper::camelize()`
 - Deprecated `Admin` class
+- Deprecated `AdminExtension` class
 - Deprecated default template loading on exception mechanism
 
 ### Fixed

--- a/Event/AdminEventExtension.php
+++ b/Event/AdminEventExtension.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\AdminBundle\Event;
 
-use Sonata\AdminBundle\Admin\AdminExtension;
+use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -25,7 +25,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  *
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AdminEventExtension extends AdminExtension
+class AdminEventExtension extends AbstractAdminExtension
 {
     protected $eventDispatcher;
 

--- a/Resources/doc/reference/extensions.rst
+++ b/Resources/doc/reference/extensions.rst
@@ -8,10 +8,10 @@ alter newly created objects and other admin features.
 
 .. code-block:: php
 
-    use Sonata\AdminBundle\Admin\AdminExtension;
+    use Sonata\AdminBundle\Admin\AbstractAdminExtension;
     use Sonata\AdminBundle\Form\FormMapper;
 
-    class PublishStatusAdminExtension extends AdminExtension
+    class PublishStatusAdminExtension extends AbstractAdminExtension
     {
         public function configureFormFields(FormMapper $formMapper)
         {

--- a/Resources/doc/reference/form_help_message.rst
+++ b/Resources/doc/reference/form_help_message.rst
@@ -89,12 +89,12 @@ This Extension for example adds a note field to some entities which use a custom
 
     namespace AppBundle\Admin\Extension;
 
-    use Sonata\AdminBundle\Admin\AdminExtension;
+    use Sonata\AdminBundle\Admin\AbstractAdminExtension;
     use Sonata\AdminBundle\Datagrid\DatagridMapper;
     use Sonata\AdminBundle\Form\FormMapper;
     use Sonata\AdminBundle\Show\ShowMapper;
 
-    class NoteAdminExtension extends AdminExtension
+    class NoteAdminExtension extends AbstractAdminExtension
     {
 
         // add this field to the datagrid every time its available

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -121,7 +121,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $securityHandler->isGranted($admin, 'CUSTOM_ROLE', $admin)->willReturn(true);
         $securityHandler->isGranted($admin, 'EXTRA_CUSTOM_ROLE', $admin)->willReturn(false);
         $customExtension = $this->prophesize(
-            'Sonata\AdminBundle\Admin\AdminExtension'
+            'Sonata\AdminBundle\Admin\AbstractAdminExtension'
         );
         $customExtension->getAccessMapping($admin)->willReturn(
             array('custom_action' => array('CUSTOM_ROLE', 'EXTRA_CUSTOM_ROLE'))
@@ -159,7 +159,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $securityHandler->isGranted($admin, 'CUSTOM_ROLE', $admin)->willReturn(true);
         $securityHandler->isGranted($admin, 'EXTRA_CUSTOM_ROLE', $admin)->willReturn(false);
         $customExtension = $this->prophesize(
-            'Sonata\AdminBundle\Admin\AdminExtension'
+            'Sonata\AdminBundle\Admin\AbstractAdminExtension'
         );
         $customExtension->getAccessMapping($admin)->willReturn(
             array('custom_action' => array('CUSTOM_ROLE', 'EXTRA_CUSTOM_ROLE'))
@@ -183,7 +183,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $securityHandler->isGranted($admin, 'CUSTOM_ROLE', $admin)->willReturn(true);
         $securityHandler->isGranted($admin, 'EXTRA_CUSTOM_ROLE', $admin)->willReturn(true);
         $customExtension = $this->prophesize(
-            'Sonata\AdminBundle\Admin\AdminExtension'
+            'Sonata\AdminBundle\Admin\AbstractAdminExtension'
         );
         $customExtension->getAccessMapping($admin)->willReturn(
             array('custom_action' => array('CUSTOM_ROLE', 'EXTRA_CUSTOM_ROLE'))
@@ -206,7 +206,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         );
         $securityHandler->isGranted($admin, 'EDIT_ROLE', $admin)->willReturn(true);
         $customExtension = $this->prophesize(
-            'Sonata\AdminBundle\Admin\AdminExtension'
+            'Sonata\AdminBundle\Admin\AbstractAdminExtension'
         );
         $customExtension->getAccessMapping($admin)->willReturn(
             array('edit_action' => array('EDIT_ROLE'))

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -5,6 +5,10 @@ UPGRADE 3.x
 
 The `Admin` class is deprecated. Use `AbstractAdmin` instead.
 
+## Deprecated AdminExtension class
+
+The `AdminExtension` class is deprecated. Use `AbstractAdminExtension` instead.
+
 ## Deprecated template fallback mechanism
 
 The Twig extension method that fallback to a default template when the specified one does not exist.


### PR DESCRIPTION
This follows Symfony coding standard rules.

Ref: http://symfony.com/doc/current/contributing/code/standards.html#naming-conventions

- [x] Rename the class
- [x] Update the documentation
- [x] Restore the deprecated `AdminExtension` class
- [ ] Squash commits
