### PR TITLE
Use valid syntax for method call argument

### DIFF
--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -37,7 +37,7 @@
             <argument type="service" id="sonata.admin.pool"/>
             <argument type="service" id="logger" on-invalid="ignore"/>
             <call method="setBreadcrumbsBuilder">
-                <service id="sonata.admin.breadcrumbs_builder"/>
+                <argument type="service" id="sonata.admin.breadcrumbs_builder"/>
             </call>
         </service>
         <!-- controller as services -->


### PR DESCRIPTION
Closes #3948 

### Changelog

```markdown
### Fixed
- Fixes broken extractor
```

### Subject

I broke the extractor, and did not notice it. Adding a smoke test for the service would be helpful

- [ ] Add a smoke test