### PR TITLE
Bugfix for batch checkbox not working if "icheck" is disabled

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -110,16 +110,22 @@ file that was distributed with this source code.
                                             <script>
                                                 {% block batch_javascript %}
                                                     jQuery(document).ready(function ($) {
-                                                        $('#list_batch_checkbox').on('ifChanged', function () {
-                                                            $(this)
+                                                        // Toggle individual checkboxes when the batch checkbox is changed
+                                                        $('#list_batch_checkbox').on('ifChanged change', function () {
+                                                            var checkboxes = $(this)
                                                                 .closest('table')
                                                                 .find('td.sonata-ba-list-field-batch input[type="checkbox"], div.sonata-ba-list-field-batch input[type="checkbox"]')
-                                                                .iCheck($(this).is(':checked') ? 'check' : 'uncheck')
                                                             ;
+                                                            if (window.SONATA_CONFIG.USE_ICHECK) {
+                                                                checkboxes.iCheck($(this).is(':checked') ? 'check' : 'uncheck');
+                                                            } else {
+                                                                checkboxes.prop('checked', this.checked);
+                                                            }
                                                         });
 
+                                                        // Add a CSS class to rows when they are selected
                                                         $('td.sonata-ba-list-field-batch input[type="checkbox"], div.sonata-ba-list-field-batch input[type="checkbox"]')
-                                                            .on('ifChanged', function () {
+                                                            .on('ifChanged change', function () {
                                                                 $(this)
                                                                     .closest('tr, div.sonata-ba-list-field-batch')
                                                                     .toggleClass('sonata-ba-list-row-selected', $(this).is(':checked'))


### PR DESCRIPTION
I am targetting the 3.x branch, because this is a bugfix.

## Changelog

```markdown
### Fixed
- The "batch" checkbox at the top of the list would not work when iCheck is disabled.
```

## Subject
When you disable iCheck (by putting "sonata_admin.options.use_icheck: false" in your configuration), the checkbox at the top of the list would not work anymore. This is due to the fact that currently only the "ifChanged" event from iCheck is handled, instead of the standard "change" event for checkboxes. This patch fixes this. Unfortunately, putting only the standard "change" event doesn't work either, because of this issue: https://github.com/fronteed/iCheck/issues/244, so we need to intercept both.

I also added documentation to the JavaScript code related to the patch.