### PR TITLE
Fix DefaultRouteGenerator cache tests with Symfony 3.1

### DIFF
--- a/Route/AdminPoolLoader.php
+++ b/Route/AdminPoolLoader.php
@@ -75,11 +75,15 @@ class AdminPoolLoader extends Loader
             }
 
             $reflection = new \ReflectionObject($admin);
-            $collection->addResource(new FileResource($reflection->getFileName()));
+            if (file_exists($reflection->getFileName())) {
+                $collection->addResource(new FileResource($reflection->getFileName()));
+            }
         }
 
         $reflection = new \ReflectionObject($this->container);
-        $collection->addResource(new FileResource($reflection->getFileName()));
+        if (file_exists($reflection->getFileName())) {
+            $collection->addResource(new FileResource($reflection->getFileName()));
+        }
 
         return $collection;
     }

--- a/Route/RoutesCache.php
+++ b/Route/RoutesCache.php
@@ -59,7 +59,9 @@ class RoutesCache
             $routes = array();
 
             $reflection = new \ReflectionObject($admin);
-            $resources[] = new FileResource($reflection->getFileName());
+            if (file_exists($reflection->getFileName())) {
+                $resources[] = new FileResource($reflection->getFileName());
+            }
 
             if (!$admin->getRoutes()) {
                 throw new \RuntimeException('Invalid data type, AdminInterface::getRoutes must return a RouteCollection');


### PR DESCRIPTION
### Subject

`Symfony\Component\Config\Resource\FileResource` fail if the given path is invalid since Symfony 3.1.

It was the case from the begining because of mocking an interface.

A condition is added to the `RoutesCache` class.

Ref: https://github.com/phpDocumentor/ReflectionDocBlock/pull/72#issuecomment-222651257