### PR TITLE
make sure the test is running at the project level where JMSDiExtraBu…

### DIFF
--- a/Tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
@@ -16,6 +16,13 @@ use Sonata\AdminBundle\Annotation\Admin;
 
 class AnnotationCompilerPassTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        if (!class_exists('JMS\DiExtraBundle\Metadata\ClassMetadata')) {
+            $this->markTestSkipped('JMSDiExtraBundle not available');
+        }
+    }
+
     public function testInvalidAdminAnnotation()
     {
         /*


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is the latest stable version.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - fix tests when they are started at the project level where JMSDiExtraBundle might not be available.
```

## Subject

<!-- Describe your Pull Request content here -->

fix tests when they are started at the project level where JMSDiExtraBundle might not be available.