### PR TITLE
Always show the "Select" button in "sonata_type_model_list"

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -112,10 +112,6 @@ div.sonata-actions {
     font-weight: bold;
 }
 
-.sonata-ba-list tr:hover td.sonata-ba-list-field.sonata-ba-list-field-select a {
-    visibility: visible;
-}
-
 td.sonata-ba-list-field.sonata-ba-list-field-boolean i {
     margin-right: 1ex;
 }
@@ -131,9 +127,6 @@ td.sonata-ba-list-field.sonata-ba-list-field-integer {
 
 td.sonata-ba-list-field.sonata-ba-list-field-select {
     text-align: center;
-}
-td.sonata-ba-list-field.sonata-ba-list-field-select a {
-    visibility: hidden;
 }
 
 div.sonata-ba-modal-edit-one-to-one td.sonata-ba-list-field-batch,

--- a/Resources/views/CRUD/list__select.html.twig
+++ b/Resources/views/CRUD/list__select.html.twig
@@ -12,8 +12,8 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    <a class="btn btn-default" href="{{ admin.generateUrl('list') }}">
-        <i class="fa fa-arrow-right"></i>
+    <a class="btn btn-primary" href="{{ admin.generateUrl('list') }}">
+        <i class="fa fa-check"></i>
         {{ 'list_select'|trans({}, 'SonataAdminBundle') }}
     </a>
 {% endblock %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
Rebase of https://github.com/sonata-project/SonataAdminBundle/pull/3252

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Changed
- The `Select` button is always visible and has a primary check style in `sonata_type_model_list` popups
```

### Subject
The `Select` button is always visible and never hidden. This is a improvement for mobile devices.

<!-- Describe your Pull Request content here -->

Before
![bildschirmfoto 2016-05-29 um 08 59 52](https://cloud.githubusercontent.com/assets/3440437/15631795/c669d616-257b-11e6-89aa-da36dfe1531b.PNG)

After
![bildschirmfoto 2016-05-30 um 16 55 03](https://cloud.githubusercontent.com/assets/3440437/15652564/4d9431ca-2687-11e6-8485-0aa8d1134888.PNG)

