### PR TITLE
Make export fields translateable

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -584,7 +584,22 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
         $datagrid = $this->getDatagrid();
         $datagrid->buildPager();
 
-        return $this->getModelManager()->getDataSourceIterator($datagrid, $this->getExportFields());
+        $fields = array();
+
+        foreach ($this->getExportFields() as $key => $field) {
+            $label = $this->getTranslationLabel($field, 'export', 'label');
+            $transLabel = $this->trans($label);
+
+            // NEXT_MAJOR: Remove this hack, because all field labels will be translated with the major release
+            // No translation key exists
+            if ($transLabel == $label) {
+                $fields[$key] = $field;
+            } else {
+                $fields[$transLabel] = $field;
+            }
+        }
+
+        return $this->getModelManager()->getDataSourceIterator($datagrid, $fields);
     }
 
     /**

--- a/Resources/doc/reference/action_export.rst
+++ b/Resources/doc/reference/action_export.rst
@@ -12,6 +12,13 @@ This document will cover the Export action and related configuration options.
 Basic configuration
 -------------------
 
+Translation
+~~~~~~~~~~~
+
+All field names are translated by default.
+An internal mechanism checks if a field matching the translator strategy label exists in the current translation file
+and will use the field name as a fallback.
+
 .. note::
 
     **TODO**:


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs https://github.com/sonata-project/SonataAdminBundle/pull/3527

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Added
- export fields names are now translated
```

### Subject

The export function now checks, if a label exists with the name created by the translator strategy.

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [x] Update the tests

