### PR TITLE
Fixed wrong route in "list__select.html.twig"

### DIFF
--- a/Resources/views/CRUD/list__select.html.twig
+++ b/Resources/views/CRUD/list__select.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    <a class="btn btn-default" href="{{ admin.generateObjectUrl('edit', object) }}">
+    <a class="btn btn-default" href="{{ admin.generateObjectUrl('list') }}">
         <i class="fa fa-arrow-right"></i>
         {{ 'list_select'|trans({}, 'SonataAdminBundle') }}
     </a>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rebase of #2859
Closes #

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Fixed wrong route in `list__select.html.twig`
```

### Subject
The button should show a `list` route instead of the `edit` route.