### PR TITLE
Sonata throws Exception on renderViewElementCompare()

### DIFF
--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -49,7 +49,7 @@ class SonataAdminExtension extends \Twig_Extension
         return array(
             new \Twig_SimpleFilter('render_list_element', array($this, 'renderListElement'), array('is_safe' => array('html'), 'needs_environment' => true)),
             new \Twig_SimpleFilter('render_view_element', array($this, 'renderViewElement'), array('is_safe' => array('html'), 'needs_environment' => true)),
-            new \Twig_SimpleFilter('render_view_element_compare', array($this, 'renderViewElementCompare'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('render_view_element_compare', array($this, 'renderViewElementCompare'), array('is_safe' => array('html'), 'needs_environment' => true)),
             new \Twig_SimpleFilter('render_relation_element', array($this, 'renderRelationElement')),
             new \Twig_SimpleFilter('sonata_urlsafeid', array($this, 'getUrlsafeIdentifier')),
             new \Twig_SimpleFilter('sonata_xeditable_type', array($this, 'getXEditableType')),


### PR DESCRIPTION
By integrating the EntityAuditBundle into SonataAdmin we want to compare revisions of an entity. Clicking the "compare revisions"-Button (route: admin/{entity}/{id}/history/{base_revision}/{compare_revision}/compare) causes the following exception:

An exception has been thrown during the rendering of a template ("Catchable Fatal Error: Argument 1 passed to Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderViewElementCompare() must be an instance of Twig_Environment, instance of Sonata\DoctrineORMAdminBundle\Admin\FieldDescription given, [...] in SonataAdminBundle:CRUD:base_show_compare.html.twig at line 25. 

Solution: renderViewElementCompare() needs Twig_Einvironment.