### PR TITLE
Add breadcrumbs dropdowns

### DIFF
--- a/src/Resources/public/css/styles.css
+++ b/src/Resources/public/css/styles.css
@@ -170,6 +170,25 @@ body > .header .logo {
     background-color: #f5f5f5;
 }
 
+.navbar-top-links.breadcrumb .dropdown-menu {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    margin-left: 5px;
+    margin-top: 0; /* remove the gap so it doesn't close */
+}
+
+.navbar-top-links.breadcrumb .dropdown:hover .dropdown-menu {
+    display: block;
+}
+
+.navbar-top-links.breadcrumb .dropdown-menu > li > a > .glyphicon,
+.navbar-top-links.breadcrumb .dropdown-menu > li > a > .fa,
+.navbar-top-links.breadcrumb .dropdown-menu > li > a > .ion {
+    width: 14px;
+    text-align: center;
+    margin-right: 5px;
+}
+
 .navbar-top-links .dropdown-menu li {
     display: block;
 }
@@ -181,6 +200,7 @@ body > .header .logo {
 .navbar-top-links .dropdown-menu li a {
     padding: 3px 20px;
     min-height: 0;
+    display: block;
 }
 
 .navbar-top-links .dropdown-menu li a div {

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -156,29 +156,31 @@ file that was distributed with this source code.
                                             {% if _breadcrumb is empty %}
                                                 {% if action is defined %}
                                                     {% for menu in breadcrumbs_builder.breadcrumbs(admin, action) %}
-                                                        {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
-                                                        {%- set label = menu.label -%}
-                                                        {%- if translation_domain is not same as(false) -%}
-                                                            {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
-                                                        {%- endif -%}
+                                                        <li class="{% if menu.hasChildren %}dropdown{% endif %} {% if loop.last %}active{% endif %}">
+                                                            {% if menu.hasChildren %}
+                                                                <a href="{{ menu.uri|default('#') }}">
+                                                                    {{ menu.label|raw }}
+                                                                    <b class="caret"></b>
+                                                                </a>
+                                                            {% elseif menu.uri is not empty %}
+                                                                <a href="{{ menu.uri }}">{{ menu.label|raw }}</a>
+                                                            {% else %}
+                                                                <span>{{ menu.label }}</span>
+                                                            {% endif %}
 
-                                                        {% if not loop.last %}
-                                                            <li>
-                                                                {% if menu.uri is not empty %}
-                                                                    <a href="{{ menu.uri }}">
-                                                                        {% if menu.extra('safe_label', true) %}
-                                                                            {{- label|raw -}}
-                                                                        {% else %}
-                                                                            {{- label -}}
-                                                                        {% endif %}
-                                                                    </a>
-                                                                {% else %}
-                                                                    <span>{{ label }}</span>
-                                                                {% endif %}
-                                                            </li>
-                                                        {% else %}
-                                                            <li class="active"><span>{{ label|truncate(100) }}</span></li>
-                                                        {% endif %}
+                                                            {% if menu.hasChildren %}
+                                                                <ul class="dropdown-menu">
+                                                                    {% for childMenu in menu.children %}
+                                                                        <li>
+                                                                            <a href="{{ childMenu.uri }}">
+                                                                                <i class="{{ childMenu.extra('icon', 'fa fa-angle-right') }}"></i>
+                                                                                {{ childMenu.label }}
+                                                                            </a>
+                                                                        </li>
+                                                                    {% endfor %}
+                                                                </ul>
+                                                            {% endif %}
+                                                        </li>
                                                     {% endfor %}
                                                 {% endif %}
                                             {% else %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is a new feature with BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rebase of #3258 
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Added dropdowns to the breadcrumb menu
```
## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
- [ ] Update the tests
- [ ] Update the documentation
## Subject

This PR adds dropdowns in breadcrumbs, so each breadcrumb element gets (if necessary) a dropdown which contains its corresponding action links, so it's easier to find the one you need. 

![e8e23108-611c-11e5-8eaa-eb1499de0418](https://cloud.githubusercontent.com/assets/3440437/17149659/8a549ed0-536c-11e6-8988-098c5ada86a8.gif)
