### PR TITLE
Moved body of configureActionButtons to getActionButtons

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2636,13 +2636,51 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      */
     final public function getActionButtons($action, $object = null)
     {
-        $list = $this->configureActionButtons($action, $object);
+        $buttonList = array();
 
-        foreach ($this->getExtensions() as $extension) {
-            $list = $extension->configureActionButtons($this, $list, $action, $object);
+        if (in_array($action, array('tree', 'show', 'edit', 'delete', 'list', 'batch'))) {
+            $buttonList['create'] = array(
+                'template' => 'SonataAdminBundle:Button:create_button.html.twig',
+            );
         }
 
-        return $list;
+        if (in_array($action, array('show', 'delete', 'acl', 'history')) && $object) {
+            $buttonList['edit'] = array(
+                'template' => 'SonataAdminBundle:Button:edit_button.html.twig',
+            );
+        }
+
+        if (in_array($action, array('show', 'edit', 'acl')) && $object) {
+            $buttonList['history'] = array(
+                'template' => 'SonataAdminBundle:Button:history_button.html.twig',
+            );
+        }
+
+        if (in_array($action, array('edit', 'history')) && $object) {
+            $buttonList['acl'] = array(
+                'template' => 'SonataAdminBundle:Button:acl_button.html.twig',
+            );
+        }
+
+        if (in_array($action, array('edit', 'history', 'acl')) && $object) {
+            $buttonList['show'] = array(
+                'template' => 'SonataAdminBundle:Button:show_button.html.twig',
+            );
+        }
+
+        if (in_array($action, array('show', 'edit', 'delete', 'acl', 'batch'))) {
+            $buttonList['list'] = array(
+                'template' => 'SonataAdminBundle:Button:list_button.html.twig',
+            );
+        }
+
+        $buttonList = $this->configureActionButtons($buttonList, $action, $object);
+
+        foreach ($this->getExtensions() as $extension) {
+            $buttonList = $extension->configureActionButtons($this, $buttonList, $action, $object);
+        }
+
+        return $buttonList;
     }
 
     /**
@@ -2732,52 +2770,15 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     /**
      * Configure buttons for an action.
      *
-     * @param string $action
-     * @param object $object
+     * @param array  $buttonList List of all action buttons
+     * @param string $action     Current action route
+     * @param object $object     Current object
      *
      * @return array
      */
-    protected function configureActionButtons($action, $object = null)
+    protected function configureActionButtons($buttonList, $action, $object = null)
     {
-        $list = array();
-
-        if (in_array($action, array('tree', 'show', 'edit', 'delete', 'list', 'batch'))) {
-            $list['create'] = array(
-                'template' => 'SonataAdminBundle:Button:create_button.html.twig',
-            );
-        }
-
-        if (in_array($action, array('show', 'delete', 'acl', 'history')) && $object) {
-            $list['edit'] = array(
-                'template' => 'SonataAdminBundle:Button:edit_button.html.twig',
-            );
-        }
-
-        if (in_array($action, array('show', 'edit', 'acl')) && $object) {
-            $list['history'] = array(
-                'template' => 'SonataAdminBundle:Button:history_button.html.twig',
-            );
-        }
-
-        if (in_array($action, array('edit', 'history')) && $object) {
-            $list['acl'] = array(
-                'template' => 'SonataAdminBundle:Button:acl_button.html.twig',
-            );
-        }
-
-        if (in_array($action, array('edit', 'history', 'acl')) && $object) {
-            $list['show'] = array(
-                'template' => 'SonataAdminBundle:Button:show_button.html.twig',
-            );
-        }
-
-        if (in_array($action, array('show', 'edit', 'delete', 'acl', 'batch'))) {
-            $list['list'] = array(
-                'template' => 'SonataAdminBundle:Button:list_button.html.twig',
-            );
-        }
-
-        return $list;
+        return $buttonList;
     }
 
      /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `AbstractAdmin::buildDatagrid` method is now private
 - `AbstractAdmin::urlize` method is now protected and final
 - `AbstractAdmin::defineFormBuilder` method is now private
+- `AbstractAdmin::configureActionButtons` method signature has changed
+- Moved default buttons from `AbstractAdmin::configureActionButtons` to `AbstractAdmin::getActionButtons`
 
 ### Removed
 - Removed BC handler for deprecated `view` `_action`

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -359,20 +359,18 @@ You can add custom items to the actions menu for a specific action by overriding
 
 .. code-block:: php
 
-    protected function configureActionButtons($action, $object = null)
+    protected function configureActionButtons($buttonList, $action, $object = null)
     {
-        $list = parent::configureActionButtons($action, $object);
-
         if (in_array($action, array('show', 'edit', 'acl')) && $object) {
-            $list['custom'] = array(
+            $buttonList['custom'] = array(
                 'template' => 'AppBundle:Button:custom_button.html.twig',
             );
         }
 
         // Remove history action
-        unset($list['history']);
+        unset($buttonList['history']);
 
-        return $list;
+        return $buttonList;
     }
 
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -34,6 +34,8 @@ The following methods changed their visiblity to protected:
 If you extend an `AbstractAdmin`, you can't override the following methods anymore, because they are final now:
  * `urlize`
 
+The method signature of `configureActionButtons` has changed. A new parameter `buttonList` was added.
+
 ## AdminExtension
 If you have implemented a custom admin extension, you must adapt the signature of the following new methods to match the one in `AdminExtensionInterface` again:
  * `configureActionButtons`


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Should be merged with #3855

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Changed
- `AbstractAdmin::configureActionButtons` method signature has changed
- Moved default buttons from `AbstractAdmin::configureActionButtons` to `AbstractAdmin::getActionButtons`
```

### Subject

Moved all default action buttons to `getActionButtons` so all `configure*` methods are empty by default. This will help to close our API.

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [X] Changed signature
- [X] Update the documentation
- [X] Add an upgrade note

