### PR TITLE
Added configureActionMenu to admin

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2820,6 +2820,169 @@ EOT;
     }
 
     /**
+     * Gets the action menu.
+     *
+     * @param string              $action
+     * @param AdminInterface|null $childAdmin
+     *
+     * @return MenuItemInterface
+     */
+    final public function getActionMenu($action, AdminInterface $childAdmin = null)
+    {
+        $menu = $this->menuFactory->createItem('root');
+        $menu->setChildrenAttribute('class', 'nav navbar-nav');
+        $menu->setExtra('translation_domain', $this->translationDomain);
+
+        $object = $this->getSubject();
+
+        if (in_array($action, array('tree', 'show', 'edit', 'delete', 'list', 'batch'))
+            && $this->hasAccess('create')
+            && $this->hasRoute('create')
+        ) {
+            if ($this->getSubClasses()) {
+                $menu->addChild('divider', array(
+                    'label' => '',
+                    'divider' => true,
+                    'attributes' => array(
+                        'class' => 'divider',
+                    ),
+                    'extras' => array(
+                        'translation_domain' => false,
+                    ),
+                ));
+
+                foreach ($this->getSubClasses() as $subClass) {
+                    $menu->createItem('active', array(
+                        'uri' => $this->generateUrl('create', array('subclass' => $subClass)),
+                        'label' => $subClass,
+                        'extras' => array(
+                            'safe_label' => true,
+                        ),
+                        'attributes' => array(
+                            'icon' => 'fa fa-plus-circle',
+                        ),
+                    ));
+                }
+
+                $menu->addChild('divider', array(
+                    'label' => '',
+                    'divider' => true,
+                    'attributes' => array(
+                        'class' => 'divider',
+                    ),
+                    'extras' => array(
+                        'translation_domain' => false,
+                    ),
+                ));
+            } else {
+                $menu->createItem('active', array(
+                    'uri' => $this->generateUrl('create'),
+                    'label' => 'link_action_create',
+                    'extras' => array(
+                        'safe_label' => true,
+                    ),
+                    'attributes' => array(
+                        'icon' => 'fa fa-plus-circle',
+                    ),
+                ));
+            }
+        }
+
+        if (in_array($action, array('show', 'delete', 'acl', 'history'))
+            && $this->canAccessObject('edit', $object)
+            && $this->hasRoute('edit')
+        ) {
+            $menu->createItem('edit', array(
+                'uri' => $this->generateObjectUrl('edit', $object),
+                'label' => 'link_action_edit',
+                'extras' => array(
+                    'safe_label' => true,
+                ),
+                'attributes' => array(
+                    'icon' => 'fa fa-edit',
+                ),
+            ));
+        }
+
+        if (in_array($action, array('show', 'edit', 'acl'))
+            && $this->canAccessObject('history', $object)
+            && $this->hasRoute('history')
+        ) {
+            $menu->createItem('history', array(
+                'uri' => $this->generateObjectUrl('history', $object),
+                'label' => 'link_action_history',
+                'extras' => array(
+                    'safe_label' => true,
+                ),
+                'attributes' => array(
+                    'icon' => 'fa fa-archive',
+                ),
+            ));
+        }
+
+        if (in_array($action, array('edit', 'history'))
+            && $this->isAclEnabled()
+            && $this->canAccessObject('acl', $object)
+            && $this->hasRoute('acl')
+        ) {
+            $menu->createItem('acl', array(
+                'uri' => $this->generateObjectUrl('acl', $object),
+                'label' => 'link_action_acl',
+                'extras' => array(
+                    'safe_label' => true,
+                ),
+                'attributes' => array(
+                    'icon' => 'fa fa-users',
+                ),
+            ));
+        }
+
+        if (in_array($action, array('edit', 'history', 'acl'))
+            && $this->canAccessObject('show', $object)
+            && count($this->getShow()) > 0
+            && $this->hasRoute('show')
+        ) {
+            $menu->createItem('show', array(
+                'uri' => $this->generateObjectUrl('show', $object),
+                'label' => 'link_action_show',
+                'extras' => array(
+                    'safe_label' => true,
+                ),
+                'attributes' => array(
+                    'icon' => 'fa fa-eye',
+                ),
+            ));
+        }
+
+        if (in_array($action, array('show', 'edit', 'delete', 'acl', 'batch'))
+            && $this->hasAccess('list')
+            && $this->hasRoute('list')
+        ) {
+            $menu->createItem('list', array(
+                'uri' => $this->generateUrl('list'),
+                'label' => 'link_action_list',
+                'extras' => array(
+                    'safe_label' => true,
+                ),
+                'attributes' => array(
+                    'icon' => 'fa fa-list',
+                ),
+            ));
+        }
+
+        $this->configureActionMenu($menu, $action, $childAdmin);
+
+        foreach ($this->getExtensions() as $extension) {
+            // NEXT_MAJOR: remove method check in next major release
+            if (method_exists($extension, 'configureActionMenu')) {
+                $extension->configureActionMenu($this, $menu, $action, $childAdmin);
+            }
+        }
+
+        return $menu;
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @deprecated since 3.x, to be removed in 4.0
@@ -3020,6 +3183,17 @@ EOT;
         }
 
         return $defaultFilterValues;
+    }
+
+    /**
+     * Configures the menu for an action.
+     *
+     * @param MenuItemInterface $menu
+     * @param string            $action
+     * @param AdminInterface    $childAdmin
+     */
+    protected function configureActionMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
+    {
     }
 
     /**

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -540,6 +540,13 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     private $breadcrumbsBuilder;
 
     /**
+     * The actionBuilder component.
+     *
+     * @var ActionBuilderInterface
+     */
+    private $actionBuilder;
+
+    /**
      * @param string $code
      * @param string $class
      * @param string $baseControllerName
@@ -2820,6 +2827,46 @@ EOT;
     }
 
     /**
+     * NEXT_MAJOR : remove this method.
+     *
+     * @return ActionBuilderInterface
+     */
+    final public function getActionBuilder()
+    {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.'.
+            ' Use the sonata.admin.action_builder service instead.',
+            E_USER_DEPRECATED
+        );
+
+        if ($this->actionBuilder === null) {
+            $this->actionBuilder = new ActionBuilder();
+        }
+
+        return $this->actionBuilder;
+    }
+
+    /**
+     * NEXT_MAJOR : remove this method.
+     *
+     * @param ActionBuilderInterface
+     *
+     * @return AbstractAdmin
+     */
+    final public function setActionBuilder(ActionBuilderInterface $value)
+    {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.'.
+            ' Use the sonata.admin.action_builder service instead.',
+            E_USER_DEPRECATED
+        );
+
+        $this->actionBuilder = $value;
+
+        return $this;
+    }
+
+    /**
      * Gets the action menu.
      *
      * @param string              $action
@@ -2829,157 +2876,13 @@ EOT;
      */
     final public function getActionMenu($action, AdminInterface $childAdmin = null)
     {
-        $menu = $this->menuFactory->createItem('root');
-        $menu->setChildrenAttribute('class', 'nav navbar-nav');
-        $menu->setExtra('translation_domain', $this->translationDomain);
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.'.
+            ' Use Sonata\AdminBundle\Admin\ActionBuilder::getActionMenu instead.',
+            E_USER_DEPRECATED
+        );
 
-        $object = $this->getSubject();
-
-        if (in_array($action, array('tree', 'show', 'edit', 'delete', 'list', 'batch'))
-            && $this->hasAccess('create')
-            && $this->hasRoute('create')
-        ) {
-            if ($this->getSubClasses()) {
-                $menu->addChild('divider', array(
-                    'label' => '',
-                    'divider' => true,
-                    'attributes' => array(
-                        'class' => 'divider',
-                    ),
-                    'extras' => array(
-                        'translation_domain' => false,
-                    ),
-                ));
-
-                foreach ($this->getSubClasses() as $subClass) {
-                    $menu->createItem('active', array(
-                        'uri' => $this->generateUrl('create', array('subclass' => $subClass)),
-                        'label' => $subClass,
-                        'extras' => array(
-                            'safe_label' => true,
-                        ),
-                        'attributes' => array(
-                            'icon' => 'fa fa-plus-circle',
-                        ),
-                    ));
-                }
-
-                $menu->addChild('divider', array(
-                    'label' => '',
-                    'divider' => true,
-                    'attributes' => array(
-                        'class' => 'divider',
-                    ),
-                    'extras' => array(
-                        'translation_domain' => false,
-                    ),
-                ));
-            } else {
-                $menu->createItem('active', array(
-                    'uri' => $this->generateUrl('create'),
-                    'label' => 'link_action_create',
-                    'extras' => array(
-                        'safe_label' => true,
-                    ),
-                    'attributes' => array(
-                        'icon' => 'fa fa-plus-circle',
-                    ),
-                ));
-            }
-        }
-
-        if (in_array($action, array('show', 'delete', 'acl', 'history'))
-            && $this->canAccessObject('edit', $object)
-            && $this->hasRoute('edit')
-        ) {
-            $menu->createItem('edit', array(
-                'uri' => $this->generateObjectUrl('edit', $object),
-                'label' => 'link_action_edit',
-                'extras' => array(
-                    'safe_label' => true,
-                ),
-                'attributes' => array(
-                    'icon' => 'fa fa-edit',
-                ),
-            ));
-        }
-
-        if (in_array($action, array('show', 'edit', 'acl'))
-            && $this->canAccessObject('history', $object)
-            && $this->hasRoute('history')
-        ) {
-            $menu->createItem('history', array(
-                'uri' => $this->generateObjectUrl('history', $object),
-                'label' => 'link_action_history',
-                'extras' => array(
-                    'safe_label' => true,
-                ),
-                'attributes' => array(
-                    'icon' => 'fa fa-archive',
-                ),
-            ));
-        }
-
-        if (in_array($action, array('edit', 'history'))
-            && $this->isAclEnabled()
-            && $this->canAccessObject('acl', $object)
-            && $this->hasRoute('acl')
-        ) {
-            $menu->createItem('acl', array(
-                'uri' => $this->generateObjectUrl('acl', $object),
-                'label' => 'link_action_acl',
-                'extras' => array(
-                    'safe_label' => true,
-                ),
-                'attributes' => array(
-                    'icon' => 'fa fa-users',
-                ),
-            ));
-        }
-
-        if (in_array($action, array('edit', 'history', 'acl'))
-            && $this->canAccessObject('show', $object)
-            && count($this->getShow()) > 0
-            && $this->hasRoute('show')
-        ) {
-            $menu->createItem('show', array(
-                'uri' => $this->generateObjectUrl('show', $object),
-                'label' => 'link_action_show',
-                'extras' => array(
-                    'safe_label' => true,
-                ),
-                'attributes' => array(
-                    'icon' => 'fa fa-eye',
-                ),
-            ));
-        }
-
-        if (in_array($action, array('show', 'edit', 'delete', 'acl', 'batch'))
-            && $this->hasAccess('list')
-            && $this->hasRoute('list')
-        ) {
-            $menu->createItem('list', array(
-                'uri' => $this->generateUrl('list'),
-                'label' => 'link_action_list',
-                'extras' => array(
-                    'safe_label' => true,
-                ),
-                'attributes' => array(
-                    'icon' => 'fa fa-list',
-                ),
-            ));
-        }
-
-        $this->configureActionMenu($menu, $action, $childAdmin);
-
-        foreach ($this->getExtensions() as $extension) {
-            // NEXT_MAJOR: remove method check in next major release
-            if (method_exists($extension, 'configureActionMenu')) {
-                $extension->configureActionMenu($this, $menu, $action, $childAdmin);
-            }
-        }
-
-        return $menu;
+        return $this->getActionBuilder()->getActionMenu($this, $action, $childAdmin);
     }
 
     /**

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2821,6 +2821,8 @@ EOT;
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated since 3.x, to be removed in 4.0
      */
     public function configureActionButtons($action, $object = null)
     {
@@ -2890,6 +2892,8 @@ EOT;
      * @param mixed  $object
      *
      * @return array
+     *
+     * @deprecated since 3.x, to be removed in 4.0
      */
     public function getActionButtons($action, $object = null)
     {

--- a/Admin/AbstractAdminExtension.php
+++ b/Admin/AbstractAdminExtension.php
@@ -181,6 +181,8 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated since 3.x, to be removed in 4.0
      */
     public function configureActionButtons(AdminInterface $admin, $list, $action, $object)
     {

--- a/Admin/ActionBuilder.php
+++ b/Admin/ActionBuilder.php
@@ -1,0 +1,203 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+final class ActionBuilder implements ActionBuilderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getActionMenu(AdminInterface $admin, $action, AdminInterface $childAdmin = null)
+    {
+        $menu = $admin->getMenuFactory()->createItem('root');
+        $menu->setChildrenAttribute('class', 'nav navbar-nav');
+        $menu->setExtra('translation_domain', $admin->getTranslationDomain());
+
+        $object = $admin->getSubject();
+
+        if (in_array($action, array('tree', 'show', 'edit', 'delete', 'list', 'batch'))
+            && $admin->hasAccess('create')
+            && $admin->hasRoute('create')
+        ) {
+            if ($admin->getSubClasses()) {
+                $menu->addChild(
+                    'divider',
+                    array(
+                        'label' => '',
+                        'divider' => true,
+                        'attributes' => array(
+                            'class' => 'divider',
+                        ),
+                        'extras' => array(
+                            'translation_domain' => false,
+                        ),
+                    )
+                );
+
+                foreach ($admin->getSubClasses() as $subClass) {
+                    $menu->createItem(
+                        'active',
+                        array(
+                            'uri' => $admin->generateUrl('create', array('subclass' => $subClass)),
+                            'label' => $subClass,
+                            'extras' => array(
+                                'safe_label' => true,
+                            ),
+                            'attributes' => array(
+                                'icon' => 'fa fa-plus-circle',
+                            ),
+                        )
+                    );
+                }
+
+                $menu->addChild(
+                    'divider',
+                    array(
+                        'label' => '',
+                        'divider' => true,
+                        'attributes' => array(
+                            'class' => 'divider',
+                        ),
+                        'extras' => array(
+                            'translation_domain' => false,
+                        ),
+                    )
+                );
+            } else {
+                $menu->createItem(
+                    'active',
+                    array(
+                        'uri' => $admin->generateUrl('create'),
+                        'label' => 'link_action_create',
+                        'extras' => array(
+                            'safe_label' => true,
+                        ),
+                        'attributes' => array(
+                            'icon' => 'fa fa-plus-circle',
+                        ),
+                    )
+                );
+            }
+        }
+
+        if (in_array($action, array('show', 'delete', 'acl', 'history'))
+            && $admin->canAccessObject('edit', $object)
+            && $admin->hasRoute('edit')
+        ) {
+            $menu->createItem(
+                'edit',
+                array(
+                    'uri' => $admin->generateObjectUrl('edit', $object),
+                    'label' => 'link_action_edit',
+                    'extras' => array(
+                        'safe_label' => true,
+                    ),
+                    'attributes' => array(
+                        'icon' => 'fa fa-edit',
+                    ),
+                )
+            );
+        }
+
+        if (in_array($action, array('show', 'edit', 'acl'))
+            && $admin->canAccessObject('history', $object)
+            && $admin->hasRoute('history')
+        ) {
+            $menu->createItem(
+                'history',
+                array(
+                    'uri' => $admin->generateObjectUrl('history', $object),
+                    'label' => 'link_action_history',
+                    'extras' => array(
+                        'safe_label' => true,
+                    ),
+                    'attributes' => array(
+                        'icon' => 'fa fa-archive',
+                    ),
+                )
+            );
+        }
+
+        if (in_array($action, array('edit', 'history'))
+            && $admin->isAclEnabled()
+            && $admin->canAccessObject('acl', $object)
+            && $admin->hasRoute('acl')
+        ) {
+            $menu->createItem(
+                'acl',
+                array(
+                    'uri' => $admin->generateObjectUrl('acl', $object),
+                    'label' => 'link_action_acl',
+                    'extras' => array(
+                        'safe_label' => true,
+                    ),
+                    'attributes' => array(
+                        'icon' => 'fa fa-users',
+                    ),
+                )
+            );
+        }
+
+        if (in_array($action, array('edit', 'history', 'acl'))
+            && $admin->canAccessObject('show', $object)
+            && count($admin->getShow()) > 0
+            && $admin->hasRoute('show')
+        ) {
+            $menu->createItem(
+                'show',
+                array(
+                    'uri' => $admin->generateObjectUrl('show', $object),
+                    'label' => 'link_action_show',
+                    'extras' => array(
+                        'safe_label' => true,
+                    ),
+                    'attributes' => array(
+                        'icon' => 'fa fa-eye',
+                    ),
+                )
+            );
+        }
+
+        if (in_array($action, array('show', 'edit', 'delete', 'acl', 'batch'))
+            && $admin->hasAccess('list')
+            && $admin->hasRoute('list')
+        ) {
+            $menu->createItem(
+                'list',
+                array(
+                    'uri' => $admin->generateUrl('list'),
+                    'label' => 'link_action_list',
+                    'extras' => array(
+                        'safe_label' => true,
+                    ),
+                    'attributes' => array(
+                        'icon' => 'fa fa-list',
+                    ),
+                )
+            );
+        }
+
+        $admin->configureActionMenu($menu, $action, $childAdmin);
+
+        foreach ($admin->getExtensions() as $extension) {
+            // NEXT_MAJOR: remove method check in next major release
+            if (method_exists($extension, 'configureActionMenu')) {
+                $extension->configureActionMenu($admin, $menu, $action, $childAdmin);
+            }
+        }
+
+        return $menu;
+    }
+}

--- a/Admin/ActionBuilderInterface.php
+++ b/Admin/ActionBuilderInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+use Knp\Menu\ItemInterface;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+interface ActionBuilderInterface
+{
+    /**
+     * Get action menu for $action.
+     *
+     * @param AdminInterface $admin
+     * @param string         $action     the name of the action we want to get a menu for
+     * @param AdminInterface $childAdmin
+     *
+     * @return ItemInterface the menu
+     */
+    public function getActionMenu(AdminInterface $admin, $action, AdminInterface $childAdmin = null);
+}

--- a/Admin/AdminExtensionInterface.php
+++ b/Admin/AdminExtensionInterface.php
@@ -185,19 +185,6 @@ interface AdminExtensionInterface
     public function postRemove(AdminInterface $admin, $object);
 
     /*
-     * Get all action buttons for an action
-     *
-     * @param AdminInterface $admin
-     * @param array          $list
-     * @param string         $action
-     * @param mixed          $object
-     *
-     * @return array
-     */
-    // TODO: Uncomment in next major release
-    // public function configureActionButtons(AdminInterface $admin, $list, $action, $object);
-
-    /*
      * NEXT_MAJOR: Uncomment in next major release
      *
      * Returns a list of default filters

--- a/Admin/AdminExtensionInterface.php
+++ b/Admin/AdminExtensionInterface.php
@@ -193,4 +193,15 @@ interface AdminExtensionInterface
      * @param array          $filterValues
      */
     // public function configureDefaultFilterValues(AdminInterface $admin, array &$filterValues);
+
+    /*
+     * Configures the menu for an action.
+     *
+     * @param AdminInterface    $admin
+     * @param MenuItemInterface $menu
+     * @param string            $action
+     * @param AdminInterface    $childAdmin
+     */
+    // TODO: Uncomment in next major release
+    // public function configureActionMenu(AdminInterface $admin, MenuItemInterface $menu, $action, AdminInterface $childAdmin = null);
 }

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -1038,15 +1038,6 @@ interface AdminInterface
      */
     public function checkAccess($action, $object = null);
 
-    /*
-     * Configure buttons for an action
-     *
-     * @param string $action
-     * @param object $object
-     *
-     */
-    // public function configureActionButtons($action, $object = null);
-
 //    TODO: uncomment this method for next major release
 //    /**
 //     * Hook to handle access authorization, without throw Exception

--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -395,6 +395,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             'pager_links' => 'SonataAdminBundle:Pager:links.html.twig',
             'pager_results' => 'SonataAdminBundle:Pager:results.html.twig',
             'tab_menu_template' => 'SonataAdminBundle:Core:tab_menu_template.html.twig',
+            'action_menu_template' => 'SonataAdminBundle:Core:action_menu_template.html.twig',
             'knp_menu_template' => 'SonataAdminBundle:Menu:sonata_menu.html.twig',
             'outer_list_rows_mosaic' => 'SonataAdminBundle:CRUD:list_outer_rows_mosaic.html.twig',
             'outer_list_rows_list' => 'SonataAdminBundle:CRUD:list_outer_rows_list.html.twig',

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -293,6 +293,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('pager_links')->defaultValue('SonataAdminBundle:Pager:links.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('pager_results')->defaultValue('SonataAdminBundle:Pager:results.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('tab_menu_template')->defaultValue('SonataAdminBundle:Core:tab_menu_template.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('action_menu_template')->defaultValue('SonataAdminBundle:Core:action_menu_template.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('knp_menu_template')->defaultValue('SonataAdminBundle:Menu:sonata_menu.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('action_create')->defaultValue('SonataAdminBundle:CRUD:dashboard__action_create.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('button_acl')->defaultValue('SonataAdminBundle:Button:acl_button.html.twig')->cannotBeEmpty()->end()

--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -24,6 +24,7 @@
             <argument type="service" id="service_container"/>
             <argument/>
         </service>
+        <service id="sonata.admin.action_builder" class="Sonata\AdminBundle\Admin\ActionBuilder"/>
         <service id="sonata.admin.breadcrumbs_builder" class="Sonata\AdminBundle\Admin\BreadcrumbsBuilder">
             <argument>%sonata.admin.configuration.breadcrumbs%</argument>
         </service>

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -359,26 +359,30 @@ You can add custom items to the actions menu for a specific action by overriding
 
 .. code-block:: php
 
-    public function configureActionButtons($action, $object = null)
+    protected function configureActionMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
     {
-        $list = parent::configureActionButtons($action, $object);
-
         if (in_array($action, array('show', 'edit', 'acl')) && $object) {
-            $list['custom'] = array(
-                'template' => 'AppBundle:Button:custom_button.html.twig',
-            );
+            $menu->addChild('custom', array('uri' => $this->generateUrl('custom'));
         }
-
-        // Remove history action
-        unset($list['history']);
-
-        return $list;
     }
 
 
 .. figure:: ../images/custom_action_buttons.png
    :align: center
    :alt: Custom action buttons
+
+
+If you want to use the Action Menu in a different way, you can replace the Menu Template:
+
+   .. configuration-block::
+
+       .. code-block:: yaml
+
+           # app/config/config.yml
+
+           sonata_admin:
+               templates:
+                   action_menu_template:  AppBundle:Admin:own_action_menu_template.html.twig
 
 Disable content stretching
 --------------------------

--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -162,6 +162,7 @@ Full Configuration Options
                 pager_links:          'SonataAdminBundle:Pager:links.html.twig'
                 pager_results:        'SonataAdminBundle:Pager:results.html.twig'
                 tab_menu_template:    'SonataAdminBundle:Core:tab_menu_template.html.twig'
+                action_menu_template: 'SonataAdminBundle:Core:action_menu_template.html.twig'
                 knp_menu_template:    'SonataAdminBundle:Menu:sonata_menu.html.twig'
             assets:
                 stylesheets:

--- a/Resources/doc/reference/templates.rst
+++ b/Resources/doc/reference/templates.rst
@@ -137,6 +137,7 @@ You can specify your templates in the config.yml file, like so:
                 pager_links:                    SonataAdminBundle:Pager:links.html.twig
                 pager_results:                  SonataAdminBundle:Pager:results.html.twig
                 tab_menu_template:              SonataAdminBundle:Core:tab_menu_template.html.twig
+                action_menu_template:           SonataAdminBundle:Core:action_menu_template.html.twig
                 history_revision_timestamp:     SonataAdminBundle:CRUD:history_revision_timestamp.html.twig
                 short_object_description:       SonataAdminBundle:Helper:short-object-description.html.twig
                 search_result_block:            SonataAdminBundle:Block:block_search_result.html.twig

--- a/Resources/views/CRUD/action.html.twig
+++ b/Resources/views/CRUD/action.html.twig
@@ -15,6 +15,12 @@ file that was distributed with this source code.
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
 {%- endblock -%}
 
+{% block action_menu %}
+    {% if action is defined %}
+        {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('action_menu_template')}, 'twig') }}
+    {% endif %}
+{% endblock %}
+
 {% block tab_menu %}
     {% if action is defined %}
         {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}

--- a/Resources/views/CRUD/base_acl.html.twig
+++ b/Resources/views/CRUD/base_acl.html.twig
@@ -15,6 +15,12 @@ file that was distributed with this source code.
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
 {%- endblock -%}
 
+{% block action_menu %}
+    {% if action is defined %}
+        {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('action_menu_template')}, 'twig') }}
+    {% endif %}
+{% endblock %}
+
 {% import 'SonataAdminBundle:CRUD:base_acl_macro.html.twig' as acl %}
 
 {% block form %}

--- a/Resources/views/CRUD/base_edit.html.twig
+++ b/Resources/views/CRUD/base_edit.html.twig
@@ -27,6 +27,12 @@ file that was distributed with this source code.
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
 {%- endblock -%}
 
+{% block action_menu %}
+    {% if action is defined %}
+        {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('action_menu_template')}, 'twig') }}
+    {% endif %}
+{% endblock %}
+
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
 
 {% use 'SonataAdminBundle:CRUD:base_edit_form.html.twig' with form as parentForm %}

--- a/Resources/views/CRUD/base_history.html.twig
+++ b/Resources/views/CRUD/base_history.html.twig
@@ -15,6 +15,12 @@ file that was distributed with this source code.
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
 {%- endblock -%}
 
+{% block action_menu %}
+    {% if action is defined %}
+        {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('action_menu_template')}, 'twig') }}
+    {% endif %}
+{% endblock %}
+
 {% block content %}
 
     <div class="row">

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -15,6 +15,12 @@ file that was distributed with this source code.
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
 {%- endblock -%}
 
+{% block action_menu %}
+    {% if action is defined %}
+        {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('action_menu_template')}, 'twig') }}
+    {% endif %}
+{% endblock %}
+
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
 
 {% block list_table %}

--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -17,6 +17,12 @@ file that was distributed with this source code.
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
 {%- endblock -%}
 
+{% block action_menu %}
+    {% if action is defined %}
+        {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('action_menu_template')}, 'twig') }}
+    {% endif %}
+{% endblock %}
+
 {% block tab_menu %}
     {{ knp_menu_render(admin.sidemenu(action), {
         'currentClass' : 'active',

--- a/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/Resources/views/CRUD/batch_confirmation.html.twig
@@ -15,6 +15,12 @@ file that was distributed with this source code.
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
 {%- endblock -%}
 
+{% block action_menu %}
+    {% if action is defined %}
+        {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('action_menu_template')}, 'twig') }}
+    {% endif %}
+{% endblock %}
+
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
 
 {% block content %}

--- a/Resources/views/CRUD/delete.html.twig
+++ b/Resources/views/CRUD/delete.html.twig
@@ -15,6 +15,12 @@ file that was distributed with this source code.
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
 {%- endblock -%}
 
+{% block action_menu %}
+    {% if action is defined %}
+        {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('action_menu_template')}, 'twig') }}
+    {% endif %}
+{% endblock %}
+
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
 
 {% block content %}

--- a/Resources/views/Core/action_menu_template.html.twig
+++ b/Resources/views/Core/action_menu_template.html.twig
@@ -1,0 +1,128 @@
+{% extends 'knp_menu.html.twig' %}
+
+{% block item %}
+{% import "knp_menu.html.twig" as macros %}
+{% if item.displayed %}
+    {%- set attributes = item.attributes %}
+    {%- set is_dropdown = attributes.dropdown|default(false) %}
+    {%- set divider_prepend = attributes.divider_prepend|default(false) %}
+    {%- set divider_append = attributes.divider_append|default(false) %}
+
+{# unset bootstrap specific attributes #}
+    {%- set attributes = attributes|merge({'dropdown': null, 'divider_prepend': null, 'divider_append': null }) %}
+
+    {%- if divider_prepend %}
+        {{ block('dividerElement') }}
+    {%- endif %}
+
+{# building the class of the item #}
+    {%- set classes = item.attribute('class') is not empty ? [item.attribute('class')] : [] %}
+
+    {%- if matcher is defined %} {# KnpMenu 2.0#}
+        {%- if matcher.isCurrent(item) %}
+            {%- set classes = classes|merge([options.currentClass]) %}
+        {%- elseif matcher.isAncestor(item, options.depth) %}
+            {%- set classes = classes|merge([options.ancestorClass]) %}
+        {%- endif %}
+    {%- else %} {# KnpMenu 1.X #}
+        {%- if item.current %}
+        {%- set classes = classes|merge([options.currentClass]) %}
+        {%- elseif item.currentAncestor %}
+        {%- set classes = classes|merge([options.ancestorClass]) %}
+        {%- endif %}
+    {%- endif %}
+
+    {%- if item.actsLikeFirst %}
+        {%- set classes = classes|merge([options.firstClass]) %}
+    {%- endif %}
+    {%- if item.actsLikeLast %}
+        {%- set classes = classes|merge([options.lastClass]) %}
+    {%- endif %}
+
+{# building the class of the children #}
+    {%- set childrenClasses = item.childrenAttribute('class') is not empty ? [item.childrenAttribute('class')] : [] %}
+    {%- set childrenClasses = childrenClasses|merge(['menu_level_' ~ item.level]) %}
+
+{# adding classes for dropdown #}
+    {%- if is_dropdown %}
+        {%- set classes = classes|merge(['dropdown']) %}
+        {%- set childrenClasses = childrenClasses|merge(['dropdown-menu']) %}
+    {%- endif %}
+
+{# putting classes together #}
+    {%- if classes is not empty %}
+        {%- set attributes = attributes|merge({'class': classes|join(' ')}) %}
+    {%- endif %}
+    {%- set listAttributes = item.childrenAttributes|merge({'class': childrenClasses|join(' ') }) %}
+
+{# displaying the item #}
+    <li{{ macros.attributes(attributes) }}>
+        {%- if is_dropdown %}
+            {{ block('dropdownElement') }}
+        {%- elseif item.uri is not empty and (not item.current or options.currentAsLink) %}
+            {{ block('linkElement') }}
+        {%- else %}
+            {{ block('spanElement') }}
+        {%- endif %}
+{# render the list of children#}
+        {{ block('list') }}
+    </li>
+
+    {%- if divider_append %}
+        {{ block('dividerElement') }}
+    {%- endif %}
+{% endif %}
+{% endblock %}
+
+{% block dividerElement %}
+{% if item.level == 1 %}
+    <li class="divider-vertical"></li>
+{% else %}
+    <li class="divider"></li>
+{% endif %}
+{% endblock %}
+
+{% block linkElement %}
+    <a href="{{ item.uri }}"{{ macros.attributes(item.linkAttributes) }}>
+        {% if item.attribute('icon') is not empty  %}
+            <i class="{{ item.attribute('icon') }}" aria-hidden="true"></i>
+        {% endif %}
+        {{ block('label') }}
+    </a>
+{% endblock %}
+
+{% block spanElement %}
+    <span {{ macros.attributes(item.labelAttributes) }}>
+        {% if item.attribute('icon') is not empty  %}
+            <i class="{{ item.attribute('icon') }}" aria-hidden="true"></i>
+        {% endif %}
+        {{ block('label') }}
+    </span>
+{% endblock %}
+
+{% block dropdownElement %}
+    {%- set classes = item.linkAttribute('class') is not empty ? [item.linkAttribute('class')] : [] %}
+    {%- set classes = classes|merge(['dropdown-toggle']) %}
+    {%- set attributes = item.linkAttributes %}
+    {%- set attributes = attributes|merge({'class': classes|join(' ')}) %}
+    {%- set attributes = attributes|merge({'data-toggle': 'dropdown'}) %}
+    <a href="#"{{ macros.attributes(attributes) }}>
+        {% if item.attribute('icon') is not empty  %}
+            <i class="{{ item.attribute('icon') }}" aria-hidden="true"></i>
+        {% endif %}
+        {{ block('label') }}
+        <b class="caret"></b>
+    </a>
+{% endblock %}
+
+{% block label %}
+{{-
+    item.label|trans(
+        item.getExtra('translation_params', {}),
+        item.getExtra(
+            'translation_domain',
+            item.getParent() ? item.getParent().getExtra('translation_domain') : null
+        )
+    )
+-}}
+{% endblock %}

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -13,6 +13,7 @@ file that was distributed with this source code.
 {% set _show                 = block('show') %}
 {% set _list_table           = block('list_table') %}
 {% set _list_filters         = block('list_filters') %}
+{% set _action_menu          = block('action_menu') %}
 {% set _tab_menu             = block('tab_menu') %}
 {% set _content              = block('content') %}
 {% set _title                = block('title') %}
@@ -254,7 +255,7 @@ file that was distributed with this source code.
 
                         {% block sonata_page_content_header %}
                             {% block sonata_page_content_nav %}
-                                {% if _tab_menu is not empty or _actions is not empty or _list_filters_actions is not empty %}
+                                {% if _tab_menu is not empty or _action_menu is not empty or _actions is not empty or _list_filters_actions is not empty %}
                                     <nav class="navbar navbar-default" role="navigation">
                                         <div class="container-fluid">
                                             {% block tab_menu_navbar_header %}
@@ -281,6 +282,10 @@ file that was distributed with this source code.
                                                 {% endif %}
 
                                                 {% block sonata_admin_content_actions_wrappers %}
+                                                    {% if _action_menu is not empty %}
+                                                        {{ _action_menu|raw }}
+                                                    {% endif %}
+
                                                     {% if _actions|replace({ '<li>': '', '</li>': '' })|trim is not empty %}
                                                         <ul class="nav navbar-nav navbar-right">
                                                         {% if _actions|split('</a>')|length > 2 %}

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1623,6 +1623,31 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($entity, $admin->getSubject()); // model manager must be used only once
     }
 
+    public function testGetActionMenu()
+    {
+        $item = $this->getMock('Knp\Menu\ItemInterface');
+        $item
+            ->expects($this->once())
+            ->method('setChildrenAttribute')
+            ->with('class', 'nav navbar-nav');
+        $item
+            ->expects($this->once())
+            ->method('setExtra')
+            ->with('translation_domain', 'foo_bar_baz');
+
+        $menuFactory = $this->getMock('Knp\Menu\FactoryInterface');
+        $menuFactory
+            ->expects($this->once())
+            ->method('createItem')
+            ->will($this->returnValue($item));
+
+        $modelAdmin = new ModelAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'SonataFooBundle:ModelAdmin');
+        $modelAdmin->setMenuFactory($menuFactory);
+        $modelAdmin->setTranslationDomain('foo_bar_baz');
+
+        $modelAdmin->getActionMenu('foo');
+    }
+
     /**
      * @covers Sonata\AdminBundle\Admin\AbstractAdmin::configureActionButtons
      */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is BC for now...

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4066
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Added `AbstractAdmin::getActionMenu` method
- Added `AbstractAdmin::configureActionMenu` method

### Deprecated
- Deprecated `AbstractAdmin::getActionButtons` method
- Deprecated `AbstractAdmin::configureActionButtons` method
```
## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
- [ ] move menu creation to new `ActionBuilder` class
- [ ] use translation strategy to translate **Create sublass** item
- [ ] Find a BC way to support `AbstractAdmin::getActionMenu` and `AbstractAdmin::getActionButtons`
- [ ] Testing
- [x] Updated the docs
## Subject

As mentioned in #4066, adding the `configureActionButtons` method was a bad idea, because we have no control what is done in the twig templates. This change added a starting point to replace the action menu with a knp menu implementation with the next major.
