### PR TITLE
Fix wrong view role check on AbstractAdmin::getSearchResultLink

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2873,7 +2873,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     final public function getSearchResultLink($object)
     {
         foreach ($this->searchResultActions as $action) {
-            if ($this->hasRoute($action) && $this->isGranted(strtoupper($action), $object)) {
+            if ($this->hasRoute($action) && $this->hasAccess($action, $object)) {
                 return $this->generateObjectUrl($action, $object);
             }
         }


### PR DESCRIPTION
### Changelog
```markdown
### Fixed
- Fix wrong view role check on `AbstractAdmin::getSearchResultLink`
```

### Subject

If the search link is a show action, it will check against the `SHOW` role.

This role does not exists. The right one is `VIEW`.
