### PR TITLE
Checks the type of $subject against $this->class

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1626,8 +1626,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      */
     public function setSubject($subject)
     {
-        if (get_class($subject) != $this->class) {
-            throw new \RuntimeException(sprintf('You are trying to set entity %s to an admin class registered with %s entity', get_class($subject), $this->class));
+        if (!is_a($subject, $this->class, true)) {
+            throw new \RuntimeException(sprintf('You are trying to set entity %s which is not the one registered with this admin class', get_class($subject), $this->class));
         }
 
         $this->subject = $subject;

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1627,16 +1627,14 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     public function setSubject($subject)
     {
         if (!is_a($subject, $this->class, true)) {
-            trigger_error(
-                sprintf(
-<<<EOT
+            $message = <<<EOT
 You are trying to set entity an instance of "%s",
 which is not the one registered with this admin class ("%s").
 This is deprecated since 3.x and will no longer be supported in 4.0.
-EOT,
-                    get_class($subject),
-                    $this->className
-                ),
+EOT;
+
+            trigger_error(
+                sprintf($message, get_class($subject), $this->class),
                 E_USER_DEPRECATED
             ); // NEXT_MAJOR : throw an exception instead
         }

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1627,7 +1627,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     public function setSubject($subject)
     {
         if (!is_a($subject, $this->class, true)) {
-            throw new \RuntimeException(sprintf('You are trying to set entity %s which is not the one registered with this admin class', get_class($subject), $this->class));
+            throw new \RuntimeException(sprintf('You are trying to set entity %s which is not the one registered with this admin class', get_class($subject)));
         }
 
         $this->subject = $subject;

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1626,6 +1626,10 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      */
     public function setSubject($subject)
     {
+        if (get_class($subject) != $this->class) {
+            throw new \RuntimeException(sprintf('You are trying to set entity %s to an admin class registered with %s entity', get_class($subject), $this->class));
+        }
+
         $this->subject = $subject;
     }
 

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1627,7 +1627,10 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     public function setSubject($subject)
     {
         if (!is_a($subject, $this->class, true)) {
-            throw new \RuntimeException(sprintf('You are trying to set entity %s which is not the one registered with this admin class', get_class($subject)));
+            throw new \RuntimeException(sprintf(
+                'You are trying to set entity %s which is not the one registered with this admin class',
+                get_class($subject)
+            ));
         }
 
         $this->subject = $subject;

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1627,10 +1627,18 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     public function setSubject($subject)
     {
         if (!is_a($subject, $this->class, true)) {
-            throw new \RuntimeException(sprintf(
-                'You are trying to set entity %s which is not the one registered with this admin class',
-                get_class($subject)
-            ));
+            trigger_error(
+                sprintf(
+<<<EOT
+You are trying to set entity an instance of "%s",
+which is not the one registered with this admin class ("%s").
+This is deprecated since 3.x and will no longer be supported in 4.0.
+EOT,
+                    get_class($subject),
+                    $this->className
+                ),
+                E_USER_DEPRECATED
+            ); // NEXT_MAJOR : throw an exception instead
         }
 
         $this->subject = $subject;

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1626,7 +1626,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      */
     public function setSubject($subject)
     {
-        if (!is_a($subject, $this->class, true)) {
+        if (is_object($subject) && !is_a($subject, $this->class, true)) {
             $message = <<<'EOT'
 You are trying to set entity an instance of "%s",
 which is not the one registered with this admin class ("%s").

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1627,7 +1627,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     public function setSubject($subject)
     {
         if (!is_a($subject, $this->class, true)) {
-            $message = <<<EOT
+            $message = <<<'EOT'
 You are trying to set entity an instance of "%s",
 which is not the one registered with this admin class ("%s").
 This is deprecated since 3.x and will no longer be supported in 4.0.

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -58,17 +58,22 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
     public function testGetClass()
     {
-        $class = 'Application\Sonata\NewsBundle\Entity\Post';
+        $class = 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post';
         $baseControllerName = 'SonataNewsBundle:PostAdmin';
 
         $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
 
-        $testObject = new \stdClass();
-        $admin->setSubject($testObject);
-        $this->assertSame('stdClass', $admin->getClass());
+        $admin->setSubject(new \Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\BlogPost());
+        $this->assertSame(
+            'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\BlogPost',
+            $admin->getClass()
+        );
 
         $admin->setSubClasses(array('foo'));
-        $this->assertSame('stdClass', $admin->getClass());
+        $this->assertSame(
+            'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\BlogPost',
+            $admin->getClass()
+        );
 
         $admin->setSubject(null);
         $admin->setSubClasses(array());
@@ -604,18 +609,28 @@ class AdminTest extends \PHPUnit_Framework_TestCase
      */
     public function testSubClass()
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin(
+            'sonata.post.admin.post',
+            'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post',
+            'SonataNewsBundle:PostAdmin'
+        );
         $this->assertFalse($admin->hasSubClass('test'));
         $this->assertFalse($admin->hasActiveSubClass());
         $this->assertCount(0, $admin->getSubClasses());
         $this->assertNull($admin->getActiveSubClass());
         $this->assertNull($admin->getActiveSubclassCode());
-        $this->assertSame('NewsBundle\Entity\Post', $admin->getClass());
+        $this->assertSame(
+            'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post',
+            $admin->getClass()
+        );
 
         // Just for the record, if there is no inheritance set, the getSubject is not used
         // the getSubject can also lead to some issue
-         $admin->setSubject(new \stdClass());
-        $this->assertSame('stdClass', $admin->getClass());
+        $admin->setSubject(new \Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\BlogPost());
+        $this->assertSame(
+            'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\BlogPost',
+            $admin->getClass()
+        );
 
         $admin->setSubClasses(array('extended1' => 'NewsBundle\Entity\PostExtended1', 'extended2' => 'NewsBundle\Entity\PostExtended2'));
         $this->assertFalse($admin->hasSubClass('test'));
@@ -624,7 +639,10 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $admin->getSubClasses());
         $this->assertNull($admin->getActiveSubClass());
         $this->assertNull($admin->getActiveSubclassCode());
-        $this->assertSame('stdClass', $admin->getClass());
+        $this->assertSame(
+            'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\BlogPost',
+            $admin->getClass()
+        );
 
         $request = new \Symfony\Component\HttpFoundation\Request(array('subclass' => 'extended1'));
         $admin->setRequest($request);
@@ -632,9 +650,15 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($admin->hasSubClass('extended1'));
         $this->assertTrue($admin->hasActiveSubClass());
         $this->assertCount(2, $admin->getSubClasses());
-        $this->assertSame('stdClass', $admin->getActiveSubClass());
+        $this->assertSame(
+            'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\BlogPost',
+            $admin->getActiveSubClass()
+        );
         $this->assertSame('extended1', $admin->getActiveSubclassCode());
-        $this->assertSame('stdClass', $admin->getClass());
+        $this->assertSame(
+            'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\BlogPost',
+            $admin->getClass()
+        );
 
         $request->query->set('subclass', 'inject');
         $this->assertNull($admin->getActiveSubclassCode());
@@ -1804,7 +1828,11 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $formBuilder->expects($this->any())->method('getForm')->will($this->returnValue(null));
 
         $tagAdmin = $this->getMockBuilder('Sonata\AdminBundle\Tests\Fixtures\Admin\TagAdmin')
-            ->disableOriginalConstructor()
+            ->setConstructorArgs(array(
+                'admin.tag',
+                'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Tag',
+                'MyBundle:MyController'
+            ))
             ->setMethods(array('getFormBuilder'))
             ->getMock();
 

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1831,7 +1831,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs(array(
                 'admin.tag',
                 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Tag',
-                'MyBundle:MyController'
+                'MyBundle:MyController',
             ))
             ->setMethods(array('getFormBuilder'))
             ->getMock();

--- a/Tests/Admin/BreadcrumbsBuilderTest.php
+++ b/Tests/Admin/BreadcrumbsBuilderTest.php
@@ -14,9 +14,9 @@ namespace Sonata\AdminBundle\Tests\Admin;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilder;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin;
+use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Comment;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\DummySubject;
 use Symfony\Component\HttpFoundation\Request;
-use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Comment;
 
 /**
  * This test class contains unit and integration tests. Maybe it could be

--- a/Tests/Admin/BreadcrumbsBuilderTest.php
+++ b/Tests/Admin/BreadcrumbsBuilderTest.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\DummySubject;
 use Symfony\Component\HttpFoundation\Request;
+use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Comment;
 
 /**
  * This test class contains unit and integration tests. Maybe it could be
@@ -30,18 +31,18 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetBreadcrumbs()
     {
-        $class = 'Application\Sonata\NewsBundle\Entity\Post';
+        $class = 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\DummySubject';
         $baseControllerName = 'SonataNewsBundle:PostAdmin';
 
         $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
         $commentAdmin = new CommentAdmin(
             'sonata.post.admin.comment',
-            'Application\Sonata\NewsBundle\Entity\Comment',
+            'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Comment',
             'SonataNewsBundle:CommentAdmin'
         );
         $subCommentAdmin = new CommentAdmin(
             'sonata.post.admin.comment',
-            'Application\Sonata\NewsBundle\Entity\Comment',
+            'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Comment',
             'SonataNewsBundle:CommentAdmin'
         );
         $admin->addChild($commentAdmin);
@@ -73,7 +74,7 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
 
         $modelManager->expects($this->exactly(1))
             ->method('find')
-            ->with('Application\Sonata\NewsBundle\Entity\Post', 42)
+            ->with('Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\DummySubject', 42)
             ->will($this->returnValue(new DummySubject()));
 
         $menuFactory->expects($this->exactly(5))
@@ -98,26 +99,26 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('getLabel')
             ->withConsecutive(
                 array('dashboard'),
-                array('Post_list'),
+                array('DummySubject_list'),
                 array('Comment_list'),
                 array('Comment_repost'),
 
                 array('dashboard'),
-                array('Post_list'),
+                array('DummySubject_list'),
                 array('Comment_list'),
                 array('Comment_flag'),
 
                 array('dashboard'),
-                array('Post_list'),
+                array('DummySubject_list'),
                 array('Comment_list'),
                 array('Comment_edit'),
 
                 array('dashboard'),
-                array('Post_list'),
+                array('DummySubject_list'),
                 array('Comment_list'),
 
                 array('dashboard'),
-                array('Post_list'),
+                array('DummySubject_list'),
                 array('Comment_list')
             )
             ->will($this->onConsecutiveCalls(
@@ -175,7 +176,7 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
                 array('someOriginalLabel'),
                 array('dummy subject representation'),
                 array('someOkayishLabel'),
-                array('dummy subject representation')
+                array('this is a comment')
             )
             ->will($this->returnValue($menu));
 
@@ -186,7 +187,7 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         $commentAdmin->getBreadcrumbs('edit');
 
         $commentAdmin->getBreadcrumbs('list');
-        $commentAdmin->setSubject(new DummySubject());
+        $commentAdmin->setSubject(new Comment());
         $commentAdmin->getBreadcrumbs('reply');
     }
 
@@ -195,7 +196,7 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetBreadcrumbsWithNoCurrentAdmin()
     {
-        $class = 'Application\Sonata\NewsBundle\Entity\Post';
+        $class = 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\DummySubject';
         $baseControllerName = 'SonataNewsBundle:PostAdmin';
 
         $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
@@ -232,11 +233,11 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('getLabel')
             ->withConsecutive(
                 array('dashboard'),
-                array('Post_list'),
-                array('Post_repost'),
+                array('DummySubject_list'),
+                array('DummySubject_repost'),
 
                 array('dashboard'),
-                array('Post_list')
+                array('DummySubject_list')
             )
             ->will($this->onConsecutiveCalls(
                 'someLabel',

--- a/Tests/Fixtures/Bundle/Entity/BlogPost.php
+++ b/Tests/Fixtures/Bundle/Entity/BlogPost.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity;
+
+class BlogPost extends Post
+{
+}

--- a/Tests/Fixtures/Bundle/Entity/Comment.php
+++ b/Tests/Fixtures/Bundle/Entity/Comment.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity;
+
+class Comment
+{
+    public function __toString()
+    {
+        return 'this is a comment';
+    }
+}


### PR DESCRIPTION
I am targeting branch 3.x, because it's a patch.

Fixes #2585 

## Changelog

```markdown
### Changed
- `AbstractAdmin::setSubject` in order to check that given `$subject` matches registered admin class entity.
```

## Subject

Checks the type of `$subject` against `$this->class`

