### PR TITLE
Fixed duplicate translation in filters

### DIFF
--- a/Form/Type/Filter/ChoiceType.php
+++ b/Form/Type/Filter/ChoiceType.php
@@ -31,6 +31,8 @@ class ChoiceType extends AbstractType
     const TYPE_EQUAL = 3;
 
     /**
+     * @deprecated since 3.x, to be removed with 4.0
+     *
      * @var TranslatorInterface
      */
     protected $translator;
@@ -67,16 +69,31 @@ class ChoiceType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_CONTAINS => $this->translator->trans('label_type_contains', array(), 'SonataAdminBundle'),
-            self::TYPE_NOT_CONTAINS => $this->translator->trans('label_type_not_contains', array(), 'SonataAdminBundle'),
-            self::TYPE_EQUAL => $this->translator->trans('label_type_equals', array(), 'SonataAdminBundle'),
+            self::TYPE_CONTAINS => 'label_type_contains',
+            self::TYPE_NOT_CONTAINS => 'label_type_not_contains',
+            self::TYPE_EQUAL => 'label_type_equals',
         );
 
         if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
             $choices = array_flip($choices);
         }
 
-        $operatorChoices = $options['operator_type'] !== 'hidden' ? array('choices' => $choices) : array();
+        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            foreach ($choices as $key => $value) {
+                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
+            }
+        }
+
+        $operatorChoices = array();
+        if ($options['operator_type'] !== 'hidden') {
+            $operatorChoices['choices'] = $choices;
+
+            // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
+            if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                $operatorChoices['choice_translation_domain'] = 'SonataAdminBundle';
+            }
+        }
 
         $builder
             ->add('type', $options['operator_type'], array_merge(array('required' => false), $options['operator_options'], $operatorChoices))

--- a/Form/Type/Filter/DateRangeType.php
+++ b/Form/Type/Filter/DateRangeType.php
@@ -28,6 +28,8 @@ class DateRangeType extends AbstractType
     const TYPE_NOT_BETWEEN = 2;
 
     /**
+     * @deprecated since 3.x, to be removed with 4.0
+     *
      * @var TranslatorInterface
      */
     protected $translator;
@@ -64,16 +66,33 @@ class DateRangeType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_BETWEEN => $this->translator->trans('label_date_type_between', array(), 'SonataAdminBundle'),
-            self::TYPE_NOT_BETWEEN => $this->translator->trans('label_date_type_not_between', array(), 'SonataAdminBundle'),
+            self::TYPE_BETWEEN => 'label_date_type_between',
+            self::TYPE_NOT_BETWEEN => 'label_date_type_not_between',
         );
 
         if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
             $choices = array_flip($choices);
         }
 
+        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            foreach ($choices as $key => $value) {
+                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
+            }
+        }
+
+        $choiceOptions = array(
+            'choices' => $choices,
+            'required' => false,
+        );
+
+        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        }
+
         $builder
-            ->add('type', 'choice', array('choices' => $choices, 'required' => false))
+            ->add('type', 'choice', $choiceOptions)
             ->add('value', $options['field_type'], $options['field_options'])
         ;
     }

--- a/Form/Type/Filter/DateTimeRangeType.php
+++ b/Form/Type/Filter/DateTimeRangeType.php
@@ -28,6 +28,8 @@ class DateTimeRangeType extends AbstractType
     const TYPE_NOT_BETWEEN = 2;
 
     /**
+     * @deprecated since 3.x, to be removed with 4.0
+     *
      * @var TranslatorInterface
      */
     protected $translator;
@@ -64,16 +66,33 @@ class DateTimeRangeType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_BETWEEN => $this->translator->trans('label_date_type_between', array(), 'SonataAdminBundle'),
-            self::TYPE_NOT_BETWEEN => $this->translator->trans('label_date_type_not_between', array(), 'SonataAdminBundle'),
+            self::TYPE_BETWEEN => 'label_date_type_between',
+            self::TYPE_NOT_BETWEEN => 'label_date_type_not_between',
         );
 
         if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
             $choices = array_flip($choices);
         }
 
+        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            foreach ($choices as $key => $value) {
+                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
+            }
+        }
+
+        $choiceOptions = array(
+            'choices' => $choices,
+            'required' => false,
+        );
+
+        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        }
+
         $builder
-            ->add('type', 'choice', array('choices' => $choices, 'required' => false))
+            ->add('type', 'choice', $choiceOptions)
             ->add('value', $options['field_type'], $options['field_options'])
         ;
     }

--- a/Form/Type/Filter/DateTimeType.php
+++ b/Form/Type/Filter/DateTimeType.php
@@ -39,6 +39,8 @@ class DateTimeType extends AbstractType
     const TYPE_NOT_NULL = 7;
 
     /**
+     * @deprecated since 3.x, to be removed with 4.0
+     *
      * @var TranslatorInterface
      */
     protected $translator;
@@ -75,21 +77,38 @@ class DateTimeType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_EQUAL => $this->translator->trans('label_date_type_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_GREATER_EQUAL => $this->translator->trans('label_date_type_greater_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_GREATER_THAN => $this->translator->trans('label_date_type_greater_than', array(), 'SonataAdminBundle'),
-            self::TYPE_LESS_EQUAL => $this->translator->trans('label_date_type_less_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_LESS_THAN => $this->translator->trans('label_date_type_less_than', array(), 'SonataAdminBundle'),
-            self::TYPE_NULL => $this->translator->trans('label_date_type_null', array(), 'SonataAdminBundle'),
-            self::TYPE_NOT_NULL => $this->translator->trans('label_date_type_not_null', array(), 'SonataAdminBundle'),
+            self::TYPE_EQUAL => 'label_date_type_equal',
+            self::TYPE_GREATER_EQUAL => 'label_date_type_greater_equal',
+            self::TYPE_GREATER_THAN => 'label_date_type_greater_than',
+            self::TYPE_LESS_EQUAL => 'label_date_type_less_equal',
+            self::TYPE_LESS_THAN => 'label_date_type_less_than',
+            self::TYPE_NULL => 'label_date_type_null',
+            self::TYPE_NOT_NULL => 'label_date_type_not_null',
         );
 
         if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
             $choices = array_flip($choices);
         }
 
+        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            foreach ($choices as $key => $value) {
+                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
+            }
+        }
+
+        $choiceOptions = array(
+            'choices' => $choices,
+            'required' => false,
+        );
+
+        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        }
+
         $builder
-            ->add('type', 'choice', array('choices' => $choices, 'required' => false))
+            ->add('type', 'choice', $choiceOptions)
             ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))
         ;
     }

--- a/Form/Type/Filter/DateType.php
+++ b/Form/Type/Filter/DateType.php
@@ -39,6 +39,8 @@ class DateType extends AbstractType
     const TYPE_NOT_NULL = 7;
 
     /**
+     * @deprecated since 3.x, to be removed with 4.0
+     *
      * @var TranslatorInterface
      */
     protected $translator;
@@ -75,21 +77,38 @@ class DateType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_EQUAL => $this->translator->trans('label_date_type_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_GREATER_EQUAL => $this->translator->trans('label_date_type_greater_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_GREATER_THAN => $this->translator->trans('label_date_type_greater_than', array(), 'SonataAdminBundle'),
-            self::TYPE_LESS_EQUAL => $this->translator->trans('label_date_type_less_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_LESS_THAN => $this->translator->trans('label_date_type_less_than', array(), 'SonataAdminBundle'),
-            self::TYPE_NULL => $this->translator->trans('label_date_type_null', array(), 'SonataAdminBundle'),
-            self::TYPE_NOT_NULL => $this->translator->trans('label_date_type_not_null', array(), 'SonataAdminBundle'),
+            self::TYPE_EQUAL => 'label_date_type_equal',
+            self::TYPE_GREATER_EQUAL => 'label_date_type_greater_equal',
+            self::TYPE_GREATER_THAN => 'label_date_type_greater_than',
+            self::TYPE_LESS_EQUAL => 'label_date_type_less_equal',
+            self::TYPE_LESS_THAN => 'label_date_type_less_than',
+            self::TYPE_NULL => 'label_date_type_null',
+            self::TYPE_NOT_NULL => 'label_date_type_not_null',
         );
 
         if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
             $choices = array_flip($choices);
         }
 
+        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            foreach ($choices as $key => $value) {
+                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
+            }
+        }
+
+        $choiceOptions = array(
+            'choices' => $choices,
+            'required' => false,
+        );
+
+        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        }
+
         $builder
-            ->add('type', 'choice', array('choices' => $choices, 'required' => false))
+            ->add('type', 'choice', $choiceOptions)
             ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))
         ;
     }

--- a/Form/Type/Filter/NumberType.php
+++ b/Form/Type/Filter/NumberType.php
@@ -35,6 +35,8 @@ class NumberType extends AbstractType
     const TYPE_LESS_THAN = 5;
 
     /**
+     * @deprecated since 3.x, to be removed with 4.0
+     *
      * @var TranslatorInterface
      */
     protected $translator;
@@ -72,19 +74,36 @@ class NumberType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_EQUAL => $this->translator->trans('label_type_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_GREATER_EQUAL => $this->translator->trans('label_type_greater_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_GREATER_THAN => $this->translator->trans('label_type_greater_than', array(), 'SonataAdminBundle'),
-            self::TYPE_LESS_EQUAL => $this->translator->trans('label_type_less_equal', array(), 'SonataAdminBundle'),
-            self::TYPE_LESS_THAN => $this->translator->trans('label_type_less_than', array(), 'SonataAdminBundle'),
+            self::TYPE_EQUAL => 'label_type_equal',
+            self::TYPE_GREATER_EQUAL => 'label_type_greater_equal',
+            self::TYPE_GREATER_THAN => 'label_type_greater_than',
+            self::TYPE_LESS_EQUAL => 'label_type_less_equal',
+            self::TYPE_LESS_THAN => 'label_type_less_than',
         );
 
         if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
             $choices = array_flip($choices);
         }
 
+        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            foreach ($choices as $key => $value) {
+                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
+            }
+        }
+
+        $choiceOptions = array(
+            'choices' => $choices,
+            'required' => false,
+        );
+
+        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        }
+
         $builder
-            ->add('type', 'choice', array('choices' => $choices, 'required' => false))
+            ->add('type', 'choice', $choiceOptions)
             ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))
         ;
     }

--- a/Tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
+++ b/Tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
@@ -36,7 +36,7 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
 
         $this->assertContains(
             '<option value="1">[trans]label_type_contains[/trans]</option>',
-           $html
+            $html
         );
 
         $this->assertContains(
@@ -83,12 +83,11 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
     {
         $mock = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
 
-        $mock->expects($this->exactly(3))
-            ->method('trans')
+        $mock->method('trans')
             ->will($this->returnCallback(function ($arg) {
                 return $arg;
             })
-            );
+        );
 
         $extensions = parent::getExtensions();
         $guesser = $this->getMock('Symfony\Component\Form\FormTypeGuesserInterface');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #3283

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed duplicate translation for list filters
```

## Subject

The filters in the list were translated two times, once in the php classes and a second time in the twig template. 

Before
![bildschirmfoto 2016-07-31 um 19 30 33](https://cloud.githubusercontent.com/assets/3440437/17278140/7ba3cd24-5755-11e6-893d-666abbe78980.PNG)

After
![bildschirmfoto 2016-07-31 um 19 31 46](https://cloud.githubusercontent.com/assets/3440437/17278139/7ba2d644-5755-11e6-8188-37fb7254da53.PNG)




