### PR TITLE
Remove ModelAutocompleteType::getParent override

### DIFF
--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -153,14 +153,6 @@ class ModelAutocompleteType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
-    {
-        return 'form';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getBlockPrefix()
     {
         return 'sonata_type_model_autocomplete';


### PR DESCRIPTION
I am targetting this branch, because it's a code patch.

## Changelog
```markdown
### Removed
- Removed useless `ModelAutocompleteType::getParent` override
```

## Subject

This override is useless because it's the default behavior of `Symfony\Component\Form\AbstractType`.

Ref: https://github.com/symfony/symfony/blob/v2.3.42/src/Symfony/Component/Form/AbstractType.php#L52-L55