### PR TITLE
Final dependency injection classes

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -25,7 +25,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AddDependencyCallsCompilerPass implements CompilerPassInterface
+final class AddDependencyCallsCompilerPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}

--- a/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
+++ b/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AddFilterTypeCompilerPass implements CompilerPassInterface
+final class AddFilterTypeCompilerPass implements CompilerPassInterface
 {
     /**
      * @param ContainerBuilder $container

--- a/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class ExtensionCompilerPass implements CompilerPassInterface
+final class ExtensionCompilerPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}

--- a/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
+++ b/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class GlobalVariablesCompilerPass implements CompilerPassInterface
+final class GlobalVariablesCompilerPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,7 +22,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  *
  * @author  Michael Williams <mtotheikle@gmail.com>
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     /**
      * Generates the configuration tree.

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  * @author  Michael Williams <michael.williams@funsational.com>
  */
-class SonataAdminExtension extends Extension implements PrependExtensionInterface
+final class SonataAdminExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * @param array            $configs   An array of configuration settings

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -9,6 +9,16 @@ Please read [3.x](https://github.com/sonata-project/SonataAdminBundle/tree/3.x) 
 
 See also the [diff code](https://github.com/sonata-project/SonataAdminBundle/compare/3.x...4.0.0).
 
+## Final classes
+
+Some classes and methods are now `final` and should not be overridden:
+
+* `Sonata\Admin\AbstractAdmin::getActionButtons`
+* `Sonata\Admin\AbstractAdmin::getBatchActions`
+* `Sonata\Admin\AbstractAdmin::urlize`
+* `Sonata\AdminBundle\Translator\Extractor\JMSTranslatorBundle\AdminExtractor`
+* `Sonata\AdminBundle\Twig\Extension`
+
 ## Admin
 If you have implemented a custom admin, you must adapt the signature of the following new methods to match the one in `AdminInterface` again:
  * `hasAccess`
@@ -31,9 +41,6 @@ The following methods changed their visiblity to protected:
  * `configure`
  * `urlize`
 
-If you extend an `AbstractAdmin`, you can't override the following methods anymore, because they are final now:
- * `urlize`
-
 The method signature of `configureActionButtons` has changed. A new parameter `buttonList` was added.
 
 ## AdminExtension
@@ -42,14 +49,6 @@ If you have implemented a custom admin extension, you must adapt the signature o
  * `configureBatchActions`
  * `getAccessMapping`
 
-## AbstractAdmin
-The API of the following methods was closed by making them final, you can't override these methods anymore:
- * `getActionButtons`
- * `getBatchActions`
-
 ## SonataAdminExtension
 The Twig filters that come with the bundle will no longer load a default template when used with a missing template.
 The `sonata_admin` twig extension is now final. You may no longer extend it.
-
-## AdminExtractor
-The `AdminExtractor` class is now final, you may no longer extend it.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -16,6 +16,7 @@ Some classes and methods are now `final` and should not be overridden:
 * `Sonata\Admin\AbstractAdmin::getActionButtons`
 * `Sonata\Admin\AbstractAdmin::getBatchActions`
 * `Sonata\Admin\AbstractAdmin::urlize`
+* `Sonata\AdminBundle\DependencyInjection\SonataAdminExtension`
 * `Sonata\AdminBundle\Translator\Extractor\JMSTranslatorBundle\AdminExtractor`
 * `Sonata\AdminBundle\Twig\Extension`
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -16,6 +16,10 @@ Some classes and methods are now `final` and should not be overridden:
 * `Sonata\Admin\AbstractAdmin::getActionButtons`
 * `Sonata\Admin\AbstractAdmin::getBatchActions`
 * `Sonata\Admin\AbstractAdmin::urlize`
+* `Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass`
+* `Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass`
+* `Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass`
+* `Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass`
 * `Sonata\AdminBundle\DependencyInjection\Configuration`
 * `Sonata\AdminBundle\DependencyInjection\SonataAdminExtension`
 * `Sonata\AdminBundle\Translator\Extractor\JMSTranslatorBundle\AdminExtractor`

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -16,6 +16,7 @@ Some classes and methods are now `final` and should not be overridden:
 * `Sonata\Admin\AbstractAdmin::getActionButtons`
 * `Sonata\Admin\AbstractAdmin::getBatchActions`
 * `Sonata\Admin\AbstractAdmin::urlize`
+* `Sonata\AdminBundle\DependencyInjection\Configuration`
 * `Sonata\AdminBundle\DependencyInjection\SonataAdminExtension`
 * `Sonata\AdminBundle\Translator\Extractor\JMSTranslatorBundle\AdminExtractor`
 * `Sonata\AdminBundle\Twig\Extension`


### PR DESCRIPTION
### Changelog

```markdown
### Changed
- Class `Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass` is now final
- Class `Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass` is now final
- Class `Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass` is now final
- Class `Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass` is now final
- Class `Sonata\AdminBundle\DependencyInjection\Configuration` is now final
- Class `Sonata\AdminBundle\DependencyInjection\SonataAdminExtension` is now final
```

### Subject

Because those classes should never be overridden.
