### PR TITLE
[WIP] Dependency injection tests refactor

### DIFF
--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -11,37 +11,49 @@
 
 namespace Sonata\AdminBundle\Tests;
 
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
 use Sonata\AdminBundle\DependencyInjection\Configuration;
+use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
 use Symfony\Component\Config\Definition\Processor;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends AbstractExtensionConfigurationTestCase
 {
-    public function testOptions()
+    public function testEmpty()
     {
-        $config = $this->process(array());
-
-        $this->assertTrue($config['options']['html5_validate']);
-        $this->assertNull($config['options']['pager_links']);
-        $this->assertTrue($config['options']['confirm_exit']);
-        $this->assertTrue($config['options']['use_icheck']);
+        $this->assertProcessedConfigurationEquals($this->getDefaultExpectedConfiguration(), array(
+            __DIR__.'/../Fixtures/config/empty.yml',
+        ));
     }
 
     public function testOptionsWithInvalidFormat()
     {
         $this->setExpectedException('Symfony\Component\Config\Definition\Exception\InvalidTypeException');
 
-        $config = $this->process(array(array(
-            'options' => array(
-                'html5_validate' => '1',
-            ),
-        )));
+        $this->assertProcessedConfigurationEquals(array(), array(
+            __DIR__.'/../Fixtures/config/options_invalid_format.yml',
+        ));
     }
 
-    public function testCustomTemplatesPerAdmin()
+    public function testAdminServices()
     {
-        $config = $this->process(array(array(
+        $expectedConfiguration = array_replace_recursive($this->getDefaultExpectedConfiguration(), array(
             'admin_services' => array(
                 'my_admin_id' => array(
+                    'model_manager' => null,
+                    'form_contractor' => null,
+                    'show_builder' => null,
+                    'list_builder' => null,
+                    'datagrid_builder' => null,
+                    'translator' => null,
+                    'configuration_pool' => null,
+                    'route_generator' => null,
+                    'validator' => null,
+                    'security_handler' => null,
+                    'label' => null,
+                    'menu_factory' => null,
+                    'route_builder' => null,
+                    'label_translator_strategy' => null,
+                    'pager_type' => null,
                     'templates' => array(
                         'form' => array('form.twig.html', 'form_extra.twig.html'),
                         'view' => array('user_block' => 'SonataAdminBundle:mycustomtemplate.html.twig'),
@@ -49,153 +61,92 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
             ),
-        )));
+        ));
 
-        $this->assertSame('SonataAdminBundle:mycustomtemplate.html.twig', $config['admin_services']['my_admin_id']['templates']['view']['user_block']);
+        $this->assertProcessedConfigurationEquals($expectedConfiguration, array(
+            __DIR__.'/../Fixtures/config/admin_services.yml',
+        ));
     }
 
-    public function testAdminServicesDefault()
+    public function testDashboardRoles()
     {
-        $config = $this->process(array(array(
-            'admin_services' => array('my_admin_id' => array()),
-        )));
-
-        $this->assertSame(array(
-            'model_manager' => null,
-            'form_contractor' => null,
-            'show_builder' => null,
-            'list_builder' => null,
-            'datagrid_builder' => null,
-            'translator' => null,
-            'configuration_pool' => null,
-            'route_generator' => null,
-            'validator' => null,
-            'security_handler' => null,
-            'label' => null,
-            'menu_factory' => null,
-            'route_builder' => null,
-            'label_translator_strategy' => null,
-            'pager_type' => null,
-            'templates' => array(
-                'form' => array(),
-                'filter' => array(),
-                'view' => array(),
-            ),
-        ), $config['admin_services']['my_admin_id']);
-    }
-
-    public function testDashboardWithoutRoles()
-    {
-        $config = $this->process(array());
-
-        $this->assertEmpty($config['dashboard']['blocks'][0]['roles']);
-    }
-
-    public function testDashboardWithRoles()
-    {
-        $config = $this->process(array(array(
+        $expectedConfiguration = array_replace_recursive($this->getDefaultExpectedConfiguration(), array(
             'dashboard' => array(
-                'blocks' => array(array(
-                    'roles' => array('ROLE_ADMIN'),
-                    'type' => 'my.type',
-                )),
+                'blocks' => array(
+                    array(
+                        'position' => 'right',
+                        'roles' => array('ROLE_ADMIN'),
+                        'type' => 'my.type',
+                        'settings' => array(),
+                        'class' => 'col-md-4',
+                    ),
+                ),
             ),
-        )));
+        ));
 
-        $this->assertSame($config['dashboard']['blocks'][0]['roles'], array('ROLE_ADMIN'));
+        $this->assertProcessedConfigurationEquals($expectedConfiguration, array(
+            __DIR__.'/../Fixtures/config/dashboard_roles.yml',
+        ));
     }
 
     public function testDashboardGroups()
     {
-        $config = $this->process(array(array(
+        $expectedConfiguration = array_replace_recursive($this->getDefaultExpectedConfiguration(), array(
             'dashboard' => array(
                 'groups' => array(
                     'bar' => array(
                         'label' => 'foo',
                         'icon' => '<i class="fa fa-edit"></i>',
+                        'on_top' => false,
+                        'item_adds' => array(),
+                        'roles' => array(),
                         'items' => array(
-                            'item1',
-                            'item2',
                             array(
+                                'admin' => 'item1',
+                                'label' => '',
+                                'route' => '',
+                                'route_params' => array(),
+                                'route_absolute' => true,
+                            ),
+                            array(
+                                'admin' => 'item2',
+                                'label' => '',
+                                'route' => '',
+                                'route_params' => array(),
+                                'route_absolute' => true,
+                            ),
+                            array(
+                                'admin' => '',
                                 'label' => 'fooLabel',
                                 'route' => 'fooRoute',
                                 'route_params' => array('bar' => 'foo'),
                                 'route_absolute' => true,
                             ),
                             array(
+                                'admin' => '',
                                 'label' => 'barLabel',
                                 'route' => 'barRoute',
+                                'route_params' => array(),
+                                'route_absolute' => true,
                             ),
                         ),
                     ),
                 ),
             ),
-        )));
+        ));
 
-        $this->assertCount(4, $config['dashboard']['groups']['bar']['items']);
-        $this->assertSame(
-            $config['dashboard']['groups']['bar']['items'][0],
-            array(
-                'admin' => 'item1',
-                'label' => '',
-                'route' => '',
-                'route_params' => array(),
-                'route_absolute' => true,
-            )
-        );
-        $this->assertSame(
-            $config['dashboard']['groups']['bar']['items'][1],
-            array(
-                'admin' => 'item2',
-                'label' => '',
-                'route' => '',
-                'route_params' => array(),
-                'route_absolute' => true,
-            )
-        );
-        $this->assertSame(
-            $config['dashboard']['groups']['bar']['items'][2],
-            array(
-                'label' => 'fooLabel',
-                'route' => 'fooRoute',
-                'route_params' => array('bar' => 'foo'),
-                'route_absolute' => true,
-                'admin' => '',
-            )
-        );
-        $this->assertSame(
-            $config['dashboard']['groups']['bar']['items'][3],
-            array(
-                'label' => 'barLabel',
-                'route' => 'barRoute',
-                'route_params' => array(),
-                'admin' => '',
-                'route_absolute' => true,
-            )
-        );
+        $this->assertProcessedConfigurationEquals($expectedConfiguration, array(
+            __DIR__.'/../Fixtures/config/dashboard_groups.yml',
+        ));
     }
 
     public function testDashboardGroupsWithBadItemsParams()
     {
         $this->setExpectedException('\InvalidArgumentException', 'Expected either parameters "route" and "label" for array items');
 
-        $config = $this->process(array(array(
-            'dashboard' => array(
-                'groups' => array(
-                    'bar' => array(
-                        'label' => 'foo',
-                        'icon' => '<i class="fa fa-edit"></i>',
-                        'items' => array(
-                            'item1',
-                            'item2',
-                            array(
-                                'route' => 'fooRoute',
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-        )));
+        $this->assertProcessedConfigurationEquals(array(), array(
+            __DIR__.'/../Fixtures/config/dashboard_groups_with_bad_items_params.yml',
+        ));
     }
 
     /**
@@ -210,5 +161,160 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $processor = new Processor();
 
         return $processor->processConfiguration(new Configuration(), $configs);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getContainerExtension()
+    {
+        return new SonataAdminExtension();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration();
+    }
+
+    private function getDefaultExpectedConfiguration()
+    {
+        return array(
+            'security' => array(
+                'handler' => 'sonata.admin.security.handler.noop',
+                'information' => array(),
+                'admin_permissions' => array(
+                    'CREATE',
+                    'LIST',
+                    'DELETE',
+                    'UNDELETE',
+                    'EXPORT',
+                    'OPERATOR',
+                    'MASTER',
+                ),
+                'object_permissions' => array(
+                    'VIEW',
+                    'EDIT',
+                    'DELETE',
+                    'UNDELETE',
+                    'OPERATOR',
+                    'MASTER',
+                    'OWNER',
+                ),
+                'acl_user_manager' => null,
+            ),
+            'title' => 'Sonata Admin',
+            'title_logo' => 'bundles/sonataadmin/logo_title.png',
+            'dashboard' => array(
+                'groups' => array(),
+                'blocks' => array(
+                    array(
+                        'position' => 'left',
+                        'settings' => array(),
+                        'type' => 'sonata.admin.block.admin_list',
+                        'roles' => array(),
+                    ),
+                ),
+            ),
+            'admin_services' => array(),
+            'templates' => array(
+                'user_block' => 'SonataAdminBundle:Core:user_block.html.twig',
+                'add_block' => 'SonataAdminBundle:Core:add_block.html.twig',
+                'layout' => 'SonataAdminBundle::standard_layout.html.twig',
+                'ajax' => 'SonataAdminBundle::ajax_layout.html.twig',
+                'dashboard' => 'SonataAdminBundle:Core:dashboard.html.twig',
+                'search' => 'SonataAdminBundle:Core:search.html.twig',
+                'list' => 'SonataAdminBundle:CRUD:list.html.twig',
+                'filter' => 'SonataAdminBundle:Form:filter_admin_fields.html.twig',
+                'show' => 'SonataAdminBundle:CRUD:show.html.twig',
+                'show_compare' => 'SonataAdminBundle:CRUD:show_compare.html.twig',
+                'edit' => 'SonataAdminBundle:CRUD:edit.html.twig',
+                'preview' => 'SonataAdminBundle:CRUD:preview.html.twig',
+                'history' => 'SonataAdminBundle:CRUD:history.html.twig',
+                'acl' => 'SonataAdminBundle:CRUD:acl.html.twig',
+                'history_revision_timestamp' => 'SonataAdminBundle:CRUD:history_revision_timestamp.html.twig',
+                'action' => 'SonataAdminBundle:CRUD:action.html.twig',
+                'select' => 'SonataAdminBundle:CRUD:list__select.html.twig',
+                'list_block' => 'SonataAdminBundle:Block:block_admin_list.html.twig',
+                'search_result_block' => 'SonataAdminBundle:Block:block_search_result.html.twig',
+                'short_object_description' => 'SonataAdminBundle:Helper:short-object-description.html.twig',
+                'delete' => 'SonataAdminBundle:CRUD:delete.html.twig',
+                'batch' => 'SonataAdminBundle:CRUD:list__batch.html.twig',
+                'batch_confirmation' => 'SonataAdminBundle:CRUD:batch_confirmation.html.twig',
+                'inner_list_row' => 'SonataAdminBundle:CRUD:list_inner_row.html.twig',
+                'outer_list_rows_mosaic' => 'SonataAdminBundle:CRUD:list_outer_rows_mosaic.html.twig',
+                'outer_list_rows_list' => 'SonataAdminBundle:CRUD:list_outer_rows_list.html.twig',
+                'outer_list_rows_tree' => 'SonataAdminBundle:CRUD:list_outer_rows_tree.html.twig',
+                'base_list_field' => 'SonataAdminBundle:CRUD:base_list_field.html.twig',
+                'pager_links' => 'SonataAdminBundle:Pager:links.html.twig',
+                'pager_results' => 'SonataAdminBundle:Pager:results.html.twig',
+                'tab_menu_template' => 'SonataAdminBundle:Core:tab_menu_template.html.twig',
+                'knp_menu_template' => 'SonataAdminBundle:Menu:sonata_menu.html.twig',
+            ),
+            'assets' => array(
+                'stylesheets' => array(
+                    'bundles/sonatacore/vendor/bootstrap/dist/css/bootstrap.min.css',
+                    'bundles/sonatacore/vendor/components-font-awesome/css/font-awesome.min.css',
+                    'bundles/sonatacore/vendor/ionicons/css/ionicons.min.css',
+                    'bundles/sonataadmin/vendor/admin-lte/dist/css/AdminLTE.min.css',
+                    'bundles/sonataadmin/vendor/admin-lte/dist/css/skins/skin-black.min.css',
+                    'bundles/sonataadmin/vendor/iCheck/skins/square/blue.css',
+                    'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css',
+                    'bundles/sonataadmin/vendor/jqueryui/themes/base/jquery-ui.css',
+                    'bundles/sonatacore/vendor/select2/select2.css',
+                    'bundles/sonatacore/vendor/select2-bootstrap-css/select2-bootstrap.min.css',
+                    'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/css/bootstrap-editable.css',
+                    'bundles/sonataadmin/css/styles.css',
+                    'bundles/sonataadmin/css/layout.css',
+                    'bundles/sonataadmin/css/tree.css',
+                ),
+                'javascripts' => array(
+                    'bundles/sonatacore/vendor/jquery/dist/jquery.min.js',
+                    'bundles/sonataadmin/vendor/jquery.scrollTo/jquery.scrollTo.min.js',
+                    'bundles/sonatacore/vendor/moment/min/moment.min.js',
+                    'bundles/sonataadmin/vendor/jqueryui/ui/minified/jquery-ui.min.js',
+                    'bundles/sonataadmin/vendor/jqueryui/ui/minified/i18n/jquery-ui-i18n.min.js',
+                    'bundles/sonatacore/vendor/bootstrap/dist/js/bootstrap.min.js',
+                    'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js',
+                    'bundles/sonataadmin/vendor/jquery-form/jquery.form.js',
+                    'bundles/sonataadmin/jquery/jquery.confirmExit.js',
+                    'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/js/bootstrap-editable.min.js',
+                    'bundles/sonatacore/vendor/select2/select2.min.js',
+                    'bundles/sonataadmin/vendor/admin-lte/dist/js/app.min.js',
+                    'bundles/sonataadmin/vendor/iCheck/icheck.min.js',
+                    'bundles/sonataadmin/vendor/slimScroll/jquery.slimscroll.min.js',
+                    'bundles/sonataadmin/vendor/waypoints/lib/jquery.waypoints.min.js',
+                    'bundles/sonataadmin/vendor/waypoints/lib/shortcuts/sticky.min.js',
+                    'bundles/sonataadmin/Admin.js',
+                    'bundles/sonataadmin/treeview.js',
+                ),
+            ),
+            'extensions' => array(
+                'admins' => array(),
+                'excludes' => array(),
+                'implements' => array(),
+                'extends' => array(),
+                'instanceof' => array(),
+                'uses' => array(),
+            ),
+            'persist_filters' => false,
+            'show_mosaic_button' => true,
+            'options' => array(
+                'html5_validate' => true,
+                'pager_links' => null,
+                'confirm_exit' => true,
+                'use_icheck' => true,
+                'sort_admins' => false,
+                'use_select2' => true,
+                'use_bootlint' => false,
+                'use_stickyforms' => true,
+                'form_type' => 'standard',
+                'dropdown_number_groups_per_colums' => 2,
+                'title_mode' => 'both',
+                'lock_protection' => false,
+            ),
+        );
     }
 }

--- a/Tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/Tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class SonataAdminExtensionTest extends AbstractExtensionTestCase
+{
+    public function testLoad()
+    {
+        $this->container->compile();
+        $this->load();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getContainerExtensions()
+    {
+        return array(
+            new SonataAdminExtension(),
+        );
+    }
+}

--- a/Tests/Fixtures/config/admin_services.yml
+++ b/Tests/Fixtures/config/admin_services.yml
@@ -1,0 +1,8 @@
+sonata_admin:
+    admin_services:
+        my_admin_id:
+            templates:
+                form: [form.twig.html, form_extra.twig.html]
+                view:
+                    user_block: SonataAdminBundle:mycustomtemplate.html.twig
+                filter: []

--- a/Tests/Fixtures/config/dashboard_groups.yml
+++ b/Tests/Fixtures/config/dashboard_groups.yml
@@ -1,0 +1,11 @@
+sonata_admin:
+    dashboard:
+        groups:
+            bar:
+                label: foo
+                icon: '<i class="fa fa-edit"></i>'
+                items:
+                    - item1
+                    - item2
+                    - { label: fooLabel, route: fooRoute, route_params: { bar: foo }, route_absolute: true }
+                    - { label: barLabel, route: barRoute }

--- a/Tests/Fixtures/config/dashboard_groups_with_bad_items_params.yml
+++ b/Tests/Fixtures/config/dashboard_groups_with_bad_items_params.yml
@@ -1,0 +1,10 @@
+sonata_admin:
+    dashboard:
+        groups:
+            bar:
+                label: foo
+                icon: '<i class="fa fa-edit"></i>'
+                items:
+                    - item1
+                    - item2
+                    - { route: barRoute }

--- a/Tests/Fixtures/config/dashboard_roles.yml
+++ b/Tests/Fixtures/config/dashboard_roles.yml
@@ -1,0 +1,5 @@
+sonata_admin:
+    dashboard:
+        block:
+            - roles: [ROLE_ADMIN]
+              type: my.type

--- a/Tests/Fixtures/config/empty.yml
+++ b/Tests/Fixtures/config/empty.yml
@@ -1,0 +1,1 @@
+sonata_admin: ~

--- a/Tests/Fixtures/config/options_invalid_format.yml
+++ b/Tests/Fixtures/config/options_invalid_format.yml
@@ -1,0 +1,3 @@
+sonata_admin:
+    options:
+        html5_validate: '1'

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/intl-bundle": "^2.2.4",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
-        "symfony/yaml": "^2.3 || ^3.0"
+        "symfony/yaml": "^2.3 || ^3.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^0.7.6"
     },
     "conflict": {
         "jms/di-extra-bundle": "<1.7.0"


### PR DESCRIPTION
### Subject

Let's use [matthiasnoback/symfony-dependency-injection-test](https://github.com/matthiasnoback/SymfonyDependencyInjectionTest) to make tests cleaner and easier.
### To do
- [x] Bundle tests
- [x] Configuration tests
- [ ] Extension tests
- [ ] Test issue proof of #3909 and add a not to **never** put legacy for `addClassToCompile` test
