### PR TITLE
Revert: Making AbstractAdmin::defineFormBuilder private

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -3016,7 +3016,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      *
      * @param FormBuilderInterface $formBuilder
      */
-    private function defineFormBuilder(FormBuilderInterface $formBuilder)
+    public function defineFormBuilder(FormBuilderInterface $formBuilder)
     {
         $mapper = new FormMapper($this->getFormContractor(), $formBuilder, $this);
 

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2654,6 +2654,25 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     }
 
     /**
+     * This method is being called by the main admin class and the child class,
+     * the getFormBuilder is only call by the main admin class.
+     *
+     * @param FormBuilderInterface $formBuilder
+     */
+    public function defineFormBuilder(FormBuilderInterface $formBuilder)
+    {
+        $mapper = new FormMapper($this->getFormContractor(), $formBuilder, $this);
+
+        $this->configureFormFields($mapper);
+
+        foreach ($this->getExtensions() as $extension) {
+            $extension->configureFormFields($mapper);
+        }
+
+        $this->attachInlineValidator();
+    }
+
+    /**
      * Hook to run after initilization.
      */
     protected function configure()
@@ -3008,25 +3027,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
         foreach ($this->getExtensions() as $extension) {
             $extension->configureDatagridFilters($mapper);
         }
-    }
-
-    /**
-     * This method is being called by the main admin class and the child class,
-     * the getFormBuilder is only call by the main admin class.
-     *
-     * @param FormBuilderInterface $formBuilder
-     */
-    public function defineFormBuilder(FormBuilderInterface $formBuilder)
-    {
-        $mapper = new FormMapper($this->getFormContractor(), $formBuilder, $this);
-
-        $this->configureFormFields($mapper);
-
-        foreach ($this->getExtensions() as $extension) {
-            $extension->configureFormFields($mapper);
-        }
-
-        $this->attachInlineValidator();
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #3939 

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Changed
- `AbstractAdmin::defineFormBuilder` method is public again
```

### Subject

This method is called by `AdminType::buildForm`.