### PR TITLE
Do not use provided ID on editAction if concerning the child

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -221,7 +221,8 @@ class CRUDController extends Controller
     /**
      * Edit action.
      *
-     * @param int|string|null $id Optional ID to use instead of globally provided default.
+     * @param int|string|null $id Optional ID representing the main admin subject.
+     *                            This should not be used for child admins.
      *
      * @return Response|RedirectResponse
      *
@@ -574,7 +575,8 @@ class CRUDController extends Controller
     /**
      * Show action.
      *
-     * @param int|string|null $id
+     * @param int|string|null $id      Optional ID representing the main admin subject.
+     *                                 This should not be used for child admins.
      * @param Request         $request
      *
      * @return Response
@@ -612,7 +614,8 @@ class CRUDController extends Controller
     /**
      * Show history revisions for object.
      *
-     * @param int|string|null $id
+     * @param int|string|null $id      Optional ID representing the main admin subject.
+     *                                 This should not be used for child admins.
      * @param Request         $request
      *
      * @return Response
@@ -659,7 +662,8 @@ class CRUDController extends Controller
     /**
      * View history revision of object.
      *
-     * @param int|string|null $id
+     * @param int|string|null $id       Optional ID representing the main admin subject.
+     *                                  This should not be used for child admins.
      * @param string|null     $revision
      * @param Request         $request
      *
@@ -720,7 +724,8 @@ class CRUDController extends Controller
     /**
      * Compare history revisions of object.
      *
-     * @param int|string|null $id
+     * @param int|string|null $id               Optional ID representing the main admin subject.
+     *                                          This should not be used for child admins.
      * @param int|string|null $base_revision
      * @param int|string|null $compare_revision
      * @param Request         $request
@@ -839,7 +844,8 @@ class CRUDController extends Controller
     /**
      * Returns the Response object associated to the acl action.
      *
-     * @param int|string|null $id
+     * @param int|string|null $id      Optional ID representing the main admin subject.
+     *                                 This should not be used for child admins.
      * @param Request         $request
      *
      * @return Response|RedirectResponse

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -156,8 +156,7 @@ class CRUDController extends Controller
     public function deleteAction($id)
     {
         $request = $this->getRequest();
-        $id = $request->get($this->admin->getIdParameter());
-        $object = $this->admin->getObject($id);
+        $object = $this->admin->getObject($this->resolveSubjectId($request, $id));
 
         if (!$object) {
             throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
@@ -235,9 +234,7 @@ class CRUDController extends Controller
         // the key used to lookup the template
         $templateKey = 'edit';
 
-        // If the $id variable is provided AND the child ID is not needed, do not reload it.
-        $id = $id && 'id' === $this->admin->getIdParameter() ? $id : $request->get($this->admin->getIdParameter());
-        $object = $this->admin->getObject($id);
+        $object = $this->admin->getObject($this->resolveSubjectId($request, $id));
 
         if (!$object) {
             throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
@@ -587,9 +584,7 @@ class CRUDController extends Controller
     public function showAction($id = null)
     {
         $request = $this->getRequest();
-        $id = $request->get($this->admin->getIdParameter());
-
-        $object = $this->admin->getObject($id);
+        $object = $this->admin->getObject($this->resolveSubjectId($request, $id));
 
         if (!$object) {
             throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
@@ -626,9 +621,7 @@ class CRUDController extends Controller
     public function historyAction($id = null)
     {
         $request = $this->getRequest();
-        $id = $request->get($this->admin->getIdParameter());
-
-        $object = $this->admin->getObject($id);
+        $object = $this->admin->getObject($this->resolveSubjectId($request, $id));
 
         if (!$object) {
             throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
@@ -675,9 +668,7 @@ class CRUDController extends Controller
     public function historyViewRevisionAction($id = null, $revision = null)
     {
         $request = $this->getRequest();
-        $id = $request->get($this->admin->getIdParameter());
-
-        $object = $this->admin->getObject($id);
+        $object = $this->admin->getObject($this->resolveSubjectId($request, $id));
 
         if (!$object) {
             throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
@@ -741,9 +732,7 @@ class CRUDController extends Controller
 
         $this->admin->checkAccess('historyCompareRevisions');
 
-        $id = $request->get($this->admin->getIdParameter());
-
-        $object = $this->admin->getObject($id);
+        $object = $this->admin->getObject($this->resolveSubjectId($request, $id));
 
         if (!$object) {
             throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
@@ -861,9 +850,7 @@ class CRUDController extends Controller
             throw $this->createNotFoundException('ACL are not enabled for this admin');
         }
 
-        $id = $request->get($this->admin->getIdParameter());
-
-        $object = $this->admin->getObject($id);
+        $object = $this->admin->getObject($this->resolveSubjectId($request, $id));
 
         if (!$object) {
             throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
@@ -929,6 +916,27 @@ class CRUDController extends Controller
         }
 
         return $this->container->get('request');
+    }
+
+    /**
+     * Returns the subject ID to use.
+     *
+     * If not provided or concerning a child admin, get it from the request.
+     *
+     * Otherwise, just return the parameter.
+     *
+     * @param Request         $request
+     * @param int|string|null $subjectId
+     *
+     * @return int|null|string
+     */
+    final protected function resolveSubjectId(Request $request, $subjectId = null)
+    {
+        if (is_null($subjectId) || 'id' !== $this->admin->getIdParameter()) {
+            return $request->get($this->admin->getIdParameter());
+        }
+
+        return $subjectId;
     }
 
     /**

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -234,7 +234,8 @@ class CRUDController extends Controller
         // the key used to lookup the template
         $templateKey = 'edit';
 
-        $id = $id ?: $request->get($this->admin->getIdParameter());
+        // If the $id variable is provided AND the child ID is not needed, do not reload it.
+        $id = $id && 'id' === $this->admin->getIdParameter() ? $id : $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
         if (!$object) {


### PR DESCRIPTION
I am targetting this branch, because it's a bugfix

Ref: https://github.com/sonata-project/SonataAdminBundle/commit/be82d59407de9a2613fcd700e78d86794fdc464e#commitcomment-17941270

## Changelog

```markdown
### Fixed
- Regression on edit action for child admin since version 3.3.1
- Respect optional ID parameter on all `CRUDController` actions
```

## Subject

The $id parameter provided by CRUDController::editAction is always the object ID of the parent admin class.

When the related admin is a child, we always have to load it from the request.

This is a fix for a regression introduce in #3961.

@jforet @rande Can you test and confirm this solve your issue?

It's a quickfix of a critical issue with no test. If you have some suggestion to add preventive test before merge, I'm hearing! :+1: 

cc @curry684 