### PR TITLE
changed injection of container to injection of pool

### DIFF
--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -66,7 +66,7 @@
         </service>
         <!-- twig -->
         <service id="sonata.admin.twig.global" class="Sonata\AdminBundle\Twig\GlobalVariables">
-            <argument type="service" id="service_container"/>
+            <argument type="service" id="sonata.admin.pool"/>
         </service>
     </services>
 </container>

--- a/Tests/Twig/GlobalVariablesTest.php
+++ b/Tests/Twig/GlobalVariablesTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig;
+
+use Sonata\AdminBundle\Twig\GlobalVariables;
+
+/**
+ * @author Ahmet Akbana <ahmetakbana@gmail.com>
+ */
+class GlobalVariablesTest extends \PHPUnit_Framework_TestCase
+{
+    private $code;
+    private $action;
+    private $admin;
+    private $pool;
+
+    public function setUp()
+    {
+        $this->code = 'sonata.page.admin.page|sonata.page.admin.snapshot';
+        $this->action = 'list';
+        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
+    }
+
+    public function testUrl()
+    {
+        $this->admin->expects($this->once())
+            ->method('generateUrl')
+            ->with('sonata.page.admin.page|sonata.page.admin.snapshot.list', array('foo'), false)
+            ->willReturn(true);
+
+        $this->pool->expects($this->once())
+            ->method('getAdminByAdminCode')
+            ->with('sonata.page.admin.page')
+            ->willReturn($this->admin);
+
+        $globalVariables = new GlobalVariables($this->pool);
+
+        $globalVariables->url($this->code, $this->action, array('foo'));
+    }
+
+    public function testObjectUrl()
+    {
+        $this->admin->expects($this->once())
+            ->method('generateObjectUrl')
+            ->with('sonata.page.admin.page|sonata.page.admin.snapshot.list', 'foo', array('bar'), false)
+            ->willReturn(true);
+
+        $this->pool->expects($this->once())
+            ->method('getAdminByAdminCode')
+            ->with('sonata.page.admin.page')
+            ->willReturn($this->admin);
+
+        $globalVariables = new GlobalVariables($this->pool);
+
+        $globalVariables->objectUrl($this->code, $this->action, 'foo', array('bar'));
+    }
+
+    /**
+     * @group legacy
+     * NEXT_MAJOR: remove this method
+     */
+    public function testWithContainer()
+    {
+        $this->admin->expects($this->once())
+            ->method('generateUrl')
+            ->with('sonata.page.admin.page|sonata.page.admin.snapshot.list', array('foo'), false)
+            ->willReturn(true);
+
+        $this->pool->expects($this->once())
+            ->method('getAdminByAdminCode')
+            ->with('sonata.page.admin.page')
+            ->willReturn($this->admin);
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->once())
+            ->method('get')
+            ->with('sonata.admin.pool')
+            ->willReturn($this->pool);
+
+        $globalVariables = new GlobalVariables($container);
+
+        $globalVariables->url($this->code, $this->action, array('foo'));
+    }
+
+    /**
+     * NEXT_MAJOR: remove this method.
+     */
+    public function testInvalidArgumentException()
+    {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            '$adminPool should be an instance of Sonata\AdminBundle\Admin\Pool'
+        );
+
+        new GlobalVariables('foo');
+    }
+}

--- a/Twig/GlobalVariables.php
+++ b/Twig/GlobalVariables.php
@@ -102,7 +102,7 @@ class GlobalVariables
      */
     private function getCodeAction($code, $action)
     {
-        if ($pipe = strpos('|', $code)) {
+        if ($pipe = strpos($code, '|')) {
             // convert code=sonata.page.admin.page|sonata.page.admin.snapshot, action=list
             // to => sonata.page.admin.page|sonata.page.admin.snapshot.list
             $action = $code.'.'.$action;

--- a/Twig/GlobalVariables.php
+++ b/Twig/GlobalVariables.php
@@ -15,23 +15,44 @@ use Sonata\AdminBundle\Admin\Pool;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class GlobalVariables.
- *
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class GlobalVariables
 {
     /**
      * @var ContainerInterface
+     *
+     * @deprecated Since version 3.x, will be removed in 4.0.
+     * NEXT_MAJOR : remove this property
      */
     protected $container;
 
     /**
-     * @param ContainerInterface $container
+     * @var Pool
      */
-    public function __construct(ContainerInterface $container)
+    protected $adminPool;
+
+    /**
+     * @param ContainerInterface|Pool $adminPool
+     */
+    public function __construct($adminPool)
     {
-        $this->container = $container;
+        // NEXT_MAJOR : remove this block and set adminPool from parameter.
+        if ($adminPool instanceof ContainerInterface) {
+            @trigger_error(
+                'Using an instance of Symfony\Component\DependencyInjection\ContainerInterface is deprecated since 
+                version 3.x and will be removed in 4.0. Use Sonata\AdminBundle\Admin\Pool instead.',
+                E_USER_DEPRECATED
+            );
+
+            $this->adminPool = $adminPool->get('sonata.admin.pool');
+        } elseif ($adminPool instanceof Pool) {
+            $this->adminPool = $adminPool;
+        } else {
+            throw new \InvalidArgumentException(
+                '$adminPool should be an instance of Sonata\AdminBundle\Admin\Pool'
+            );
+        }
     }
 
     /**
@@ -39,7 +60,7 @@ class GlobalVariables
      */
     public function getAdminPool()
     {
-        return $this->container->get('sonata.admin.pool');
+        return $this->adminPool;
     }
 
     /**

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated injection of container to GlobalVariables
+
+The `$container` property in `Twig/GlobalVariables` is deprecated.
+
 ## Deprecated ModelTypeList for rename
 
 The `Sonata\AdminBundle\Form\Type\ModelTypeList` class is now deprecated.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because I would like to improve code and test coverage

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- Changed injection of `$container` to `$adminPool` in `Twig/GlobalVariables`

### Deprecated
- The `$container` property in `Twig/GlobalVariables`
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Add test for the class

## Subject

Improving code and test coverage
<!-- Describe your Pull Request content here -->
