### PR TITLE
Allow RouteCollection::clearExcept to have only one string argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Updated AdminLTE theme to version 2.3.3
+- `RouteCollection::clearExcept` can now have a single string argument
 
 ### Deprecated
 - Deprecated `BaseFieldDescription::camelize()`

--- a/Resources/doc/reference/routing.rst
+++ b/Resources/doc/reference/routing.rst
@@ -299,6 +299,8 @@ the ``clearExcept()`` method. This method accepts an array of routes you want to
         {
             // Only `list` and `edit` route will be active
             $collection->clearExcept(array('list', 'edit'));
+            // You can also pass a single string argument
+            $collection->clearExcept('list');
         }
     }
 

--- a/Route/RouteCollection.php
+++ b/Route/RouteCollection.php
@@ -183,12 +183,16 @@ class RouteCollection
     /**
      * Remove all routes except routes in $routeList.
      *
-     * @param array $routeList
+     * @param string[]|string $routeList
      *
      * @return RouteCollection
      */
-    public function clearExcept(array $routeList)
+    public function clearExcept($routeList)
     {
+        if (!is_array($routeList)) {
+            $routeList = array($routeList);
+        }
+
         $routeCodeList = array();
         foreach ($routeList as $name) {
             $routeCodeList[] = $this->getCode($name);

--- a/Tests/Route/RouteCollectionTest.php
+++ b/Tests/Route/RouteCollectionTest.php
@@ -80,6 +80,10 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($routeCollection->has('edit'));
         $this->assertFalse($routeCollection->has('view'));
         $this->assertFalse($routeCollection->has('list'));
+
+        $routeCollection->clearExcept('create');
+        $this->assertTrue($routeCollection->has('create'));
+        $this->assertFalse($routeCollection->has('edit'));
     }
 
     public function testGetWithException()


### PR DESCRIPTION
On some very simple admin classes allowing just listing, you can now do something like this:

```php
$collection->clearExcept('list');
```

Instead of this:

```php
$collection->clearExcept(['list']);
```