### PR TITLE
Fixed route caching bug

### DIFF
--- a/Route/DefaultRouteGenerator.php
+++ b/Route/DefaultRouteGenerator.php
@@ -137,6 +137,9 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
      */
     private function getCode(AdminInterface $admin, $name)
     {
+        $this->loaded = array();
+        $this->caches = array();
+
         $this->loadCache($admin);
 
         if ($admin->isChild()) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed caching bug in the route generator
```


## Subject

When you have two admins with a parent child relation and a show and edit action, you got different links in the tab menu.

viewing an edit action: `/admin/core23/invoice/invoice/10/sending/list`
viewing a show action: `/admin/core23/invoice/sending/list?id=10`

It looks like the `show` action is ignoring the parent prefix.

## Steps to reproduce

```php
class InvoiceAdmin extends AbstractAdmin {
	// ...

    /**
     * {@inheritdoc}
     */
    protected function configureTabMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
    {
        if (!$childAdmin && !in_array($action, array('edit'))) {
            return;
        }

        $admin = $this->isChild() ? $this->getParent() : $this;

        $id = $admin->getRequest()->get('id');

        $menu->addChild($this->trans('sidemenu.link_list_sendings'), array(
            'uri' => $admin->generateUrl('core23.invoice.admin.sending.list', array(
                'id' => $id,
            )),
        ));
    }
}
```

```php
class SendingAdmin extends AbstractAdmin {
    protected $parentAssociationMapping = 'invoice';

    // ...
}
```

**admin.xml**
```xml
        <service id="core23.invoice.admin.invoice" class="Core23\InvoiceBundle\Admin\InvoiceAdmin">
            <tag name="sonata.admin" manager_type="orm" group="core23_invoice" label="invoice" label_catalogue="%core23.invoice.admin.translation_domain%"
                 label_translator_strategy="sonata.admin.label.strategy.underscore" />
            <argument />
            <argument>%core23.invoice.manager.invoice.entity%</argument>
            <argument>%core23.invoice.admin.invoice.controller%</argument>

            <call method="addChild">
                <argument type="service" id="core23.invoice.admin.sending" />
            </call>
        </service>

        <service id="core23.invoice.admin.sending" class="Core23\InvoiceBundle\Admin\SendingAdmin">
            <tag name="sonata.admin" manager_type="orm" group="core23_invoice" label="sending" label_catalogue="%core23.invoice.admin.translation_domain%"
                 label_translator_strategy="sonata.admin.label.strategy.underscore" show_in_dashboard="false" />
            <argument />
            <argument>%core23.invoice.manager.sending.entity%</argument>
            <argument>%core23.invoice.admin.sending.controller%</argument>
        </service>
```
