### PR TITLE
Test if read_only is defined on the form view

### DIFF
--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -65,7 +65,7 @@ file that was distributed with this source code.
                                 {% elseif admin_code %}
                                     'admin_code':  '{{ admin_code }}',
                                 {% endif %}
-                                
+
                                  // subclass
                                 {% if app.request.query.get('subclass') %}
                                     'subclass': '{{ app.request.query.get('subclass') }}',

--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 {% spaceless %}
 
     <input type="text" id="{{ id }}_autocomplete_input" value=""
-        {%- if read_only %} readonly="readonly"{% endif -%}
+        {%- if read_only is defined and read_only %} readonly="readonly"{% endif -%}
         {%- if disabled %} disabled="disabled"{% endif -%}
         {%- if required %} required="required"{% endif %}
     />
@@ -34,7 +34,7 @@ file that was distributed with this source code.
                 placeholder: '{{ placeholder ?: allowClearPlaceholder }}', // allowClear needs placeholder to work properly
                 allowClear: {{ required ? 'false' : 'true' }},
                 enable: {{ disabled ? 'false' : 'true' }},
-                readonly: {{ read_only ? 'true' : 'false' }},
+                readonly: {{ read_only is defined and read_only or attr.readonly is defined and attr.readonly ? 'true' : 'false' }},
                 minimumInputLength: {{ minimum_input_length }},
                 multiple: {{ multiple ? 'true' : 'false' }},
                 width: '{{ width }}',


### PR DESCRIPTION
I am targetting this branch, because this is a bugfix.

Fixes #3996

## Changelog

```markdown
### Fixed
- Not working `read_only` option on Twig with Symfony 3
```

## Subject

This option does not exist anymore on Symfony 3.0+

@qbbr Could you please test this PR and confirm this solve your issue?