### PR TITLE
Fixed wrong imports in tests

### DIFF
--- a/Tests/Block/AdminListBlockServiceTest.php
+++ b/Tests/Block/AdminListBlockServiceTest.php
@@ -13,12 +13,13 @@ namespace Sonata\AdminBundle\Tests\Block;
 
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Block\AdminListBlockService;
-use Sonata\BlockBundle\Tests\Block\AbstractBlockServiceTest;
+use Sonata\AdminBundle\Tests\Fixtures\Block\FakeBlockService;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-class AdminListBlockServiceTest extends AbstractBlockServiceTest
+class AdminListBlockServiceTest extends AbstractBlockServiceTestCase
 {
     /**
      * @var Pool

--- a/Tests/Block/AdminSearchBlockServiceTest.php
+++ b/Tests/Block/AdminSearchBlockServiceTest.php
@@ -14,12 +14,12 @@ namespace Sonata\AdminBundle\Tests\Block;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Block\AdminSearchBlockService;
 use Sonata\AdminBundle\Search\SearchHandler;
-use Sonata\BlockBundle\Tests\Block\AbstractBlockServiceTest;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-class AdminSearchBlockServiceTest extends AbstractBlockServiceTest
+class AdminSearchBlockServiceTest extends AbstractBlockServiceTestCase
 {
     /**
      * @var Pool

--- a/Tests/Block/AdminStatsBlockServiceTest.php
+++ b/Tests/Block/AdminStatsBlockServiceTest.php
@@ -13,12 +13,12 @@ namespace Sonata\AdminBundle\Tests\Block;
 
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Block\AdminStatsBlockService;
-use Sonata\BlockBundle\Tests\Block\AbstractBlockServiceTest;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-class AdminStatsBlockServiceTest extends AbstractBlockServiceTest
+class AdminStatsBlockServiceTest extends AbstractBlockServiceTestCase
 {
     /**
      * @var Pool

--- a/Tests/Fixtures/Block/FakeBlockService.php
+++ b/Tests/Fixtures/Block/FakeBlockService.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\AdminBundle\Tests\Block;
+namespace Sonata\AdminBundle\Tests\Fixtures\Block;
 
 use Sonata\AdminBundle\Block\AdminListBlockService;
 use Symfony\Component\OptionsResolver\OptionsResolver;

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/common": "^2.2",
         "doctrine/inflector": "^1.0",
         "knplabs/knp-menu-bundle": "^2.1.1",
-        "sonata-project/block-bundle": "^3.0",
+        "sonata-project/block-bundle": "^3.1.1",
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/exporter": "^1.0",
         "symfony/class-loader": "^2.3 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a fix for the unit tests in the stable branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- unit tests use the correct namespace in imports.
```

## Subject

This fixes the imports in the test cases. The sub namespace `Tests` isn't public anymore.

