### PR TITLE
Add keys method to mappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.x]
 ### Added
 - Added AbstractAdmin, replacing Admin
+- Added `BaseMapper::keys` method
 
 ### Changed
 - Updated AdminLTE theme to version 2.3.3

--- a/Datagrid/DatagridMapper.php
+++ b/Datagrid/DatagridMapper.php
@@ -108,6 +108,14 @@ class DatagridMapper extends BaseMapper
     /**
      * {@inheritdoc}
      */
+    final public function keys()
+    {
+        return array_keys($this->datagrid->getFilters());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function remove($key)
     {
         $this->admin->removeFilterFieldDescription($key);

--- a/Datagrid/ListMapper.php
+++ b/Datagrid/ListMapper.php
@@ -148,6 +148,14 @@ class ListMapper extends BaseMapper
     /**
      * {@inheritdoc}
      */
+    final public function keys()
+    {
+        return array_keys($this->list->getElements());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function reorder(array $keys)
     {
         $this->list->reorder($keys);

--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -163,6 +163,14 @@ class FormMapper extends BaseGroupedMapper
     /**
      * {@inheritdoc}
      */
+    final public function keys()
+    {
+        return array_keys($this->formBuilder->all());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function remove($key)
     {
         $this->admin->removeFormFieldDescription($key);

--- a/Mapper/BaseMapper.php
+++ b/Mapper/BaseMapper.php
@@ -71,6 +71,14 @@ abstract class BaseMapper
      */
     abstract public function remove($key);
 
+    // To be uncommented on 4.0.
+    /**
+     * Returns configured keys.
+     *
+     * @return string[]
+     */
+    //abstract public function keys();
+
     /**
      * @param array $keys field names
      *

--- a/Show/ShowMapper.php
+++ b/Show/ShowMapper.php
@@ -116,6 +116,14 @@ class ShowMapper extends BaseGroupedMapper
     /**
      * {@inheritdoc}
      */
+    final public function keys()
+    {
+        return array_keys($this->list->getElements());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function reorder(array $keys)
     {
         $this->admin->reorderShowGroup($this->getCurrentGroupName(), $keys);

--- a/Tests/Datagrid/DatagridMapperTest.php
+++ b/Tests/Datagrid/DatagridMapperTest.php
@@ -226,6 +226,17 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
         $this->fail('Failed asserting that exception of type "\RuntimeException" is thrown.');
     }
 
+    public function testKeys()
+    {
+        $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');
+        $fieldDescription2 = $this->getFieldDescriptionMock('fooName2', 'fooLabel2');
+
+        $this->datagridMapper->add($fieldDescription1, null, array('field_name' => 'fooFilterName1'));
+        $this->datagridMapper->add($fieldDescription2, null, array('field_name' => 'fooFilterName2'));
+
+        $this->assertSame(array('fooName1', 'fooName2'), $this->datagridMapper->keys());
+    }
+
     public function testReorder()
     {
         $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');

--- a/Tests/Datagrid/ListMapperTest.php
+++ b/Tests/Datagrid/ListMapperTest.php
@@ -215,6 +215,17 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testKeys()
+    {
+        $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');
+        $fieldDescription2 = $this->getFieldDescriptionMock('fooName2', 'fooLabel2');
+
+        $this->listMapper->add($fieldDescription1);
+        $this->listMapper->add($fieldDescription2);
+
+        $this->assertSame(array('fooName1', 'fooName2'), $this->listMapper->keys());
+    }
+
     public function testReorder()
     {
         $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');

--- a/Tests/Form/FormMapperTest.php
+++ b/Tests/Form/FormMapperTest.php
@@ -380,6 +380,20 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array(), $this->admin->getFormTabs());
     }
 
+    public function testKeys()
+    {
+        $this->contractor->expects($this->any())
+            ->method('getDefaultOptions')
+            ->will($this->returnValue(array()));
+
+        $this->formMapper
+            ->add('foo', 'bar')
+            ->add('baz', 'foobaz')
+        ;
+
+        $this->assertSame(array('foo', 'baz'), $this->formMapper->keys());
+    }
+
     private function getFieldDescriptionMock($name = null, $label = null, $translationDomain = null)
     {
         $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\BaseFieldDescription');

--- a/Tests/Show/ShowMapperTest.php
+++ b/Tests/Show/ShowMapperTest.php
@@ -353,6 +353,17 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
         $this->fail('Failed asserting that duplicate field name exception of type "\RuntimeException" is thrown.');
     }
 
+    public function testKeys()
+    {
+        $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');
+        $fieldDescription2 = $this->getFieldDescriptionMock('fooName2', 'fooLabel2');
+
+        $this->showMapper->add($fieldDescription1);
+        $this->showMapper->add($fieldDescription2);
+
+        $this->assertSame(array('fooName1', 'fooName2'), $this->showMapper->keys());
+    }
+
     public function testReorder()
     {
         $this->assertSame(array(), $this->admin->getShowGroups());


### PR DESCRIPTION
Add `keys` method to `DatagridMapper`, `ShowMapper`, `FormMapper` and `ListMapper`.

This will permit to get all the configured keys.

For example, this could be used to do an advanced key ordering on `BaseMapper::reorder` method.

For me, this PR is RTM. But I would like a review from @sonata-project/contributors before merge it.