### PR TITLE
Revert "Fix CRUDController::editAction ignoring its optional parameter"

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -221,7 +221,7 @@ class CRUDController extends Controller
     /**
      * Edit action.
      *
-     * @param int|string|null $id Optional ID to use instead of globally provided default.
+     * @param int|string|null $id
      *
      * @return Response|RedirectResponse
      *
@@ -234,7 +234,7 @@ class CRUDController extends Controller
         // the key used to lookup the template
         $templateKey = 'edit';
 
-        $id = $id ?: $request->get($this->admin->getIdParameter());
+        $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
         if (!$object) {


### PR DESCRIPTION
Reverts sonata-project/SonataAdminBundle#3961

## Changelog

```markdown
### Fixed
 - Reverted #3961 to fix a regression concerning child admins on edit route
```

## Subject

#3961 brought a regression with child admins.

More info here: https://github.com/sonata-project/SonataAdminBundle/commit/be82d59407de9a2613fcd700e78d86794fdc464e#commitcomment-17941270