### PR TITLE
Hide filters with a default value

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -778,6 +778,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
             $parameters = array_merge(
                 $this->getModelManager()->getDefaultSortValues($this->getClass()),
                 $this->datagridValues,
+                $this->getDefaultFilterValues(),
                 $filters
             );
 
@@ -1648,7 +1649,7 @@ which is not the one registered with this admin class ("%s").
 This is deprecated since 3.x and will no longer be supported in 4.0.
 EOT;
 
-            trigger_error(
+            @trigger_error(
                 sprintf($message, get_class($subject), $this->class),
                 E_USER_DEPRECATED
             ); // NEXT_MAJOR : throw an exception instead
@@ -2937,6 +2938,25 @@ EOT;
     }
 
     /**
+     * Checks if a filter type is set to a default value.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    final public function isDefaultFilter($name)
+    {
+        $filter = $this->getFilterParameters();
+        $default = $this->getDefaultFilterValues();
+
+        if (!array_key_exists($name, $filter) || !array_key_exists($name, $default)) {
+            return false;
+        }
+
+        return $filter[$name] == $default[$name];
+    }
+
+    /**
      * Check object existence and access, without throw Exception.
      *
      * @param string $action
@@ -2947,6 +2967,27 @@ EOT;
     public function canAccessObject($action, $object)
     {
         return $object && $this->id($object) && $this->hasAccess($action, $object);
+    }
+
+    /**
+     * Returns a list of default filters.
+     *
+     * @return array
+     */
+    final protected function getDefaultFilterValues()
+    {
+        $defaultFilterValues = array();
+
+        $this->configureDefaultFilterValues($defaultFilterValues);
+
+        foreach ($this->getExtensions() as $extension) {
+            // NEXT_MAJOR: remove method check in next major release
+            if (method_exists($extension, 'configureDefaultFilterValues')) {
+                $extension->configureDefaultFilterValues($this, $defaultFilterValues);
+            }
+        }
+
+        return $defaultFilterValues;
     }
 
     /**
@@ -3217,6 +3258,15 @@ EOT;
         }
 
         return $access;
+    }
+
+    /**
+     * Returns a list of default filters.
+     *
+     * @param array $filterValues
+     */
+    protected function configureDefaultFilterValues(array &$filterValues)
+    {
     }
 
     /**

--- a/Admin/AbstractAdminExtension.php
+++ b/Admin/AbstractAdminExtension.php
@@ -186,4 +186,14 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     {
         return $list;
     }
+
+    /**
+     * Returns a list of default filters.
+     *
+     * @param AdminInterface $admin
+     * @param array          $filterValues
+     */
+    public function configureDefaultFilterValues(AdminInterface $admin, array &$filterValues)
+    {
+    }
 }

--- a/Admin/AdminExtensionInterface.php
+++ b/Admin/AdminExtensionInterface.php
@@ -194,4 +194,14 @@ interface AdminExtensionInterface
      */
     // TODO: Uncomment in next major release
     // public function configureActionButtons(AdminInterface $admin, $list, $action, $object);
+
+    /*
+     * NEXT_MAJOR: Uncomment in next major release
+     *
+     * Returns a list of default filters
+     *
+     * @param AdminInterface $admin
+     * @param array          $filterValues
+     */
+    // public function configureDefaultFilterValues(AdminInterface $admin, array &$filterValues);
 }

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -1070,4 +1070,22 @@ interface AdminInterface
 //     * @param bool $isShown
 //     */
 //    public function showMosaicButton($isShown);
+
+    /*
+     * Checks if a filter type is set to a default value
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+//    NEXT_MAJOR: uncomment this method in 4.0
+    // public function isDefaultFilter($name);
+
+    /*
+     * Returns a list of default filters.
+     *
+     * @return array
+     */
+//    NEXT_MAJOR: uncomment this method in 4.0
+    // public function getDefaultFilterValues();
 }

--- a/Resources/doc/reference/action_list.rst
+++ b/Resources/doc/reference/action_list.rst
@@ -329,19 +329,18 @@ If you don't need the advanced filters, or all your ``operator_type`` are hidden
 Default filters
 ^^^^^^^^^^^^^^^
 
-Default filters can be added to the datagrid values by overriding the ``$datagridValues`` property which is also used for default sorting.
+Default filters can be added to the datagrid values by using the ``configureDefaultFilterValues`` method.
 A filter has a ``value`` and an optional ``type``. If no ``type`` is given the default type ``is equal`` is used.
 
 .. code-block:: php
 
-    protected $datagridValues = array(
-        '_page' => 1,
-        '_sort_order' => 'ASC',
-        '_sort_by' => 'id',
-        'foo' => array(
-            'value' => 'bar'
-        )
-    );
+    public function configureDefaultFilterValues(array &$filterValues)
+    {
+        $filterValues['foo'] = array(
+            'type'  => ChoiceFilter::TYPE_CONTAINS,
+            'value' => 'bar',
+        );
+    }
 
 Available types are represented through classes which can be found here:
 https://github.com/sonata-project/SonataCoreBundle/tree/master/Form/Type

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -217,9 +217,10 @@ file that was distributed with this source code.
 
                 <ul class="dropdown-menu" role="menu">
                     {% for filter in admin.datagrid.filters if (filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null) %}
+                        {% set filterActive = ((filter.isActive() or filter.options['show_filter']) and not admin.isDefaultFilter(filter.formName)) %}
                         <li>
                             <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
-                                <i class="fa {{ (filter.isActive() or filter.options['show_filter']) ? 'fa-check-square-o' : 'fa-square-o' }}"></i>{{ admin.trans(filter.label, {}, filter.translationDomain) }}
+                                <i class="fa {{ filterActive ? 'fa-check-square-o' : 'fa-square-o' }}"></i>{{ admin.trans(filter.label, {}, filter.translationDomain) }}
                             </a>
                         </li>
                     {% endfor %}
@@ -243,7 +244,9 @@ file that was distributed with this source code.
                             <div class="col-sm-9">
                                 {% set withAdvancedFilter = false %}
                                 {% for filter in admin.datagrid.filters %}
-                                    <div class="form-group {% block sonata_list_filter_group_class %}{% endblock %}" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ (filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null) ? 'true' : 'false' }}" style="display: {% if (filter.isActive() and filter.options['show_filter'] is null) or (filter.options['show_filter'] is same as(true)) %}block{% else %}none{% endif %}">
+                                    {% set filterActive = ((filter.isActive() and filter.options['show_filter'] is null) or (filter.options['show_filter'] is same as(true))) and not admin.isDefaultFilter(filter.formName) %}
+                                    {% set filterVisible = filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null %}
+                                    <div class="form-group {% block sonata_list_filter_group_class %}{% endblock %}" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ filterVisible ? 'true' : 'false' }}" style="display: {% if filterActive %}block{% else %}none{% endif %}">
                                         {% if filter.label is not same as(false) %}
                                             <label for="{{ form.children[filter.formName].children['value'].vars.id }}" class="col-sm-3 control-label">{{ admin.trans(filter.label, {}, filter.translationDomain) }}</label>
                                         {% endif %}

--- a/Tests/Fixtures/Admin/FilteredAdmin.php
+++ b/Tests/Fixtures/Admin/FilteredAdmin.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+
+class FilteredAdmin extends AbstractAdmin
+{
+    protected function configureDefaultFilterValues(array &$filterValues)
+    {
+        $filterValues['foo'] = array(
+            'type' => '1',
+            'value' => 'bar',
+        );
+        $filterValues['baz'] = array(
+            'type' => '2',
+            'value' => 'test',
+        );
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a new BC feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rebase of #4017

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added new methods to set default values for the list view
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [x] Update the documentation

## Subject

If you set a filter to the `AbstractAdmin::$datagridValues`, the filter is always shown. This PR adds a feature to have a better solution for default values, so filters that matches the default value are now hidden.
