### PR TITLE
Deprecate exporter class and service

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -555,6 +555,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
 
     /**
      * {@inheritdoc}
+     *
+     * NEXT_MAJOR: return null to indicate no override
      */
     public function getExportFormats()
     {

--- a/Bridge/Exporter/AdminExporter.php
+++ b/Bridge/Exporter/AdminExporter.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Bridge\Exporter;
+
+use Exporter\Exporter;
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Grégoire Paris <postmaster@greg0ire.fr>
+ */
+final class AdminExporter
+{
+    /**
+     * @var Exporter service from the exporter bundle
+     */
+    private $exporter;
+
+    /**
+     * @param Exporter will be used to get global settings
+     */
+    public function __construct(Exporter $exporter)
+    {
+        $this->exporter = $exporter;
+    }
+
+    /**
+     * Queries an admin for its default export formats, and falls back on global settings.
+     *
+     * @param AdminInterface $admin the current admin object
+     *
+     * @return string[] an array of formats
+     */
+    public function getAvailableFormats(AdminInterface $admin)
+    {
+        $adminExportFormats = $admin->getExportFormats();
+
+        // NEXT_MAJOR : compare with null
+        if ($adminExportFormats != array('json', 'xml', 'csv', 'xls')) {
+            return $adminExportFormats;
+        }
+
+        return $this->exporter->getAvailableFormats();
+    }
+
+    /**
+     * Builds an export filename from the class associated with the provided admin,
+     * the current date, and the provided format.
+     *
+     * @param AdminInterface $admin  the current admin object
+     * @param string         $format the format of the export file
+     */
+    public function getExportFilename(AdminInterface $admin, $format)
+    {
+        $class = $admin->getClass();
+
+        return sprintf(
+            'export_%s_%s.%s',
+            strtolower(substr($class, strripos($class, '\\') + 1)),
+            date('Y_m_d_H_i_s', strtotime('now')),
+            $format
+        );
+    }
+}

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -110,6 +110,9 @@ class CRUDController extends Controller
             'form' => $formView,
             'datagrid' => $datagrid,
             'csrf_token' => $this->getCsrfToken('sonata.batch'),
+            'export_formats' => $this->has('sonata.admin.admin_exporter') ?
+                $this->get('sonata.admin.admin_exporter')->getAvailableFormats($this->admin) :
+                $this->admin->getExportFormats(),
         ), null);
     }
 

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -819,7 +819,12 @@ class CRUDController extends Controller
             $format
         );
 
-        return $this->get('sonata.admin.exporter')->getResponse(
+        // NEXT_MAJOR : require sonata-project/exporter ^1.6 and remove this
+        $exporter = $this->has('sonata.exporter.exporter') ?
+            $this->get('sonata.exporter.exporter') :
+            $this->get('sonata.admin.exporter');
+
+        return $exporter->getResponse(
             $format,
             $filename,
             $this->admin->getDataSourceIterator()

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -800,6 +800,10 @@ class CRUDController extends Controller
         $format = $request->get('format');
 
         $allowedExportFormats = (array) $this->admin->getExportFormats();
+        // NEXT_MAJOR: simplify this condition
+        if ($allowedExportFormats == array('json', 'xml', 'csv', 'xls') && $this->has('sonata.exporter.exporter')) {
+            $allowedExportFormats = $this->get('sonata.exporter.exporter')->getAvailableFormats();
+        }
 
         if (!in_array($format, $allowedExportFormats)) {
             throw new \RuntimeException(
@@ -819,7 +823,7 @@ class CRUDController extends Controller
             $format
         );
 
-        // NEXT_MAJOR : require sonata-project/exporter ^1.6 and remove this
+        // NEXT_MAJOR : require sonata-project/exporter ^1.7 and remove this
         $exporter = $this->has('sonata.exporter.exporter') ?
             $this->get('sonata.exporter.exporter') :
             $this->get('sonata.admin.exporter');

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -60,6 +60,13 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $loader->load('block.xml');
         $loader->load('menu.xml');
 
+        if (method_exists('Symfony\Component\DependencyInjection\Definition', 'setDeprecated')) {
+            // NEXT_MAJOR : remove this block
+            $container->getDefinition('sonata.admin.exporter')->setDeprecated(
+                'The service "%service_id%" is deprecated in favor of the "sonata.exporter.exporter" service'
+            );
+        }
+
         // TODO: Go back on xml configuration when bumping requirements to SF 2.6+
         $sidebarMenu = $container->getDefinition('sonata.admin.sidebar_menu');
         if (method_exists($sidebarMenu, 'setFactory')) {

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -60,8 +60,12 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $loader->load('block.xml');
         $loader->load('menu.xml');
 
+        if (isset($bundles['SonataExporterBundle'])) {
+            $loader->load('exporter.xml');
+        }
+
+        // NEXT_MAJOR : remove this block
         if (method_exists('Symfony\Component\DependencyInjection\Definition', 'setDeprecated')) {
-            // NEXT_MAJOR : remove this block
             $container->getDefinition('sonata.admin.exporter')->setDeprecated(
                 'The service "%service_id%" is deprecated in favor of the "sonata.exporter.exporter" service'
             );

--- a/Export/Exporter.php
+++ b/Export/Exporter.php
@@ -13,6 +13,12 @@ namespace Sonata\AdminBundle\Export;
 
 use Sonata\CoreBundle\Exporter\Exporter as BaseExporter;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\Exporter class is deprecated since version 3.x and will be removed in 4.0.'.
+    ' Use Exporter\Exporter instead',
+    E_USER_DEPRECATED
+);
+
 /**
  * NEXT_MAJOR: remove this class.
  *

--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -53,6 +53,7 @@
         <service id="sonata.admin.audit.manager" class="Sonata\AdminBundle\Model\AuditManager">
             <argument type="service" id="service_container"/>
         </service>
+        <!-- NEXT_MAJOR : remove this service -->
         <service id="sonata.admin.exporter" class="Sonata\AdminBundle\Export\Exporter"/>
         <service id="sonata.admin.search.handler" class="Sonata\AdminBundle\Search\SearchHandler">
             <argument type="service" id="sonata.admin.pool"/>

--- a/Resources/config/exporter.xml
+++ b/Resources/config/exporter.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.admin.admin_exporter" class="Sonata\AdminBundle\Bridge\Exporter\AdminExporter">
+            <argument type="service" id="sonata.exporter.exporter"/>
+        </service>
+    </services>
+</container>

--- a/Resources/doc/reference/action_export.rst
+++ b/Resources/doc/reference/action_export.rst
@@ -1,16 +1,19 @@
 The Export action
 =================
 
-.. note::
-
-    This document is a stub representing a new work in progress. If you're reading
-    this you can help contribute, **no matter what your experience level with Sonata
-    is**. Check out the `issues on GitHub`_ for more information about how to get involved.
-
 This document will cover the Export action and related configuration options.
 
 Basic configuration
 -------------------
+
+If you have registered the ``SonataExporterBundle`` bundle in the kernel of your application,
+you can benefit from a lot of flexibility:
+
+* You can configure default exporters globally.
+* You can add custom exporters, also globally.
+* You can configure every default writer.
+
+See `the exporter bundle documentation`_ for more information.
 
 Translation
 ~~~~~~~~~~~
@@ -19,58 +22,59 @@ All field names are translated by default.
 An internal mechanism checks if a field matching the translator strategy label exists in the current translation file
 and will use the field name as a fallback.
 
-Customizing export
-~~~~~~~~~~~~~~~~~~
+Picking which fields to export
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To customize available export formats just overwrite AbstractAdmin::getExportFormats()
-
-.. code-block:: php
-
-    <?php
-    // src/AppBundle/Admin/PersonAdmin.php
-
-    class PersonAdmin extends AbstractAdmin
-    {
-        /**
-         * {@inheritdoc}
-         */
-        public function getExportFormats()
-        {
-            return array(
-                'json', 'xml', 'csv', 'xls',
-            );
-        }
-    }
-
-If you want to customize the list of fields to export, overwrite AbstractAdmin::getExportFields() like
-this:
+By default, all fields are exported. More accurately, it depends on the
+persistence backend you are using, but for instance, the doctrine ORM backend
+exports all fields (associations are not exported). If you want to change this
+behavior for a specific admin, you can override the ``getExportFields()`` method:
 
 .. code-block:: php
 
     <?php
-    // src/AppBundle/Admin/PersonAdmin.php
 
-    class PersonAdmin extends AbstractAdmin
+    public function getExportFields()
     {
-        /**
-         * @return array
-         */
-        public function getExportFields() {
-            return array(
-                'Id' => 'id',
-                'First Name' => 'firstName',
-                'Last Name' => 'lastName',
-                'Contact' => 'contact.phone',
-            );
-        }
+        return array('givenName', 'familyName', 'contact.phone');
     }
 
 .. note::
 
     Note that you can use `contact.phone` to access the `phone` property of `Contact` entity
 
-To add more customization to your export you can overwrite AbstractAdmin::getDataSourceIterator().
-Supposing you want to change date format in your export file. You can do it like this:
+You can also tweak the list by creating an admin extension that implements the
+``configureExportFields()`` method.
+
+.. code-block:: php
+
+    public function configureExportFields(AdminInterface $admin, array $fields)
+    {
+        unset($fields['updatedAt']);
+
+        return $fields;
+    }
+
+
+Overriding the export formats for a specific admin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Changing the export formats can be done by defining a ``getExportFormats()``
+method in your admin class.
+
+.. code-block:: php
+
+    <?php
+
+    public function getExportFormats()
+    {
+        return array('pdf', 'html');
+    }
+
+Customizing the query used to fetch the results
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you want to customize the query used to fetch the results for a specific admin,
+you can override the ``getDataSourceIterator()`` method:
 
 .. code-block:: php
 
@@ -90,9 +94,7 @@ Supposing you want to change date format in your export file. You can do it like
 .. note::
 
     **TODO**:
-    * any global (yml) options that affect the export actions
-    * how to add new export formats
-    * customising the query used to fetch the results
+    * customising the templates used to render the output
+    * publish the exporter documentation on the project's website and update the link
 
-.. _`issues on Github`: https://github.com/sonata-project/SonataAdminBundle/issues/1519
 .. _`the exporter bundle documentation`: https://github.com/sonata-project/exporter/blob/1.x/docs/reference/symfony.rst

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -176,8 +176,11 @@ file that was distributed with this source code.
                                 </div>
 
 
+                                {# NEXT_MAJOR : remove this assignment #}
+                                {% set export_formats = export_formats|default(admin.exportFormats) %}
+
                                 <div class="pull-right">
-                                    {% if admin.hasRoute('export') and admin.isGranted('EXPORT') and admin.getExportFormats()|length %}
+                                    {% if admin.hasRoute('export') and admin.isGranted('EXPORT') and export_formats|length %}
                                         <div class="btn-group">
                                             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                                                 <i class="fa fa-share-square-o" aria-hidden="true"></i>
@@ -185,7 +188,7 @@ file that was distributed with this source code.
                                                 <span class="caret"></span>
                                             </button>
                                             <ul class="dropdown-menu">
-                                                {% for format in admin.getExportFormats() %}
+                                                {% for format in export_formats %}
                                                 <li>
                                                     <a href="{{ admin.generateUrl('export', admin.modelmanager.paginationparameters(admin.datagrid, 0) + {'format' : format}) }}">
                                                         <i class="fa fa-arrow-circle-o-down" aria-hidden="true"></i>

--- a/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
+++ b/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
@@ -50,8 +50,12 @@ This template can be customized to match your needs. You should only extends the
                                 {% endblock %}
                             </div>
                         </div>
+
+                        {# NEXT_MAJOR : remove this assignment #}
+                        {% set export_formats = export_formats|default(admin.getExportFormats) %}
+
                         <div class="mosaic-inner-text">
-                            {% if (admin.hasRoute('batch') and batchactions|length > 0) or (admin.hasRoute('export') and admin.isGranted("EXPORT") and admin.getExportFormats()|length) %}
+                            {% if (admin.hasRoute('batch') and batchactions|length > 0) or (admin.hasRoute('export') and admin.isGranted("EXPORT") and export_formats|length) %}
                                 <input type="checkbox" name="idx[]" value="{{ admin.id(object) }}">
                             {% else %}
                                 &nbsp;

--- a/Tests/Bridge/Exporter/AdminExporterTest.php
+++ b/Tests/Bridge/Exporter/AdminExporterTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Bridge\Exporter;
+
+use Exporter\Exporter;
+use Sonata\AdminBundle\Bridge\Exporter\AdminExporter;
+
+class AdminExporterTest extends \PHPUnit_Framework_TestCase
+{
+    public function provideExportFormats()
+    {
+        return array(
+            'no override' => array(array('xls'), array('json', 'xml', 'csv', 'xls'), array('xls')),
+            'override in admin' => array(array('csv'), array('csv'), array('xls')),
+        );
+    }
+
+    /**
+     * @dataProvider provideExportFormats
+     */
+    public function testAdminHasPriorityOverGlobalSettings(array $expectedFormats, array $adminFormats, array $globalFormats)
+    {
+        $writers = array();
+        foreach ($globalFormats as $exportFormat) {
+            $writer = $this->getMock('Exporter\Writer\TypedWriterInterface');
+            $writer->expects($this->once())
+                ->method('getFormat')
+                ->will($this->returnValue($exportFormat));
+            $writers[] = $writer;
+        }
+
+        $exporter = new Exporter($writers);
+        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin->expects($this->once())
+            ->method('getExportFormats')
+            ->will($this->returnValue($adminFormats));
+        $adminExporter = new AdminExporter($exporter);
+        $this->assertSame($expectedFormats, $adminExporter->getAvailableFormats($admin));
+    }
+
+    public function testGetExportFilename()
+    {
+        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin->expects($this->once())
+            ->method('getClass')
+            ->will($this->returnValue('MyProject\AppBundle\Model\MyClass'));
+        $adminExporter = new AdminExporter(new Exporter());
+        $this->assertRegexp(
+            '#export_myclass_\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2}.csv#',
+            $adminExporter->getExportFilename($admin, 'csv')
+        );
+    }
+}

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -42,6 +42,8 @@ use Symfony\Component\Security\Csrf\CsrfToken;
  * Test for CRUDController.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
+ *
+ * @group legacy
  */
 class CRUDControllerTest extends PHPUnit_Framework_TestCase
 {

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -2429,7 +2429,7 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->method('getExportFormats')
             ->will($this->returnValue(array('json')));
 
-        $this->admin->expects($this->once())
+        $this->admin->expects($this->any())
             ->method('getClass')
             ->will($this->returnValue('Foo'));
 

--- a/Tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/Tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
+
+class SonataAdminExtensionTest extends AbstractExtensionTestCase
+{
+    public function testLoadsExporterServiceDefinitionWhenExporterBundleIsRegistered()
+    {
+        $this->container->setParameter('kernel.bundles', array('SonataExporterBundle' => 'whatever'));
+        $this->load();
+        $this->assertContainerBuilderHasService(
+            'sonata.admin.admin_exporter',
+            'Sonata\AdminBundle\Bridge\Exporter\AdminExporter'
+        );
+    }
+
+    protected function getContainerExtensions()
+    {
+        return array(new SonataAdminExtension());
+    }
+}

--- a/Tests/Export/ExporterTest.php
+++ b/Tests/Export/ExporterTest.php
@@ -16,6 +16,8 @@ use Sonata\AdminBundle\Export\Exporter;
 use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
+ * NEXT_MAJOR: remove this class.
+ *
  * @group legacy
  */
 class ExporterTest extends PHPUnit_Framework_TestCase

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -65,6 +65,12 @@ All files under the ``Tests`` directory are now correctly handled as internal te
 You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).
 
+### Exporter service and class
+
+The `sonata.admin.exporter` is deprecated in favor of the `sonata.exporter.exporter` service.
+To make this service available, you have to install `sonata-project.exporter` ^1.7
+and enable the bundle as described in the documentation.
+
 UPGRADE FROM 3.2 to 3.3
 =======================
 

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     "require-dev": {
         "jms/di-extra-bundle": "^1.7",
         "jms/translation-bundle": "^1.2",
+        "matthiasnoback/symfony-dependency-injection-test": "^0.1 || ^1.0",
         "sensio/generator-bundle": "^2.3 || ^3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/exporter": "^1.7",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
         "symfony/yaml": "^2.3 || ^3.0"
     },
     "conflict": {
-        "jms/di-extra-bundle": "<1.7.0"
+        "jms/di-extra-bundle": "<1.7.0",
+        "sonata-project/exporter": "1.6.0"
     },
     "suggest": {
         "jms/di-extra-bundle": "Annotations for Admin definition",

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "jms/translation-bundle": "^1.2",
         "sensio/generator-bundle": "^2.3 || ^3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
+        "sonata-project/exporter": "^1.7",
         "sonata-project/intl-bundle": "^2.2.4",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "symfony/yaml": "^2.3 || ^3.0"


### PR DESCRIPTION
I am targetting this branch, because this is BC

Closes #3124 , #1550 (I think)
## Changelog

``` markdown
### Changed
- The export and list actions now integrate the sonata exporter bundle

### Deprecated
- Exporter class and service : use equivalents from `sonata-project/exporter` instead.
```
## To do
- [x] Wait for 1.6.0 to be released
- [x] Fix symfony 2.3 compatibility problem (the `deprecated` tag is not supported)
- [x] Wait for 1.7.0 to be released
- [x] Refactor `CrudController::exportAction()` to use a dedicated, unit-tested service when available
- [x] Create the `sonata.admin.admin_exporter` service when the exporter bundle is registered
- [x] Use `getAvailableFormats()` to display the formats list
- [x] Document all this
## Subject

This deprecates the export class and service
