### PR TITLE
Fixed wrong phpdoc in FormMapper

### DIFF
--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -181,8 +181,7 @@ class FormMapper extends BaseGroupedMapper
     }
 
     /**
-     * @return FormBuilderInterface
-     *                              Removes a group.
+     * Removes a group.
      *
      * @param string $group          The group to delete
      * @param string $tab            The tab the group belongs to, defaults to 'default'


### PR DESCRIPTION
### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Fixed wrong phpdoc in FormMapper
```

### Subject

The `@return` doc exists twice in `FormMapper::removeGroup`.