### PR TITLE
use RuntimeException instead of non existing RunTimeException

### DIFF
--- a/Admin/FieldDescriptionCollection.php
+++ b/Admin/FieldDescriptionCollection.php
@@ -96,7 +96,7 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
      */
     public function offsetSet($offset, $value)
     {
-        throw new \RunTimeException('Cannot set value, use add');
+        throw new \RuntimeException('Cannot set value, use add');
     }
 
     /**

--- a/Command/ExplainAdminCommand.php
+++ b/Command/ExplainAdminCommand.php
@@ -42,7 +42,7 @@ class ExplainAdminCommand extends ContainerAwareCommand
         $admin = $this->getContainer()->get($input->getArgument('admin'));
 
         if (!$admin instanceof \Sonata\AdminBundle\Admin\AdminInterface) {
-            throw new \RunTimeException(sprintf('Service "%s" is not an admin class', $input->getArgument('admin')));
+            throw new \RuntimeException(sprintf('Service "%s" is not an admin class', $input->getArgument('admin')));
         }
 
         $output->writeln('<comment>AdminBundle Information</comment>');

--- a/Filter/FilterFactory.php
+++ b/Filter/FilterFactory.php
@@ -46,19 +46,19 @@ class FilterFactory implements FilterFactoryInterface
     public function create($name, $type, array $options = array())
     {
         if (!$type) {
-            throw new \RunTimeException('The type must be defined');
+            throw new \RuntimeException('The type must be defined');
         }
 
         $id = isset($this->types[$type]) ? $this->types[$type] : false;
 
         if (!$id) {
-            throw new \RunTimeException(sprintf('No attached service to type named `%s`', $type));
+            throw new \RuntimeException(sprintf('No attached service to type named `%s`', $type));
         }
 
         $filter = $this->container->get($id);
 
         if (!$filter instanceof FilterInterface) {
-            throw new \RunTimeException(sprintf('The service `%s` must implement `FilterInterface`', $id));
+            throw new \RuntimeException(sprintf('The service `%s` must implement `FilterInterface`', $id));
         }
 
         $filter->initialize($name, $options);

--- a/Tests/Admin/FieldDescriptionCollectionTest.php
+++ b/Tests/Admin/FieldDescriptionCollectionTest.php
@@ -58,7 +58,7 @@ class FieldDescriptionCollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        RunTimeException
+     * @expectedException        RuntimeException
      * @expectedExceptionMessage Cannot set value, use add
      */
     public function testArrayAccessSetField()

--- a/Tests/Filter/FilterTest.php
+++ b/Tests/Filter/FilterTest.php
@@ -99,7 +99,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RunTimeException
+     * @expectedException RuntimeException
      */
     public function testExceptionOnNonDefinedFieldName()
     {

--- a/Tests/Security/Handler/AclSecurityHandlerTest.php
+++ b/Tests/Security/Handler/AclSecurityHandlerTest.php
@@ -120,7 +120,7 @@ class AclSecurityHandlerTest extends \PHPUnit_Framework_TestCase
         $authorizationChecker = $this->getAuthorizationCheckerMock();
         $authorizationChecker->expects($this->any())
             ->method('isGranted')
-            ->will($this->throwException(new \RunTimeException('FAIL')));
+            ->will($this->throwException(new \RuntimeException('FAIL')));
 
         $aclProvider = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
 

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -300,7 +300,7 @@ EOT;
     }
 
     /**
-     * @throws \RunTimeException
+     * @throws \RuntimeException
      *
      * @param mixed                     $element
      * @param FieldDescriptionInterface $fieldDescription


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is a bugfix as `RunTimeException` never exist.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- use `RuntimeException` instead of non existing `RunTimeException`
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

`RunTimeException` does not exist, use `RuntimeException` instead.

