### PR TITLE
Closing API for AbstractAdmin::configureActionButtons and AbstractAdmin::getActionButtons

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2729,52 +2729,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function configureActionButtons($action, $object = null)
-    {
-        $list = array();
-
-        if (in_array($action, array('tree', 'show', 'edit', 'delete', 'list', 'batch'))) {
-            $list['create'] = array(
-                'template' => 'SonataAdminBundle:Button:create_button.html.twig',
-            );
-        }
-
-        if (in_array($action, array('show', 'delete', 'acl', 'history')) && $object) {
-            $list['edit'] = array(
-                'template' => 'SonataAdminBundle:Button:edit_button.html.twig',
-            );
-        }
-
-        if (in_array($action, array('show', 'edit', 'acl')) && $object) {
-            $list['history'] = array(
-                'template' => 'SonataAdminBundle:Button:history_button.html.twig',
-            );
-        }
-
-        if (in_array($action, array('edit', 'history')) && $object) {
-            $list['acl'] = array(
-                'template' => 'SonataAdminBundle:Button:acl_button.html.twig',
-            );
-        }
-
-        if (in_array($action, array('edit', 'history', 'acl')) && $object) {
-            $list['show'] = array(
-                'template' => 'SonataAdminBundle:Button:show_button.html.twig',
-            );
-        }
-
-        if (in_array($action, array('show', 'edit', 'delete', 'acl', 'batch'))) {
-            $list['list'] = array(
-                'template' => 'SonataAdminBundle:Button:list_button.html.twig',
-            );
-        }
-
-        return $list;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getActionButtons($action, $object = null)
     {
         $list = $this->configureActionButtons($action, $object);
@@ -2848,6 +2802,57 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      */
     protected function configureRoutes(RouteCollection $collection)
     {
+    }
+
+    /**
+     * Configure buttons for an action.
+     *
+     * @param string $action
+     * @param object $object
+     *
+     * @return array
+     */
+    protected function configureActionButtons($action, $object = null)
+    {
+        $list = array();
+
+        if (in_array($action, array('tree', 'show', 'edit', 'delete', 'list', 'batch'))) {
+            $list['create'] = array(
+                'template' => 'SonataAdminBundle:Button:create_button.html.twig',
+            );
+        }
+
+        if (in_array($action, array('show', 'delete', 'acl', 'history')) && $object) {
+            $list['edit'] = array(
+                'template' => 'SonataAdminBundle:Button:edit_button.html.twig',
+            );
+        }
+
+        if (in_array($action, array('show', 'edit', 'acl')) && $object) {
+            $list['history'] = array(
+                'template' => 'SonataAdminBundle:Button:history_button.html.twig',
+            );
+        }
+
+        if (in_array($action, array('edit', 'history')) && $object) {
+            $list['acl'] = array(
+                'template' => 'SonataAdminBundle:Button:acl_button.html.twig',
+            );
+        }
+
+        if (in_array($action, array('edit', 'history', 'acl')) && $object) {
+            $list['show'] = array(
+                'template' => 'SonataAdminBundle:Button:show_button.html.twig',
+            );
+        }
+
+        if (in_array($action, array('show', 'edit', 'delete', 'acl', 'batch'))) {
+            $list['list'] = array(
+                'template' => 'SonataAdminBundle:Button:list_button.html.twig',
+            );
+        }
+
+        return $list;
     }
 
      /**

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2729,7 +2729,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function getActionButtons($action, $object = null)
+    final public function getActionButtons($action, $object = null)
     {
         $list = $this->configureActionButtons($action, $object);
 

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -1083,14 +1083,6 @@ interface AdminInterface
      */
     public function getDashboardActions();
 
-     /**
-      * Configure buttons for an action.
-      *
-      * @param string $action
-      * @param object $object
-      */
-     public function configureActionButtons($action, $object = null);
-
     /**
      * Hook to handle access authorization, without throw Exception.
      *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - `AbstractAdmin::configureActionButtons` method is now protected
+- `AbstractAdmin::getActionButtons` is now final
 
 ### Removed
 - Removed BC handler for deprecated `view` `_action`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [4.x]
 ### Added
 - Add the `hasAccess` method to the AdminInterface
-- Add the ``configureActionButtons`` method to the AdminInterface
 - Add the `getExportFields` method to the AdminInterface
 - Add the `setTemplates` method to the AdminInterface
 - Add the `setTemplate` method to the AdminInterface
@@ -21,6 +20,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add the ``configureBatchActions`` method to the AdminExtensionInterface
 - Added the `getAccessMapping` method to the AdminExtensionInterface
 - Add the `isCurrentRoute` method to the AdminInterface
+
+### Changed
+- `AbstractAdmin::configureActionButtons` method is now protected
 
 ### Removed
 - Removed BC handler for deprecated `view` `_action`

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -359,7 +359,7 @@ You can add custom items to the actions menu for a specific action by overriding
 
 .. code-block:: php
 
-    public function configureActionButtons($action, $object = null)
+    protected function configureActionButtons($action, $object = null)
     {
         $list = parent::configureActionButtons($action, $object);
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -25,6 +25,8 @@ If you have implemented a custom admin, you must adapt the signature of the foll
  * `getDashboardActions`
  * `getActionButtons`
  * `isCurrentRoute`
+ 
+The method `configureActionButtons` is now protected.
 
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -34,6 +34,10 @@ If you have implemented a custom admin extension, you must adapt the signature o
  * `configureBatchActions`
  * `getAccessMapping`
 
+## AbstractAdmin
+The API of the following methods was closed by making them final, you can't override this methods anymore:
+ * `getActionButtons`
+
 ## SonataAdminExtension
 The Twig filters that come with the bundle will no longer load a default template when used with a missing template.
 The `sonata_admin` twig extension is now final. You may no longer extend it.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Changed
- `AbstractAdmin::configureActionButtons` method is now protected
- `AbstractAdmin::getActionButtons` is now final
```

### Subject

There is no reason for a public access to `AbstractAdmin::configureActionButtons`.

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [X] Update the documentation
- [X] Add an upgrade note
- [X] Move body of `configureActionButtons` to `getActionButtons`
