### PR TITLE
Bug: XSS vulnerability

### DIFF
--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -88,6 +88,8 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
                 )
             );
 
+            $menu->setExtra('safe_label', false);
+
             return $this->buildBreadcrumbs($childAdmin, $action, $menu);
         }
 

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -142,7 +142,13 @@ file that was distributed with this source code.
                                                         {% if not loop.last  %}
                                                             <li>
                                                                 {% if menu.uri is not empty %}
-                                                                    <a href="{{ menu.uri }}">{{ menu.label|raw }}</a>
+                                                                    <a href="{{ menu.uri }}">
+                                                                        {% if menu.extra('safe_label', true) %}
+                                                                            {{- menu.label|raw -}}
+                                                                        {% else %}
+                                                                            {{- menu.label -}}
+                                                                        {% endif %}
+                                                                    </a>
                                                                 {% else %}
                                                                     {{ menu.label }}
                                                                 {% endif %}

--- a/Tests/Admin/BreadcrumbsBuilderTest.php
+++ b/Tests/Admin/BreadcrumbsBuilderTest.php
@@ -370,6 +370,7 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         $adminSubjectMenu->addChild('Ma classe fille', array(
             'uri' => '/myadmin/my-object/mychildadmin/list',
         ))->shouldBeCalled()->willReturn($childMenu->reveal());
+        $adminSubjectMenu->setExtra('safe_label', false)->willReturn($childMenu);
 
         $childMenu->addChild('My subject')
             ->shouldBeCalled()->willReturn($leafMenu->reveal());
@@ -482,7 +483,9 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         $menu->addChild('My subject')->willReturn($menu);
         $menu->addChild('My subject', array('uri' => null))->willReturn($menu);
         $menu->addChild('Ma classe fille', array('uri' => null))->willReturn($menu);
+        $menu->setExtra('safe_label', false)->willReturn($menu);
         $menu->addChild('Mon action', array())->willReturn($menu);
+
 
         $breadcrumbsBuilder->buildBreadCrumbs($admin->reveal(), $action);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is a bug fix



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

```markdown
### Fixed
- XSS Vulnerability in breadcrumbs
```

## Subject

<!-- Describe your Pull Request content here -->

Fix {{ menu.label }} instead of {{menu.label | raw}}

This fixes breadcrumbs xss vulnerability in Sonata Admin Bundle