### PR TITLE
Use admin entry as service ID

### DIFF
--- a/Admin/Pool.php
+++ b/Admin/Pool.php
@@ -169,8 +169,8 @@ class Pool
             return $admins;
         }
 
-        foreach ($this->adminGroups[$group]['items'] as $id) {
-            $admins[] = $this->getInstance($id);
+        foreach ($this->adminGroups[$group]['items'] as $item) {
+            $admins[] = $this->getInstance($item['admin']);
         }
 
         return $admins;


### PR DESCRIPTION
### Changelog

```markdown
### Fixed
- Fixed `Pool::getAdminsByGroup()` for the new admin groups values
```

### Subject

In df42796fde5d850f04440fb344cac25caad25268, the admin groups variable was
changed from containing only service IDs to containing an array of options
per item.

To get the service ID, the 'admin' entry should be used.

This is a bug in 3.0.0, but I can't see a way to target 3.0 specifically. Is there any way
to get this into a 3.0.1 versions or how do you handle that?