### PR TITLE
fix getMetadataFor detection

### DIFF
--- a/Command/ExplainAdminCommand.php
+++ b/Command/ExplainAdminCommand.php
@@ -89,9 +89,18 @@ class ExplainAdminCommand extends ContainerAwareCommand
             $output->writeln(sprintf('  - % -25s  % -15s % -15s', $name, $fieldDescription->getType(), $fieldDescription->getTemplate()));
         }
 
+        $metadata = false;
+
         if ($this->getContainer()->has('validator.validator_factory')) {
-            $metadata = $this->getContainer()->get('validator.validator_factory')->getMetadataFor($admin->getClass());
-        } else {
+            $factory = $this->getContainer()->get('validator.validator_factory');
+
+            if (method_exists($factory, 'getMetadataFor')) {
+                $metadata = $factory->getMetadataFor($admin->getClass());
+            }
+        }
+
+        // NEXT_MAJOR: remove method check in next major release
+        if (!$metadata) {
             $metadata = $this->getContainer()->get('validator')->getMetadataFor($admin->getClass());
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is the stable one

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix how metadata information are retrieved when admin information are dumped

```

## Subject

Fix how metadata information are retrieved when admin information are dumped
