### PR TITLE
Provide _ALL type Role for role base security

### DIFF
--- a/Resources/doc/reference/security.rst
+++ b/Resources/doc/reference/security.rst
@@ -109,19 +109,20 @@ either a super admin (``ROLE_SUPER_ADMIN``) **or** has the permission.
 
 The permissions are:
 
-==========   ========================================
+==========   ==================================================
 Permission   Description
-==========   ========================================
+==========   ==================================================
 LIST         view the list of objects
 VIEW         view the detail of one object
 CREATE       create a new object
 EDIT         update an existing object
 DELETE       delete an existing object
 EXPORT       (for the native Sonata export links)
-==========   ========================================
+ALL          grants LIST, VIEW, CREATE, EDIT, DELETE and EXPORT
+==========   ==================================================
 
 Each permission is relative to an admin: if you try to get a list in FooAdmin (declared as ``app.admin.foo``
-service), Sonata will check if the user has the ``ROLE_APP_ADMIN_FOO_EDIT`` role.
+service), Sonata will check if the user has the ``ROLE_APP_ADMIN_FOO_EDIT`` or ``ROLE_APP_ADMIN_FOO_ALL`` roles.
 
 The role name will be based on the name of your admin service. For instance, ``acme.blog.post.admin`` will become ``ROLE_ACME_BLOG_POST_ADMIN_{ACTION}``.
 
@@ -156,6 +157,9 @@ So our ``security.yml`` file may look something like this:
                 ROLE_STAFF:             [ROLE_USER, ROLE_SONATA_FOO_READER]
                 ROLE_ADMIN:             [ROLE_STAFF, ROLE_SONATA_FOO_EDITOR, ROLE_SONATA_FOO_ADMIN]
                 ROLE_SUPER_ADMIN:       [ROLE_ADMIN, ROLE_ALLOWED_TO_SWITCH]
+
+                # you could alternatively use for an admin who has all rights 
+                ROLE_ALL_ADMIN:         [ROLE_STAFF, ROLE_SONATA_FOO_ALL]
 
             # set access_strategy to unanimous, else you may have unexpected behaviors
             access_decision_manager:

--- a/Security/Handler/RoleSecurityHandler.php
+++ b/Security/Handler/RoleSecurityHandler.php
@@ -62,6 +62,8 @@ class RoleSecurityHandler implements SecurityHandlerInterface
             $attributes[$pos] = sprintf($this->getBaseRole($admin), $attribute);
         }
 
+        $attributes[] = sprintf($this->getBaseRole($admin), 'ALL');
+
         try {
             return $this->authorizationChecker->isGranted($this->superAdminRoles)
                 || $this->authorizationChecker->isGranted($attributes, $object);

--- a/Tests/Security/Handler/RoleSecurityHandlerTest.php
+++ b/Tests/Security/Handler/RoleSecurityHandlerTest.php
@@ -104,6 +104,10 @@ class RoleSecurityHandlerTest extends \PHPUnit_Framework_TestCase
                     return true;
                 }
 
+                if (in_array('ROLE_FOO_BAR_BAZ_ALL', $attributes)) {
+                    return true;
+                }
+
                 return false;
             }));
 
@@ -173,6 +177,9 @@ class RoleSecurityHandlerTest extends \PHPUnit_Framework_TestCase
             array(false, array(), 'foo.bar.baz.xyz', 'BAZ', new \stdClass()),
             array(false, array(), 'foo.bar.baz.xyz', array('BAZ'), new \stdClass()),
             array(false, array('ROLE_AUTH_EXCEPTION'), 'foo.bar.baz.xyz', array('BAZ'), new \stdClass()),
+
+            // ALL role
+            array(true, array(), 'foo.bar.baz', 'LIST'),
         );
     }
 


### PR DESCRIPTION
I targeted this branch because it was the lastest branch when the PR was created. There is no BC break so really could be applied to all active branches IMO.

## Subject

This allows user to give coarse grained access to an admin area by
granting LIST,VIEW,CREATE,EDIT,DELETE and EXPORT to a user with the
corresponding _ALL role. So if an app has an admin area with service id
acme.user.admin and they provide a user with ROLE_ACME_USER_ADMIN_ALL
they automatically have LIST,VIEW,CREATE,EDIT,DELETE.

This is the implementation for #3806 
Fixes #3806 

## Changelog

```markdown
### Added
- Added additional `_ALL` role check to `RolesecurityHandler`
```