### PR TITLE
Closing api for AbstractAdmin::getBatchActions

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -980,7 +980,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function getBatchActions()
+    final public function getBatchActions()
     {
         $actions = array();
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `AbstractAdmin::defineFormBuilder` method is now private
 - `AbstractAdmin::configureActionButtons` method signature has changed
 - Moved default buttons from `AbstractAdmin::configureActionButtons` to `AbstractAdmin::getActionButtons`
+- `AbstractAdmin::getBatchActions` is now final
 
 ### Removed
 - Removed BC handler for deprecated `view` `_action`

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -368,15 +368,6 @@ class CRUDController extends Controller
             unset($data['_sonata_csrf_token']);
         }
 
-        // NEXT_MAJOR: Remove reflection check.
-        $reflector = new \ReflectionMethod($this->admin, 'getBatchActions');
-        if ($reflector->getDeclaringClass()->getName() === get_class($this->admin)) {
-            @trigger_error('Override Sonata\AdminBundle\Admin\AbstractAdmin::getBatchActions method'
-                .' is deprecated since version 3.x.'
-                .' Use Sonata\AdminBundle\Admin\AbstractAdmin::configureBatchActions instead.'
-                .' The method will be final in 4.0.', E_USER_DEPRECATED
-            );
-        }
         $batchActions = $this->admin->getBatchActions();
         if (!array_key_exists($action, $batchActions)) {
             throw new \RuntimeException(sprintf('The `%s` batch action is not defined', $action));

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -3217,11 +3217,6 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->controller->batchAction($this->request);
     }
 
-    /**
-     * NEXT_MAJOR: Remove this legacy group.
-     *
-     * @group legacy
-     */
     public function testBatchActionActionNotDefined()
     {
         $this->setExpectedException('RuntimeException', 'The `foo` batch action is not defined');
@@ -3253,11 +3248,6 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * NEXT_MAJOR: Remove this legacy group.
-     *
-     * @group legacy
-     */
     public function testBatchActionMethodNotExist()
     {
         $this->setExpectedException('RuntimeException', 'A `Sonata\AdminBundle\Controller\CRUDController::batchActionFoo` method must be callable');
@@ -3280,11 +3270,6 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->controller->batchAction($this->request);
     }
 
-    /**
-     * NEXT_MAJOR: Remove this legacy group.
-     *
-     * @group legacy
-     */
     public function testBatchActionWithoutConfirmation()
     {
         $batchActions = array('delete' => array('label' => 'Foo Bar', 'ask_confirmation' => false));
@@ -3335,11 +3320,6 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('list?', $result->getTargetUrl());
     }
 
-    /**
-     * NEXT_MAJOR: Remove this legacy group.
-     *
-     * @group legacy
-     */
     public function testBatchActionWithoutConfirmation2()
     {
         $batchActions = array('delete' => array('label' => 'Foo Bar', 'ask_confirmation' => false));
@@ -3391,11 +3371,6 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('list?', $result->getTargetUrl());
     }
 
-    /**
-     * NEXT_MAJOR: Remove this legacy group.
-     *
-     * @group legacy
-     */
     public function testBatchActionWithConfirmation()
     {
         $batchActions = array('delete' => array('label' => 'Foo Bar', 'translation_domain' => 'FooBarBaz', 'ask_confirmation' => true));
@@ -3450,11 +3425,6 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('SonataAdminBundle:CRUD:batch_confirmation.html.twig', $this->template);
     }
 
-    /**
-     * NEXT_MAJOR: Remove this legacy group.
-     *
-     * @group legacy
-     */
     public function testBatchActionNonRelevantAction()
     {
         $controller = new BatchAdminController();
@@ -3484,11 +3454,6 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('list?', $result->getTargetUrl());
     }
 
-    /**
-     * NEXT_MAJOR: Remove this legacy group.
-     *
-     * @group legacy
-     */
     public function testBatchActionNonRelevantAction2()
     {
         $controller = new BatchAdminController();
@@ -3518,11 +3483,6 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('list?', $result->getTargetUrl());
     }
 
-    /**
-     * NEXT_MAJOR: Remove this legacy group.
-     *
-     * @group legacy
-     */
     public function testBatchActionNoItems()
     {
         $batchActions = array('delete' => array('label' => 'Foo Bar', 'ask_confirmation' => true));
@@ -3549,11 +3509,6 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('list?', $result->getTargetUrl());
     }
 
-    /**
-     * NEXT_MAJOR: Remove this legacy group.
-     *
-     * @group legacy
-     */
     public function testBatchActionNoItemsEmptyQuery()
     {
         $controller = new BatchAdminController();
@@ -3597,11 +3552,6 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('batchActionBar executed', $result->getContent());
     }
 
-    /**
-     * NEXT_MAJOR: Remove this legacy group.
-     *
-     * @group legacy
-     */
     public function testBatchActionWithRequesData()
     {
         $batchActions = array('delete' => array('label' => 'Foo Bar', 'ask_confirmation' => false));

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -43,8 +43,9 @@ If you have implemented a custom admin extension, you must adapt the signature o
  * `getAccessMapping`
 
 ## AbstractAdmin
-The API of the following methods was closed by making them final, you can't override this methods anymore:
+The API of the following methods was closed by making them final, you can't override these methods anymore:
  * `getActionButtons`
+ * `getBatchActions`
 
 ## SonataAdminExtension
 The Twig filters that come with the bundle will no longer load a default template when used with a missing template.


### PR DESCRIPTION
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Changed
- Made `AbstractAdmin::getBatchActions` final
```

### Subject

This change closes the api for `AbstractAdmin::getBatchActions` in favor of `AbstractAdmin::configureBatchActions`

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [X] Change method signature
- [X] Add an upgrade note

