### PR TITLE
Fixed wrong phpdoc

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2843,35 +2843,35 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param FormMapper $form
      */
     protected function configureFormFields(FormMapper $form)
     {
     }
 
     /**
-     * {@inheritdoc}
+     * @param ListMapper $list
      */
     protected function configureListFields(ListMapper $list)
     {
     }
 
     /**
-     * {@inheritdoc}
+     * @param DatagridMapper $filter
      */
     protected function configureDatagridFilters(DatagridMapper $filter)
     {
     }
 
     /**
-     * {@inheritdoc}
+     * @param ShowMapper $show
      */
     protected function configureShowFields(ShowMapper $show)
     {
     }
 
     /**
-     * {@inheritdoc}
+     * @param RouteCollection $collection
      */
     protected function configureRoutes(RouteCollection $collection)
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->



### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Wrong phpdoc for `AbstractAdmin::configure**`
```

### Subject

The protected methods doesn't have parents with any phpdoc.

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [X] Update phpdoc

