### PR TITLE
Fixed incorrect translation of entity names

### DIFF
--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -112,6 +112,9 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
                     'uri' => $admin->hasRoute($this->config['child_admin_route']) && $admin->hasAccess($this->config['child_admin_route'], $admin->getSubject()) ?
                     $admin->generateUrl($this->config['child_admin_route'], array('id' => $id)) :
                     null,
+                    'extras' => array(
+                        'translation_domain' => false,
+                    ),
                 )
             );
 
@@ -123,7 +126,11 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
         if ('list' === $action && $admin->isChild()) {
             $menu->setUri(false);
         } elseif ('create' !== $action && $admin->hasSubject()) {
-            $menu = $menu->addChild($admin->toString($admin->getSubject()));
+            $menu = $menu->addChild($admin->toString($admin->getSubject()), array(
+                'extras' => array(
+                    'translation_domain' => false,
+                ),
+            ));
         } else {
             $menu = $this->createMenuItem(
                 $admin,

--- a/Tests/Admin/BreadcrumbsBuilderTest.php
+++ b/Tests/Admin/BreadcrumbsBuilderTest.php
@@ -404,6 +404,9 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
 
         $adminListMenu->addChild('My subject', array(
             'uri' => '/myadmin/my-object',
+            'extras' => array(
+                'translation_domain' => false,
+            ),
         ))->shouldBeCalled()->willReturn($adminSubjectMenu->reveal());
 
         $adminSubjectMenu->addChild('My child class', array(
@@ -414,8 +417,11 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         ))->shouldBeCalled()->willReturn($childMenu->reveal());
         $adminSubjectMenu->setExtra('safe_label', false)->willReturn($childMenu);
 
-        $childMenu->addChild('My subject')
-            ->shouldBeCalled()->willReturn($leafMenu->reveal());
+        $childMenu->addChild('My subject', array(
+            'extras' => array(
+                'translation_domain' => false,
+            ),
+        ))->shouldBeCalled()->willReturn($leafMenu->reveal());
 
         $breadcrumbs = $breadcrumbsBuilder->getBreadcrumbs($childAdmin->reveal(), $action);
         $this->assertCount(5, $breadcrumbs);
@@ -529,9 +535,16 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
                 'translation_domain' => 'FooBundle',
             ),
         ))->willReturn($menu->reveal());
-        $menu->addChild('My subject')->willReturn($menu);
+        $menu->addChild('My subject', array(
+            'extras' => array(
+                'translation_domain' => false,
+            ),
+        ))->willReturn($menu);
         $menu->addChild('My subject', array(
             'uri' => null,
+            'extras' => array(
+                'translation_domain' => false,
+            ),
         ))->willReturn($menu);
         $menu->addChild('My child class', array(
             'extras' => array(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a patch for #4070.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed translation of entities in breadcrumb
```

## Subject

Removed unneeded translation of entitiy names in breadcrumb.
