### PR TITLE
Closing API methods in AbstractAdmin

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -591,9 +591,9 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Hook to run after initilization
      */
-    public function configure()
+    protected function configure()
     {
     }
 
@@ -765,7 +765,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function buildDatagrid()
+    private function buildDatagrid()
     {
         if ($this->datagrid) {
             return;
@@ -927,7 +927,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      *
      * @return string
      */
-    public function urlize($word, $sep = '_')
+    final protected function urlize($word, $sep = '_')
     {
         return strtolower(preg_replace('/[^a-z0-9_]/i', $sep.'$1', $word));
     }
@@ -1222,7 +1222,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      *
      * @param FormBuilderInterface $formBuilder
      */
-    public function defineFormBuilder(FormBuilderInterface $formBuilder)
+    private function defineFormBuilder(FormBuilderInterface $formBuilder)
     {
         $mapper = new FormMapper($this->getFormContractor(), $formBuilder, $this);
 

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -591,13 +591,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * Hook to run after initilization
-     */
-    protected function configure()
-    {
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function update($object)
@@ -763,62 +756,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
-     * {@inheritdoc}
-     */
-    private function buildDatagrid()
-    {
-        if ($this->datagrid) {
-            return;
-        }
-
-        $filterParameters = $this->getFilterParameters();
-
-        // transform _sort_by from a string to a FieldDescriptionInterface for the datagrid.
-        if (isset($filterParameters['_sort_by']) && is_string($filterParameters['_sort_by'])) {
-            if ($this->hasListFieldDescription($filterParameters['_sort_by'])) {
-                $filterParameters['_sort_by'] = $this->getListFieldDescription($filterParameters['_sort_by']);
-            } else {
-                $filterParameters['_sort_by'] = $this->getModelManager()->getNewFieldDescriptionInstance(
-                    $this->getClass(),
-                    $filterParameters['_sort_by'],
-                    array()
-                );
-
-                $this->getListBuilder()->buildField(null, $filterParameters['_sort_by'], $this);
-            }
-        }
-
-        // initialize the datagrid
-        $this->datagrid = $this->getDatagridBuilder()->getBaseDatagrid($this, $filterParameters);
-
-        $this->datagrid->getPager()->setMaxPageLinks($this->maxPageLinks);
-
-        $mapper = new DatagridMapper($this->getDatagridBuilder(), $this->datagrid, $this);
-
-        // build the datagrid filter
-        $this->configureDatagridFilters($mapper);
-
-        // ok, try to limit to add parent filter
-        if ($this->isChild() && $this->getParentAssociationMapping() && !$mapper->has($this->getParentAssociationMapping())) {
-            $mapper->add($this->getParentAssociationMapping(), null, array(
-                'show_filter' => false,
-                'label' => false,
-                'field_type' => 'sonata_type_model_hidden',
-                'field_options' => array(
-                    'model_manager' => $this->getModelManager(),
-                ),
-                'operator_type' => 'hidden',
-            ), null, null, array(
-                'admin_code' => $this->getParent()->getCode(),
-            ));
-        }
-
-        foreach ($this->getExtensions() as $extension) {
-            $extension->configureDatagridFilters($mapper);
-        }
-    }
-
-    /**
      * Returns the name of the parent related field, so the field can be use to set the default
      * value (ie the parent object) or to filter the object.
      *
@@ -917,19 +854,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
         }
 
         return $this->cachedBaseRouteName;
-    }
-
-    /**
-     * urlize the given word.
-     *
-     * @param string $word
-     * @param string $sep  the separator
-     *
-     * @return string
-     */
-    final protected function urlize($word, $sep = '_')
-    {
-        return strtolower(preg_replace('/[^a-z0-9_]/i', $sep.'$1', $word));
     }
 
     /**
@@ -1214,25 +1138,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
         $this->defineFormBuilder($formBuilder);
 
         return $formBuilder;
-    }
-
-    /**
-     * This method is being called by the main admin class and the child class,
-     * the getFormBuilder is only call by the main admin class.
-     *
-     * @param FormBuilderInterface $formBuilder
-     */
-    private function defineFormBuilder(FormBuilderInterface $formBuilder)
-    {
-        $mapper = new FormMapper($this->getFormContractor(), $formBuilder, $this);
-
-        $this->configureFormFields($mapper);
-
-        foreach ($this->getExtensions() as $extension) {
-            $extension->configureFormFields($mapper);
-        }
-
-        $this->attachInlineValidator();
     }
 
     /**
@@ -2770,6 +2675,26 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
+     * Hook to run after initilization.
+     */
+    protected function configure()
+    {
+    }
+
+    /**
+     * urlize the given word.
+     *
+     * @param string $word
+     * @param string $sep  the separator
+     *
+     * @return string
+     */
+    final protected function urlize($word, $sep = '_')
+    {
+        return strtolower(preg_replace('/[^a-z0-9_]/i', $sep.'$1', $word));
+    }
+
+    /**
      * @param FormMapper $form
      */
     protected function configureFormFields(FormMapper $form)
@@ -3085,6 +3010,81 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
         }
 
         return $access;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    private function buildDatagrid()
+    {
+        if ($this->datagrid) {
+            return;
+        }
+
+        $filterParameters = $this->getFilterParameters();
+
+        // transform _sort_by from a string to a FieldDescriptionInterface for the datagrid.
+        if (isset($filterParameters['_sort_by']) && is_string($filterParameters['_sort_by'])) {
+            if ($this->hasListFieldDescription($filterParameters['_sort_by'])) {
+                $filterParameters['_sort_by'] = $this->getListFieldDescription($filterParameters['_sort_by']);
+            } else {
+                $filterParameters['_sort_by'] = $this->getModelManager()->getNewFieldDescriptionInstance(
+                    $this->getClass(),
+                    $filterParameters['_sort_by'],
+                    array()
+                );
+
+                $this->getListBuilder()->buildField(null, $filterParameters['_sort_by'], $this);
+            }
+        }
+
+        // initialize the datagrid
+        $this->datagrid = $this->getDatagridBuilder()->getBaseDatagrid($this, $filterParameters);
+
+        $this->datagrid->getPager()->setMaxPageLinks($this->maxPageLinks);
+
+        $mapper = new DatagridMapper($this->getDatagridBuilder(), $this->datagrid, $this);
+
+        // build the datagrid filter
+        $this->configureDatagridFilters($mapper);
+
+        // ok, try to limit to add parent filter
+        if ($this->isChild() && $this->getParentAssociationMapping() && !$mapper->has($this->getParentAssociationMapping())) {
+            $mapper->add($this->getParentAssociationMapping(), null, array(
+                'show_filter' => false,
+                'label' => false,
+                'field_type' => 'sonata_type_model_hidden',
+                'field_options' => array(
+                    'model_manager' => $this->getModelManager(),
+                ),
+                'operator_type' => 'hidden',
+            ), null, null, array(
+                'admin_code' => $this->getParent()->getCode(),
+            ));
+        }
+
+        foreach ($this->getExtensions() as $extension) {
+            $extension->configureDatagridFilters($mapper);
+        }
+    }
+
+    /**
+     * This method is being called by the main admin class and the child class,
+     * the getFormBuilder is only call by the main admin class.
+     *
+     * @param FormBuilderInterface $formBuilder
+     */
+    private function defineFormBuilder(FormBuilderInterface $formBuilder)
+    {
+        $mapper = new FormMapper($this->getFormContractor(), $formBuilder, $this);
+
+        $this->configureFormFields($mapper);
+
+        foreach ($this->getExtensions() as $extension) {
+            $extension->configureFormFields($mapper);
+        }
+
+        $this->attachInlineValidator();
     }
 
     /**

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -678,8 +678,6 @@ interface AdminInterface
      */
     public function getDataSourceIterator();
 
-    public function configure();
-
     /**
      * @param mixed $object
      *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - `AbstractAdmin::configureActionButtons` method is now protected
 - `AbstractAdmin::getActionButtons` is now final
+- `AbstractAdmin::configure` method is now protected
+- `AbstractAdmin::buildDatagrid` method is now private
+- `AbstractAdmin::urlize` method is now protected and final
+- `AbstractAdmin::defineFormBuilder` method is now private
 
 ### Removed
 - Removed BC handler for deprecated `view` `_action`
@@ -38,6 +42,7 @@ specified in a field description cannot be found was removed.
   - `sonata.admin.label.strategy.noop`
   - `sonata.admin.label.strategy.underscore`
 - Removed deprecated `AbstractAdmin::buildSideMenu` method
+- `AdminInterface::configure` was removed
 
 ## [3.x]
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -25,8 +25,14 @@ If you have implemented a custom admin, you must adapt the signature of the foll
  * `getDashboardActions`
  * `getActionButtons`
  * `isCurrentRoute`
+  
+The following methods changed their visiblity to protected:
+ * `configureActionButtons`
+ * `configure`
+ * `urlize`
  
-The method `configureActionButtons` is now protected.
+If you extend an `AbstractAdmin`, you can't override the following methods anymore, because they are final now:
+ * `urlize`
 
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

### Changelog
<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Changed
- `AbstractAdmin::configure` method is now protected
- `AbstractAdmin::buildDatagrid` method is now private
- `AbstractAdmin::urlize` method is now protected and final
- `AbstractAdmin::defineFormBuilder` method is now private

### Removed
- `AdminInterface::configure` was removed
```

### Subject

Closing the API for `AbstractAdmin` by decreasing the method visiblity. This methods shouldn't be called outsite the admin class.

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [x] Update the documentation
- [x] Add an upgrade note

