### PR TITLE
fix(bc): form type support of >2.8

### DIFF
--- a/Form/Type/AclMatrixType.php
+++ b/Form/Type/AclMatrixType.php
@@ -33,10 +33,24 @@ class AclMatrixType extends AbstractType
         $aclValueType = $options['acl_value'] instanceof UserInterface ? 'user' : 'role';
         $aclValueData = $options['acl_value'] instanceof UserInterface ? $options['acl_value']->getUsername() : $options['acl_value'];
 
-        $builder->add($aclValueType, 'hidden', array('data' => $aclValueData));
+        $builder->add(
+            $aclValueType,
+            // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+                : 'hidden',
+            array('data' => $aclValueData)
+        );
 
         foreach ($options['permissions'] as $permission => $attributes) {
-            $builder->add($permission, 'checkbox', $attributes);
+            $builder->add(
+                $permission,
+                // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Symfony\Component\Form\Extension\Core\Type\CheckboxType'
+                    : 'checkbox',
+                $attributes
+            );
         }
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because…

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #
Fixes #

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - symfony 3 type support in AclMatrixType

```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject
Support symfony3 form type naming 
<!-- Describe your Pull Request content here -->

