### PR TITLE
Moved translation of batch action_label to template

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -417,14 +417,17 @@ class CRUDController extends Controller
             true;
 
         if ($askConfirmation && $confirmation != 'ok') {
-            $translationDomain = $batchActions[$action]['translation_domain'] ?: $this->admin->getTranslationDomain();
-            $actionLabel = $this->admin->trans($batchActions[$action]['label'], array(), $translationDomain);
+            $actionLabel = $batchActions[$action]['label'];
+            $batchTranslationDomain = isset($batchActions[$action]['translation_domain']) ?
+                $batchActions[$action]['translation_domain'] :
+                $this->admin->getTranslationDomain();
 
             $formView = $datagrid->getForm()->createView();
 
             return $this->render($this->admin->getTemplate('batch_confirmation'), array(
                 'action' => 'list',
                 'action_label' => $actionLabel,
+                'batch_translation_domain' => $batchTranslationDomain,
                 'datagrid' => $datagrid,
                 'form' => $formView,
                 'data' => $data,

--- a/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/Resources/views/CRUD/batch_confirmation.html.twig
@@ -21,6 +21,9 @@ file that was distributed with this source code.
     <div class="sonata-ba-delete">
         <div class="box box-danger">
             <div class="box-header">
+                {% if batch_translation_domain is not same as(false) %}
+                    {% set action_label = action_label|trans({}, batch_translation_domain) %}
+                {% endif %}
                 <h4 class="box-title">{% trans with {'%action%': action_label} from 'SonataAdminBundle' %}title_batch_confirmation{% endtrans %}</h4>
             </div>
             <div class="box-body">

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -3403,11 +3403,6 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $this->admin->expects($this->once())
-            ->method('trans')
-            ->with($this->equalTo('Foo Bar'), $this->anything(), $this->equalTo('FooBarBaz'))
-            ->will($this->returnValue('Foo Bar'));
-
         $data = array('action' => 'delete', 'idx' => array('123', '456'), 'all_elements' => false);
 
         $this->request->setMethod('POST');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Moved translation of batch action_label to twig template
```

## Subject

We use twig for translating several labels and text. This should also been done for batch action. The new `batch_translation_domain` parameter could be used for other translations too.
