### PR TITLE
Handle Symfony BC for Datagrid hidden types

### DIFF
--- a/Datagrid/Datagrid.php
+++ b/Datagrid/Datagrid.php
@@ -126,7 +126,12 @@ class Datagrid implements DatagridInterface
             $this->formBuilder->add($filter->getFormName(), $type, $options);
         }
 
-        $this->formBuilder->add('_sort_by', 'hidden');
+        // NEXT_MAJOR: Remove BC trick when bumping Symfony requirement to 2.8+
+        $hiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+            : 'hidden';
+
+        $this->formBuilder->add('_sort_by', $hiddenType);
         $this->formBuilder->get('_sort_by')->addViewTransformer(new CallbackTransformer(
             function ($value) {
                 return $value;
@@ -136,9 +141,9 @@ class Datagrid implements DatagridInterface
             }
         ));
 
-        $this->formBuilder->add('_sort_order', 'hidden');
-        $this->formBuilder->add('_page', 'hidden');
-        $this->formBuilder->add('_per_page', 'hidden');
+        $this->formBuilder->add('_sort_order', $hiddenType);
+        $this->formBuilder->add('_page', $hiddenType);
+        $this->formBuilder->add('_per_page', $hiddenType);
 
         $this->form = $this->formBuilder->getForm();
         $this->form->submit($this->values);


### PR DESCRIPTION
I am targetting this branch, because it's a BC bugfix.

## Changelog

```markdown
### Fixed
- Handle Symfony BC for Datagrid hidden types
```

## Subject

Use `HiddenType` class instead of `hidden` string for Symfony 2.8+.
