### PR TITLE
Fix not aligned checkbox and radio on horizontal form

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -324,7 +324,8 @@ file that was distributed with this source code.
         {% endif %}
 
         {% if sonata_admin is defined and sonata_admin.options['form_type'] == 'horizontal' %}
-            {% if label is same as(false) %}
+            {# Add an offset if no label or is a checkbox/radio #}
+            {% if label is same as(false) or form.vars.checked is defined %}
                 {% if 'collection' in form.parent.vars.block_prefixes %}
                     {% set div_class = div_class ~ ' col-sm-12' %}
                 {% else %}


### PR DESCRIPTION
I am targetting this branch, because this is a bugfix.

Fixes #3951 

## Changelog

```markdown
### Fixed
- Not aligned checkbox and radio on horizontal form
```

## Subject

With Twitter Bootstrap, checkbox and radio inputs need a col-sm-offset-* class to get aligned with the other inputs.

Before:

![selection_913](https://cloud.githubusercontent.com/assets/1698357/16153635/6f439f4e-34a7-11e6-9b4a-7034bbbfaf3c.png)

After:

![image](https://cloud.githubusercontent.com/assets/1698357/16153644/743d6b2e-34a7-11e6-9fbb-88b43beea7aa.png)

@EmmanuelVella can you please review and confirm this one?