### PR TITLE
WIP: Reduce breadcrumbs builder admin coupling

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1845,7 +1845,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      */
     public function getBreadcrumbs($action)
     {
-        return $this->getBreadcrumbsBuilder()->getBreadcrumbs($this, $action);
+        return $this->getBreadcrumbsBuilder()->getBreadcrumbs($action);
     }
 
     /**
@@ -1865,7 +1865,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
         }
 
         return $this->breadcrumbs[$action] = $this->getBreadcrumbsBuilder()
-            ->buildBreadcrumbs($this, $action, $menu);
+            ->buildBreadcrumbs($action, $menu);
     }
 
     /**
@@ -1874,7 +1874,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     final public function getBreadcrumbsBuilder()
     {
         if ($this->breadcrumbsBuilder === null) {
-            $this->breadcrumbsBuilder = new BreadcrumbsBuilder();
+            $this->breadcrumbsBuilder = new BreadcrumbsBuilder($this);
         }
 
         return $this->breadcrumbsBuilder;

--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -76,13 +76,13 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
         $childAdmin = $admin->getCurrentChildAdmin();
 
         if ($childAdmin) {
-            $id = $admin->getRequest()->get($admin->getIdParameter());
-
             $menu = $menu->addChild(
                 $admin->toString($admin->getSubject()),
                 array(
                     'uri' => $admin->hasRoute('edit') && $admin->isGranted('EDIT') ?
-                    $admin->generateUrl('edit', array('id' => $id)) :
+                    $admin->generateUrl('edit', array(
+                        'id' => $admin->getRequest()->get($admin->getIdParameter()),
+                    )) :
                     null,
                 )
             );

--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -21,16 +21,29 @@ use Knp\Menu\ItemInterface;
 final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
 {
     /**
+     * @var AdminInterface might be the current admin or one of its ancestors.
+     */
+    private $admin;
+
+    /**
+     * @param AdminInterface will be used to get various services. To be replaced by several dependencies
+     */
+    public function __construct(AdminInterface $admin)
+    {
+        $this->admin = $admin;
+    }
+
+    /**
      * {@inheritdoc}
      */
-    public function getBreadcrumbs(AdminInterface $admin, $action)
+    public function getBreadcrumbs($action)
     {
         $breadcrumbs = array();
-        if ($admin->isChild()) {
-            return $admin->getParent()->getBreadcrumbs($action);
+        if ($this->admin->isChild()) {
+            return $this->admin->getParent()->getBreadcrumbs($action);
         }
 
-        $menu = $admin->buildBreadcrumbs($action);
+        $menu = $this->admin->buildBreadcrumbs($action);
 
         do {
             $breadcrumbs[] = $menu;
@@ -45,43 +58,41 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function buildBreadcrumbs(AdminInterface $admin, $action, ItemInterface $menu = null)
+    public function buildBreadcrumbs($action, ItemInterface $menu = null)
     {
         if (!$menu) {
-            $menu = $admin->getMenuFactory()->createItem('root');
+            $menu = $this->admin->getMenuFactory()->createItem('root');
 
             $menu = $this->createMenuItem(
-                $admin,
                 $menu,
                 'dashboard',
                 'SonataAdminBundle',
-                array('uri' => $admin->getRouteGenerator()->generate(
+                array('uri' => $this->admin->getRouteGenerator()->generate(
                     'sonata_admin_dashboard'
                 ))
             );
         }
 
         $menu = $this->createMenuItem(
-            $admin,
             $menu,
-            sprintf('%s_list', $admin->getClassnameLabel()),
+            sprintf('%s_list', $this->admin->getClassnameLabel()),
             null,
             array(
-                'uri' => $admin->hasRoute('list') && $admin->isGranted('LIST') ?
-                $admin->generateUrl('list') :
+                'uri' => $this->admin->hasRoute('list') && $this->admin->isGranted('LIST') ?
+                $this->admin->generateUrl('list') :
                 null,
             )
         );
 
-        $childAdmin = $admin->getCurrentChildAdmin();
+        $childAdmin = $this->admin->getCurrentChildAdmin();
 
         if ($childAdmin) {
             $menu = $menu->addChild(
-                $admin->toString($admin->getSubject()),
+                $this->admin->toString($this->admin->getSubject()),
                 array(
-                    'uri' => $admin->hasRoute('edit') && $admin->isGranted('EDIT') ?
-                    $admin->generateUrl('edit', array(
-                        'id' => $admin->getRequest()->get($admin->getIdParameter()),
+                    'uri' => $this->admin->hasRoute('edit') && $this->admin->isGranted('EDIT') ?
+                    $this->admin->generateUrl('edit', array(
+                        'id' => $this->admin->getRequest()->get($this->admin->getIdParameter()),
                     )) :
                     null,
                 )
@@ -90,15 +101,14 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
             return $childAdmin->buildBreadcrumbs($action, $menu);
         }
 
-        if ('list' === $action && $admin->isChild()) {
+        if ('list' === $action && $this->admin->isChild()) {
             $menu->setUri(false);
-        } elseif ('create' !== $action && $admin->hasSubject()) {
-            $menu = $menu->addChild($admin->toString($admin->getSubject()));
+        } elseif ('create' !== $action && $this->admin->hasSubject()) {
+            $menu = $menu->addChild($this->admin->toString($this->admin->getSubject()));
         } else {
             $menu = $this->createMenuItem(
-                $admin,
                 $menu,
-                sprintf('%s_%s', $admin->getClassnameLabel(), $action)
+                sprintf('%s_%s', $this->admin->getClassnameLabel(), $action)
             );
         }
 
@@ -109,24 +119,22 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
      * Creates a new menu item from a simple name. The name is normalized and
      * translated with the specified translation domain.
      *
-     * @param AdminInterface $admin             used for translation
-     * @param ItemInterface  $menu              will be modified and returned
-     * @param string         $name              the source of the final label
-     * @param string         $translationDomain for label translation
-     * @param array          $options           menu item options
+     * @param ItemInterface $menu              will be modified and returned
+     * @param string        $name              the source of the final label
+     * @param string        $translationDomain for label translation
+     * @param array         $options           menu item options
      *
      * @return ItemInterface
      */
     private function createMenuItem(
-        AdminInterface $admin,
         ItemInterface $menu,
         $name,
         $translationDomain = null,
         $options = array()
     ) {
         return $menu->addChild(
-            $admin->trans(
-                $admin->getLabelTranslatorStrategy()->getLabel(
+            $this->admin->trans(
+                $this->admin->getLabelTranslatorStrategy()->getLabel(
                     $name,
                     'breadcrumb',
                     'link'

--- a/Admin/BreadcrumbsBuilderInterface.php
+++ b/Admin/BreadcrumbsBuilderInterface.php
@@ -25,26 +25,20 @@ interface BreadcrumbsBuilderInterface
     /**
      * Get breadcrumbs for $action.
      *
-     * @param AdminInterface $admin
-     * @param string         $action the name of the action we want to get a
-     *                               breadcrumbs for
+     * @param string $action the name of the action we want to get a
+     *                       breadcrumbs for
      *
      * @return mixed array|Traversable the breadcrumbs
      */
-    public function getBreadcrumbs(AdminInterface $admin, $action);
+    public function getBreadcrumbs($action);
 
     /**
      * Builds breadcrumbs for $action, starting from $menu.
      *
      * Note: the method will be called by the top admin instance (parent => child)
      *
-     * @param AdminInterface     $admin
      * @param string             $action
      * @param ItemInterface|null $menu
      */
-    public function buildBreadcrumbs(
-        AdminInterface $admin,
-        $action,
-        ItemInterface $menu = null
-    );
+    public function buildBreadcrumbs($action, ItemInterface $menu = null);
 }

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1642,7 +1642,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             'Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface'
         );
         $action = 'myaction';
-        $builder->getBreadcrumbs($admin, $action)->shouldBeCalled();
+        $builder->getBreadcrumbs($action)->shouldBeCalled();
         $admin->setBreadcrumbsBuilder($builder->reveal())->getBreadcrumbs($action);
     }
 
@@ -1656,7 +1656,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         );
         $action = 'myaction';
         $menu = $this->getMock('Knp\Menu\ItemInterface');
-        $builder->buildBreadcrumbs($admin, $action, $menu)
+        $builder->buildBreadcrumbs($action, $menu)
             ->shouldBeCalledTimes(1)
             ->willReturn($menu);
         $admin->setBreadcrumbsBuilder($builder->reveal());

--- a/Tests/Admin/BreadcrumbsBuilderTest.php
+++ b/Tests/Admin/BreadcrumbsBuilderTest.php
@@ -266,14 +266,11 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         $breadcrumbs->getParent()->willreturn($root);
         $breadcrumbs = $breadcrumbs->reveal();
         $action = 'my_action';
-        $breadcrumbsBuilder = new BreadcrumbsBuilder();
         $admin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
         $admin->isChild()->willReturn(false);
         $admin->buildBreadcrumbs($action)->willReturn($breadcrumbs);
-        $this->assertSame(array($breadcrumbs), $breadcrumbsBuilder->getBreadcrumbs(
-            $admin->reveal(),
-            $action
-        ));
+        $breadcrumbsBuilder = new BreadcrumbsBuilder($admin->reveal());
+        $this->assertSame(array($breadcrumbs), $breadcrumbsBuilder->getBreadcrumbs($action));
     }
 
     public function testUnitChildGetBreadCrumbs()
@@ -281,16 +278,16 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         $parentMenu = 'parent menu';
 
         $action = 'my_action';
-        $breadcrumbsBuilder = new BreadcrumbsBuilder();
         $parentAdmin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
         $parentAdmin->getBreadcrumbs($action)->willReturn($parentMenu);
         $admin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
         $admin->isChild()->willReturn(true);
         $admin->getParent()->willReturn($parentAdmin->reveal());
+        $breadcrumbsBuilder = new BreadcrumbsBuilder($admin->reveal());
 
         $this->assertSame(
             'parent menu',
-            $breadcrumbsBuilder->getBreadcrumbs($admin->reveal(), $action)
+            $breadcrumbsBuilder->getBreadcrumbs($action)
         );
     }
 
@@ -309,8 +306,6 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testUnitBuildBreadcrumbs($action)
     {
-        $breadcrumbsBuilder = new BreadcrumbsBuilder();
-
         $menu = $this->prophesize('Knp\Menu\ItemInterface');
         $menuFactory = $this->prophesize('Knp\Menu\MenuFactory');
         $menuFactory->createItem('root')->willReturn($menu);
@@ -381,6 +376,7 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         $menu->addChild('My subject')->willReturn($menu);
         $menu->addChild('My subject', array('uri' => null))->willReturn($menu);
 
-        $breadcrumbsBuilder->buildBreadCrumbs($admin->reveal(), $action);
+        $breadcrumbsBuilder = new BreadcrumbsBuilder($admin->reveal());
+        $breadcrumbsBuilder->buildBreadCrumbs($action);
     }
 }

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -46,6 +46,20 @@ If you have implemented a custom admin extension, you must adapt the signature o
 The API of the following methods was closed by making them final, you can't override this methods anymore:
  * `getActionButtons`
 
+## BreacrumbsBuilder
+The breadcrumbs builder is now stateful, its interface looses the `$admin` parameters.
+You need to change your calls like this:
+
+```php
+// Before
+$breadcrumbsBuilder->getBreadcrumbs($admin, 'my_action');
+$breadcrumbsBuilder->buildBreadcrumbs($admin, $menu);
+
+// After
+$breadcrumbsBuilder->getBreadcrumbs('my_action');
+$breadcrumbsBuilder->buildBreadcrumbs($menu);
+```
+
 ## SonataAdminExtension
 The Twig filters that come with the bundle will no longer load a default template when used with a missing template.
 The `sonata_admin` twig extension is now final. You may no longer extend it.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -25,12 +25,12 @@ If you have implemented a custom admin, you must adapt the signature of the foll
  * `getDashboardActions`
  * `getActionButtons`
  * `isCurrentRoute`
-  
+
 The following methods changed their visiblity to protected:
  * `configureActionButtons`
  * `configure`
  * `urlize`
- 
+
 If you extend an `AbstractAdmin`, you can't override the following methods anymore, because they are final now:
  * `urlize`
 


### PR DESCRIPTION
Closes #3833

### Changelog

```markdown
### Changed
The `BreadcrumsBuilderInterface` was simplified.
```

### Subject

This PR attempts to reduce the AbstractAdmin <=> BreadcrumbsBuilderInterface

### To do

- [x] Make the breadcrumbs builder stateful
- [ ] Stop using the admin for this:
  -  [ ] the menu factory
  -  [ ] the route generator
  -  [ ] getting a classname to generate a translation string
  -  [ ] checking if a route exists
  -  [ ] checking if access is granted
  -  [ ] doing the translation
- [ ] remove the admin dependency
- [ ] create a breadcrumbs builder service
- [ ] ~~Deprecate~~ Remove admin proxy methods and use breadcrumbs builder methods instead