### PR TITLE
Fixed sonata_top_nav_menu visibility

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -162,28 +162,30 @@ file that was distributed with this source code.
                         </div>
 
                         {% block sonata_top_nav_menu %}
-                            <div class="navbar-custom-menu">
-                                <ul class="nav navbar-nav">
-                                    {% block sonata_top_nav_menu_add_block %}
-                                        <li class="dropdown">
-                                            <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-                                                <i class="fa fa-plus-square fa-fw"></i> <i class="fa fa-caret-down"></i>
-                                            </a>
-                                            {% include sonata_admin.adminPool.getTemplate('add_block') %}
-                                        </li>
-                                    {% endblock %}
-                                    {% block sonata_top_nav_menu_user_block %}
-                                        <li class="dropdown user-menu">
-                                            <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-                                                <i class="fa fa-user fa-fw"></i> <i class="fa fa-caret-down"></i>
-                                            </a>
-                                            <ul class="dropdown-menu dropdown-user">
-                                                {% include sonata_admin.adminPool.getTemplate('user_block') %}
-                                            </ul>
-                                        </li>
-                                    {% endblock %}
-                                </ul>
-                            </div>
+                            {% if app.user and is_granted('ROLE_SONATA_ADMIN') %}
+                                <div class="navbar-custom-menu">
+                                    <ul class="nav navbar-nav">
+                                        {% block sonata_top_nav_menu_add_block %}
+                                            <li class="dropdown">
+                                                <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+                                                    <i class="fa fa-plus-square fa-fw"></i> <i class="fa fa-caret-down"></i>
+                                                </a>
+                                                {% include sonata_admin.adminPool.getTemplate('add_block') %}
+                                            </li>
+                                        {% endblock %}
+                                        {% block sonata_top_nav_menu_user_block %}
+                                            <li class="dropdown user-menu">
+                                                <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+                                                    <i class="fa fa-user fa-fw"></i> <i class="fa fa-caret-down"></i>
+                                                </a>
+                                                <ul class="dropdown-menu dropdown-user">
+                                                    {% include sonata_admin.adminPool.getTemplate('user_block') %}
+                                                </ul>
+                                            </li>
+                                        {% endblock %}
+                                    </ul>
+                                </div>
+                            {% endif %}
                         {% endblock %}
                     </nav>
                 {% endblock sonata_nav %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because there's no BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #3579

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed visibility of block `sonata_top_nav_menu` contents
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->

Added security checks in order to show contents of block sonata_top_nav_menu only to logged in users. So far `add` and `user` dropdowns were visible to everyone.