### PR TITLE
Add aria-hidden to icon

### DIFF
--- a/Resources/views/Block/block_rss_dashboard.html.twig
+++ b/Resources/views/Block/block_rss_dashboard.html.twig
@@ -14,7 +14,7 @@ file that was distributed with this source code.
 {% block block %}
     <div class="box box-warning">
         <div class="box-header with-border">
-            <h3 class="box-title sonata-feed-title"><i class="fa fa-rss"></i> {{ settings.title }}</h3>
+            <h3 class="box-title sonata-feed-title"><i class="fa fa-rss" aria-hidden="true"></i> {{ settings.title }}</h3>
         </div>
 
         <div class="sonata-feeds-container list-group">

--- a/Resources/views/Block/block_search_result.html.twig
+++ b/Resources/views/Block/block_search_result.html.twig
@@ -26,12 +26,12 @@ file that was distributed with this source code.
                         <span class="badge">{{ pager.getNbResults() }}</span>
                     {% elseif admin.hasRoute('create') and admin.isGranted('CREATE') %}
                         <a href="{{ admin.generateUrl('create') }}" class="btn btn-box-tool">
-                            <i class="fa fa-plus"></i>
+                            <i class="fa fa-plus" aria-hidden="true"></i>
                         </a>
                     {% endif %}
                     {% if admin.hasRoute('list') and admin.isGranted('LIST') %}
                         <a href="{{ admin.generateUrl('list') }}" class="btn btn-box-tool">
-                            <i class="fa fa-list"></i>
+                            <i class="fa fa-list" aria-hidden="true"></i>
                         </a>
                     {% endif %}
                 </div>

--- a/Resources/views/Block/block_stats.html.twig
+++ b/Resources/views/Block/block_stats.html.twig
@@ -23,7 +23,7 @@ file that was distributed with this source code.
             <i class="fa {{ settings.icon }}"></i>
         </div>
         <a href="{{ admin.generateUrl('list', {filter: settings.filters}) }}" class="small-box-footer">
-            {{ 'stats_view_more'|trans({}, 'SonataAdminBundle') }} <i class="fa fa-arrow-circle-right"></i>
+            {{ 'stats_view_more'|trans({}, 'SonataAdminBundle') }} <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
         </a>
     </div>
 {% endblock %}

--- a/Resources/views/Button/acl_button.html.twig
+++ b/Resources/views/Button/acl_button.html.twig
@@ -10,6 +10,6 @@ file that was distributed with this source code.
 #}
 {% if admin.isAclEnabled() and admin.canAccessObject('acl', object) and admin.hasRoute('acl') %}
     <a class="sonata-action-element" href="{{ admin.generateObjectUrl('acl', object) }}">
-        <i class="fa fa-users"></i>
+        <i class="fa fa-users" aria-hidden="true"></i>
         {{ 'link_action_acl'|trans({}, 'SonataAdminBundle') }}</a>
 {% endif %}

--- a/Resources/views/Button/create_button.html.twig
+++ b/Resources/views/Button/create_button.html.twig
@@ -12,14 +12,14 @@ file that was distributed with this source code.
 {% if admin.hasAccess('create') and admin.hasRoute('create') %}
     {% if admin.subClasses is empty %}
         <a class="sonata-action-element" href="{{ admin.generateUrl('create') }}">
-            <i class="fa fa-plus-circle"></i>
+            <i class="fa fa-plus-circle" aria-hidden="true"></i>
             {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }}</a>
     {% else %}
         <li class="divider" role="presentation"></li>
         {% for subclass in admin.subclasses|keys %}
             <li>
                 <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
-                    <i class="fa fa-plus-circle"></i>
+                    <i class="fa fa-plus-circle" aria-hidden="true"></i>
                     {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
                 </a>
             </li>

--- a/Resources/views/Button/edit_button.html.twig
+++ b/Resources/views/Button/edit_button.html.twig
@@ -11,6 +11,6 @@ file that was distributed with this source code.
 
 {% if admin.canAccessObject('edit', object) and admin.hasRoute('edit') %}
     <a class="sonata-action-element" href="{{ admin.generateObjectUrl('edit', object) }}">
-        <i class="fa fa-edit"></i>
+        <i class="fa fa-edit" aria-hidden="true"></i>
         {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}</a>
 {% endif %}

--- a/Resources/views/Button/history_button.html.twig
+++ b/Resources/views/Button/history_button.html.twig
@@ -11,6 +11,6 @@ file that was distributed with this source code.
 
 {% if admin.canAccessObject('history', object) and admin.hasRoute('history') %}
     <a class="sonata-action-element" href="{{ admin.generateObjectUrl('history', object) }}">
-        <i class="fa fa-archive"></i>
+        <i class="fa fa-archive" aria-hidden="true"></i>
         {{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}</a>
 {% endif %}

--- a/Resources/views/Button/list_button.html.twig
+++ b/Resources/views/Button/list_button.html.twig
@@ -11,6 +11,6 @@ file that was distributed with this source code.
 
 {% if admin.hasAccess('list') and admin.hasRoute('list') %}
     <a class="sonata-action-element" href="{{ admin.generateUrl('list') }}">
-        <i class="fa fa-list"></i>
+        <i class="fa fa-list" aria-hidden="true"></i>
         {{ 'link_action_list'|trans({}, 'SonataAdminBundle') }}</a>
 {% endif %}

--- a/Resources/views/Button/show_button.html.twig
+++ b/Resources/views/Button/show_button.html.twig
@@ -10,6 +10,6 @@ file that was distributed with this source code.
 #}
 {% if admin.canAccessObject('show', object) and admin.show|length > 0 and admin.hasRoute('show') %}
     <a class="sonata-action-element" href="{{ admin.generateObjectUrl('show', object) }}">
-        <i class="fa fa-eye"></i>
+        <i class="fa fa-eye" aria-hidden="true"></i>
         {{ 'link_action_show'|trans({}, 'SonataAdminBundle') }}</a>
 {% endif %}

--- a/Resources/views/CRUD/base_edit_form.html.twig
+++ b/Resources/views/CRUD/base_edit_form.html.twig
@@ -32,7 +32,7 @@
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">
                                 {% for name, form_tab in admin.formtabs %}
-                                    <li{% if loop.index == 1 %} class="active"{% endif %}><a href="#tab_{{ admin.uniqid }}_{{ loop.index }}" data-toggle="tab"><i class="fa fa-exclamation-circle has-errors hide"></i> {{ admin.trans(name, {}, form_tab.translation_domain) }}</a></li>
+                                    <li{% if loop.index == 1 %} class="active"{% endif %}><a href="#tab_{{ admin.uniqid }}_{{ loop.index }}" data-toggle="tab"><i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i> {{ admin.trans(name, {}, form_tab.translation_domain) }}</a></li>
                                 {% endfor %}
                             </ul>
                             <div class="tab-content">
@@ -68,40 +68,40 @@
                 {% block sonata_form_actions %}
                     {% if app.request.isxmlhttprequest %}
                         {% if admin.id(object) is not null %}
-                            <button type="submit" class="btn btn-success" name="btn_update"><i class="fa fa-save"></i> {{ 'btn_update'|trans({}, 'SonataAdminBundle') }}</button>
+                            <button type="submit" class="btn btn-success" name="btn_update"><i class="fa fa-save" aria-hidden="true"></i> {{ 'btn_update'|trans({}, 'SonataAdminBundle') }}</button>
                         {% else %}
-                            <button type="submit" class="btn btn-success" name="btn_create"><i class="fa fa-plus-circle"></i> {{ 'btn_create'|trans({}, 'SonataAdminBundle') }}</button>
+                            <button type="submit" class="btn btn-success" name="btn_create"><i class="fa fa-plus-circle" aria-hidden="true"></i> {{ 'btn_create'|trans({}, 'SonataAdminBundle') }}</button>
                         {% endif %}
                     {% else %}
                         {% if admin.supportsPreviewMode %}
                             <button class="btn btn-info persist-preview" name="btn_preview" type="submit">
-                                <i class="fa fa-eye"></i>
+                                <i class="fa fa-eye" aria-hidden="true"></i>
                                 {{ 'btn_preview'|trans({}, 'SonataAdminBundle') }}
                             </button>
                         {% endif %}
                         {% if admin.id(object) is not null %}
-                            <button type="submit" class="btn btn-success" name="btn_update_and_edit"><i class="fa fa-save"></i> {{ 'btn_update_and_edit_again'|trans({}, 'SonataAdminBundle') }}</button>
+                            <button type="submit" class="btn btn-success" name="btn_update_and_edit"><i class="fa fa-save" aria-hidden="true"></i> {{ 'btn_update_and_edit_again'|trans({}, 'SonataAdminBundle') }}</button>
 
                             {% if admin.hasroute('list') and admin.isGranted('LIST') %}
-                                <button type="submit" class="btn btn-success" name="btn_update_and_list"><i class="fa fa-save"></i> <i class="fa fa-list"></i> {{ 'btn_update_and_return_to_list'|trans({}, 'SonataAdminBundle') }}</button>
+                                <button type="submit" class="btn btn-success" name="btn_update_and_list"><i class="fa fa-save"></i> <i class="fa fa-list" aria-hidden="true"></i> {{ 'btn_update_and_return_to_list'|trans({}, 'SonataAdminBundle') }}</button>
                             {% endif %}
 
                             {% if admin.hasroute('delete') and admin.isGranted('DELETE', object) %}
                                 {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
-                                <a class="btn btn-danger" href="{{ admin.generateObjectUrl('delete', object) }}"><i class="fa fa-minus-circle"></i> {{ 'link_delete'|trans({}, 'SonataAdminBundle') }}</a>
+                                <a class="btn btn-danger" href="{{ admin.generateObjectUrl('delete', object) }}"><i class="fa fa-minus-circle" aria-hidden="true"></i> {{ 'link_delete'|trans({}, 'SonataAdminBundle') }}</a>
                             {% endif %}
 
                             {% if admin.isAclEnabled() and admin.hasroute('acl') and admin.isGranted('MASTER', object) %}
-                                <a class="btn btn-info" href="{{ admin.generateObjectUrl('acl', object) }}"><i class="fa fa-users"></i> {{ 'link_edit_acl'|trans({}, 'SonataAdminBundle') }}</a>
+                                <a class="btn btn-info" href="{{ admin.generateObjectUrl('acl', object) }}"><i class="fa fa-users" aria-hidden="true"></i> {{ 'link_edit_acl'|trans({}, 'SonataAdminBundle') }}</a>
                             {% endif %}
                         {% else %}
                             {% if admin.hasroute('edit') and admin.isGranted('EDIT') %}
-                                <button class="btn btn-success" type="submit" name="btn_create_and_edit"><i class="fa fa-save"></i> {{ 'btn_create_and_edit_again'|trans({}, 'SonataAdminBundle') }}</button>
+                                <button class="btn btn-success" type="submit" name="btn_create_and_edit"><i class="fa fa-save" aria-hidden="true"></i> {{ 'btn_create_and_edit_again'|trans({}, 'SonataAdminBundle') }}</button>
                             {% endif %}
                             {% if admin.hasroute('list') and admin.isGranted('LIST') %}
-                                <button type="submit" class="btn btn-success" name="btn_create_and_list"><i class="fa fa-save"></i> <i class="fa fa-list"></i> {{ 'btn_create_and_return_to_list'|trans({}, 'SonataAdminBundle') }}</button>
+                                <button type="submit" class="btn btn-success" name="btn_create_and_list"><i class="fa fa-save"></i> <i class="fa fa-list" aria-hidden="true"></i> {{ 'btn_create_and_return_to_list'|trans({}, 'SonataAdminBundle') }}</button>
                             {% endif %}
-                            <button class="btn btn-success" type="submit" name="btn_create_and_create"><i class="fa fa-plus-circle"></i> {{ 'btn_create_and_create_a_new_one'|trans({}, 'SonataAdminBundle') }}</button>
+                            <button class="btn btn-success" type="submit" name="btn_create_and_create"><i class="fa fa-plus-circle" aria-hidden="true"></i> {{ 'btn_create_and_create_a_new_one'|trans({}, 'SonataAdminBundle') }}</button>
                         {% endif %}
                     {% endif %}
                 {% endblock %}

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -83,7 +83,7 @@ file that was distributed with this source code.
                 {% else %}
                     {% block no_result_content %}
                         <div class="info-box">
-                            <span class="info-box-icon bg-aqua"><i class="fa fa-arrow-circle-right"></i></span>
+                            <span class="info-box-icon bg-aqua"><i class="fa fa-arrow-circle-right" aria-hidden="true"></i></span>
                             <div class="info-box-content">
                                 <span class="info-box-text">{{ 'no_result'|trans({}, 'SonataAdminBundle') }}</span>
                                 <div class="progress">
@@ -163,7 +163,7 @@ file that was distributed with this source code.
                                     {% if admin.hasRoute('export') and admin.isGranted('EXPORT') and admin.getExportFormats()|length %}
                                         <div class="btn-group">
                                             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-                                                <i class="fa fa-share-square-o"></i>
+                                                <i class="fa fa-share-square-o" aria-hidden="true"></i>
                                                 {{ "label_export_download"|trans({}, "SonataAdminBundle") }}
                                                 <span class="caret"></span>
                                             </button>
@@ -171,7 +171,7 @@ file that was distributed with this source code.
                                                 {% for format in admin.getExportFormats() %}
                                                 <li>
                                                     <a href="{{ admin.generateUrl('export', admin.modelmanager.paginationparameters(admin.datagrid, 0) + {'format' : format}) }}">
-                                                        <i class="fa fa-arrow-circle-o-down"></i>
+                                                        <i class="fa fa-arrow-circle-o-down" aria-hidden="true"></i>
                                                         {{ ("export_format_" ~ format)|trans({}, 'SonataAdminBundle') }}
                                                     </a>
                                                 <li>
@@ -211,7 +211,7 @@ file that was distributed with this source code.
 
             <li class="dropdown sonata-actions">
                 <a href="#" class="dropdown-toggle sonata-ba-action" data-toggle="dropdown">
-                    <i class="fa fa-filter"></i>
+                    <i class="fa fa-filter" aria-hidden="true"></i>
                     {{ 'link_filters'|trans({}, 'SonataAdminBundle') }} <b class="caret"></b>
                 </a>
 
@@ -263,7 +263,7 @@ file that was distributed with this source code.
                                         <div class="col-sm-1">
                                             <label class="control-label">
                                                 <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
-                                                    <i class="fa fa-minus-circle"></i>
+                                                    <i class="fa fa-minus-circle" aria-hidden="true"></i>
                                                 </a>
                                             </label>
                                         </div>
@@ -282,7 +282,7 @@ file that was distributed with this source code.
 
                                 <div class="form-group">
                                     <button type="submit" class="btn btn-primary">
-                                        <i class="fa fa-filter"></i> {{ 'btn_filter'|trans({}, 'SonataAdminBundle') }}
+                                        <i class="fa fa-filter" aria-hidden="true"></i> {{ 'btn_filter'|trans({}, 'SonataAdminBundle') }}
                                     </button>
 
                                     <a class="btn btn-default" href="{{ admin.generateUrl('list', {filters: 'reset'}) }}">
@@ -293,7 +293,7 @@ file that was distributed with this source code.
                                 {% if withAdvancedFilter %}
                                     <div class="form-group">
                                         <a href="#" data-toggle="advanced-filter">
-                                            <i class="fa fa-cogs"></i>
+                                            <i class="fa fa-cogs" aria-hidden="true"></i>
                                             {{ 'btn_advanced_filters'|trans({}, 'SonataAdminBundle') }}
                                         </a>
                                     </div>

--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
                     {% for name, show_tab in admin.showtabs %}
                         <li{% if loop.first %} class="active"{% endif %}>
                             <a href="#tab_{{ admin.uniqid }}_{{ loop.index }}" data-toggle="tab">
-                                <i class="fa fa-exclamation-circle has-errors hide"></i>
+                                <i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i>
                                 {{ admin.trans(name, {}, show_tab.translation_domain) }}
                             </a>
                         </li>

--- a/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/Resources/views/CRUD/batch_confirmation.html.twig
@@ -49,7 +49,7 @@ file that was distributed with this source code.
                         {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
 
                         <a class="btn btn-success" href="{{ admin.generateUrl('list') }}">
-                            <i class="fa fa-th-list"></i> {{ 'link_action_list'|trans({}, 'SonataAdminBundle') }}
+                            <i class="fa fa-th-list" aria-hidden="true"></i> {{ 'link_action_list'|trans({}, 'SonataAdminBundle') }}
                         </a>
                     {% endif %}
                 </form>

--- a/Resources/views/CRUD/dashboard__action.html.twig
+++ b/Resources/views/CRUD/dashboard__action.html.twig
@@ -1,4 +1,4 @@
 <a class="btn btn-link btn-flat" href="{{ action.url }}">
-    <i class="fa fa-{{ action.icon }}"></i>
+    <i class="fa fa-{{ action.icon }}" aria-hidden="true"></i>
     {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
 </a>

--- a/Resources/views/CRUD/dashboard__action_create.html.twig
+++ b/Resources/views/CRUD/dashboard__action_create.html.twig
@@ -1,11 +1,11 @@
 {% if admin.subClasses is empty %}
     <a class="btn btn-link btn-flat" href="{{ action.url }}">
-        <i class="fa fa-{{ action.icon }}"></i>
+        <i class="fa fa-{{ action.icon }}" aria-hidden="true"></i>
         {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
     </a>
 {% else %}
     <a class="btn btn-link btn-flat dropdown-toggle" data-toggle="dropdown" href="#">
-        <i class="fa fa-{{ action.icon }}"></i>
+        <i class="fa fa-{{ action.icon }}" aria-hidden="true"></i>
         {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
         <span class="caret"></span>
     </a>

--- a/Resources/views/CRUD/delete.html.twig
+++ b/Resources/views/CRUD/delete.html.twig
@@ -32,12 +32,12 @@ file that was distributed with this source code.
                     <input type="hidden" name="_method" value="DELETE">
                     <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
 
-                    <button type="submit" class="btn btn-danger"><i class="fa fa-trash"></i> {{ 'btn_delete'|trans({}, 'SonataAdminBundle') }}</button>
+                    <button type="submit" class="btn btn-danger"><i class="fa fa-trash" aria-hidden="true"></i> {{ 'btn_delete'|trans({}, 'SonataAdminBundle') }}</button>
                     {% if admin.hasRoute('edit') and admin.isGranted('EDIT', object) %}
                         {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
 
                         <a class="btn btn-success" href="{{ admin.generateObjectUrl('edit', object) }}">
-                            <i class="fa fa-pencil"></i>
+                            <i class="fa fa-pencil" aria-hidden="true"></i>
                             {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}</a>
                     {% endif %}
                 </form>

--- a/Resources/views/CRUD/list__action_delete.html.twig
+++ b/Resources/views/CRUD/list__action_delete.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% if admin.isGranted('DELETE', object) and admin.hasRoute('delete') %}
     <a href="{{ admin.generateObjectUrl('delete', object) }}" class="btn btn-sm btn-default delete_link" title="{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}">
-        <i class="fa fa-times"></i>
+        <i class="fa fa-times" aria-hidden="true"></i>
         {{ 'action_delete'|trans({}, 'SonataAdminBundle') }}
     </a>
 {% endif %}

--- a/Resources/views/CRUD/list__action_edit.html.twig
+++ b/Resources/views/CRUD/list__action_edit.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% if admin.isGranted('EDIT', object) and admin.hasRoute('edit') %}
     <a href="{{ admin.generateObjectUrl('edit', object) }}" class="btn btn-sm btn-default edit_link" title="{{ 'action_edit'|trans({}, 'SonataAdminBundle') }}">
-        <i class="fa fa-pencil"></i>
+        <i class="fa fa-pencil" aria-hidden="true"></i>
         {{ 'action_edit'|trans({}, 'SonataAdminBundle') }}
     </a>
 {% endif %}

--- a/Resources/views/CRUD/list__action_show.html.twig
+++ b/Resources/views/CRUD/list__action_show.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% if admin.isGranted('VIEW', object) and admin.hasRoute('show') %}
     <a href="{{ admin.generateObjectUrl('show', object) }}" class="btn btn-sm btn-default view_link" title="{{ 'action_show'|trans({}, 'SonataAdminBundle') }}">
-        <i class="fa fa-search-plus"></i>
+        <i class="fa fa-search-plus" aria-hidden="true"></i>
         {{ 'action_show'|trans({}, 'SonataAdminBundle') }}
     </a>
 {% endif %}

--- a/Resources/views/CRUD/list__select.html.twig
+++ b/Resources/views/CRUD/list__select.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 
 {% block field %}
     <a class="btn btn-primary" href="{{ admin.generateUrl('list') }}">
-        <i class="fa fa-check"></i>
+        <i class="fa fa-check" aria-hidden="true"></i>
         {{ 'list_select'|trans({}, 'SonataAdminBundle') }}
     </a>
 {% endblock %}

--- a/Resources/views/CRUD/preview.html.twig
+++ b/Resources/views/CRUD/preview.html.twig
@@ -19,11 +19,11 @@ file that was distributed with this source code.
 
 {% block formactions %}
     <button class="btn btn-success" type="submit" name="btn_preview_approve">
-        <i class="fa fa-check"></i>
+        <i class="fa fa-check" aria-hidden="true"></i>
         {{ 'btn_preview_approve'|trans({}, 'SonataAdminBundle') }}
     </button>
     <button class="btn btn-danger" type="submit" name="btn_preview_decline">
-        <i class="fa fa-times"></i>
+        <i class="fa fa-times" aria-hidden="true"></i>
         {{ 'btn_preview_decline'|trans({}, 'SonataAdminBundle') }}
     </button>
 {% endblock %}

--- a/Resources/views/CRUD/select_subclass.html.twig
+++ b/Resources/views/CRUD/select_subclass.html.twig
@@ -25,7 +25,7 @@ file that was distributed with this source code.
                     <a href="{{ admin.generateUrl(action, {'subclass': subclass }) }}"
                        class="btn btn-app btn-block"
                             >
-                        <i class="fa fa-plus-square"></i>
+                        <i class="fa fa-plus-square" aria-hidden="true"></i>
                         {{ subclass|trans({}, admin.translationdomain|default('SonataAdminBundle')) }}
                     </a>
                 </div>

--- a/Resources/views/CRUD/tree.html.twig
+++ b/Resources/views/CRUD/tree.html.twig
@@ -21,11 +21,11 @@ file that was distributed with this source code.
         {% for element in collection if not root %}
             <li>
                 <div class="sonata-tree__item">
-                    {% if element.parent %}<i class="fa fa-caret-right"></i>{% endif %}
-                    <i class="fa fa-code"></i>
+                    {% if element.parent %}<i class="fa fa-caret-right" aria-hidden="true"></i>{% endif %}
+                    <i class="fa fa-code" aria-hidden="true"></i>
                     <a class="sonata-tree__item__edit" href="{{ admin.generateObjectUrl('edit', element) }}">{{ element.name }}</a>
                     <i class="text-muted">{{ element.description }}</i>
-                    <a class="label label-default pull-right" href="{{ admin.generateObjectUrl('edit', element) }}">edit <i class="fa fa-magic"></i></a>
+                    <a class="label label-default pull-right" href="{{ admin.generateObjectUrl('edit', element) }}">edit <i class="fa fa-magic" aria-hidden="true"></i></a>
                     {% if true %}<span class="label label-warning pull-right">true</span>{% endif %}
                 </div>
 
@@ -61,7 +61,7 @@ file that was distributed with this source code.
                                     <a href="{{ admin.generateUrl('tree', { 'context': context.id }) }}">
                                         {% if currentContext and context.id == currentContext.id %}
                                             <span class="pull-right">
-                                                <i class="fa fa-check"></i>
+                                                <i class="fa fa-check" aria-hidden="true"></i>
                                             </span>
                                         {% endif %}
                                         {{ site.name }}

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
         {% if not form.parent %}<div class="alert alert-danger">{% endif %}
             <ul class="list-unstyled">
                 {% for error in errors %}
-                    <li><i class="fa fa-exclamation-circle"></i> {{ error.message }}</li>
+                    <li><i class="fa fa-exclamation-circle" aria-hidden="true"></i> {{ error.message }}</li>
                 {% endfor %}
             </ul>
         {% if not form.parent %}</div>{% endif %}
@@ -381,7 +381,7 @@ file that was distributed with this source code.
             <div class="row">
                 <div class="col-xs-1">
                     <a href="#" class="btn btn-link sonata-collection-delete">
-                        <i class="fa fa-minus-circle"></i>
+                        <i class="fa fa-minus-circle" aria-hidden="true"></i>
                     </a>
                 </div>
                 <div class="col-xs-11">
@@ -411,7 +411,7 @@ file that was distributed with this source code.
         {% endfor %}
         {{ form_rest(form) }}
         {% if allow_add %}
-            <div><a href="#" class="btn btn-link sonata-collection-add"><i class="fa fa-plus-circle"></i></a></div>
+            <div><a href="#" class="btn btn-link sonata-collection-add"><i class="fa fa-plus-circle" aria-hidden="true"></i></a></div>
         {% endif %}
     </div>
 {% endspaceless %}

--- a/Resources/views/Menu/sonata_menu.html.twig
+++ b/Resources/views/Menu/sonata_menu.html.twig
@@ -27,7 +27,7 @@
     {% spaceless %}
         {% if item.extra('on_top') is defined and not item.extra('on_top') %}
             {% set translation_domain = item.extra('translation_domain', 'messages') %}
-            {% set icon = item.attribute('icon')|default(item.level > 1 ? '<i class="fa fa-angle-double-right"></i>' : '') %}
+            {% set icon = item.attribute('icon')|default(item.level > 1 ? '<i class="fa fa-angle-double-right" aria-hidden="true"></i>' : '') %}
         {% else %}
             {% set icon = item.extra('icon') %}
         {% endif %}

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -186,7 +186,7 @@ file that was distributed with this source code.
                                         {% block sonata_top_nav_menu_add_block %}
                                             <li class="dropdown">
                                                 <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-                                                    <i class="fa fa-plus-square fa-fw"></i> <i class="fa fa-caret-down"></i>
+                                                    <i class="fa fa-plus-square fa-fw" aria-hidden="true"></i> <i class="fa fa-caret-down" aria-hidden="true"></i>
                                                 </a>
                                                 {% include sonata_admin.adminPool.getTemplate('add_block') %}
                                             </li>
@@ -194,7 +194,7 @@ file that was distributed with this source code.
                                         {% block sonata_top_nav_menu_user_block %}
                                             <li class="dropdown user-menu">
                                                 <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-                                                    <i class="fa fa-user fa-fw"></i> <i class="fa fa-caret-down"></i>
+                                                    <i class="fa fa-user fa-fw" aria-hidden="true"></i> <i class="fa fa-caret-down" aria-hidden="true"></i>
                                                 </a>
                                                 <ul class="dropdown-menu dropdown-user">
                                                     {% include sonata_admin.adminPool.getTemplate('user_block') %}
@@ -221,7 +221,7 @@ file that was distributed with this source code.
                                         <input type="text" name="q" value="{{ app.request.get('q') }}" class="form-control" placeholder="{{ 'search_placeholder'|trans({}, 'SonataAdminBundle') }}">
                                             <span class="input-group-btn">
                                                 <button class="btn btn-flat" type="submit">
-                                                    <i class="fa fa-search"></i>
+                                                    <i class="fa fa-search" aria-hidden="true"></i>
                                                 </button>
                                             </span>
                                     </div>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it's backward compatibibile changes

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Improve accessibility by adding `aria-hidden="true"`
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->
You could read more about it on: http://fontawesome.io/accessibility/

Main part is: 
> The assistive technology may read the unicode equivalent, which could not match up to what the icon means in context, or worse is just plain confusing 

## Todo

 - [x] Make Travis green