### PR TITLE
Deprecate $context argument of createQuery

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1321,6 +1321,12 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      */
     public function createQuery($context = 'list')
     {
+        if (func_num_args() > 0) {
+            @trigger_error(
+                'The $context argument of '.__METHOD.' is deprecated since 3.x, to be removed in 4.0.',
+                E_USER_DEPRECATED
+            );
+        }
         $query = $this->getModelManager()->createQuery($this->class);
 
         foreach ($this->extensions as $extension) {

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -179,7 +179,7 @@ interface AdminInterface
     public function getManagerType();
 
     /**
-     * @param string $context
+     * @param string $context NEXT_MAJOR: remove this argument
      *
      * @return ProxyQueryInterface
      */

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1747,6 +1747,26 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($menu, $admin->buildBreadcrumbs($action, $menu));
     }
 
+    /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @group legacy
+     */
+    public function testCreateQueryLegacyCallWorks()
+    {
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AbstractAdmin', array(
+            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin',
+        ));
+        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager->expects($this->once())
+            ->method('createQuery')
+            ->with('My\Class')
+            ->willReturn('a query');
+
+        $admin->setModelManager($modelManager);
+        $this->assertSame('a query', $admin->createQuery('list'));
+    }
+
     private function createTagAdmin(Post $post)
     {
         $postAdmin = $this->getMockBuilder('Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin')

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -36,3 +36,10 @@ You can no longer rely on that and should always specify templates that exist.
 - `getBreadcrumbs` is deprecated in favor of the homonym method of the `sonata.admin.breadcrumbs_builder` service.
 - The breadcrumbs builder accessors are deprecated,
 the `sonata.admin.breadcrumbs_builder` service should be used directly instead.
+
+## Deprecated AbstractAdmin method argument
+
+The `$context` argument is deprecated and will be removed.
+Instead of relying on it (and using a `switch` statement),
+rely on an abstraction, and inject different implementations of this abstraction in different actions.
+Here is [an example](https://github.com/sonata-project/SonataAdminBundle/pull/3247#issuecomment-217744025).


### PR DESCRIPTION
Closes #3795

### Changelog

```markdown
### Deprecated
- The `$context` argument of `AdminInterface::createQuery` was deprecated.
```

### Subject



Having a variable named $context is a code smell indicating a possible
violation of the Open-Close Principle. Removing this argument should
lead to better architecture.