### PR TITLE
Remove buildBreadcrumbs from the public interface

### DIFF
--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -43,10 +43,15 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
     }
 
     /**
-     * {@inheritdoc}
-     * NEXT_MAJOR : make this method private.
+     * Builds breadcrumbs for $action, starting from $menu.
+     *
+     * Note: the method will be called by the top admin instance (parent => child)
+     *
+     * @param AdminInterface     $admin
+     * @param string             $action
+     * @param ItemInterface|null $menu
      */
-    public function buildBreadcrumbs(AdminInterface $admin, $action, ItemInterface $menu = null)
+    private function buildBreadcrumbs(AdminInterface $admin, $action, ItemInterface $menu = null)
     {
         if (!$menu) {
             $menu = $admin->getMenuFactory()->createItem('root');

--- a/Admin/BreadcrumbsBuilderInterface.php
+++ b/Admin/BreadcrumbsBuilderInterface.php
@@ -11,8 +11,6 @@
 
 namespace Sonata\AdminBundle\Admin;
 
-use Knp\Menu\ItemInterface;
-
 /**
  * Builds a breacrumbs. There is a dependency on the AdminInterface because
  * this object holds useful object to deal with this task, but there is
@@ -32,20 +30,4 @@ interface BreadcrumbsBuilderInterface
      * @return mixed array|Traversable the breadcrumbs
      */
     public function getBreadcrumbs(AdminInterface $admin, $action);
-
-    /**
-     * Builds breadcrumbs for $action, starting from $menu.
-     *
-     * Note: the method will be called by the top admin instance (parent => child)
-     * NEXT_MAJOR : remove this method from the public interface.
-     *
-     * @param AdminInterface     $admin
-     * @param string             $action
-     * @param ItemInterface|null $menu
-     */
-    public function buildBreadcrumbs(
-        AdminInterface $admin,
-        $action,
-        ItemInterface $menu = null
-    );
 }

--- a/Tests/Admin/BreadcrumbsBuilderTest.php
+++ b/Tests/Admin/BreadcrumbsBuilderTest.php
@@ -240,6 +240,9 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         $menu->addChild('Ma classe fille', array('uri' => null))->willReturn($menu);
         $menu->addChild('Mon action', array())->willReturn($menu);
 
-        $breadcrumbsBuilder->buildBreadCrumbs($admin->reveal(), $action);
+        $reflection = new \ReflectionMethod('Sonata\AdminBundle\Admin\BreadcrumbsBuilder', 'buildBreadcrumbs');
+        $reflection->setAccessible(true);
+
+        $reflection->invoke($breadcrumbsBuilder, $admin->reveal(), $action);
     }
 }

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -55,6 +55,12 @@ If you have implemented a custom admin extension, you must adapt the signature o
  * `configureBatchActions`
  * `getAccessMapping`
 
+## BreadcrumbsBuilder
+The `buildBreacrumbs` method may no longer be called from outside the class.
+
+## BreadcrumbsBuilderInterface
+The `buildBreacrumbs` method has been removed from the interface.
+
 ## SonataAdminExtension
 The Twig filters that come with the bundle will no longer load a default template when used with a missing template.
 The `sonata_admin` twig extension is now final. You may no longer extend it.


### PR DESCRIPTION
## Changelog


```markdown
### Removed
- The `BreadcrumbsBuilder::buildBreadcrumbs()` public visibility
- The `BreadcrumbsBuilderInterface::buildBreadcrumbs()` method
```

## Subject

This was needed before, because the breadcrumbs building process was
half in the admin class, half in this class.