### PR TITLE
Close admin extractor

### DIFF
--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -22,7 +22,7 @@ use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class AdminExtractor implements ExtractorInterface, TranslatorInterface, SecurityHandlerInterface, LabelTranslatorStrategyInterface
+final class AdminExtractor implements ExtractorInterface, TranslatorInterface, SecurityHandlerInterface, LabelTranslatorStrategyInterface
 {
     /**
      * @var LoggerInterface

--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -104,10 +104,6 @@ final class AdminExtractor implements ExtractorInterface, TranslatorInterface, S
             $admin->setSecurityHandler($this);
             $admin->setLabelTranslatorStrategy($this);
 
-//            foreach ($admin->getChildren() as $child) {
-//                $child->setTranslator($this);
-//            }
-
             // call the different public method
             $methods = array(
                 'getShow' => array(array()),
@@ -259,7 +255,6 @@ final class AdminExtractor implements ExtractorInterface, TranslatorInterface, S
     {
         $message = new Message($id, $domain);
 
-        //        $this->logger->debug(sprintf('extract: %s - domain:%s', $id, $domain));
 
         $trace = debug_backtrace(false);
         if (isset($trace[1]['file'])) {

--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -255,7 +255,6 @@ final class AdminExtractor implements ExtractorInterface, TranslatorInterface, S
     {
         $message = new Message($id, $domain);
 
-
         $trace = debug_backtrace(false);
         if (isset($trace[1]['file'])) {
             $message->addSource(new FileSource($trace[1]['file']));

--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -125,7 +125,11 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
             );
 
             if ($this->logger) {
-                $this->logger->info(sprintf('Retrieving message from admin:%s - class: %s', $admin->getCode(), get_class($admin)));
+                $this->logger->info(sprintf(
+                    'Retrieving message from admin:%s - class: %s',
+                    $admin->getCode(),
+                    get_class($admin)
+                ));
             }
 
             foreach ($methods as $method => $calls) {
@@ -134,7 +138,11 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
                         call_user_func_array(array($admin, $method), $args);
                     } catch (\Exception $e) {
                         if ($this->logger) {
-                            $this->logger->error(sprintf('ERROR : admin:%s - Raise an exception : %s', $admin->getCode(), $e->getMessage()));
+                            $this->logger->error(sprintf(
+                                'ERROR : admin:%s - Raise an exception : %s',
+                                $admin->getCode(),
+                                $e->getMessage()
+                            ));
                         }
 
                         throw $e;

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -25,12 +25,12 @@ If you have implemented a custom admin, you must adapt the signature of the foll
  * `getDashboardActions`
  * `getActionButtons`
  * `isCurrentRoute`
-  
+
 The following methods changed their visiblity to protected:
  * `configureActionButtons`
  * `configure`
  * `urlize`
- 
+
 If you extend an `AbstractAdmin`, you can't override the following methods anymore, because they are final now:
  * `urlize`
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -50,3 +50,6 @@ The API of the following methods was closed by making them final, you can't over
 ## SonataAdminExtension
 The Twig filters that come with the bundle will no longer load a default template when used with a missing template.
 The `sonata_admin` twig extension is now final. You may no longer extend it.
+
+## AdminExtractor
+The `AdminExtractor` class is now final, you may no longer extend it.


### PR DESCRIPTION
### Changelog

```markdown
### Changed
- The class `Sonata\AdminBundle\Translator\Extractor\JMSTranslatorBundle\AdminExtractor` is now `final`.
```

### Subject

This closes the admin extractor, I don't think it is meant to be extended.

Not sure if the corresponding service should be made private.