### PR TITLE
Fixed missing tab translation

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1359,6 +1359,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
 
         $menu = $this->menuFactory->createItem('root');
         $menu->setChildrenAttribute('class', 'nav navbar-nav');
+        $menu->setExtra('translation_domain', $this->translationDomain);
 
         // Prevents BC break with KnpMenuBundle v1.x
         if (method_exists($menu, 'setCurrentUri')) {

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1526,6 +1526,31 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($admin->getSubject());
     }
 
+    public function testGetSideMenu()
+    {
+        $item = $this->getMock('Knp\Menu\ItemInterface');
+        $item
+            ->expects($this->once())
+            ->method('setChildrenAttribute')
+            ->with('class', 'nav navbar-nav');
+        $item
+            ->expects($this->once())
+            ->method('setExtra')
+            ->with('translation_domain', 'foo_bar_baz');
+
+        $menuFactory = $this->getMock('Knp\Menu\FactoryInterface');
+        $menuFactory
+            ->expects($this->once())
+            ->method('createItem')
+            ->will($this->returnValue($item));
+
+        $modelAdmin = new ModelAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'SonataFooBundle:ModelAdmin');
+        $modelAdmin->setMenuFactory($menuFactory);
+        $modelAdmin->setTranslationDomain('foo_bar_baz');
+
+        $modelAdmin->getSideMenu('foo');
+    }
+
     /**
      * @return array
      */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because…

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #2883, #2946

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Ignoring `translation_domain` in tab menu
```

## Subject

The `translation_domain` of the admin was ignored when rendering a tab menu defined under `configureTabMenu`. The default domain `messages` was used instead.

Before
![bildschirmfoto 2016-07-01 um 23 11 21](https://cloud.githubusercontent.com/assets/3440437/16534655/becea1d6-3fe1-11e6-9f89-a580ca80595b.PNG)

After

![bildschirmfoto 2016-07-01 um 23 11 10](https://cloud.githubusercontent.com/assets/3440437/16534654/becbede2-3fe1-11e6-947e-729c152337fa.PNG)
