### PR TITLE
Moves crud association templates to admin-bundle

### DIFF
--- a/Admin/BaseFieldDescription.php
+++ b/Admin/BaseFieldDescription.php
@@ -506,4 +506,12 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     {
         return false !== $this->getOption('virtual_field', false);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function describesAssociation()
+    {
+        return $this->describesSingleValuedAssociation() || $this->describesCollectionValuedAssociation();
+    }
 }

--- a/Admin/FieldDescriptionInterface.php
+++ b/Admin/FieldDescriptionInterface.php
@@ -289,4 +289,25 @@ interface FieldDescriptionInterface
      * @return mixed
      */
     public function getFieldValue($object, $fieldName);
+
+    /**
+     * Returns whether this object describes an association between two related models.
+     *
+     * @return bool
+     */
+    public function describesAssociation();
+
+    /**
+     * Returns whether this object describes a single-valued (N..1) association.
+     *
+     * @return bool
+     */
+    public function describesSingleValuedAssociation();
+
+    /**
+     * Returns whether this object describes a collection-valued (N..*) association.
+     *
+     * @return bool
+     */
+    public function describesCollectionValuedAssociation();
 }

--- a/Builder/AbstractFormContractor.php
+++ b/Builder/AbstractFormContractor.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Builder;
+
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+
+/**
+ * @author ju1ius
+ */
+abstract class AbstractFormContractor implements FormContractorInterface
+{
+    /**
+     * @var FormFactoryInterface
+     */
+    protected $formFactory;
+
+    /**
+     * @param FormFactoryInterface $formFactory
+     */
+    public function __construct(FormFactoryInterface $formFactory)
+    {
+        $this->formFactory = $formFactory;
+    }
+
+    /**
+     * @return FormFactoryInterface
+     */
+    final public function getFormFactory()
+    {
+        return $this->formFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function getFormBuilder($name, array $options = array())
+    {
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        $formType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
+
+        return $this->getFormFactory()->createNamedBuilder($name, $formType, null, $options);
+    }
+
+    /**
+     * @param string                    $type
+     * @param FieldDescriptionInterface $fieldDescription
+     *
+     * @return array
+     *
+     * @throws \LogicException If an invalid option was provided.
+     * @throws \LogicException If an association widget has no related admin class.
+     * @throws \LogicException If an association widget has no related model.
+     * @throws \LogicException If an association widget's related model cannot be handled.
+     */
+    public function getDefaultOptions($type, FieldDescriptionInterface $fieldDescription)
+    {
+        $options = array();
+        $options['sonata_field_description'] = $fieldDescription;
+
+        if (in_array($type, array(
+            'sonata_type_model', 'sonata_type_model_list',
+            'sonata_type_model_hidden', 'sonata_type_model_autocomplete',
+        ), true)) {
+            if ($fieldDescription->getOption('edit', 'standard') !== 'standard') {
+                throw new \LogicException(sprintf(
+                    'The `%s` type does not accept an `edit` option anymore,'
+                    .' please review the UPGRADE-2.1.md file from the SonataAdminBundle',
+                    $type
+                ));
+            }
+            if (!$fieldDescription->getTargetEntity()) {
+                throw new \LogicException(sprintf(
+                    'The field "%s" in class "%s" does not have a target model defined.'
+                    .' Please make sure your association mapping is properly configured.',
+                    $fieldDescription->getName(),
+                    $fieldDescription->getAdmin()->getClass()
+                ));
+            }
+        }
+
+        if (in_array($type, array(
+            'sonata_type_admin',
+            'sonata_type_model_autocomplete',
+            'sonata_type_collection',
+        ), true)) {
+            if (!$fieldDescription->getAssociationAdmin()) {
+                throw $this->createMissingAssociationAdminException($fieldDescription);
+            }
+        }
+
+        if (in_array($type, array(
+            'sonata_type_model', 'sonata_type_model_list',
+            'sonata_type_model_hidden', 'sonata_type_model_autocomplete',
+        ), true)) {
+            $options['class'] = $fieldDescription->getTargetEntity();
+            $options['model_manager'] = $fieldDescription->getAdmin()->getModelManager();
+        } elseif ($type === 'sonata_type_admin') {
+            if (!$fieldDescription->describesSingleValuedAssociation()) {
+                throw new \LogicException(sprintf(
+                    'The `sonata_type_admin` type only handles single-valued associations.'
+                    .' Try using `sonata_type_collection` or one of the `sonata_type_model` variants'
+                    .' for field `%s`.',
+                    $fieldDescription->getName()
+                ));
+            }
+
+            // set sensitive default value to have a component working fine out of the box
+            $options['delete'] = false;
+
+            $options['data_class'] = $fieldDescription->getAssociationAdmin()->getClass();
+            $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'admin'));
+        } elseif ($type === 'sonata_type_collection') {
+            if (!$fieldDescription->describesCollectionValuedAssociation()) {
+                throw new \LogicException(sprintf(
+                    'The `sonata_type_collection` type only handles collection-valued associations.'
+                    .' Try using `sonata_type_admin` or one of the `sonata_type_model` variants'
+                    .' for field `%s`',
+                    $fieldDescription->getName()
+                ));
+            }
+            $options['type'] = 'sonata_type_admin';
+            $options['modifiable'] = true;
+            $options['type_options'] = array(
+                'sonata_field_description' => $fieldDescription,
+                'data_class' => $fieldDescription->getAssociationAdmin()->getClass(),
+            );
+        }
+
+        return $options;
+    }
+
+    /**
+     * @param FieldDescriptionInterface $fieldDescription
+     *
+     * @return \LogicException
+     */
+    protected function createMissingAssociationAdminException(FieldDescriptionInterface $fieldDescription)
+    {
+        $msg = "The current field `{$fieldDescription->getName()}` is not linked to an admin. Please create one";
+        if ($fieldDescription->describesAssociation()) {
+            if ($fieldDescription->getTargetEntity()) {
+                $msg .= " for the target model: `{$fieldDescription->getTargetEntity()}`";
+            }
+            $msg .= ', make sure your association mapping is properly configured, or';
+        } else {
+            $msg .= ', and';
+        }
+        $msg .= ' use the `admin_code` option to link it.';
+
+        return new \LogicException($msg);
+    }
+}

--- a/Builder/Exception/MissingAssociationAdminException.php
+++ b/Builder/Exception/MissingAssociationAdminException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Builder\Exception;
+
+/**
+ * Signals that a field description is missing an association admin when a form type requires it.
+ *
+ * @author ju1ius <ju1ius@laposte.net>
+ */
+final class MissingAssociationAdminException extends \LogicException
+{
+}

--- a/Builder/Exception/MissingTargetModelClassException.php
+++ b/Builder/Exception/MissingTargetModelClassException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Builder\Exception;
+
+/**
+ * Signals that a field description is missing an association target model class when a form type requires it.
+ *
+ * @author ju1ius <ju1ius@laposte.net>
+ */
+final class MissingTargetModelClassException extends \LogicException
+{
+}

--- a/Builder/Exception/UnhandledAssociationTypeException.php
+++ b/Builder/Exception/UnhandledAssociationTypeException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Builder\Exception;
+
+/**
+ * Signals that a form field cannot be used to handle a particular association type.
+ *
+ * For example, when a CollectionType is used with a singled-value association.
+ *
+ * @author ju1ius <ju1ius@laposte.net>
+ */
+final class UnhandledAssociationTypeException extends \LogicException
+{
+}

--- a/Resources/views/CRUD/Association/list_collection.html.twig
+++ b/Resources/views/CRUD/Association/list_collection.html.twig
@@ -1,0 +1,40 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends admin.getTemplate('base_list_field') %}
+
+{% block field %}
+    {% set route_name = field_description.options.route.name %}
+
+    {% for element in value %}
+        {%- if field_description.associationAdmin.hasAccess(route_name, element) -%}
+            {{ block('relation_link') }}
+        {%- else -%}
+            {{ block('relation_value') }}
+        {%- endif -%}
+        {{ not loop.last ? ', ' }}
+    {% endfor %}
+
+{% endblock %}
+
+{%- block relation_link -%}
+    <a href="{{ field_description.associationAdmin.generateObjectUrl(
+        route_name,
+        element,
+        field_description.options.route.parameters
+    ) }}">
+        {{- element|render_relation_element(field_description) -}}
+    </a>
+{%- endblock -%}
+
+{%- block relation_value -%}
+    {{ element|render_relation_element(field_description) }}
+{%- endblock -%}

--- a/Resources/views/CRUD/Association/list_single.html.twig
+++ b/Resources/views/CRUD/Association/list_single.html.twig
@@ -1,0 +1,33 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends admin.getTemplate('base_list_field') %}
+
+{% block field %}
+    {% if value %}
+        {% set route_name = field_description.options.route.name %}
+
+        {% if
+            field_description.hasAssociationAdmin
+            and field_description.associationAdmin.hasAccess(route_name, value)
+        %}
+            <a href="{{ field_description.associationAdmin.generateObjectUrl(
+                route_name,
+                value,
+                field_description.options.route.parameters
+            ) }}">
+                {{- value|render_relation_element(field_description) -}}
+            </a>
+        {% else %}
+            {{ value|render_relation_element(field_description) }}
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/Resources/views/CRUD/Association/show_collection.html.twig
+++ b/Resources/views/CRUD/Association/show_collection.html.twig
@@ -1,0 +1,45 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+
+{% block field%}
+    {% set route_name = field_description.options.route.name %}
+
+    <ul class="sonata-ba-association-show-many">
+        {% for element in value %}
+            <li>
+                {% if
+                    field_description.hasAssociationAdmin
+                    and field_description.associationAdmin.hasAccess(route_name, element)
+                %}
+                    {{ block('relation_link') }}
+                {% else %}
+                    {{ block('relation_value') }}
+                {% endif %}
+            </li>
+        {% endfor %}
+    </ul>
+{% endblock %}
+
+{%- block relation_link -%}
+    <a href="{{ field_description.associationAdmin.generateObjectUrl(
+        route_name,
+        element,
+        field_description.options.route.parameters
+    ) }}">
+        {{- element|render_relation_element(field_description) -}}
+    </a>
+{%- endblock -%}
+
+{%- block relation_value -%}
+    {{ element|render_relation_element(field_description) }}
+{%- endblock -%}

--- a/Resources/views/CRUD/Association/show_single.html.twig
+++ b/Resources/views/CRUD/Association/show_single.html.twig
@@ -1,0 +1,33 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+
+{% block field %}
+    {% if value %}
+        {% set route_name = field_description.options.route.name %}
+
+        {% if
+            field_description.hasAssociationAdmin
+            and field_description.associationAdmin.hasAccess(route_name, value)
+        %}
+            <a href="{{ field_description.associationAdmin.generateObjectUrl(
+                route_name,
+                value,
+                field_description.options.route.parameters
+            ) }}">
+                {{- value|render_relation_element(field_description) -}}
+            </a>
+        {% else %}
+            {{ value|render_relation_element(field_description) }}
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/Resources/views/Form/Type/Collection/create.js.twig
+++ b/Resources/views/Form/Type/Collection/create.js.twig
@@ -1,0 +1,44 @@
+(function ($, Admin) {
+    {# Parameters must be passed by the widget's template #}
+    var fieldId = '{{ id }}';
+    var submitUrl = '{{ url }}';
+
+    window['SonataTypeCollectionCreate_' + fieldId] = function (link) {
+        link.onclick = null;
+        $(link).on('click', handleCreateButtonClicked).trigger('click');
+
+        return false;
+    };
+
+    function getFieldContainer () {
+        return $('#field_container_' + fieldId);
+    }
+
+    function handleCreateButtonClicked (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        var $form = $(event.target).closest('form');
+        $form.ajaxSubmit({
+            url: submitUrl,
+            method: 'POST',
+            dataType: 'html',
+            data: {_xml_http_request: true},
+            success: function (html) {
+                if (!html.length) {
+                    return;
+                }
+                getFieldContainer().replaceWith(html);
+                var $newContainer = getFieldContainer();
+
+                Admin.shared_setup($newContainer);
+                if ($form.find('input[type="file"]').length) {
+                    $form.attr('enctype', 'multipart/form-data');
+                    $form.attr('encoding', 'multipart/form-data');
+                }
+
+                $('#sonata-ba-field-container-' + fieldId).trigger('sonata.add_element');
+                $newContainer.trigger('sonata.add_element');
+            }
+        });
+    }
+}(jQuery, Admin));

--- a/Resources/views/Form/Type/Collection/inline_table.html.twig
+++ b/Resources/views/Form/Type/Collection/inline_table.html.twig
@@ -1,0 +1,56 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            {% for field_name, nested_field in form.children|first.children %}
+                {% if field_name == '_delete' %}
+                    <th>
+                        {{- 'action_delete'|trans({}, 'SonataAdminBundle') -}}
+                    </th>
+                {% else %}
+                    <th class="{{ [
+                            nested_field.vars['required']  ? 'required' : '',
+                            nested_field.vars['attr']['hidden']|default(false) ? 'hidden' : ''
+                        ]|join(' ') }}"
+                    >
+                        {{ nested_field.vars['sonata_admin'].admin.trans(
+                            nested_field.vars.label,
+                            {},
+                            nested_field.vars.translation_domain
+                        ) }}
+                    </th>
+                {% endif %}
+            {% endfor %}
+        </tr>
+    </thead>
+    <tbody class="sonata-ba-tbody">
+        {% for nested_group_field_name, nested_group_field in form.children %}
+            <tr>
+                {% for field_name, nested_field in nested_group_field.children %}
+                    <td class="{{ [
+                            'control-group',
+                            "sonata-ba-td-#{id}-#{field_name}",
+                            nested_field.vars.errors|length ? 'error' : '',
+                            nested_field.vars['attr']['hidden']|default(false) ? 'hidden' : ''
+                        ]|join(' ') }}"
+                    >
+                        {% if _association_admin.formFieldDescriptions[field_name] is defined %}
+                            {{ form_widget(nested_field) }}
+                            {% do nested_group_field.setRendered() %}
+                        {% else %}
+                            {% if field_name == '_delete' %}
+                                {{ form_widget(nested_field, {label_render: false}) }}
+                            {% else %}
+                                {{ form_widget(nested_field) }}
+                            {% endif %}
+                        {% endif %}
+                        {% if nested_field.vars.errors|length %}
+                            <div class="help-inline sonata-ba-field-error-messages">
+                                {{ form_errors(nested_field) }}
+                            </div>
+                        {% endif %}
+                    </td>
+                {% endfor %}
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/Resources/views/Form/Type/Collection/inline_tabs.html.twig
+++ b/Resources/views/Form/Type/Collection/inline_tabs.html.twig
@@ -1,0 +1,49 @@
+<div class="sonata-ba-tabs">
+    {% for nested_group_field in form.children %}
+        <div>
+            <div class="nav-tabs-custom">
+                <ul class="nav nav-tabs">
+                    {% for name, form_group in _association_admin.formGroups %}
+                        <li class="{{ loop.first ? 'active' }}">
+                            <a href="#{{ _association_admin.uniqid }}_{{ loop.parent.loop.index }}_{{ loop.index }}"
+                               data-toggle="tab"
+                            >
+                                <i class="icon-exclamation-sign has-errors hide"></i>
+                                {{ _association_admin.trans(name, {}, form_group.translation_domain) }}
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+                <div class="tab-content">
+                    {% for name, form_group in _association_admin.formGroups %}
+                        <div class="tab-pane {{ loop.first ? 'active' }}"
+                             id="{{ _association_admin.uniqid }}_{{ loop.parent.loop.index }}_{{ loop.index }}"
+                        >
+                            <fieldset>
+                                <div class="sonata-ba-collapsed-fields">
+                                    {% for field_name in form_group.fields %}
+                                        {% set nested_field = nested_group_field.children[field_name] %}
+                                        <div class="sonata-ba-field-{{ id }}-{{ field_name }}">
+                                            {% if _association_admin.hasFormFieldDescription(field_name) %}
+                                                {{ form_row(nested_field, {
+                                                    inline: 'natural',
+                                                    edit: 'inline'
+                                                }) }}
+                                                {% do nested_group_field.setRendered() %}
+                                            {% else %}
+                                                {{ form_row(nested_field) }}
+                                            {% endif %}
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            </fieldset>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+            {% if nested_group_field['_delete'] is defined %}
+                {{ form_row(nested_group_field['_delete']) }}
+            {% endif %}
+        </div>
+    {% endfor %}
+</div>

--- a/Resources/views/Form/Type/Collection/sortable.js.twig
+++ b/Resources/views/Form/Type/Collection/sortable.js.twig
@@ -1,0 +1,48 @@
+(function ($) {
+    var containerSelector = '#field_container_{{ id }} .sonata-ba-{{ table ? 'tbody' : 'tabs' }}';
+    var itemSelector = '.sonata-ba-{{ table ? 'td' : 'field' }}-{{ id }}-{{ sort_field }}';
+    var $sortableContainer = $(containerSelector).sortable({
+        axis: 'y',
+        opacity: 0.6,
+        items: '> {{ table ? 'tr' : 'div' }}',
+        stop: applyPositions()
+    });
+
+    // refresh the sortable container when a new element is added,
+    // the event is triggered in create.js.twig
+    $('#sonata-ba-field-container-{{ id }}').on('sonata.add_element', function () {
+        applyPositions();
+        $sortableContainer.sortable('refresh');
+    });
+
+    applyPositions();
+
+    function applyPositions () {
+        $sortableContainer.find(itemSelector).each(applyPosition);
+        updateInputs();
+    }
+
+    function updateInputs () {
+        $sortableContainer.find(itemSelector + ' input').each(function (n, input) {
+            $(input).val(n + 1);
+        });
+    }
+
+    function applyPosition (_, element) {
+        // remove the sortable handler and put it back
+        var $element = $(element);
+        {% if table %}
+            $element.find('.sonata-ba-sortable-handler').remove();
+            $('<span>')
+                .attr('class', 'sonata-ba-sortable-handler ui-icon ui-icon-grip-solid-horizontal')
+                .appendTo($element);
+        {% else %}
+            var $tabs = $element.closest('.nav-tabs-custom').find('> .nav-tabs');
+            $tabs.find('.sonata-ba-sortable-handler').remove();
+            $('<li class="sonata-ba-sortable-handler pull-right"/>')
+                .prepend('<span class="ui-icon ui-icon-grip-solid-horizontal"/>')
+                .appendTo($tabs);
+        {% endif %}
+        $element.find('input').hide();
+    }
+}(jQuery));

--- a/Resources/views/Form/Type/Model/dialog.html.twig
+++ b/Resources/views/Form/Type/Model/dialog.html.twig
@@ -1,0 +1,15 @@
+<div class="modal fade" id="field_dialog_{{ id }}" role="dialog" tabindex="-1"
+     aria-labelledby="field_dialog_title_{{ id }}" aria-hidden="true"
+>
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
+                    &times;
+                </button>
+                <h4 class="modal-title" id="field_dialog_title_{{ id }}"></h4>
+            </div>
+            <div class="modal-body"></div>
+        </div>
+    </div>
+</div>

--- a/Resources/views/Form/Type/Model/dialog.js.twig
+++ b/Resources/views/Form/Type/Model/dialog.js.twig
@@ -1,0 +1,433 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+{#
+
+This code manages the association dialog for the 'sonata_type_model_list' and 'sonata_type_model' widgets
+
+#}
+
+{% set widget = update_short_object_description is defined ? 'model_list' : 'model' %}
+{% set routes = {
+    retrieveFormElement: retrieve_form_element,
+    updateShortObjectDescription: update_short_object_description|default
+} %}
+
+(function ($, Admin) {
+    {# Parameters passed from the widget's template #}
+    var fieldId = '{{ id }}';
+    var fieldLabel = '{{ label }}';
+    var routes = {{ routes|json_encode|raw }};
+
+    /** @type {Dialog} */
+    var dialog;
+
+    /**
+     * @constructor
+     */
+    function Dialog (id, title) {
+        this.$dialog = $('#field_dialog_' + id).appendTo(document.body);
+        this.$body = this.$dialog.find('.modal-body');
+        this.$title = this.$dialog.find('.modal-title').html(title);
+        this.$spinner = $('<div/>')
+            .append('<i class="fa fa-refresh fa-spin fa-3x fa-fw"/>')
+            .append('<span class="sr-only">Loading...</span>')
+            .css({
+                position: 'absolute',
+                top: '50%', left: '50%',
+                transform: 'translate(-50%, -50%)', webkitTransform: 'translate(-50%, -50%)'
+            });
+        Admin.setup_list_modal(this.$dialog);
+    }
+    Dialog.prototype = {
+        show: function () {
+            this.setLoading();
+            this.$dialog.modal('show');
+            return this;
+        },
+        hide: function () {
+            this.$dialog.modal('hide');
+            return this;
+        },
+        setContent: function (body) {
+            this.$body.html(body);
+            Admin.shared_setup(this.$body);
+            return this;
+        },
+        setLoading: function () {
+            this.$body.empty().append(this.$spinner);
+            return this;
+        }
+    };
+
+    /**
+     * Creates the dialog singleton instance if it doesn't exist.
+     */
+    function createDialog () {
+        if (!dialog) {
+            dialog = new Dialog(fieldId, fieldLabel);
+        }
+    }
+
+    /**
+     * Returns whether the given element is an anchor (it's a link to it's current location)
+     *
+     * @param {jQuery} $el
+     * @returns {boolean}
+     */
+    function isAnchor ($el) {
+        var href = ($el.attr('href') || '').trim();
+        return $el.is('a') && (!href || href[0] === '#');
+    }
+
+    /**
+     * Returns the actual input element of the widget
+     *
+     * @returns {jQuery}
+     */
+    function getField () {
+        return $('#' + fieldId);
+    }
+
+    /**
+     * Returns the widget's input element wrapper
+     *
+     * @returns {jQuery}
+     */
+    function getFieldWidget () {
+        return $('#field_widget_' + fieldId);
+    }
+
+    /**
+     * Returns the widget's field container.
+     *
+     * @returns {jQuery}
+     */
+    function getFieldContainer () {
+        return $('#field_container_' + fieldId);
+    }
+
+    {#
+        Create action dialog
+        -------------------------------------------------------------------------------------------------------------
+    #}
+
+    /**
+     * Success handler for the create dialog form submission.
+     *
+     * Updates the related widget depending on it's type (sonata_type_model or sonata_type_model_list).
+     *
+     * @param {string} objectId The identifier of the related model object.
+     */
+    function handleCreateDialogSuccess (objectId) {
+        {% if widget == 'model_list' %}
+            updateShortObjectDescription(objectId);
+        {% else %}
+            retrieveFormElement(objectId);
+        {% endif %}
+    }
+
+    /**
+     * Retrieves the updated form element after a new item has been created,
+     * and replaces our widget with the updated one.
+     *
+     * @param {string} objectId The identifier of the related model object.
+     * @fires 'sonata-admin-append-form-element'
+     */
+    function retrieveFormElement (objectId) {
+        getFieldWidget().closest('form').ajaxSubmit({
+            url: routes.retrieveFormElement,
+            method: 'POST',
+            dataType: 'html',
+            data: {_xml_http_request: true},
+            success: function (html) {
+                getFieldContainer().replaceWith(html);
+                var $newElement = getField().find('[value="' + objectId + '"]');
+                if ($newElement.is("input")) {
+                    $newElement.attr('checked', 'checked');
+                } else {
+                    $newElement.attr('selected', 'selected');
+                }
+                getFieldContainer().trigger('sonata-admin-append-form-element');
+            }
+        });
+    }
+
+    /**
+     * Installs our event handlers for the create dialog body.
+     *
+     * @param {Dialog} dialog
+     */
+    function setupCreateDialog (dialog) {
+        dialog.$body.find('a').on('click', handleCreateDialogClick);
+        dialog.$body.find('form').on('submit', handleCreateDialogSubmit);
+    }
+
+    /**
+     * Handles link clicks in the create dialog.
+     *
+     * We just fetch the url and repopulate the dialog.
+     *
+     * @param {jQuery.Event} event
+     */
+    function handleCreateDialogClick (event) {
+        var $link = $(event.currentTarget);
+        if (isAnchor($link) || $link.hasClass('sonata-ba-action')) {
+            return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+
+        dialog.setLoading();
+        $.ajax({
+            url: $link.href,
+            data: {_xml_http_request: true}
+        }).done(function (html) {
+            dialog.setContent(html);
+            setupCreateDialog(dialog);
+        });
+    }
+
+    /**
+     * Handles form submissions in the create dialog.
+     *
+     * We submit the form via AJAX and update the related input on success.
+     *
+     * @param {jQuery.Event} event
+     */
+    function handleCreateDialogSubmit (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        var $form = $(event.target);
+
+        dialog.setLoading();
+        $form.ajaxSubmit({
+            url: $form.attr('action'),
+            method: $form.attr('method'),
+            data: {_xml_http_request: true},
+            success: function (data) {
+                dialog.hide();
+                // if the crud action return ok, then the element has been added
+                // so the widget container must be refresh with the last option available
+                if (data.result === 'ok') {
+                    handleCreateDialogSuccess(data.objectId);
+                }
+            }
+        });
+    }
+
+    /**
+     * The event handler for the create button.
+     *
+     * @param {jQuery.Event} event
+     */
+    function handleCreateButtonClicked (event) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        var $link = $(event.currentTarget);
+
+        dialog.show();
+        $.ajax({
+            url: $link.attr('href'),
+            dataType: 'html'
+        }).done(function (html) {
+            dialog.setContent(html);
+            setupCreateDialog(dialog);
+        });
+    }
+
+    /**
+     * The inline event handler for the create button.
+     *
+     * It is done this way for historical reasons, and should be refactored to use event delegation.
+     *
+     * @param {HTMLElement} link
+     * @returns {boolean}
+     */
+    window['SonataTypeModelListCreate_' + fieldId] = function (link) {
+        createDialog();
+        // remove the inline event handler and replace it with our own
+        link.onclick = null;
+        $(link).on('click', handleCreateButtonClicked).trigger('click');
+
+        return false;
+    };
+
+    {% if widget == 'model_list' %}
+
+        {#
+            List action dialog
+            ----------------------------------------------------------------------------------------------------------
+        #}
+
+        /**
+         * Updates the input's value with the given identifier, and loads the related object's sort description.
+         *
+         * @param {string} objectId The identifier of the related model object.
+         */
+        function updateShortObjectDescription (objectId) {
+            getField().val(objectId);
+            var $widget = getFieldWidget().empty();
+            if (!objectId) {
+                return;
+            }
+            $('<i class="fa fa-refresh fa-spin fa-fw"/>').css({
+                display: 'block',
+                margin: '0 auto'
+            }).appendTo($widget);
+
+            $.ajax({
+                dataType: 'html',
+                url: routes.updateShortObjectDescription.replace('__SONATA_OBJECT_ID__', objectId)
+            }).done(function (html) {
+                $widget.html(html);
+            });
+        }
+
+        /**
+         * Handles link clicks in the select dialog.
+         *
+         * If the user actually selected a list item, we close the dialog and update the related input.
+         * Otherwise we just fetch the url and repopulate the dialog.
+         *
+         * @param {jQuery.Event} event
+         * @returns {*}
+         */
+        function handleSelectDialogClick (event) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            var $target = $(event.currentTarget);
+            var $selected = $target.closest('.sonata-ba-list-field', dialog.$body);
+
+            // the user does not click on a row column
+            if (!$selected.length) {
+                dialog.setLoading();
+                return $.ajax({
+                    url: $target.attr('href'),
+                    dataType: 'html'
+                }).done(function (html) {
+                    dialog.setContent(html);
+                    setupListDialog(dialog);
+                });
+            }
+
+            dialog.hide();
+            updateShortObjectDescription($selected.attr('objectId'));
+        }
+
+        /**
+         * Handles form submissions in the select dialog.
+         *
+         * This usually means the list has been filtered, or the pager parameters modified,
+         * so we just submit the form via AJAX and load the HTML response.
+         *
+         * @param {jQuery.Event} event
+         */
+        function handleSelectDialogSubmit (event) {
+            event.preventDefault();
+            var $form = $(event.target);
+
+            dialog.setLoading();
+            $form.ajaxSubmit({
+                method: $form.attr('method'),
+                url: $form.attr('action'),
+                dataType: 'html',
+                data: {_xml_http_request: true},
+                success: function (html) {
+                    dialog.setContent(html);
+                    setupListDialog(dialog);
+                }
+            });
+        }
+
+        /**
+         * Installs our event handlers for the list dialog body.
+         *
+         * @param {Dialog} dialog
+         */
+        function setupListDialog (dialog) {
+            dialog.$body.find('a').on('click', handleSelectDialogClick);
+            dialog.$body.find('form').on('submit', handleSelectDialogSubmit);
+        }
+
+        /**
+         * The event handler for the select (list) button.
+         *
+         * @param {jQuery.Event} event
+         */
+        function handleSelectButtonClicked (event) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            var $link = $(event.currentTarget);
+
+            dialog.show();
+            $.ajax({
+                url: $link.attr('href'),
+                dataType: 'html'
+            }).done(function (html) {
+                dialog.setContent(html);
+                setupListDialog(dialog);
+            });
+        }
+
+        /**
+         * The inline event handler for the select (list) button.
+         *
+         * It is done this way for historical reasons, and should be refactored to use event delegation.
+         *
+         * @param {HTMLElement} link
+         * @returns {boolean}
+         */
+        window['SonataTypeModelListSelect_' + fieldId] = function (link) {
+            createDialog();
+            link.onclick = null;
+            $(link).on('click', handleSelectButtonClicked).trigger('click');
+
+            return false;
+        };
+
+        /**
+         * The event handler for the unlink (delete) button.
+         *
+         * @param {jQuery.Event} event
+         */
+        function handleUnlinkClicked (event) {
+            event.preventDefault();
+            var $field = getField();
+
+            if ($field.find('option').length) {
+                $field.attr('selectedIndex', '-1')
+                    .children('option:selected')
+                    .attr('selected', false);
+            }
+
+            updateShortObjectDescription('');
+        }
+
+        /**
+         * The inline event handler for the unlink (delete) button.
+         *
+         * It is done this way for historical reasons, and should be refactored to use event delegation.
+         *
+         * @param {HTMLElement} link
+         * @returns {boolean}
+         */
+        window['SonataTypeModelListUnlink_' + fieldId] = function (link) {
+            link.onclick = null;
+            $(link).on('click', handleUnlinkClicked).trigger('click');
+
+            return false;
+        };
+    {% endif %}
+
+}(jQuery, Admin));

--- a/Resources/views/Form/Type/sonata_type_collection.html.twig
+++ b/Resources/views/Form/Type/sonata_type_collection.html.twig
@@ -1,0 +1,76 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% set _field_description = sonata_admin.field_description %}
+{% set _association_admin = _field_description.associationAdmin %}
+
+{% set _display_btn_add = (
+    _association_admin.hasAccess('create')
+    and btn_add
+    and not (
+        _field_description.options.limit is defined
+        and form.children|length > _field_description.options.limit
+    )
+) %}
+
+
+<div id="field_container_{{ id }}" class="field-container">
+    <div id="field_widget_{{ id }}">
+        {% if sonata_admin.edit == 'inline' %}
+            {% if sonata_admin.inline == 'table' and form.children|length %}
+                {% include 'SonataAdminBundle:Form/Type/Collection:inline_table.html.twig' %}
+            {% elseif form.children|length %}
+                {% include 'SonataAdminBundle:Form/Type/Collection:inline_tabs.html.twig' %}
+            {% endif %}
+        {% else %}
+            {{ form_widget(form) }}
+        {% endif %}
+    </div>
+    {% if _display_btn_add %}
+        <div id="field_actions_{{ id }}" class="field-actions">
+            <a  href="{{ _association_admin.generateUrl(
+                    'create',
+                    _field_description.getOption('link_parameters', {})
+                ) }}"
+                onclick="return SonataTypeCollectionCreate_{{ id }}(this);"
+                class="btn btn-success btn-sm sonata-ba-action"
+                title="{{ btn_add|trans({}, btn_catalogue) }}"
+            >
+                <i class="fa fa-plus-circle"></i>
+                <span>{{ btn_add|trans({}, btn_catalogue) }}</span>
+            </a>
+        </div>
+        <script>
+            {% include 'SonataAdminBundle:Form/Type/Collection:create.js.twig' with {
+                id: id,
+                url: path(
+                    'sonata_admin_append_form_element',
+                    {
+                        code: sonata_admin.admin.root.code,
+                        elementId: id,
+                        objectId: sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
+                        uniqid: sonata_admin.admin.root.uniqid,
+                        subclass: app.request.query.get('subclass'),
+                    } + _field_description.getOption('link_parameters', {})
+                )
+            } only %}
+        </script>
+    {% endif %}
+    {% if _field_description.options.sortable|default %}
+        <script>
+            {% include 'SonataAdminBundle:Form/Type/Collection:sortable.js.twig' with {
+                id: id,
+                sort_field: _field_description.options.sortable,
+                table: sonata_admin.inline == 'table'
+            } only %}
+        </script>
+    {% endif %}
+</div>

--- a/Resources/views/Form/Type/sonata_type_model.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model.html.twig
@@ -1,0 +1,47 @@
+{% set _field_description = sonata_admin.field_description %}
+{% set _association_admin = _field_description.associationAdmin %}
+
+{% set _display_btn_add = (
+    _association_admin.hasAccess('create')
+    and btn_add
+    and not (
+        _field_description.options.limit is defined
+        and form.children|length > _field_description.options.limit
+    )
+) %}
+
+
+<div id="field_container_{{ id }}" class="field-container">
+    <div id="field_widget_{{ id }}" >
+        {{ form_widget(form) }}
+    </div>
+    {% if _display_btn_add %}
+        <div id="field_actions_{{ id }}" class="field-actions">
+            <a  href="{{ _association_admin.generateUrl(
+                    'create',
+                    _field_description.getOption('link_parameters', {})
+                ) }}"
+                onclick="return SonataTypeModelListCreate_{{ id }}(this);"
+                class="btn btn-success btn-sm sonata-ba-action"
+                title="{{ btn_add|trans({}, btn_catalogue) }}"
+            >
+                <i class="fa fa-plus-circle"></i>
+                <span>{{ btn_add|trans({}, btn_catalogue) }}</span>
+            </a>
+        </div>
+        {% include 'SonataAdminBundle:Form/Type/Model:dialog.html.twig' with {id: id} only %}
+        <script>
+            {% include 'SonataAdminBundle:Form/Type/Model:dialog.js.twig' with {
+                id: id,
+                label: _association_admin.label|trans({}, _association_admin.translationDomain),
+                retrieve_form_element: path('sonata_admin_retrieve_form_element', {
+                    elementId: id,
+                    subclass: sonata_admin.admin.getActiveSubclassCode(),
+                    objectId: sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
+                    uniqid: sonata_admin.admin.root.uniqid,
+                    code: sonata_admin.admin.root.code
+                })
+            } only %}
+        </script>
+    {% endif %}
+</div>

--- a/Resources/views/Form/Type/sonata_type_model_list.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_list.html.twig
@@ -1,0 +1,93 @@
+{% set _field_description = sonata_admin.field_description %}
+{% set _association_admin = _field_description.associationAdmin %}
+
+{% set _display_btn_list = _association_admin.hasAccess('list') and btn_list %}
+{% set _display_btn_create = _association_admin.hasAccess('create') and btn_add %}
+{% set _display_btn_delete = _association_admin.hasAccess('delete') and btn_delete %}
+
+<div id="field_container_{{ id }}" class="field-container">
+    <span id="field_widget_{{ id }}" class="field-short-description">
+        {% if _association_admin.id(sonata_admin.value) %}
+            {{ render(path('sonata_admin_short_object_information', {
+                code: _association_admin.code,
+                objectId: _association_admin.id(sonata_admin.value),
+                uniqid: _association_admin.uniqid,
+                linkParameters: _field_description.options.link_parameters
+            })) }}
+        {% elseif _field_description.options.placeholder|default %}
+            <span class="inner-field-short-description">
+                {{ _field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}
+            </span>
+        {% endif %}
+    </span>
+    <span id="field_actions_{{ id }}" class="field-actions">
+        <span class="btn-group">
+            {% if _display_btn_list %}
+                <a  href="{{ _association_admin.generateUrl('list') }}"
+                    onclick="return SonataTypeModelListSelect_{{ id }}(this);"
+                    class="btn btn-info btn-sm sonata-ba-action"
+                    title="{{ btn_list|trans({}, btn_catalogue) }}"
+                >
+                    <i class="fa fa-list"></i>
+                    <span>{{ btn_list|trans({}, btn_catalogue) }}</span>
+                </a>
+            {% endif %}
+
+            {% if _display_btn_create %}
+                <a  href="{{ _association_admin.generateUrl('create') }}"
+                    onclick="return SonataTypeModelListCreate_{{ id }}(this);"
+                    class="btn btn-success btn-sm sonata-ba-action"
+                    title="{{ btn_add|trans({}, btn_catalogue) }}"
+                >
+                    <i class="fa fa-plus-circle"></i>
+                    <span>{{ btn_add|trans({}, btn_catalogue) }}</span>
+                </a>
+            {% endif %}
+        </span>
+
+        <span class="btn-group">
+            {% if _display_btn_delete %}
+                <a  href="#"
+                    onclick="return SonataTypeModelListUnlink_{{ id }}(this);"
+                    class="btn btn-danger btn-sm sonata-ba-action"
+                    title="{{ btn_delete|trans({}, btn_catalogue) }}"
+                >
+                    <i class="fa fa-minus-circle"></i>
+                    <span>{{ btn_delete|trans({}, btn_catalogue) }}</span>
+                </a>
+            {% endif %}
+        </span>
+    </span>
+
+    <span style="display: none">
+        {#
+            An invalid/required input must be focusable for accessibility.
+            Since we need to completely hide the form (including for screen-readers),
+            we have to disable client-side validation.
+        #}
+        {{ form_widget(form, {required: false, attr: {novalidate: 'novalidate'}}) }}
+    </span>
+
+    {{ block('sonata_help') }}
+</div>
+
+{% include 'SonataAdminBundle:Form/Type/Model:dialog.html.twig' with {id: id} only %}
+<script>
+    {% include 'SonataAdminBundle:Form/Type/Model:dialog.js.twig' with {
+        id: id,
+        label: _association_admin.label|trans({}, _association_admin.translationDomain),
+        update_short_object_description: path('sonata_admin_short_object_information', {
+            objectId: '__SONATA_OBJECT_ID__',
+            uniqid: _association_admin.uniqid,
+            code: _association_admin.code,
+            linkParameters: _field_description.options.link_parameters
+        }),
+        retrieve_form_element: path('sonata_admin_retrieve_form_element', {
+            elementId: id,
+            subclass: sonata_admin.admin.getActiveSubclassCode(),
+            objectId: sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
+            uniqid: sonata_admin.admin.root.uniqid,
+            code: sonata_admin.admin.root.code
+        })
+    } only %}
+</script>

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -513,15 +513,7 @@ file that was distributed with this source code.
 
 {% block sonata_type_model_widget %}
     {% if not sonata_admin.field_description.hasAssociationAdmin %}
-        {% if sonata_admin.field_description.describesSingleValuedAssociation %}
-            {{ value|render_relation_element(sonata_admin.field_description) }}
-        {% elseif sonata_admin.field_description.describesCollectionValuedAssociation %}
-            {% for element in value %}
-                {{ element|render_relation_element(sonata_admin.field_description) }}
-            {% endfor %}
-        {% else %}
-            {{ block('choice_widget') }}
-        {% endif %}
+        {{ block('choice_widget') }}
     {% else %}
         {% include 'SonataAdminBundle:Form/Type:sonata_type_model.html.twig' %}
     {% endif %}
@@ -539,9 +531,7 @@ file that was distributed with this source code.
 
 
 {% block sonata_type_admin_widget %}
-    {% if not sonata_admin.field_description.hasAssociationAdmin %}
-        {{ value|render_relation_element(sonata_admin.field_description) }}
-    {% elseif sonata_admin.edit == 'inline' %}
+    {% if sonata_admin.edit == 'inline' %}
         {% for field_description in sonata_admin.field_description.associationAdmin.formFieldDescriptions %}
             {{ form_row(form.children[field_description.name]) }}
         {% endfor %}
@@ -556,11 +546,5 @@ file that was distributed with this source code.
 
 
 {% block sonata_type_collection_widget %}
-    {% if not sonata_admin.field_description.hasAssociationAdmin %}
-        {% for element in value %}
-            {{ element|render_relation_element(sonata_admin.field_description) }}
-        {% endfor %}
-    {% else %}
-        {% include 'SonataAdminBundle:Form/Type:sonata_type_collection.html.twig' %}
-    {% endif %}
+    {% include 'SonataAdminBundle:Form/Type:sonata_type_collection.html.twig' %}
 {% endblock %}

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -454,10 +454,6 @@ file that was distributed with this source code.
     {% endspaceless %}
 {% endblock %}
 
-{% block sonata_type_model_autocomplete_widget %}
-    {% include template %}
-{% endblock sonata_type_model_autocomplete_widget %}
-
 {% block sonata_type_choice_field_mask_widget %}
     {{ block('choice_widget') }}
     {% set main_form_name = id|slice(0, id|length - name|length) %}
@@ -506,4 +502,65 @@ file that was distributed with this source code.
             Admin.setup_sortable_select2(jQuery('#{{ id }}'), {{ form.vars.choices|json_encode|raw }});
         });
     </script>
+{% endblock %}
+
+
+{#
+    CRUD association widgets
+    -----------------------------------------------------------------------------------------------------------------
+#}
+
+
+{% block sonata_type_model_widget %}
+    {% if not sonata_admin.field_description.hasAssociationAdmin %}
+        {% if sonata_admin.field_description.describesSingleValuedAssociation %}
+            {{ value|render_relation_element(sonata_admin.field_description) }}
+        {% elseif sonata_admin.field_description.describesCollectionValuedAssociation %}
+            {% for element in value %}
+                {{ element|render_relation_element(sonata_admin.field_description) }}
+            {% endfor %}
+        {% else %}
+            {{ block('choice_widget') }}
+        {% endif %}
+    {% else %}
+        {% include 'SonataAdminBundle:Form/Type:sonata_type_model.html.twig' %}
+    {% endif %}
+{% endblock %}
+
+
+{% block sonata_type_model_list_widget %}
+    {% include 'SonataAdminBundle:Form/Type:sonata_type_model_list.html.twig' %}
+{% endblock %}
+
+
+{% block sonata_type_model_autocomplete_widget %}
+    {% include template %}
+{% endblock %}
+
+
+{% block sonata_type_admin_widget %}
+    {% if not sonata_admin.field_description.hasAssociationAdmin %}
+        {{ value|render_relation_element(sonata_admin.field_description) }}
+    {% elseif sonata_admin.edit == 'inline' %}
+        {% for field_description in sonata_admin.field_description.associationAdmin.formFieldDescriptions %}
+            {{ form_row(form.children[field_description.name]) }}
+        {% endfor %}
+    {% else %}
+        <div id="field_container_{{ id }}" class="field-container">
+            <div id="field_widget_{{ id }}">
+                {{ form_widget(form) }}
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}
+
+
+{% block sonata_type_collection_widget %}
+    {% if not sonata_admin.field_description.hasAssociationAdmin %}
+        {% for element in value %}
+            {{ element|render_relation_element(sonata_admin.field_description) }}
+        {% endfor %}
+    {% else %}
+        {% include 'SonataAdminBundle:Form/Type:sonata_type_collection.html.twig' %}
+    {% endif %}
 {% endblock %}

--- a/Tests/Builder/AbstractFormContractorTest.php
+++ b/Tests/Builder/AbstractFormContractorTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Builder;
+
+/**
+ * @author ju1ius <ju1ius@laposte.net>
+ */
+class AbstractFormContractorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $formType
+     * @param string $targetEntity
+     * @param string $associationType
+     * @param string $associationAdmin
+     * @param string $expectedException
+     *
+     * @dataProvider testFieldDescriptionValidationProvider
+     */
+    public function testFieldDescriptionValidation($formType, $targetEntity, $associationType, $associationAdmin, $expectedException)
+    {
+        $admin = $this->getMockBuilder('Sonata\AdminBundle\Admin\AdminInterface')->getMock();
+        $admin->method('getClass')->willReturn('Foo');
+
+        $fieldDescription = $this->getMockBuilder('Sonata\AdminBundle\Admin\FieldDescriptionInterface')->getMock();
+        $fieldDescription->method('getAdmin')->willReturn($admin);
+        $fieldDescription->method('getAssociationAdmin')->willReturn($associationAdmin);
+        $fieldDescription->method('getTargetEntity')->willReturn($targetEntity);
+        $isSingleAssociation = $associationType === 'single';
+        $fieldDescription->method('describesSingleValuedAssociation')->willReturn($isSingleAssociation);
+        $fieldDescription->method('describesCollectionValuedAssociation')->willReturn(!$isSingleAssociation);
+
+        $formContractor = $this->getMockForAbstractClass(
+            'Sonata\AdminBundle\Builder\AbstractFormContractor',
+            array(),
+            '',
+            false
+        );
+
+        $this->setExpectedException($expectedException);
+        $formContractor->getDefaultOptions($formType, $fieldDescription);
+    }
+
+    public function testFieldDescriptionValidationProvider()
+    {
+        return array(
+            // MissingTargetModelClassException
+            'AdminType, no target entity' => array(
+                'Sonata\AdminBundle\Form\Type\AdminType',
+                null,
+                'single',
+                'FooAdmin',
+                'Sonata\AdminBundle\Builder\Exception\MissingTargetModelClassException',
+            ),
+            'CollectionType, no target entity' => array(
+                'Sonata\CoreBundle\Form\Type\CollectionType',
+                null,
+                'collection',
+                'FooAdmin',
+                'Sonata\AdminBundle\Builder\Exception\MissingTargetModelClassException',
+            ),
+            'ModelType, no target entity' => array(
+                'Sonata\AdminBundle\Form\Type\ModelType',
+                null,
+                'single',
+                'FooAdmin',
+                'Sonata\AdminBundle\Builder\Exception\MissingTargetModelClassException',
+            ),
+            'ModelTypeList, no target entity' => array(
+                'Sonata\AdminBundle\Form\Type\ModelTypeList',
+                null,
+                'single',
+                'FooAdmin',
+                'Sonata\AdminBundle\Builder\Exception\MissingTargetModelClassException',
+            ),
+            'ModelHiddenType, no target entity' => array(
+                'Sonata\AdminBundle\Form\Type\ModelHiddenType',
+                null,
+                'single',
+                'FooAdmin',
+                'Sonata\AdminBundle\Builder\Exception\MissingTargetModelClassException',
+            ),
+            'ModelReferenceType, no target entity' => array(
+                'Sonata\AdminBundle\Form\Type\ModelReferenceType',
+                null,
+                'single',
+                'FooAdmin',
+                'Sonata\AdminBundle\Builder\Exception\MissingTargetModelClassException',
+            ),
+            'ModelAutocompleteType, no target entity' => array(
+                'Sonata\AdminBundle\Form\Type\ModelAutocompleteType',
+                null,
+                'single',
+                'FooAdmin',
+                'Sonata\AdminBundle\Builder\Exception\MissingTargetModelClassException',
+            ),
+            // UnhandledAssociationTypeException
+            'AdminType, collection-valued association' => array(
+                'Sonata\AdminBundle\Form\Type\AdminType',
+                'Foo',
+                'collection',
+                'FooAdmin',
+                'Sonata\AdminBundle\Builder\Exception\UnhandledAssociationTypeException',
+            ),
+            'ModelTypeList, collection-valued association' => array(
+                'Sonata\AdminBundle\Form\Type\ModelTypeList',
+                'Foo',
+                'collection',
+                'FooAdmin',
+                'Sonata\AdminBundle\Builder\Exception\UnhandledAssociationTypeException',
+            ),
+            'ModelHiddenType, collection-valued association' => array(
+                'Sonata\AdminBundle\Form\Type\ModelHiddenType',
+                'Foo',
+                'collection',
+                'FooAdmin',
+                'Sonata\AdminBundle\Builder\Exception\UnhandledAssociationTypeException',
+            ),
+            'ModelReferenceType, collection-valued association' => array(
+                'Sonata\AdminBundle\Form\Type\ModelReferenceType',
+                'Foo',
+                'collection',
+                'FooAdmin',
+                'Sonata\AdminBundle\Builder\Exception\UnhandledAssociationTypeException',
+            ),
+            'CollectionType, singled-valued association' => array(
+                'Sonata\CoreBundle\Form\Type\CollectionType',
+                'Foo',
+                'single',
+                'FooAdmin',
+                'Sonata\AdminBundle\Builder\Exception\UnhandledAssociationTypeException',
+            ),
+            // MissingAssociationAdminException
+            'AdminType, no associationAdmin' => array(
+                'Sonata\AdminBundle\Form\Type\AdminType',
+                'Foo',
+                'single',
+                null,
+                'Sonata\AdminBundle\Builder\Exception\MissingAssociationAdminException',
+            ),
+            'CollectionType, no associationAdmin' => array(
+                'Sonata\CoreBundle\Form\Type\CollectionType',
+                'Foo',
+                'collection',
+                null,
+                'Sonata\AdminBundle\Builder\Exception\MissingAssociationAdminException',
+            ),
+            'ModelTypeList, no associationAdmin' => array(
+                'Sonata\AdminBundle\Form\Type\ModelTypeList',
+                'Foo',
+                'single',
+                null,
+                'Sonata\AdminBundle\Builder\Exception\MissingAssociationAdminException',
+            ),
+            'ModelAutocompleteType, no associationAdmin' => array(
+                'Sonata\AdminBundle\Form\Type\ModelAutocompleteType',
+                'Foo',
+                'single',
+                null,
+                'Sonata\AdminBundle\Builder\Exception\MissingAssociationAdminException',
+            ),
+        );
+    }
+}

--- a/Tests/Fixtures/Admin/FieldDescription.php
+++ b/Tests/Fixtures/Admin/FieldDescription.php
@@ -56,4 +56,14 @@ class FieldDescription extends BaseFieldDescription
     {
         // TODO: Implement getValue() method.
     }
+
+    public function describesSingleValuedAssociation()
+    {
+        // TODO: Implement describesSingleValuedAssociation() method.
+    }
+
+    public function describesCollectionValuedAssociation()
+    {
+        // TODO: Implement describesCollectionValuedAssociation() method.
+    }
 }


### PR DESCRIPTION
I am targetting this branch, because there are BC breaks, in this one the related.

Fixes #2511 
## Changelog

``` markdown
### Added
- Added `FieldDescriptionInterface::describesAssociation`, `FieldDescriptionInterface::describesSingleValuedAssociation`, `FieldDescriptionInterface::describesCollectionValuedAssociation` to abstract the association mapping types.
- Added `BaseFieldDescription::describesAssociation`
- Added `AbstractFormContractor` base class to centralize association form option validation & defaults.
- Added association widgets blocks and templates
```
## Subject

See #3958 for the reasoning behind the new `FieldDescriptionInterface` methods.

Please see also the related PRs to the persistence bundles:
- [doctrine-orm-admin-bundle](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/596)
- [doctrine-mongodb-admin-bundle](https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/175)
- [doctrine-phpcr-admin-bundle](https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/395)
- sadly, propel-admin-bundle is stuck on sonata-admin 2.x so no Propel...
