### PR TITLE
Allow unit test suite to run from project context

### DIFF
--- a/Tests/Menu/Integration/BaseMenuTest.php
+++ b/Tests/Menu/Integration/BaseMenuTest.php
@@ -29,10 +29,13 @@ abstract class BaseMenuTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $twigPaths = array(
+        // Adapt to both bundle and project-wide test strategy
+        $twigPaths = array_filter(array(
+            __DIR__.'/../../../../../../vendor/knplabs/knp-menu/src/Knp/Menu/Resources/views',
             __DIR__.'/../../../vendor/knplabs/knp-menu/src/Knp/Menu/Resources/views',
             __DIR__.'/../../../Resources/views',
-        );
+        ), 'is_dir');
+
         $loader = new StubFilesystemLoader($twigPaths);
         $this->environment = new \Twig_Environment($loader, array('strict_variables' => true));
     }


### PR DESCRIPTION
I am targetting this branch, because this is a bugfix.

Fixes #3766

## Changelog

```markdown
### Fixed
- Fixed unit test suite runned from a project
```

## Subject

Applied the same strategy that in this existing test to restore the ability to run AdminBundle test suite from a project context:
https://github.com/sonata-project/SonataAdminBundle/blob/3.x/Tests/Form/Widget/BaseWidgetTest.php

