### PR TITLE
Add missing deprecation message and warning for Exporter

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -828,7 +828,7 @@ class CRUDController extends Controller
             $format
         );
 
-        return $this->get('sonata.admin.exporter')->getResponse(
+        return $this->get('sonata.core.exporter')->getResponse(
             $format,
             $filename,
             $this->admin->getDataSourceIterator()

--- a/Export/Exporter.php
+++ b/Export/Exporter.php
@@ -13,8 +13,14 @@ namespace Sonata\AdminBundle\Export;
 
 use Sonata\CoreBundle\Exporter\Exporter as BaseExporter;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\Exporter class is deprecated since version 2.2.9 and will be removed in 4.0.'
+    .' Use Sonata\CoreBundle\Exporter\Exporter instead.',
+    E_USER_DEPRECATED
+);
+
 /**
- * @deprecated
+ * @deprecated since version 2.2.9, to be removed in 4.0. Use Sonata\CoreBundle\Exporter\Exporter instead.
  */
 class Exporter extends BaseExporter
 {

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -178,7 +178,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
                 }
             }));
 
-        $exporter = $this->getMock('Sonata\AdminBundle\Export\Exporter');
+        $exporter = $this->getMock('Sonata\CoreBundle\Export\Exporter');
 
         $exporter->expects($this->any())
             ->method('getResponse')

--- a/Tests/Export/ExporterTest.php
+++ b/Tests/Export/ExporterTest.php
@@ -14,6 +14,11 @@ namespace Sonata\AdminBundle\Tests\Filter;
 use Exporter\Source\ArraySourceIterator;
 use Sonata\AdminBundle\Export\Exporter;
 
+/**
+ * NEXT_MAJOR: remove this class.
+ *
+ * @group legacy
+ */
 class ExporterTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/inflector": "^1.0",
         "knplabs/knp-menu-bundle": "^2.1.1",
         "sonata-project/block-bundle": "^3.0",
-        "sonata-project/core-bundle": "^3.0",
+        "sonata-project/core-bundle": "^3.0.3",
         "sonata-project/exporter": "^1.0",
         "symfony/class-loader": "^2.3 || ^3.0",
         "symfony/config": "^2.3.9 || ^3.0",


### PR DESCRIPTION
I am targetting this branch, because it's a fix.

## Changelog

```markdown
### Fixed
- Add missing deprecation message and warning for Exporter
```

## To do

- [x] Wait tag for https://github.com/sonata-project/SonataCoreBundle/pull/308

## Subject

The class was deprecated on https://github.com/sonata-project/SonataAdminBundle/commit/ba17aa0d5aa0e993e800bb196b3ee9921df0b89b but without any indication.
