### PR TITLE
corrected css margin-left for checkbox

### DIFF
--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -358,6 +358,7 @@ td.sonata-ba-list-field .editable-empty:not(.editable-open) {
 .checkbox label,
 .radio label {
     font-weight: 700;
+    margin-left: -20px;
 }
 
 /**
@@ -370,7 +371,6 @@ td.sonata-ba-list-field .editable-empty:not(.editable-open) {
 .radio-inline div[class^="iradio"] {
     position: relative;
     margin-top: 4px \9;
-    margin-left: -20px;
     margin-right: 5px;
     margin-top: -3px;
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this change must effect 3.x branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #4038

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed css `margin-left: -20px` of checkbox. 
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->

Checkbox on filter field was shown 20px on the left to where it supposed to be. This was because all the checkboxes were being effected from a change which has been done for checkboxes on edit page.
