### PR TITLE
Make it compatible with both Select2 v3 and v4

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -56,7 +56,7 @@ var Admin = {
         });
     },
     setup_select2: function(subject) {
-        if (window.SONATA_CONFIG && window.SONATA_CONFIG.USE_SELECT2 && window.Select2) {
+        if (window.SONATA_CONFIG && window.SONATA_CONFIG.USE_SELECT2) {
             Admin.log('[core|setup_select2] configure Select2 on', subject);
 
             jQuery('select:not([data-sonata-select2="false"])', subject).each(function() {
@@ -74,7 +74,9 @@ var Admin = {
 
                 select.select2({
                     width: function(){
-                        return Admin.get_select2_width(this.element);
+                        // Select2 v3 and v4 BC. If window.Select2 is defined, then the v3 is installed.
+                        // NEXT_MAJOR: Remove Select2 v3 support.
+                        return Admin.get_select2_width(window.Select2 ? this.element : jQuery(this));
                     },
                     dropdownAutoWidth: true,
                     minimumResultsForSearch: 10,
@@ -446,7 +448,9 @@ var Admin = {
 
         subject.select2({
             width: function(){
-                return Admin.get_select2_width(this.element);
+                // Select2 v3 and v4 BC. If window.Select2 is defined, then the v3 is installed.
+                // NEXT_MAJOR: Remove Select2 v3 support.
+                return Admin.get_select2_width(window.Select2 ? this.element : jQuery(this));
             },
             dropdownAutoWidth: true,
             data: transformedData,


### PR DESCRIPTION
I am targetting this branch, because this is BC.

## Changelog

```markdown
### Added
- Support for select2 v4 (`select2.full.js` file is needed)
```

## Subject

Because changing Select2 vendor version is BC break for our case, I propose an alternative waiting #2795 to be updated and merged for next major.

The BC trick between Select2 v3 and v4 is quite simple, so let add this to make admin-bundle compatible with both.

With that, user can upgrade Select2 vendor manually without waiting the next major release of admin-bundle.