### PR TITLE
Add support composite primary key

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1625,11 +1625,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     {
         if ($this->subject === null && $this->request) {
             $id = $this->request->get($this->getIdParameter());
-            if (!preg_match('#^[0-9A-Fa-f\-]+$#', $id)) {
-                $this->subject = false;
-            } else {
-                $this->subject = $this->getModelManager()->find($this->class, $id);
-            }
+            $this->subject = $this->getModelManager()->find($this->class, $id);
         }
 
         return $this->subject;

--- a/Form/ChoiceList/ModelChoiceLoader.php
+++ b/Form/ChoiceList/ModelChoiceLoader.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Form\ChoiceList;
 
 use Doctrine\Common\Util\ClassUtils;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\Exception\RuntimeException;
@@ -109,7 +110,7 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
                     }
                 }
 
-                $id = implode('~', $this->getIdentifierValues($entity));
+                $id = implode(AdapterInterface::ID_SEPARATOR, $this->getIdentifierValues($entity));
 
                 if (!array_key_exists($valueObject, $choices)) {
                     $choices[$valueObject] = array();

--- a/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Form\DataTransformer;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 use Symfony\Component\Form\ChoiceList\LazyChoiceList;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\RuntimeException;
@@ -76,7 +77,7 @@ class ModelsToArrayTransformer implements DataTransformerInterface
 
         $array = array();
         foreach ($collection as $key => $entity) {
-            $id = implode('~', $this->getIdentifierValues($entity));
+            $id = implode(AdapterInterface::ID_SEPARATOR, $this->getIdentifierValues($entity));
 
             $array[] = $id;
         }

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -7,6 +7,11 @@ Since `AbstractAdmin::configureBatchActions` is present, you should not override
 
 This method will be final in 4.0.
 
+## Backward compatibility break for AbstractAdmin::getSubject()
+
+Now `AbstractAdmin::getSubject()` return `null` or `object` of subject entity. Previously,
+`AbstractAdmin::getSubject()` may return `false` if entity identifier not match regexp `/^[0-9A-Fa-f\-]+$/`.
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 


### PR DESCRIPTION
Closes #3870

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Fix support for composite primary key in `AbstractAdmin::getSubject`
```

### Subject

Remove primary key validation because it may extend beyond the constraint `#^[0-9A-Fa-f\-]+$#` and it can contain a character `~` if it is a composite key.
**SonataAdminBundle** does not work with composite primary key. This PR might remedy the situation.

@Soullivaneuh you can comment this, why do need constraint for primary key?