### PR TITLE
Fix CRUDController::editAction ignoring its optional parameter

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -221,7 +221,7 @@ class CRUDController extends Controller
     /**
      * Edit action.
      *
-     * @param int|string|null $id
+     * @param int|string|null $id Optional ID to use instead of globally provided default.
      *
      * @return Response|RedirectResponse
      *
@@ -234,7 +234,7 @@ class CRUDController extends Controller
         // the key used to lookup the template
         $templateKey = 'edit';
 
-        $id = $request->get($this->admin->getIdParameter());
+        $id = $id ?: $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
         if (!$object) {


### PR DESCRIPTION
I am targetting this branch, because it's broken in the current branch. Will have to be forward merged into master.

The `CRUDController::editAction` accepted an `$id` parameter which was always overwritten, serving 99% of use cases just fine, but not the exceptional case it was added for.

## Changelog

```markdown
### Fixed
 - Made CRUDController::editAction respect optional parameter
```