### PR TITLE
Fix empty list navbar

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2782,37 +2782,43 @@ EOT;
     {
         $list = array();
 
-        if (in_array($action, array('tree', 'show', 'edit', 'delete', 'list', 'batch'))) {
+        if (in_array($action, array('tree', 'show', 'edit', 'delete', 'list', 'batch')) && $this->hasAccess('create')) {
             $list['create'] = array(
                 'template' => 'SonataAdminBundle:Button:create_button.html.twig',
             );
         }
 
-        if (in_array($action, array('show', 'delete', 'acl', 'history')) && $object) {
+        if (in_array($action, array('show', 'delete', 'acl', 'history')) && $this->canAccessObject('edit', $object)) {
             $list['edit'] = array(
                 'template' => 'SonataAdminBundle:Button:edit_button.html.twig',
             );
         }
 
-        if (in_array($action, array('show', 'edit', 'acl')) && $object) {
+        if (in_array($action, array('show', 'edit', 'acl')) && $this->canAccessObject('history', $object)) {
             $list['history'] = array(
                 'template' => 'SonataAdminBundle:Button:history_button.html.twig',
             );
         }
 
-        if (in_array($action, array('edit', 'history')) && $object) {
+        if (in_array($action, array('edit', 'history'))
+            && $this->isAclEnabled()
+            && $this->canAccessObject('acl', $object)
+        ) {
             $list['acl'] = array(
                 'template' => 'SonataAdminBundle:Button:acl_button.html.twig',
             );
         }
 
-        if (in_array($action, array('edit', 'history', 'acl')) && $object) {
+        if (in_array($action, array('edit', 'history', 'acl'))
+            && $this->canAccessObject('show', $object)
+            && count($this->getShow()) > 0
+        ) {
             $list['show'] = array(
                 'template' => 'SonataAdminBundle:Button:show_button.html.twig',
             );
         }
 
-        if (in_array($action, array('show', 'edit', 'delete', 'acl', 'batch'))) {
+        if (in_array($action, array('show', 'edit', 'delete', 'acl', 'batch')) && $this->hasAccess('list')) {
             $list['list'] = array(
                 'template' => 'SonataAdminBundle:Button:list_button.html.twig',
             );
@@ -3196,5 +3202,18 @@ EOT;
         foreach ($this->getExtensions() as $extension) {
             $extension->configureRoutes($this, $this->routes);
         }
+    }
+
+    /**
+     * Check object existence and access, without throw Exception.
+     *
+     * @param string $action
+     * @param object $object
+     *
+     * @return bool
+     */
+    private function canAccessObject($action, $object)
+    {
+        return $object && $this->id($object) && $this->hasAccess($action, $object);
     }
 }

--- a/Resources/views/Button/acl_button.html.twig
+++ b/Resources/views/Button/acl_button.html.twig
@@ -9,8 +9,6 @@ file that was distributed with this source code.
 
 #}
 
-{% if admin.isAclEnabled() and admin.hasRoute('acl') and admin.id(object) and admin.isGranted('MASTER', object) %}
-    <a class="sonata-action-element" href="{{ admin.generateObjectUrl('acl', object) }}">
-        <i class="fa fa-users"></i>
-        {{ 'link_action_acl'|trans({}, 'SonataAdminBundle') }}</a>
-{% endif %}
+<a class="sonata-action-element" href="{{ admin.generateObjectUrl('acl', object) }}">
+    <i class="fa fa-users"></i>
+    {{ 'link_action_acl'|trans({}, 'SonataAdminBundle') }}</a>

--- a/Resources/views/Button/create_button.html.twig
+++ b/Resources/views/Button/create_button.html.twig
@@ -9,21 +9,19 @@ file that was distributed with this source code.
 
 #}
 
-{% if admin.hasRoute('create') and admin.isGranted('CREATE') %}
-    {% if admin.subClasses is empty %}
-        <a class="sonata-action-element" href="{{ admin.generateUrl('create') }}">
-            <i class="fa fa-plus-circle"></i>
-            {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }}</a>
-    {% else %}
-        <li class="divider" role="presentation"></li>
-        {% for subclass in admin.subclasses|keys %}
-            <li>
-                <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
-                    <i class="fa fa-plus-circle"></i>
-                    {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
-                </a>
-            </li>
-        {% endfor %}
-        <li class="divider" role="presentation"></li>
-    {% endif %}
+{% if admin.subClasses is empty %}
+    <a class="sonata-action-element" href="{{ admin.generateUrl('create') }}">
+        <i class="fa fa-plus-circle"></i>
+        {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }}</a>
+{% else %}
+    <li class="divider" role="presentation"></li>
+    {% for subclass in admin.subclasses|keys %}
+        <li>
+            <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
+                <i class="fa fa-plus-circle"></i>
+                {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
+            </a>
+        </li>
+    {% endfor %}
+    <li class="divider" role="presentation"></li>
 {% endif %}

--- a/Resources/views/Button/edit_button.html.twig
+++ b/Resources/views/Button/edit_button.html.twig
@@ -9,8 +9,6 @@ file that was distributed with this source code.
 
 #}
 
-{% if admin.hasRoute('edit') and admin.id(object) and admin.isGranted('EDIT', object) %}
-    <a class="sonata-action-element" href="{{ admin.generateObjectUrl('edit', object) }}">
-        <i class="fa fa-edit"></i>
-        {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}</a>
-{% endif %}
+<a class="sonata-action-element" href="{{ admin.generateObjectUrl('edit', object) }}">
+    <i class="fa fa-edit"></i>
+    {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}</a>

--- a/Resources/views/Button/history_button.html.twig
+++ b/Resources/views/Button/history_button.html.twig
@@ -9,8 +9,6 @@ file that was distributed with this source code.
 
 #}
 
-{% if admin.hasroute('history') and admin.id(object) and admin.isGranted('EDIT', object) %}
-    <a class="sonata-action-element" href="{{ admin.generateObjectUrl('history', object) }}">
-        <i class="fa fa-archive"></i>
-        {{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}</a>
-{% endif %}
+<a class="sonata-action-element" href="{{ admin.generateObjectUrl('history', object) }}">
+    <i class="fa fa-archive"></i>
+    {{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}</a>

--- a/Resources/views/Button/list_button.html.twig
+++ b/Resources/views/Button/list_button.html.twig
@@ -9,8 +9,6 @@ file that was distributed with this source code.
 
 #}
 
-{% if admin.hasroute('list') and admin.isGranted('LIST') %}
-    <a class="sonata-action-element" href="{{ admin.generateUrl('list') }}">
-        <i class="fa fa-list"></i>
-        {{ 'link_action_list'|trans({}, 'SonataAdminBundle') }}</a>
-{% endif %}
+<a class="sonata-action-element" href="{{ admin.generateUrl('list') }}">
+    <i class="fa fa-list"></i>
+    {{ 'link_action_list'|trans({}, 'SonataAdminBundle') }}</a>

--- a/Resources/views/Button/show_button.html.twig
+++ b/Resources/views/Button/show_button.html.twig
@@ -9,8 +9,6 @@ file that was distributed with this source code.
 
 #}
 
-{% if admin.hasroute('show') and admin.id(object) and admin.isGranted('VIEW', object) and admin.show|length > 0 %}
-    <a class="sonata-action-element" href="{{ admin.generateObjectUrl('show', object) }}">
-        <i class="fa fa-eye"></i>
-        {{ 'link_action_show'|trans({}, 'SonataAdminBundle') }}</a>
-{% endif %}
+<a class="sonata-action-element" href="{{ admin.generateObjectUrl('show', object) }}">
+    <i class="fa fa-eye"></i>
+    {{ 'link_action_show'|trans({}, 'SonataAdminBundle') }}</a>

--- a/Resources/views/CRUD/action.html.twig
+++ b/Resources/views/CRUD/action.html.twig
@@ -11,9 +11,9 @@ file that was distributed with this source code.
 
 {% extends base_template %}
 
-{% block actions %}
+{%- block actions -%}
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
-{% endblock %}
+{%- endblock -%}
 
 {% block tab_menu %}
     {% if action is defined %}

--- a/Resources/views/CRUD/base_acl.html.twig
+++ b/Resources/views/CRUD/base_acl.html.twig
@@ -11,9 +11,9 @@ file that was distributed with this source code.
 
 {% extends base_template %}
 
-{% block actions %}
+{%- block actions -%}
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
-{% endblock %}
+{%- endblock -%}
 
 {% import 'SonataAdminBundle:CRUD:base_acl_macro.html.twig' as acl %}
 

--- a/Resources/views/CRUD/base_edit.html.twig
+++ b/Resources/views/CRUD/base_edit.html.twig
@@ -23,9 +23,9 @@ file that was distributed with this source code.
     {{ block('title') }}
 {% endblock %}
 
-{% block actions %}
+{%- block actions -%}
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
-{% endblock %}
+{%- endblock -%}
 
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
 

--- a/Resources/views/CRUD/base_history.html.twig
+++ b/Resources/views/CRUD/base_history.html.twig
@@ -11,9 +11,9 @@ file that was distributed with this source code.
 
 {% extends base_template %}
 
-{% block actions %}
+{%- block actions -%}
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
-{% endblock %}
+{%- endblock -%}
 
 {% block content %}
 

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -206,7 +206,7 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block list_filters_actions %}
-    {%- if admin.datagrid.filters|length %}
+    {%- if admin.datagrid.hasDisplayableFilters %}
         <ul class="nav navbar-nav navbar-right">
 
             <li class="dropdown sonata-actions">

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -11,9 +11,9 @@ file that was distributed with this source code.
 
 {% extends base_template %}
 
-{% block actions %}
+{%- block actions -%}
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
-{% endblock %}
+{%- endblock -%}
 
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
 

--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -13,9 +13,9 @@ file that was distributed with this source code.
 
 {% import 'SonataAdminBundle:CRUD:base_show_macro.html.twig' as show_helper %}
 
-{% block actions %}
+{%- block actions -%}
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
-{% endblock %}
+{%- endblock -%}
 
 {% block tab_menu %}
     {{ knp_menu_render(admin.sidemenu(action), {

--- a/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/Resources/views/CRUD/batch_confirmation.html.twig
@@ -11,9 +11,9 @@ file that was distributed with this source code.
 
 {% extends base_template %}
 
-{% block actions %}
+{%- block actions -%}
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
-{% endblock %}
+{%- endblock -%}
 
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
 

--- a/Resources/views/CRUD/delete.html.twig
+++ b/Resources/views/CRUD/delete.html.twig
@@ -11,9 +11,9 @@ file that was distributed with this source code.
 
 {% extends base_template %}
 
-{% block actions %}
+{%- block actions -%}
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
-{% endblock %}
+{%- endblock -%}
 
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
 

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1643,6 +1643,14 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
+        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
+        $securityHandler
+            ->expects($this->once())
+            ->method('isGranted')
+            ->with($admin, 'CREATE', $admin)
+            ->will($this->returnValue(true));
+        $admin->setSecurityHandler($securityHandler);
+
         $this->assertSame($expected, $admin->getActionButtons('list', null));
     }
 

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1655,6 +1655,24 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Sonata\AdminBundle\Admin\AbstractAdmin::configureActionButtons
+     */
+    public function testGetActionButtonsListCreateDisabled()
+    {
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+
+        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
+        $securityHandler
+            ->expects($this->once())
+            ->method('isGranted')
+            ->with($admin, 'CREATE', $admin)
+            ->will($this->returnValue(false));
+        $admin->setSecurityHandler($securityHandler);
+
+        $this->assertSame(array(), $admin->getActionButtons('list', null));
+    }
+
+    /**
      * @covers Sonata\AdminBundle\Admin\AbstractAdmin::configureBatchActions
      */
     public function getBatchActions()


### PR DESCRIPTION
Pull requested against 3.x as it looks like a bug!

## Changelog

```markdown
### Changed
- Move actions buttons display logic from templates to `AbstractAdmin::configureActionButtons`
- Hide filters action button if admin doesn't have any displayable filters
### Fixed
- ability to hide the navbar if there are no displayable filters and no actions buttons
- Hide the actions navbar if empty
```

## Subject

Without these changes, it was not possible to hide the navbar even if there is no mosaic button, no displayable filters and no actions. This may have been a feature in the past because https://github.com/sonata-project/SonataAdminBundle/blob/3.x/Resources/views/standard_layout.html.twig#L241 contains emptyness checks against tabs menu, filters and actions.

For the BC beak, I don't know if I did things right by removing the checks in templates as some users may have overrided `AbstractAdmin::configureActionButtons`