### PR TITLE
Fixed wrong import in tests

### DIFF
--- a/Tests/Form/ChoiceList/ModelChoiceListTest.php
+++ b/Tests/Form/ChoiceList/ModelChoiceListTest.php
@@ -12,7 +12,7 @@
 namespace Sonata\AdminBundle\Tests\Form\ChoiceList;
 
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
-use Sonata\CoreBundle\Tests\Fixtures\Bundle\Entity\Foo;
+use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
 
 class ModelChoiceListTest extends \PHPUnit_Framework_TestCase
 {

--- a/Tests/Form/ChoiceList/ModelChoiceLoaderTest.php
+++ b/Tests/Form/ChoiceList/ModelChoiceLoaderTest.php
@@ -12,7 +12,7 @@
 namespace Sonata\AdminBundle\Tests\Form\ChoiceList;
 
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
-use Sonata\CoreBundle\Tests\Fixtures\Bundle\Entity\Foo;
+use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
 
 class ModelChoiceLoaderTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because…

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

The import path was wrong. This wouldn't work when we remove the tests from the autoloader (Refs https://github.com/sonata-project/SonataCoreBundle/pull/316).
