### PR TITLE
Use breadcrumbs builder directly

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1998,10 +1998,17 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
+     * NEXT_MAJOR : remove this method.
+     *
      * @return BreadcrumbsBuilderInterface
      */
     final public function getBreadcrumbsBuilder()
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.'.
+            ' Use the sonata.admin.breadcrumbs_builder service instead.',
+            E_USER_DEPRECATED
+        );
         if ($this->breadcrumbsBuilder === null) {
             $this->breadcrumbsBuilder = new BreadcrumbsBuilder();
         }
@@ -2010,12 +2017,19 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
+     * NEXT_MAJOR : remove this method.
+     *
      * @param BreadcrumbsBuilderInterface
      *
      * @return AbstractAdmin
      */
     final public function setBreadcrumbsBuilder(BreadcrumbsBuilderInterface $value)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.'.
+            ' Use the sonata.admin.breadcrumbs_builder service instead.',
+            E_USER_DEPRECATED
+        );
         $this->breadcrumbsBuilder = $value;
 
         return $this;

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -334,6 +334,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     /**
      * The generated breadcrumbs.
      *
+     * NEXT_MAJOR : remove this property
+     *
      * @var array
      */
     protected $breadcrumbs = array();
@@ -1961,6 +1963,12 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      */
     public function getBreadcrumbs($action)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.'.
+            ' Use Sonata\AdminBundle\Admin\BreadcrumbsBuilder::getBreadcrumbs instead.',
+            E_USER_DEPRECATED
+        );
+
         return $this->getBreadcrumbsBuilder()->getBreadcrumbs($this, $action);
     }
 
@@ -1976,6 +1984,11 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      */
     public function buildBreadcrumbs($action, MenuItemInterface $menu = null)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.',
+            E_USER_DEPRECATED
+        );
+
         if (isset($this->breadcrumbs[$action])) {
             return $this->breadcrumbs[$action];
         }

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -937,6 +937,7 @@ interface AdminInterface
     public function getPersistentParameters();
 
     /**
+     * NEXT_MAJOR: remove this signature
      * Get breadcrumbs for $action.
      *
      * @param string $action

--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -27,10 +27,10 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
     {
         $breadcrumbs = array();
         if ($admin->isChild()) {
-            return $admin->getParent()->getBreadcrumbs($action);
+            return $this->getBreadcrumbs($admin->getParent(), $action);
         }
 
-        $menu = $admin->buildBreadcrumbs($action);
+        $menu = $this->buildBreadcrumbs($admin, $action);
 
         do {
             $breadcrumbs[] = $menu;
@@ -44,6 +44,7 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
 
     /**
      * {@inheritdoc}
+     * NEXT_MAJOR : make this method private.
      */
     public function buildBreadcrumbs(AdminInterface $admin, $action, ItemInterface $menu = null)
     {
@@ -87,7 +88,7 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
                 )
             );
 
-            return $childAdmin->buildBreadcrumbs($action, $menu);
+            return $this->buildBreadcrumbs($childAdmin, $action, $menu);
         }
 
         if ('list' === $action && $admin->isChild()) {

--- a/Admin/BreadcrumbsBuilderInterface.php
+++ b/Admin/BreadcrumbsBuilderInterface.php
@@ -37,6 +37,7 @@ interface BreadcrumbsBuilderInterface
      * Builds breadcrumbs for $action, starting from $menu.
      *
      * Note: the method will be called by the top admin instance (parent => child)
+     * NEXT_MAJOR : remove this method from the public interface.
      *
      * @param AdminInterface     $admin
      * @param string             $action

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -63,6 +63,9 @@ class CRUDController extends Controller
      */
     public function render($view, array $parameters = array(), Response $response = null)
     {
+        if (!$this->isXmlHttpRequest()) {
+            $parameters['breadcrumbs_builder'] = $this->get('sonata.admin.breadcrumbs_builder');
+        }
         $parameters['admin'] = isset($parameters['admin']) ?
             $parameters['admin'] :
             $this->admin;

--- a/Controller/CoreController.php
+++ b/Controller/CoreController.php
@@ -46,11 +46,17 @@ class CoreController extends Controller
             $blocks[$block['position']][] = $block;
         }
 
-        return $this->render($this->getAdminPool()->getTemplate('dashboard'), array(
+        $parameters = array(
             'base_template' => $this->getBaseTemplate(),
             'admin_pool' => $this->container->get('sonata.admin.pool'),
             'blocks' => $blocks,
-        ));
+        );
+
+        if (!$this->getRequest()->isXmlHttpRequest()) {
+            $parameters['breadcrumbs_builder'] = $this->get('sonata.admin.breadcrumbs_builder');
+        }
+
+        return $this->render($this->getAdminPool()->getTemplate('dashboard'), $parameters);
     }
 
     /**
@@ -102,6 +108,7 @@ class CoreController extends Controller
 
         return $this->render($this->container->get('sonata.admin.pool')->getTemplate('search'), array(
             'base_template' => $this->getBaseTemplate(),
+            'breadcrumbs_builder' => $this->get('sonata.admin.breadcrumbs_builder'),
             'admin_pool' => $this->container->get('sonata.admin.pool'),
             'query' => $request->get('q'),
             'groups' => $this->getAdminPool()->getDashboardGroups(),

--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -33,6 +33,8 @@
             <argument />
         </service>
 
+        <service id="sonata.admin.breadcrumbs_builder" class="Sonata\AdminBundle\Admin\BreadcrumbsBuilder" />
+
         <!-- Services used to format the label, default is sonata.admin.label.strategy.noop -->
         <service id="sonata.admin.label.strategy.bc" class="Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy" />
         <service id="sonata.admin.label.strategy.native" class="Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy" />
@@ -45,6 +47,9 @@
             <tag name="jms_translation.extractor" alias="sonata_admin"/>
             <argument type="service" id="sonata.admin.pool" />
             <argument type="service" id="logger" on-invalid="ignore" />
+            <call method="setBreadcrumbsBuilder">
+                <service id="sonata.admin.breadcrumbs_builder" />
+            </call>
         </service>
 
         <!-- controller as services -->

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -55,6 +55,7 @@ Reference Guide
    reference/batch_actions
    reference/console
    reference/troubleshooting
+   reference/breadcrumbs
 
 Advanced Options
 ----------------

--- a/Resources/doc/reference/breadcrumbs.rst
+++ b/Resources/doc/reference/breadcrumbs.rst
@@ -1,0 +1,15 @@
+The breadcrumbs builder
+=======================
+
+The ``sonata.admin.breadcrumbs_builder`` service is used in the layout of every
+page to compute the underlying data for two breadcrumbs:
+
+* one as text, appearing in the ``title`` tag of the document's ``head`` tag;
+* the other as html, visible as an horizontal bar at the top of the page.
+
+Getting the breadcrumbs for a given action of a given admin is done like this:
+
+.. code-block:: php
+
+   <?php
+   $this->get('sonata.admin.breadcrumbs_builder')->getBreadcrumbs($admin, $action);

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -86,7 +86,7 @@ file that was distributed with this source code.
             {% else %}
                 {% if action is defined %}
                     -
-                    {% for menu in admin.breadcrumbs(action) %}
+                    {% for menu in admin.breadcrumbsBuilder.breadcrumbs(action) %}
                         {% if not loop.first %}
                             {%  if loop.index != 2 %}
                                 &gt;
@@ -138,7 +138,7 @@ file that was distributed with this source code.
                                         <ol class="nav navbar-top-links breadcrumb">
                                             {% if _breadcrumb is empty %}
                                                 {% if action is defined %}
-                                                    {% for menu in admin.breadcrumbs(action) %}
+                                                    {% for menu in admin.breadcrumbsBuilder.breadcrumbs(action) %}
                                                         {% if not loop.last  %}
                                                             <li>
                                                                 {% if menu.uri is not empty %}

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -86,7 +86,7 @@ file that was distributed with this source code.
             {% else %}
                 {% if action is defined %}
                     -
-                    {% for menu in admin.breadcrumbsBuilder.breadcrumbs(action) %}
+                    {% for menu in breadcrumbs_builder.breadcrumbs(admin, action) %}
                         {% if not loop.first %}
                             {%  if loop.index != 2 %}
                                 &gt;
@@ -138,7 +138,7 @@ file that was distributed with this source code.
                                         <ol class="nav navbar-top-links breadcrumb">
                                             {% if _breadcrumb is empty %}
                                                 {% if action is defined %}
-                                                    {% for menu in admin.breadcrumbsBuilder.breadcrumbs(action) %}
+                                                    {% for menu in breadcrumbs_builder.breadcrumbs(admin, action) %}
                                                         {% if not loop.last  %}
                                                             <li>
                                                                 {% if menu.uri is not empty %}

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -255,7 +255,7 @@ file that was distributed with this source code.
                                                         {% endfor %}
                                                     </div>
                                                 {% endif %}
-                                                
+
                                                 {% block sonata_admin_content_actions_wrappers %}
                                                     {% if _actions|replace({ '<li>': '', '</li>': '' })|trim is not empty %}
                                                         <ul class="nav navbar-nav navbar-right">

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1680,6 +1680,9 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('create', $admin->getDashboardActions());
     }
 
+    /**
+     * @group legacy
+     */
     public function testDefaultBreadcrumbsBuilder()
     {
         $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AbstractAdmin', array(
@@ -1691,6 +1694,9 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
     public function testBreadcrumbsBuilderSetter()
     {
         $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AbstractAdmin', array(

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1702,6 +1702,9 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($builder, $admin->getBreadcrumbsBuilder());
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetBreadcrumbs()
     {
         $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AbstractAdmin', array(
@@ -1715,6 +1718,9 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $admin->setBreadcrumbsBuilder($builder->reveal())->getBreadcrumbs($action);
     }
 
+    /**
+     * @group legacy
+     */
     public function testBuildBreadcrumbs()
     {
         $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AbstractAdmin', array(

--- a/Tests/Controller/CoreControllerTest.php
+++ b/Tests/Controller/CoreControllerTest.php
@@ -36,7 +36,10 @@ class CoreControllerTest extends \PHPUnit_Framework_TestCase
             $requestStack->push($request);
         }
 
+        $breadcrumbsBuilder = $this->getMock('BreadcrumbsBuilderInterface');
+
         $values = array(
+            'sonata.admin.breadcrumbs_builder' => $breadcrumbsBuilder,
             'sonata.admin.pool' => $pool,
             'templating' => $templating,
             'request' => $request,

--- a/Tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
+++ b/Tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
@@ -124,6 +124,6 @@ class AdminExtractorTest extends \PHPUnit_Framework_TestCase
                 throw new \RuntimeException('Foo throws exception');
             }));
 
-        $catalogue = $this->adminExtractor->extract();
+        $this->adminExtractor->extract();
     }
 }

--- a/Tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
+++ b/Tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
@@ -43,6 +43,11 @@ class AdminExtractorTest extends \PHPUnit_Framework_TestCase
      */
     private $barAdmin;
 
+    /**
+     * @var BreadcrumbsBuilderInterface
+     */
+    private $breadcrumbsBuilder;
+
     public function setUp()
     {
         if (!interface_exists('JMS\TranslationBundle\Translation\ExtractorInterface')) {
@@ -77,6 +82,9 @@ class AdminExtractorTest extends \PHPUnit_Framework_TestCase
 
         $this->adminExtractor = new AdminExtractor($this->pool, $logger);
         $this->adminExtractor->setLogger($logger);
+
+        $this->breadcrumbsBuilder = $this->getMock('Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface');
+        $this->adminExtractor->setBreadcrumbsBuilder($this->breadcrumbsBuilder);
     }
 
     public function testExtractEmpty()
@@ -124,6 +132,13 @@ class AdminExtractorTest extends \PHPUnit_Framework_TestCase
                 throw new \RuntimeException('Foo throws exception');
             }));
 
+        $this->adminExtractor->extract();
+    }
+
+    public function testExtractCallsBreadcrumbs()
+    {
+        $this->breadcrumbsBuilder->expects($this->exactly(2 * 6))
+            ->method('getBreadcrumbs');
         $this->adminExtractor->extract();
     }
 }

--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -17,6 +17,7 @@ use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\ExtractorInterface;
 use Psr\Log\LoggerInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
@@ -55,6 +56,11 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
     private $domain;
 
     /**
+     * @var BreadcrumbsBuilderInterface
+     */
+    private $breadcrumbsBuilder;
+
+    /**
      * @param Pool            $adminPool
      * @param LoggerInterface $logger
      */
@@ -76,6 +82,14 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
+    }
+
+    /**
+     * NEXT_MAJOR : use a constructor argument instead.
+     */
+    final public function setBreadcrumbsBuilder(BreadcrumbsBuilderInterface $breadcrumbsBuilder)
+    {
+        $this->breadcrumbsBuilder = $breadcrumbsBuilder;
     }
 
     /**
@@ -110,35 +124,53 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
 
             // call the different public method
             $methods = array(
-                'getShow' => array(array()),
-                'getDatagrid' => array(array()),
-                'getList' => array(array()),
-                'getForm' => array(array()),
-                'getBreadcrumbs' => array(
-                    array('list'),
-                    array('edit'),
-                    array('create'),
-                    array('update'),
-                    array('batch'),
-                    array('delete'),
-                ),
+                'getShow',
+                'getDatagrid',
+                'getList',
+                'getForm',
+            );
+
+            $actions = array(
+                'list',
+                'edit',
+                'create',
+                'update',
+                'batch',
+                'delete',
             );
 
             if ($this->logger) {
                 $this->logger->info(sprintf('Retrieving message from admin:%s - class: %s', $admin->getCode(), get_class($admin)));
             }
 
-            foreach ($methods as $method => $calls) {
-                foreach ($calls as $args) {
-                    try {
-                        call_user_func_array(array($admin, $method), $args);
-                    } catch (\Exception $e) {
-                        if ($this->logger) {
-                            $this->logger->error(sprintf('ERROR : admin:%s - Raise an exception : %s', $admin->getCode(), $e->getMessage()));
-                        }
-
-                        throw $e;
+            foreach ($methods as $method) {
+                try {
+                    $admin->$method();
+                } catch (\Exception $e) {
+                    if ($this->logger) {
+                        $this->logger->error(sprintf('ERROR : admin:%s - Raise an exception : %s', $admin->getCode(), $e->getMessage()));
                     }
+
+                    throw $e;
+                }
+            }
+
+            foreach ($actions as $action) {
+                try {
+                    $this->breadcrumbsBuilder->getBreadcrumbs($admin, $action);
+                } catch (\Exception $e) {
+                    if ($this->logger) {
+                        $this->logger->error(
+                            sprintf(
+                                'ERROR : admin:%s - Raises an exception : %s',
+                                $admin->getCode(),
+                                $e->getMessage()
+                            ),
+                            array('exception' => $e)
+                        );
+                    }
+
+                    throw $e;
                 }
             }
         }

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -27,3 +27,9 @@ The `AdminExtension` class is deprecated. Use `AbstractAdminExtension` instead.
 
 The Twig extension method that fallback to a default template when the specified one does not exist.
 You can no longer rely on that and should always specify templates that exist.
+
+## Deprecated AbstractAdmin methods
+- `buildBreacrumbs` is deprecated, and no replacement is given, it will become an internal method.
+- `getBreadcrumbs` is deprecated in favor of the homonym method of the `sonata.admin.breadcrumbs_builder` service.
+- The breadcrumbs builder accessors are deprecated,
+the `sonata.admin.breadcrumbs_builder` service should be used directly instead.


### PR DESCRIPTION
See #3833 

### Changelog

```markdown
### Deprecated
- `AbstractAdmin::getBreadcrumbs`, in favor of `BreadcrumbsBuilder::getBreadcrumbs`
- `AbstractAdmin::buildBreadcrumbs`, will be removed
- `AbstractAdmin::$breadcrumbs`, will be removed
```

### Subject

The ultimate goal of this PR is to remove everything breadcrumbs-related from the `AbstractAdmin` class

### To do

- [x] Deprecate the `buildBreadcrumbs` and `getBreadcrumbs` methods of `AbstractAdmin`, make sure they aren't use anymore in templates, or by the breadcrumbs builder
- [x] Deprecate `breadcrumbsBuilder` accessors of `AbstractAdmin`. Create a service for the breadcrumbs builder and use that instead
- [x] Refactor AdminExtractor so that it still finds missing translations for the breadcrumbs
