### PR TITLE
Fix bad class name for ModelListType

### DIFF
--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -269,7 +269,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
             'Sonata\\AdminBundle\\Form\\Type\\Filter\\NumberType',
             'Sonata\\AdminBundle\\Form\\Type\\ModelReferenceType',
             'Sonata\\AdminBundle\\Form\\Type\\ModelType',
-            'Sonata\\AdminBundle\\Form\\Type\\ModelTypeList',
+            'Sonata\\AdminBundle\\Form\\Type\\ModelListType',
             'Sonata\\AdminBundle\\Guesser\\TypeGuesserChain',
             'Sonata\\AdminBundle\\Guesser\\TypeGuesserInterface',
             'Sonata\\AdminBundle\\Model\\AuditManager',

--- a/Form/Type/ModelListType.php
+++ b/Form/Type/ModelListType.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Form\Type;
+
+use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * This type is used to render an hidden input text and 3 links
+ *   - an add form modal
+ *   - a list modal to select the targeted entities
+ *   - a clear selection link.
+ */
+class ModelListType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->resetViewTransformers()
+            ->addViewTransformer(new ModelToIdTransformer($options['model_manager'], $options['class']));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        if (isset($view->vars['sonata_admin'])) {
+            // set the correct edit mode
+            $view->vars['sonata_admin']['edit'] = 'list';
+        }
+        $view->vars['btn_add'] = $options['btn_add'];
+        $view->vars['btn_list'] = $options['btn_list'];
+        $view->vars['btn_delete'] = $options['btn_delete'];
+        $view->vars['btn_catalogue'] = $options['btn_catalogue'];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @todo Remove it when bumping requirements to SF 2.7+
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'model_manager' => null,
+            'class' => null,
+            'btn_add' => 'link_add',
+            'btn_list' => 'link_list',
+            'btn_delete' => 'link_delete',
+            'btn_catalogue' => 'SonataAdminBundle',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return 'text';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @todo Remove when dropping Symfony <2.8 support
+     */
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'sonata_type_model_list';
+    }
+}

--- a/Form/Type/ModelListType.php
+++ b/Form/Type/ModelListType.php
@@ -20,10 +20,24 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
- * This type is used to render an hidden input text and 3 links
- *   - an add form modal
- *   - a list modal to select the targeted entities
- *   - a clear selection link.
+ * This type can be used to select one associated model from a list.
+ *
+ * The associated model must be in a single-valued association relationship (e.g many-to-one)
+ * with the model currently edited in the parent form.
+ * The associated model must have an admin class registered.
+ *
+ * The selected model's identifier is rendered in an hidden input.
+ *
+ * When a model is selected, a short description is displayed by the widget.
+ * This description can be customized by overriding the associated admin's
+ * `short_object_description` template and/or overriding it's `toString` method.
+ *
+ * The widget also provides three action buttons:
+ *  - a button to open the associated admin list view in a dialog,
+ *    in order to select an associated model.
+ *  - a button to open the associated admin create form in a dialog,
+ *    in order to create and select an associated model.
+ *  - a button to unlink the associated model, if any.
  */
 class ModelListType extends AbstractType
 {

--- a/Form/Type/ModelTypeList.php
+++ b/Form/Type/ModelTypeList.php
@@ -11,95 +11,20 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
-use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
-use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+@trigger_error(
+    'The '.__NAMESPACE__.'\ModelTypeList class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use '.__NAMESPACE__.'\ModelListType instead.',
+    E_USER_DEPRECATED
+);
 
 /**
  * This type is used to render an hidden input text and 3 links
  *   - an add form modal
  *   - a list modal to select the targeted entities
  *   - a clear selection link.
+ *
+ * @deprecated since version 3.x, to be removed in 4.0. Use ModelListType instead
  */
-class ModelTypeList extends AbstractType
+class ModelTypeList extends ModelListType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
-    {
-        $builder
-            ->resetViewTransformers()
-            ->addViewTransformer(new ModelToIdTransformer($options['model_manager'], $options['class']));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function buildView(FormView $view, FormInterface $form, array $options)
-    {
-        if (isset($view->vars['sonata_admin'])) {
-            // set the correct edit mode
-            $view->vars['sonata_admin']['edit'] = 'list';
-        }
-        $view->vars['btn_add'] = $options['btn_add'];
-        $view->vars['btn_list'] = $options['btn_list'];
-        $view->vars['btn_delete'] = $options['btn_delete'];
-        $view->vars['btn_catalogue'] = $options['btn_catalogue'];
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @todo Remove it when bumping requirements to SF 2.7+
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function configureOptions(OptionsResolver $resolver)
-    {
-        $resolver->setDefaults(array(
-            'model_manager' => null,
-            'class' => null,
-            'btn_add' => 'link_add',
-            'btn_list' => 'link_list',
-            'btn_delete' => 'link_delete',
-            'btn_catalogue' => 'SonataAdminBundle',
-        ));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getParent()
-    {
-        return 'text';
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @todo Remove when dropping Symfony <2.8 support
-     */
-    public function getName()
-    {
-        return $this->getBlockPrefix();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
-    {
-        return 'sonata_type_model_list';
-    }
 }

--- a/Tests/Form/Type/ModelTypeListTest.php
+++ b/Tests/Form/Type/ModelTypeListTest.php
@@ -15,6 +15,11 @@ use Sonata\AdminBundle\Form\Type\ModelTypeList;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @group legacy
+ *
+ * NEXT_MAJOR: Change test class name and content according to the renaming.
+ */
 class ModelTypeListTest extends TypeTestCase
 {
     public function testGetDefaultOptions()

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,12 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated ModelTypeList for rename
+
+The `Sonata\AdminBundle\Form\Type\ModelTypeList` class is now deprecated.
+
+Use `Sonata\AdminBundle\Form\Type\ModelListType` instead.
+
 UPGRADE FROM 3.2 to 3.3
 =======================
 


### PR DESCRIPTION
I am targetting this branch, because this is a deprecation.

## Changelog

```markdown
### Deprecated
- The `Sonata\AdminBundle\Form\Type\ModelTypeList` is deprecated for `ModelListType`
```

## To do

- [x] Add an upgrade note

## Subject

All form type should finish by `Type`. This one is a mistake.