### PR TITLE
Moved translation of breadcrumbs to template

### DIFF
--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -66,7 +66,7 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
             $admin,
             $menu,
             sprintf('%s_list', $admin->getClassnameLabel()),
-            null,
+            $admin->getTranslationDomain(),
             array(
                 'uri' => $admin->hasRoute('list') && $admin->isGranted('LIST') ?
                 $admin->generateUrl('list') :
@@ -101,7 +101,8 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
             $menu = $this->createMenuItem(
                 $admin,
                 $menu,
-                sprintf('%s_%s', $admin->getClassnameLabel(), $action)
+                sprintf('%s_%s', $admin->getClassnameLabel(), $action),
+                $admin->getTranslationDomain()
             );
         }
 
@@ -127,15 +128,17 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
         $translationDomain = null,
         $options = array()
     ) {
+        $options = array_merge(array(
+            'extras' => array(
+                'translation_domain' => $translationDomain,
+            ),
+        ), $options);
+
         return $menu->addChild(
-            $admin->trans(
-                $admin->getLabelTranslatorStrategy()->getLabel(
-                    $name,
-                    'breadcrumb',
-                    'link'
-                ),
-                array(),
-                $translationDomain
+            $admin->getLabelTranslatorStrategy()->getLabel(
+                $name,
+                'breadcrumb',
+                'link'
             ),
             $options
         );

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -139,22 +139,28 @@ file that was distributed with this source code.
                                             {% if _breadcrumb is empty %}
                                                 {% if action is defined %}
                                                     {% for menu in breadcrumbs_builder.breadcrumbs(admin, action) %}
+                                                        {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
+                                                        {%- set label = menu.label -%}
+                                                        {%- if translation_domain is not same as(false) -%}
+                                                            {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
+                                                        {%- endif -%}
+
                                                         {% if not loop.last  %}
                                                             <li>
                                                                 {% if menu.uri is not empty %}
                                                                     <a href="{{ menu.uri }}">
                                                                         {% if menu.extra('safe_label', true) %}
-                                                                            {{- menu.label|raw -}}
+                                                                            {{- label|raw -}}
                                                                         {% else %}
-                                                                            {{- menu.label -}}
+                                                                            {{- label -}}
                                                                         {% endif %}
                                                                     </a>
                                                                 {% else %}
-                                                                    {{ menu.label }}
+                                                                    {{ label }}
                                                                 {% endif %}
                                                             </li>
                                                         {% else %}
-                                                            <li class="active"><span>{{ menu.label }}</span></li>
+                                                            <li class="active"><span>{{ label }}</span></li>
                                                         {% endif %}
                                                     {% endfor %}
                                                 {% endif %}

--- a/Tests/Admin/BreadcrumbsBuilderTest.php
+++ b/Tests/Admin/BreadcrumbsBuilderTest.php
@@ -302,15 +302,17 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
             'breadcrumb',
             'link'
         )->willReturn('Dashboard');
-        $admin->trans('Dashboard', array(), 'SonataAdminBundle')->willReturn(
-            'Tableau de bord'
-        );
 
         $routeGenerator = $this->prophesize('Sonata\AdminBundle\Route\RouteGeneratorInterface');
         $routeGenerator->generate('sonata_admin_dashboard')->willReturn('/dashboard');
 
         $admin->getRouteGenerator()->willReturn($routeGenerator->reveal());
-        $menu->addChild('Tableau de bord', array('uri' => '/dashboard'))->willReturn(
+        $menu->addChild('Dashboard', array(
+            'uri' => '/dashboard',
+            'extras' => array(
+                'translation_domain' => 'SonataAdminBundle',
+            ),
+        ))->willReturn(
             $dashboardMenu->reveal()
         );
         $labelTranslatorStrategy->getLabel(
@@ -326,6 +328,7 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         $childAdmin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
         $childAdmin->isChild()->willReturn(true);
         $childAdmin->getParent()->willReturn($admin->reveal());
+        $childAdmin->getTranslationDomain()->willReturn('ChildBundle');
         $childAdmin->getLabelTranslatorStrategy()
             ->shouldBeCalled()
             ->willReturn($labelTranslatorStrategy->reveal());
@@ -333,13 +336,11 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         $childAdmin->hasRoute('list')->willReturn(true);
         $childAdmin->isGranted('LIST')->willReturn(true);
         $childAdmin->generateUrl('list')->willReturn('/myadmin/my-object/mychildadmin/list');
-        $childAdmin->trans('My child class', array(), null)->willReturn('Ma classe fille');
         $childAdmin->getCurrentChildAdmin()->willReturn(null);
         $childAdmin->hasSubject()->willReturn(true);
         $childAdmin->getSubject()->willReturn('my subject');
         $childAdmin->toString('my subject')->willReturn('My subject');
 
-        $admin->trans('My class', array(), null)->willReturn('Ma classe');
         $admin->hasRoute('list')->willReturn(true);
         $admin->isGranted('LIST')->willReturn(true);
         $admin->generateUrl('list')->willReturn('/myadmin/list');
@@ -355,12 +356,16 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         $admin->hasSubject()->willReturn(true);
         $admin->getSubject()->willReturn('my subject');
         $admin->toString('my subject')->willReturn('My subject');
+        $admin->getTranslationDomain()->willReturn('FooBundle');
         $admin->getLabelTranslatorStrategy()->willReturn(
             $labelTranslatorStrategy->reveal()
         );
         $admin->getClassnameLabel()->willReturn('my_class_name');
 
-        $dashboardMenu->addChild('Ma classe', array(
+        $dashboardMenu->addChild('My class', array(
+            'extras' => array(
+                'translation_domain' => 'FooBundle',
+            ),
             'uri' => '/myadmin/list',
         ))->shouldBeCalled()->willReturn($adminListMenu->reveal());
 
@@ -368,7 +373,10 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
             'uri' => '/myadmin/my-object',
         ))->shouldBeCalled()->willReturn($adminSubjectMenu->reveal());
 
-        $adminSubjectMenu->addChild('Ma classe fille', array(
+        $adminSubjectMenu->addChild('My child class', array(
+            'extras' => array(
+                'translation_domain' => 'ChildBundle',
+            ),
             'uri' => '/myadmin/my-object/mychildadmin/list',
         ))->shouldBeCalled()->willReturn($childMenu->reveal());
         $adminSubjectMenu->setExtra('safe_label', false)->willReturn($childMenu);
@@ -410,14 +418,16 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
             'breadcrumb',
             'link'
         )->willReturn('Dashboard');
-        $admin->trans('Dashboard', array(), 'SonataAdminBundle')->willReturn(
-            'Tableau de bord'
-        );
 
         $routeGenerator = $this->prophesize('Sonata\AdminBundle\Route\RouteGeneratorInterface');
         $routeGenerator->generate('sonata_admin_dashboard')->willReturn('/dashboard');
         $admin->getRouteGenerator()->willReturn($routeGenerator->reveal());
-        $menu->addChild('Tableau de bord', array('uri' => '/dashboard'))->willReturn(
+        $menu->addChild('Dashboard', array(
+            'uri' => '/dashboard',
+            'extras' => array(
+                'translation_domain' => 'SonataAdminBundle',
+            ),
+        ))->willReturn(
             $menu->reveal()
         );
         $labelTranslatorStrategy->getLabel(
@@ -441,19 +451,20 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
                 'breadcrumb',
                 'link'
             )->willReturn('create my object');
-            $admin->trans('create my object', array(), null)->willReturn('Créer mon objet')->shouldBeCalled();
-            $menu->addChild('Créer mon objet', array())->willReturn($menu);
+            $menu->addChild('create my object', array(
+                'extras' => array(
+                    'translation_domain' => 'FooBundle',
+                ),
+            ))->willReturn($menu);
         }
         $childAdmin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $childAdmin->getTranslationDomain()->willReturn('ChildBundle');
         $childAdmin->getLabelTranslatorStrategy()->willReturn($labelTranslatorStrategy->reveal());
         $childAdmin->getClassnameLabel()->willReturn('my_child_class_name');
         $childAdmin->hasRoute('list')->willReturn(false);
-        $childAdmin->trans('My child class', array(), null)->willReturn('Ma classe fille');
-        $childAdmin->trans('My action', array(), null)->willReturn('Mon action');
         $childAdmin->getCurrentChildAdmin()->willReturn(null);
         $childAdmin->hasSubject()->willReturn(false);
 
-        $admin->trans('My class', array(), null)->willReturn('Ma classe');
         $admin->hasRoute('list')->willReturn(true);
         $admin->isGranted('LIST')->willReturn(true);
         $admin->generateUrl('list')->willReturn('/myadmin/list');
@@ -473,20 +484,34 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         $admin->hasSubject()->willReturn(true);
         $admin->getSubject()->willReturn('my subject');
         $admin->toString('my subject')->willReturn('My subject');
+        $admin->getTranslationDomain()->willReturn('FooBundle');
         $admin->getLabelTranslatorStrategy()->willReturn(
             $labelTranslatorStrategy->reveal()
         );
         $admin->getClassnameLabel()->willReturn('my_class_name');
 
-        $menu->addChild('Ma classe', array(
+        $menu->addChild('My class', array(
             'uri' => '/myadmin/list',
+            'extras' => array(
+                'translation_domain' => 'FooBundle',
+            ),
         ))->willReturn($menu->reveal());
         $menu->addChild('My subject')->willReturn($menu);
-        $menu->addChild('My subject', array('uri' => null))->willReturn($menu);
-        $menu->addChild('Ma classe fille', array('uri' => null))->willReturn($menu);
+        $menu->addChild('My subject', array(
+            'uri' => null,
+        ))->willReturn($menu);
+        $menu->addChild('My child class', array(
+            'extras' => array(
+                'translation_domain' => 'ChildBundle',
+            ),
+            'uri' => null,
+        ))->willReturn($menu);
         $menu->setExtra('safe_label', false)->willReturn($menu);
-        $menu->addChild('Mon action', array())->willReturn($menu);
-
+        $menu->addChild('My action', array(
+            'extras' => array(
+                'translation_domain' => 'ChildBundle',
+            ),
+        ))->willReturn($menu);
 
         $breadcrumbsBuilder->buildBreadCrumbs($admin->reveal(), $action);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Moved translation of breadcrumbs to twig template
```

## Subject

We use twig for translating several labels and text. This should also been done for the breadcrumb, so we could use the `KnpMenuBundle` for the whole breadcrumb generation and translation logic.
