### PR TITLE
Moved public methods to AdminInterface

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -543,7 +543,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function getExportFields()
     {

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1925,9 +1925,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @param string $name
-     *
-     * @return null|mixed
+     * {@inheritdoc}
      */
     public function getPersistentParameter($name)
     {

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1167,7 +1167,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function getTemplates()
     {

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1897,9 +1897,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Returns the classname label.
-     *
-     * @return string the classname label
+     * {@inheritdoc}
      */
     public function getClassnameLabel()
     {

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1151,7 +1151,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @param array $templates
+     * {@inheritdoc}
      */
     public function setTemplates(array $templates)
     {

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2784,10 +2784,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @param string $action
-     * @param mixed  $object
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getActionButtons($action, $object = null)
     {

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2801,9 +2801,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Get the list of actions that can be accessed directly from the dashboard.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getDashboardActions()
     {

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1159,8 +1159,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * @param string $name
-     * @param string $template
+     * {@inheritdoc}
      */
     public function setTemplate($name, $template)
     {

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -184,6 +184,13 @@ interface AdminInterface
     public function setTemplate($name, $template);
 
     /**
+     * Get all templates.
+     *
+     * @return array
+     */
+    public function getTemplates();
+
+    /**
      * @return \Sonata\AdminBundle\Model\ModelManagerInterface
      */
     public function getModelManager();

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -921,6 +921,13 @@ interface AdminInterface
     public function getSubClasses();
 
     /**
+     * Adds a new class to a list of supported sub classes.
+     *
+     * @param $subClass
+     */
+    public function addSubClass($subClass);
+
+    /**
      * Sets the list of supported sub classes.
      *
      * @param array $subClasses the list of sub classes

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -1087,6 +1087,13 @@ interface AdminInterface
      */
     public function checkAccess($action, $object = null);
 
+    /**
+     * Get the list of actions that can be accessed directly from the dashboard.
+     *
+     * @return array
+     */
+    public function getDashboardActions();
+
      /**
       * Configure buttons for an action.
       *

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -616,6 +616,13 @@ interface AdminInterface
     public function getUniqid();
 
     /**
+     * Returns the classname label.
+     *
+     * @return string the classname label
+     */
+    public function getClassnameLabel();
+
+    /**
      * @param mixed $id
      *
      * @return mixed

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -706,11 +706,10 @@ interface AdminInterface
      */
     public function delete($object);
 
-//TODO: uncomment this method for 4.0
-//    /**
-//     * @param mixed $object
-//     */
-//    public function preValidate($object);
+    /**
+     * @param mixed $object
+     */
+    public function preValidate($object);
 
     /**
      * @param mixed $object

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -973,6 +973,13 @@ interface AdminInterface
     public function getPersistentParameters();
 
     /**
+     * @param string $name
+     *
+     * @return null|mixed
+     */
+    public function getPersistentParameter($name);
+
+    /**
      * Get breadcrumbs for $action.
      *
      * @param string $action

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -1088,6 +1088,14 @@ interface AdminInterface
     public function checkAccess($action, $object = null);
 
     /**
+     * @param string $action
+     * @param mixed  $object
+     *
+     * @return array
+     */
+    public function getActionButtons($action, $object = null);
+
+    /**
      * Get the list of actions that can be accessed directly from the dashboard.
      *
      * @return array

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -914,6 +914,13 @@ interface AdminInterface
     public function isAclEnabled();
 
     /**
+     * Returns list of supported sub classes.
+     *
+     * @return array
+     */
+    public function getSubClasses();
+
+    /**
      * Sets the list of supported sub classes.
      *
      * @param array $subClasses the list of sub classes

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -176,6 +176,14 @@ interface AdminInterface
     public function setTemplates(array $templates);
 
     /**
+     * Sets a specific template.
+     *
+     * @param string $name
+     * @param string $template
+     */
+    public function setTemplate($name, $template);
+
+    /**
      * @return \Sonata\AdminBundle\Model\ModelManagerInterface
      */
     public function getModelManager();

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -643,6 +643,13 @@ interface AdminInterface
     public function getExportFormats();
 
     /**
+     * Retuns a list of exported fields.
+     *
+     * @return array
+     */
+    public function getExportFields();
+
+    /**
      * Returns SourceIterator.
      *
      * @return \Exporter\Source\SourceIteratorInterface

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -169,6 +169,13 @@ interface AdminInterface
     public function generateMenuUrl($name, array $parameters = array(), $absolute = false);
 
     /**
+     * Sets a list of templates.
+     *
+     * @param array $templates
+     */
+    public function setTemplates(array $templates);
+
+    /**
      * @return \Sonata\AdminBundle\Model\ModelManagerInterface
      */
     public function getModelManager();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add the `getExportFields` method to the AdminInterface
 - Add the `setTemplates` method to the AdminInterface
 - Add the `setTemplate` method to the AdminInterface
+- Add the `getTemplates` method to the AdminInterface
 - Add the ``configureActionButtons`` method to the AdminExtensionInterface
 - Add the ``configureBatchActions`` method to the AdminExtensionInterface
 - Added the `getAccessMapping` method to the AdminExtensionInterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add the `setTemplates` method to the AdminInterface
 - Add the `setTemplate` method to the AdminInterface
 - Add the `getTemplates` method to the AdminInterface
+- Add the `getClassnameLabel` method to the AdminInterface
 - Add the ``configureActionButtons`` method to the AdminExtensionInterface
 - Add the ``configureBatchActions`` method to the AdminExtensionInterface
 - Added the `getAccessMapping` method to the AdminExtensionInterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add the `getPersistentParameter` method to the AdminInterface
 - Add the `preValidate` method to the AdminInterface
 - Add the `getSubClasses` method to the AdminInterface
+- Add the `addSubClass` method to the AdminInterface
 - Add the ``configureActionButtons`` method to the AdminExtensionInterface
 - Add the ``configureBatchActions`` method to the AdminExtensionInterface
 - Added the `getAccessMapping` method to the AdminExtensionInterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add the `getClassnameLabel` method to the AdminInterface
 - Add the `getPersistentParameter` method to the AdminInterface
 - Add the `preValidate` method to the AdminInterface
+- Add the `getSubClasses` method to the AdminInterface
 - Add the ``configureActionButtons`` method to the AdminExtensionInterface
 - Add the ``configureBatchActions`` method to the AdminExtensionInterface
 - Added the `getAccessMapping` method to the AdminExtensionInterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add the ``configureActionButtons`` method to the AdminInterface
 - Add the `getExportFields` method to the AdminInterface
 - Add the `setTemplates` method to the AdminInterface
+- Add the `setTemplate` method to the AdminInterface
 - Add the ``configureActionButtons`` method to the AdminExtensionInterface
 - Add the ``configureBatchActions`` method to the AdminExtensionInterface
 - Added the `getAccessMapping` method to the AdminExtensionInterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add the `setTemplate` method to the AdminInterface
 - Add the `getTemplates` method to the AdminInterface
 - Add the `getClassnameLabel` method to the AdminInterface
+- Add the `getPersistentParameter` method to the AdminInterface
 - Add the ``configureActionButtons`` method to the AdminExtensionInterface
 - Add the ``configureBatchActions`` method to the AdminExtensionInterface
 - Added the `getAccessMapping` method to the AdminExtensionInterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add the `preValidate` method to the AdminInterface
 - Add the `getSubClasses` method to the AdminInterface
 - Add the `addSubClass` method to the AdminInterface
+- Add the `getDashboardActions` method to the AdminInterface
 - Add the ``configureActionButtons`` method to the AdminExtensionInterface
 - Add the ``configureBatchActions`` method to the AdminExtensionInterface
 - Added the `getAccessMapping` method to the AdminExtensionInterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add the ``configureActionButtons`` method to the AdminInterface
 - Add the `getExportFields` method to the AdminInterface
+- Add the `setTemplates` method to the AdminInterface
 - Add the ``configureActionButtons`` method to the AdminExtensionInterface
 - Add the ``configureBatchActions`` method to the AdminExtensionInterface
 - Added the `getAccessMapping` method to the AdminExtensionInterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [4.x]
 ### Added
 - Add the ``configureActionButtons`` method to the AdminInterface
+- Add the `getExportFields` method to the AdminInterface
 - Add the ``configureActionButtons`` method to the AdminExtensionInterface
 - Add the ``configureBatchActions`` method to the AdminExtensionInterface
 - Added the `getAccessMapping` method to the AdminExtensionInterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add the `getSubClasses` method to the AdminInterface
 - Add the `addSubClass` method to the AdminInterface
 - Add the `getDashboardActions` method to the AdminInterface
+- Add the `getActionButtons` method to the AdminInterface
 - Add the ``configureActionButtons`` method to the AdminExtensionInterface
 - Add the ``configureBatchActions`` method to the AdminExtensionInterface
 - Added the `getAccessMapping` method to the AdminExtensionInterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add the `getTemplates` method to the AdminInterface
 - Add the `getClassnameLabel` method to the AdminInterface
 - Add the `getPersistentParameter` method to the AdminInterface
+- Add the `preValidate` method to the AdminInterface
 - Add the ``configureActionButtons`` method to the AdminExtensionInterface
 - Add the ``configureBatchActions`` method to the AdminExtensionInterface
 - Added the `getAccessMapping` method to the AdminExtensionInterface

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -16,6 +16,7 @@ If you have implemented a custom admin, you must adapt the signature of the foll
  * `setTemplates`
  * `setTemplate`
  * `getTemplates`
+ * `getClassnameLabel`
 
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -13,6 +13,7 @@ See also the [diff code](https://github.com/sonata-project/SonataAdminBundle/com
 If you have implemented a custom admin, you must adapt the signature of the following new methods to match the one in `AdminInterface` again:
  * `configureActionButtons`
  * `getExportFields`
+ * `setTemplates`
 
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -12,6 +12,7 @@ See also the [diff code](https://github.com/sonata-project/SonataAdminBundle/com
 ## Admin
 If you have implemented a custom admin, you must adapt the signature of the following new methods to match the one in `AdminInterface` again:
  * `configureActionButtons`
+ * `getExportFields`
 
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -20,6 +20,7 @@ If you have implemented a custom admin, you must adapt the signature of the foll
  * `getPersistentParameter`
  * `preValidate`
  * `getSubClasses`
+ * `addSubClass`
 
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -18,6 +18,7 @@ If you have implemented a custom admin, you must adapt the signature of the foll
  * `getTemplates`
  * `getClassnameLabel`
  * `getPersistentParameter`
+ * `preValidate`
 
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -17,6 +17,7 @@ If you have implemented a custom admin, you must adapt the signature of the foll
  * `setTemplate`
  * `getTemplates`
  * `getClassnameLabel`
+ * `getPersistentParameter`
 
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -22,6 +22,7 @@ If you have implemented a custom admin, you must adapt the signature of the foll
  * `getSubClasses`
  * `addSubClass`
  * `getDashboardActions`
+ * `getActionButtons`
 
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -21,6 +21,7 @@ If you have implemented a custom admin, you must adapt the signature of the foll
  * `preValidate`
  * `getSubClasses`
  * `addSubClass`
+ * `getDashboardActions`
 
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -19,6 +19,7 @@ If you have implemented a custom admin, you must adapt the signature of the foll
  * `getClassnameLabel`
  * `getPersistentParameter`
  * `preValidate`
+ * `getSubClasses`
 
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -15,6 +15,7 @@ If you have implemented a custom admin, you must adapt the signature of the foll
  * `getExportFields`
  * `setTemplates`
  * `setTemplate`
+ * `getTemplates`
 
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -14,6 +14,7 @@ If you have implemented a custom admin, you must adapt the signature of the foll
  * `configureActionButtons`
  * `getExportFields`
  * `setTemplates`
+ * `setTemplate`
 
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Added
- Add the `getExportFields` method to the AdminInterface
- Add the `setTemplates` method to the AdminInterface
- Add the `setTemplate` method to the AdminInterface
- Add the `getTemplates` method to the AdminInterface
- Add the `getClassnameLabel` method to the AdminInterface
- Add the `getPersistentParameter` method to the AdminInterface
- Add the `preValidate` method to the AdminInterface
- Add the `getSubClasses` method to the AdminInterface
- Add the `addSubClass` method to the AdminInterface
- Add the `getDashboardActions` method to the AdminInterface
- Add the `getActionButtons` method to the AdminInterface
```

### Subject

Added some public methods of `Admin` to the `AdminInterface`.

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [X] Add an upgrade note

