### PR TITLE
Extending existing widget TestCase

### DIFF
--- a/Tests/Form/Widget/BaseWidgetTest.php
+++ b/Tests/Form/Widget/BaseWidgetTest.php
@@ -11,14 +11,10 @@
 
 namespace Sonata\AdminBundle\Tests\Form\Widget;
 
-use Symfony\Bridge\Twig\Extension\FormExtension;
+use Sonata\CoreBundle\Test\AbstractWidgetTestCase;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
-use Symfony\Bridge\Twig\Form\TwigRenderer;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
-use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubFilesystemLoader;
 use Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper\Fixtures\StubTranslator;
-use Symfony\Component\Form\FormView;
-use Symfony\Component\Form\Test\TypeTestCase;
 
 /**
  * Class BaseWidgetTest.
@@ -27,18 +23,8 @@ use Symfony\Component\Form\Test\TypeTestCase;
  * filter_admin_fields.html.twig. Template to use is defined by $this->type variable, that needs to be overridden in
  * child classes.
  */
-abstract class BaseWidgetTest extends TypeTestCase
+abstract class BaseWidgetTest extends AbstractWidgetTestCase
 {
-    /**
-     * @var FormExtension
-     */
-    protected $extension;
-
-    /**
-     * @var \Twig_Environment
-     */
-    protected $environment;
-
     /**
      * Current template type, form or filter.
      *
@@ -66,90 +52,44 @@ abstract class BaseWidgetTest extends TypeTestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function getEnvironment()
     {
-        parent::setUp();
+        $environment = parent::getEnvironment();
+        $environment->addGlobal('sonata_admin', $this->getSonataAdmin());
+        $environment->addExtension(new TranslationExtension(new StubTranslator()));
 
-        if (!in_array($this->type, array('form', 'filter'))) {
-            throw new \Exception('Please override $this->type in your test class specifying template to use (either form or filter)');
-        }
-
-        $rendererEngine = new TwigRendererEngine(array(
-            $this->type.'_admin_fields.html.twig',
-        ));
-
-        $csrfManagerClass =
-            interface_exists('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface') ?
-            'Symfony\Component\Security\Csrf\CsrfTokenManagerInterface' :
-            'Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface';
-
-        $renderer = new TwigRenderer($rendererEngine, $this->getMock($csrfManagerClass));
-
-        $this->extension = new FormExtension($renderer);
-
-        //this is ugly workaround for different build strategies and, possibly,
-        //different TwigBridge installation directories
-        $twigPaths = array_filter(array(
-            __DIR__.'/../../../vendor/symfony/twig-bridge/Symfony/Bridge/Twig/Resources/views/Form',
-            __DIR__.'/../../../vendor/symfony/twig-bridge/Resources/views/Form',
-            __DIR__.'/../../../vendor/symfony/symfony/src/Symfony/Bridge/Twig/Resources/views/Form',
-            __DIR__.'/../../../../../symfony/symfony/src/Symfony/Bridge/Twig/Resources/views/Form',
-        ), 'is_dir');
-
-        $twigPaths[] = __DIR__.'/../../../Resources/views/Form';
-
-        $loader = new StubFilesystemLoader($twigPaths);
-
-        $this->environment = new \Twig_Environment($loader, array('strict_variables' => true));
-        $this->environment->addGlobal('sonata_admin', $this->getSonataAdmin());
-        $this->environment->addExtension(new TranslationExtension(new StubTranslator()));
-
-        $this->environment->addExtension($this->extension);
-
-        $this->extension->initRuntime($this->environment);
+        return $environment;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function tearDown()
+    protected function getRenderingEngine()
     {
-        parent::tearDown();
+        if (!in_array($this->type, array('form', 'filter'))) {
+            throw new \Exception('Please override $this->type in your test class specifying template to use (either form or filter)');
+        }
 
-        $this->extension = null;
+        return new TwigRendererEngine(array(
+            $this->type.'_admin_fields.html.twig',
+        ));
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function getSonataAdmin()
     {
         return $this->sonataAdmin;
     }
 
     /**
-     * Renders widget from FormView, in SonataAdmin context, with optional view variables $vars. Returns plain HTML.
-     *
-     * @param FormView $view
-     * @param array    $vars
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    protected function renderWidget(FormView $view, array $vars = array())
+    protected function getTemplatePaths()
     {
-        return (string) $this->extension->renderer->searchAndRenderBlock($view, 'widget', $vars);
-    }
-
-    /**
-     * Helper method to strip newline and space characters from html string to make comparing easier.
-     *
-     * @param string $html
-     *
-     * @return string
-     */
-    protected function cleanHtmlWhitespace($html)
-    {
-        $html = preg_replace_callback('/>([^<]+)</', function ($value) {
-            return '>'.trim($value[1]).'<';
-        }, $html);
-
-        return $html;
+        return array_merge(parent::getTemplatePaths(), array(
+            __DIR__.'/../../../Resources/views/Form',
+        ));
     }
 }

--- a/Tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
+++ b/Tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
@@ -50,17 +50,6 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
         );
     }
 
-    protected function cleanHtmlAttributeWhitespace($html)
-    {
-        $html = preg_replace_callback('~<([A-Z0-9]+) \K(.*?)>~i', function ($m) {
-            $replacement = preg_replace('~\s*~', '', $m[0]);
-
-            return $replacement;
-        }, $html);
-
-        return $html;
-    }
-
     protected function getParentClass()
     {
         if (class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType')) {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/inflector": "^1.0",
         "knplabs/knp-menu-bundle": "^2.1.1",
         "sonata-project/block-bundle": "^3.1.1",
-        "sonata-project/core-bundle": "^3.0",
+        "sonata-project/core-bundle": "^3.1",
         "sonata-project/exporter": "^1.0",
         "symfony/class-loader": "^2.3 || ^3.0",
         "symfony/config": "^2.3.9 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Widget tests should extend `AbstractWidgetTestCase`
```

## To do

- [x] Waiting for a new `SonataCoreBundle` release

## Subject

Use the exsting TestCase to reduce code.