### PR TITLE
added test for ChildrenVoter

### DIFF
--- a/Tests/Menu/Matcher/Voter/ChildrenVoterTest.php
+++ b/Tests/Menu/Matcher/Voter/ChildrenVoterTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Menu\Matcher\Voter;
+
+use Knp\Menu\Matcher\Matcher;
+use Sonata\AdminBundle\Menu\Matcher\Voter\ChildrenVoter;
+
+/**
+ * @author Ahmet Akbana <ahmetakbana@gmail.com>
+ */
+class ChildrenVoterTest extends AbstractVoterTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function provideData()
+    {
+        return array(
+            'with no current' => array(array(false, false), null, new Matcher(), null),
+            'with current' => array(array(true, false), null, new Matcher(), true),
+            'with single child' => array(array(true), null, new Matcher(), true),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createVoter($dataVoter, $route)
+    {
+        return new ChildrenVoter($route);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createItem($data)
+    {
+        $childItems = array();
+        foreach ($data as $childData) {
+            $childItem = $this->getMock('Knp\Menu\ItemInterface');
+            $childItem->expects($this->any())
+                ->method('isCurrent')
+                ->willReturn($childData);
+            $childItems[] = $childItem;
+        }
+
+        $item = $this->getMock('Knp\Menu\ItemInterface');
+        $item->expects($this->any())
+            ->method('getChildren')
+            ->will($this->returnValue($childItems));
+
+        return $item;
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because I would like to improve code and test coverage

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added test for `AdminBundle\Menu\Matcher\Voter\ChildrenVoter`
```

## Subject

Adding more tests.

