### PR TITLE
Hide filters with a default value

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1055,6 +1055,23 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     /**
      * {@inheritdoc}
      */
+    public function isDefaultFilterValue($name)
+    {
+        $filter = $this->getFilterParameters();
+
+        if (!array_key_exists($name, $filter)) {
+            return false;
+        }
+
+        $default = array_key_exists($name, $this->datagridValues) ? $this->datagridValues[$name]['value'] : null;
+        $value = $filter[$name]['value'];
+
+        return $value == $default;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function generateObjectUrl($name, $object, array $parameters = array(), $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
         $parameters['id'] = $this->getUrlsafeIdentifier($object);

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -238,13 +238,13 @@ interface AdminInterface
     /**
      * @return Request
      *
-     * @throws \RuntimeException if no request is set.
+     * @throws \RuntimeException if no request is set
      */
     public function getRequest();
 
     /**
      * @return bool true if a request object is linked to this Admin, false
-     *              otherwise.
+     *              otherwise
      */
     public function hasRequest();
 
@@ -338,6 +338,15 @@ interface AdminInterface
      * @return bool
      */
     public function isCurrentRoute($name, $adminCode = null);
+
+    /**
+     * Checks if the filter matches the default value.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function isDefaultFilterValue($name);
 
     /**
      * Returns true if the admin has a FieldDescription with the given $name.

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -209,9 +209,10 @@ file that was distributed with this source code.
 
                 <ul class="dropdown-menu" role="menu">
                     {% for filter in admin.datagrid.filters if (filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null) %}
+                        {% set filterVisible = ((filter.isActive() or filter.options['show_filter']) and not admin.isDefaultFilterValue(filter.formName]) %}
                         <li>
                             <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
-                                <i class="fa {{ (filter.isActive() or filter.options['show_filter']) ? 'fa-check-square-o' : 'fa-square-o' }}"></i>{{ admin.trans(filter.label, {}, filter.translationDomain) }}
+                                <i class="fa {{ filterVisible ? 'fa-check-square-o' : 'fa-square-o' }}"></i>{{ admin.trans(filter.label, {}, filter.translationDomain) }}
                             </a>
                         </li>
                     {% endfor %}
@@ -235,7 +236,8 @@ file that was distributed with this source code.
                             <div class="col-sm-9">
                                 {% set withAdvancedFilter = false %}
                                 {% for filter in admin.datagrid.filters %}
-                                    <div class="form-group {% block sonata_list_filter_group_class %}{% endblock %}" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ (filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null) ? 'true' : 'false' }}" style="display: {% if (filter.isActive() and filter.options['show_filter'] is null) or (filter.options['show_filter'] is same as(true)) %}block{% else %}none{% endif %}">
+                                    {% set filter_active = (filter.isActive() and filter.options['show_filter'] is null) or (filter.options['show_filter'] is same as(true)) %}
+                                    <div class="form-group {% block sonata_list_filter_group_class %}{% endblock %}" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ (filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null) ? 'true' : 'false' }}" style="display: {% if filter_active %}block{% else %}none{% endif %}">
                                         {% if filter.label is not same as(false) %}
                                             <label for="{{ form.children[filter.formName].children['value'].vars.id }}" class="col-sm-3 control-label">{{ admin.trans(filter.label, {}, filter.translationDomain) }}</label>
                                         {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this changes existing UI behavior.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Filters set in `AbstractAdmin::$datagridValues` are hidden by default
```

## Subject

If you set a filter to a default value, the filter is always shown. This PR changes this behavior, so filters that matches the default value are now hidden.

Example code
```php
class FooAdmin extends AbstractAdmin 
{
    protected $datagridValues = array(
        'property' => 'default value',
    );
}
```

