### PR TITLE
fix isGranted check to respect passed object in super-admin roles check

### DIFF
--- a/Security/Handler/RoleSecurityHandler.php
+++ b/Security/Handler/RoleSecurityHandler.php
@@ -63,7 +63,7 @@ class RoleSecurityHandler implements SecurityHandlerInterface
         }
 
         try {
-            return $this->authorizationChecker->isGranted($this->superAdminRoles)
+            return $this->authorizationChecker->isGranted($this->superAdminRoles, $object)
                 || $this->authorizationChecker->isGranted($attributes, $object);
         } catch (AuthenticationCredentialsNotFoundException $e) {
             return false;

--- a/Tests/Security/Handler/RoleSecurityHandlerTest.php
+++ b/Tests/Security/Handler/RoleSecurityHandlerTest.php
@@ -212,6 +212,19 @@ class RoleSecurityHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array(), $handler->buildSecurityInformation($this->getSonataAdminObject()));
     }
 
+    public function testIsGrantedPassesObjectToSuperAdminCheck()
+    {
+        $handler = $this->getRoleSecurityHandler([]);
+        $object = new \stdClass();
+        $this->authorizationChecker->expects($this->at(0))
+            ->method('isGranted')
+            ->with([], $object);
+        $this->authorizationChecker->expects($this->at(1))
+            ->method('isGranted')
+            ->with([], $object);
+        $handler->isGranted($this->admin, [], $object);
+    }
+
     /**
      * @return RoleSecurityHandler
      */

--- a/Tests/Security/Handler/RoleSecurityHandlerTest.php
+++ b/Tests/Security/Handler/RoleSecurityHandlerTest.php
@@ -214,7 +214,7 @@ class RoleSecurityHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testIsGrantedPassesObjectToSuperAdminCheck()
     {
-        $handler = $this->getRoleSecurityHandler([]);
+        $handler = $this->getRoleSecurityHandler(array());
         $object = new \stdClass();
         $this->authorizationChecker->expects($this->at(0))
             ->method('isGranted')
@@ -222,7 +222,7 @@ class RoleSecurityHandlerTest extends \PHPUnit_Framework_TestCase
         $this->authorizationChecker->expects($this->at(1))
             ->method('isGranted')
             ->with([], $object);
-        $handler->isGranted($this->admin, [], $object);
+        $handler->isGranted($this->admin, array(), $object);
     }
 
     /**

--- a/Tests/Security/Handler/RoleSecurityHandlerTest.php
+++ b/Tests/Security/Handler/RoleSecurityHandlerTest.php
@@ -218,10 +218,10 @@ class RoleSecurityHandlerTest extends \PHPUnit_Framework_TestCase
         $object = new \stdClass();
         $this->authorizationChecker->expects($this->at(0))
             ->method('isGranted')
-            ->with([], $object);
+            ->with(array(), $object);
         $this->authorizationChecker->expects($this->at(1))
             ->method('isGranted')
-            ->with([], $object);
+            ->with(array(), $object);
         $handler->isGranted($this->admin, array(), $object);
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #3928

### Changelog


```markdown
### Fixed
- Fix `isGranted` check for `ROLE_SUPER_ADMIN` to pass object
```

### Subject

In `RoleSecurityHandler:isGranted ` we ask `authorizationChecker` if super-admin roles or the requested role is granted. While we pass the given user-object correctly to the  authorizationChecker for the check for the requested role, we are ignoring the user-object for the check for super-admin roles. In most cases this will result in a check against the current user from the token storage, which normally means the CRM-user. The fix here is to pass the user-object also to the check for the super-admin roles.

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [X] My PR stuff
- [X] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

