### PR TITLE
Added support for filter class names

### DIFF
--- a/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
+++ b/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
@@ -31,12 +31,17 @@ class AddFilterTypeCompilerPass implements CompilerPassInterface
         $types = array();
 
         foreach ($container->findTaggedServiceIds('sonata.admin.filter.type') as $id => $attributes) {
+            $serviceDefinition = $container->getDefinition($id);
+
             if (method_exists($definition, 'setShared')) { // Symfony 2.8+
-                $container->getDefinition($id)->setShared(false);
+                $serviceDefinition->setShared(false);
             } else { // For Symfony <2.8 compatibility
-                $container->getDefinition($id)->setScope(ContainerInterface::SCOPE_PROTOTYPE);
+                $serviceDefinition->setScope(ContainerInterface::SCOPE_PROTOTYPE);
             }
 
+            $types[$serviceDefinition->getClass()] = $id;
+
+            // NEXT_MAJOR: Remove the alias when dropping support for symfony 2.x
             foreach ($attributes as $eachTag) {
                 $types[$eachTag['alias']] = $id;
             }

--- a/Resources/doc/reference/action_list.rst
+++ b/Resources/doc/reference/action_list.rst
@@ -460,7 +460,7 @@ If you have the **SonataDoctrineORMAdminBundle** installed you can use the ``doc
         protected function configureDatagridFilters(DatagridMapper $datagridMapper)
         {
             $datagridMapper
-                ->add('full_text', 'doctrine_orm_callback', array(
+                ->add('full_text', CallbackFilter::class, array(
                     'callback' => array($this, 'getFullTextFilter'),
                     'field_type' => 'text'
                 ))

--- a/Tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\DependencyInjection;
+
+use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
+
+class AddFilterTypeCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    private $filterFactory;
+
+    private $fooFilter;
+
+    private $barFilter;
+
+    public function setUp()
+    {
+        $this->filterFactory = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $this->fooFilter = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $this->barFilter = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+    }
+
+    public function testProcess()
+    {
+        $containerBuilderMock = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+
+        $containerBuilderMock->expects($this->any())
+            ->method('getDefinition')
+            ->with($this->anything())
+            ->will($this->returnValueMap(array(
+                array('sonata.admin.builder.filter.factory', $this->filterFactory),
+                array('acme.demo.foo_filter', $this->fooFilter),
+                array('acme.demo.bar_filter', $this->barFilter),
+            )));
+
+        $containerBuilderMock->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with($this->equalTo('sonata.admin.filter.type'))
+            ->will($this->returnValue(array(
+                'acme.demo.foo_filter' => array(
+                    'tag1' => array(
+                        'alias' => 'foo_filter_alias',
+                    ),
+                ),
+                'acme.demo.bar_filter' => array(
+                    'tag1' => array(
+                        'alias' => 'bar_filter_alias',
+                    ),
+                ),
+            )));
+
+        $this->fooFilter->method('getClass')
+            ->will($this->returnValue('Acme\Filter\FooFilter'));
+
+        $this->barFilter->method('getClass')
+            ->will($this->returnValue('Acme\Filter\BarFilter'));
+
+        $this->filterFactory->expects($this->once())
+            ->method('replaceArgument')
+            ->with(1, $this->equalTo(array(
+                'foo_filter_alias' => 'acme.demo.foo_filter',
+                'Acme\Filter\FooFilter' => 'acme.demo.foo_filter',
+                'bar_filter_alias' => 'acme.demo.bar_filter',
+                'Acme\Filter\BarFilter' => 'acme.demo.bar_filter',
+            )));
+
+        $extensionsPass = new AddFilterTypeCompilerPass();
+        $extensionsPass->process($containerBuilderMock);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4035

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added class name support for `AbstractAdmin::configureDatagridFilters`
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [x] Update the documentation

## Subject

When using `AbstractAdmin::configureDatagridFilters`, you can now use the alias (e.g. `doctrine_orm_choice`) or the class name (`ChoiceFilter::class`), which is the symfony2.8+ style.

