### PR TITLE
Deprecate AbstractAdmin::getBatchActions method override

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -368,6 +368,15 @@ class CRUDController extends Controller
             unset($data['_sonata_csrf_token']);
         }
 
+        // NEXT_MAJOR: Remove reflection check.
+        $reflector = new \ReflectionMethod($this->admin, 'getBatchActions');
+        if ($reflector->getDeclaringClass()->getName() === get_class($this->admin)) {
+            @trigger_error('Override Sonata\AdminBundle\Admin\AbstractAdmin::getBatchActions method'
+                .' is deprecated since version 3.x.'
+                .' Use Sonata\AdminBundle\Admin\AbstractAdmin::configureBatchActions instead.'
+                .' The method will be final in 4.0.', E_USER_DEPRECATED
+            );
+        }
         $batchActions = $this->admin->getBatchActions();
         if (!array_key_exists($action, $batchActions)) {
             throw new \RuntimeException(sprintf('The `%s` batch action is not defined', $action));

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,12 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated override of AbstractAdmin::getBatchActions
+
+Since `AbstractAdmin::configureBatchActions` is present, you should not override `AbstractAdmin::getBatchActions`.
+
+This method will be final in 4.0.
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 


### PR DESCRIPTION
### Changelog

```markdown
### Deprecated
- Overriding `AbstractAdmin::configureBatchActions` is now deprecated
```

### Subject

This PR have to be merged before #3844.

It introduce a BC deprecated message warning user to not override `AbstractAdmin::configureBatchActions` anymore.

### To do

- [x] Deprecation message
- [x] Add an upgrade note
