### PR TITLE
Remove read_only option definition from ModelAutocompleteType

### DIFF
--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -41,7 +41,12 @@ class ModelAutocompleteType extends AbstractType
         $builder->setAttribute('minimum_input_length', $options['minimum_input_length']);
         $builder->setAttribute('items_per_page', $options['items_per_page']);
         $builder->setAttribute('req_param_name_page_number', $options['req_param_name_page_number']);
-        $builder->setAttribute('disabled', $options['disabled'] || $options['read_only']);
+        $builder->setAttribute(
+            'disabled',
+            $options['disabled']
+            // NEXT_MAJOR: Remove this when bumping Symfony constraint to 2.8+
+            || (array_key_exists('read_only', $options) && $options['read_only'])
+        );
         $builder->setAttribute('to_string_callback', $options['to_string_callback']);
 
         if ($options['multiple']) {
@@ -65,7 +70,6 @@ class ModelAutocompleteType extends AbstractType
         $view->vars['minimum_input_length'] = $options['minimum_input_length'];
         $view->vars['items_per_page'] = $options['items_per_page'];
         $view->vars['width'] = $options['width'];
-        $view->vars['read_only'] = $options['read_only'];
 
         // ajax parameters
         $view->vars['url'] = $options['url'];
@@ -119,7 +123,6 @@ class ModelAutocompleteType extends AbstractType
             'multiple' => false,
             'width' => '',
             'context' => '',
-            'read_only' => false,
 
             'placeholder' => '',
             'minimum_input_length' => 3, //minimum 3 chars should be typed to load ajax data

--- a/Tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/Tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -46,7 +46,6 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $this->assertSame(false, $options['cache']);
         $this->assertSame('', $options['width']);
         $this->assertFalse($options['dropdown_auto_width']);
-        $this->assertFalse($options['read_only']);
 
         $this->assertSame('', $options['url']);
         $this->assertSame(array('name' => 'sonata_admin_retrieve_autocomplete_items', 'parameters' => array()), $options['route']);


### PR DESCRIPTION
I am targetting this branch, because it's a deprecation bugfix.
## Changelog

```markdown
### Removed
- Removed useless `read_only` option definition from `ModelAutocompleteType`
```

## Subject

This option is already provided by Symfony since v2.3.

Ref: http://symfony.com/doc/2.3/reference/forms/types/form.html#read-only

It's deprecated since v2.8 and removed since v3.0.

It has to be removed on next major.

cc @pulzarraider @axzx