### PR TITLE
[POC] New admin class

### DIFF
--- a/Admin/AbstractAdminDefinition.php
+++ b/Admin/AbstractAdminDefinition.php
@@ -148,4 +148,11 @@ abstract class AbstractAdminDefinition implements AdminDefinitionInterface, Admi
     public function configureTabMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
     {
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function alterNewInstance($object)
+    {
+    }
 }

--- a/Admin/AbstractAdminDefinition.php
+++ b/Admin/AbstractAdminDefinition.php
@@ -117,6 +117,13 @@ abstract class AbstractAdminDefinition implements AdminDefinitionInterface, Admi
     /**
      * {@inheritdoc}
      */
+    public function configureListQuery(ProxyQueryInterface $query)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function configureDatagridFilters(DatagridMapper $datagridMapper)
     {
     }

--- a/Admin/AbstractAdminDefinition.php
+++ b/Admin/AbstractAdminDefinition.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+use Knp\Menu\ItemInterface as MenuItemInterface;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\AdminBundle\Show\ShowMapper;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+abstract class AbstractAdminDefinition implements AdminDefinitionInterface, AdminHookInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getExportFormats()
+    {
+        return array(
+            'json',
+            'xml',
+            'csv',
+            'xls',
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preValidate($object)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preUpdate($object)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function postUpdate($object)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prePersist($object)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function postPersist($object)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preRemove($object)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function postRemove($object)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureBatchActions(array &$actions)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preBatchAction($action, ProxyQueryInterface $query, array &$idx, $allElements)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureFormFields(FormMapper $formMapper)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureListFields(ListMapper $listMapper)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureShowFields(ShowMapper $showMapper)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureRoutes(RouteCollection $routeCollection)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureTabMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
+    {
+    }
+}

--- a/Admin/AbstractAdminDefinition.php
+++ b/Admin/AbstractAdminDefinition.php
@@ -40,6 +40,13 @@ abstract class AbstractAdminDefinition implements AdminDefinitionInterface, Admi
     /**
      * {@inheritdoc}
      */
+    public function configureExportFields(array &$fields)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function preValidate($object)
     {
     }

--- a/Admin/AbstractAdminDefinition.php
+++ b/Admin/AbstractAdminDefinition.php
@@ -103,7 +103,7 @@ abstract class AbstractAdminDefinition implements AdminDefinitionInterface, Admi
     /**
      * {@inheritdoc}
      */
-    public function configureFormFields(FormMapper $formMapper)
+    public function configureFormFields(FormMapper $formMapper, $subject)
     {
     }
 
@@ -124,7 +124,7 @@ abstract class AbstractAdminDefinition implements AdminDefinitionInterface, Admi
     /**
      * {@inheritdoc}
      */
-    public function configureShowFields(ShowMapper $showMapper)
+    public function configureShowFields(ShowMapper $showMapper, $subject)
     {
     }
 

--- a/Admin/AdminDefinitionInterface.php
+++ b/Admin/AdminDefinitionInterface.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+use Knp\Menu\ItemInterface as MenuItemInterface;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\AdminBundle\Show\ShowMapper;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+interface AdminDefinitionInterface
+{
+    /**
+     * Returns the array of allowed export formats.
+     *
+     * @return array
+     */
+    public function getExportFormats();
+
+    /**
+     * @param FormMapper $formMapperMapper
+     */
+    public function configureFormFields(FormMapper $formMapperMapper);
+
+    /**
+     * @param ListMapper $listMapperMapper
+     */
+    public function configureListFields(ListMapper $listMapperMapper);
+
+    /**
+     * @param DatagridMapper $datagridMapper
+     */
+    public function configureDatagridFilters(DatagridMapper $datagridMapper);
+
+    /**
+     * @param ShowMapper $showMapper
+     */
+    public function configureShowFields(ShowMapper $showMapper);
+
+    /**
+     * @param RouteCollection $routeCollection
+     */
+    public function configureRoutes(RouteCollection $routeCollection);
+
+    /**
+     * Allows you to customize batch actions.
+     *
+     * @param array $actions List of actions
+     */
+    public function configureBatchActions(array &$actions);
+
+    /**
+     * Configures the tab menu in your admin.
+     *
+     * @param MenuItemInterface $menu
+     * @param string            $action
+     * @param AdminInterface    $childAdmin
+     *
+     * @return mixed
+     */
+    public function configureTabMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null);
+}

--- a/Admin/AdminDefinitionInterface.php
+++ b/Admin/AdminDefinitionInterface.php
@@ -33,8 +33,15 @@ interface AdminDefinitionInterface
 
     /**
      * @param FormMapper $formMapperMapper
+     * @param mixed      $subject
      */
-    public function configureFormFields(FormMapper $formMapperMapper);
+    public function configureFormFields(FormMapper $formMapperMapper, $subject);
+
+    /**
+     * @param ShowMapper $showMapper
+     * @param mixed      $subject
+     */
+    public function configureShowFields(ShowMapper $showMapper, $subject);
 
     /**
      * @param ListMapper $listMapperMapper
@@ -45,11 +52,6 @@ interface AdminDefinitionInterface
      * @param DatagridMapper $datagridMapper
      */
     public function configureDatagridFilters(DatagridMapper $datagridMapper);
-
-    /**
-     * @param ShowMapper $showMapper
-     */
-    public function configureShowFields(ShowMapper $showMapper);
 
     /**
      * @param RouteCollection $routeCollection

--- a/Admin/AdminDefinitionInterface.php
+++ b/Admin/AdminDefinitionInterface.php
@@ -80,4 +80,11 @@ interface AdminDefinitionInterface
      * @return mixed
      */
     public function configureTabMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null);
+
+    /**
+     * Get a chance to modify a newly created instance.
+     *
+     * @param mixed $object
+     */
+    public function alterNewInstance($object);
 }

--- a/Admin/AdminDefinitionInterface.php
+++ b/Admin/AdminDefinitionInterface.php
@@ -32,6 +32,11 @@ interface AdminDefinitionInterface
     public function getExportFormats();
 
     /**
+     * @param array $fields
+     */
+    public function configureExportFields(array &$fields);
+
+    /**
      * @param FormMapper $formMapperMapper
      * @param mixed      $subject
      */

--- a/Admin/AdminDefinitionInterface.php
+++ b/Admin/AdminDefinitionInterface.php
@@ -49,6 +49,11 @@ interface AdminDefinitionInterface
     public function configureListFields(ListMapper $listMapperMapper);
 
     /**
+     * @param ProxyQueryInterface $query
+     */
+    public function configureListQuery(ProxyQueryInterface $query);
+
+    /**
      * @param DatagridMapper $datagridMapper
      */
     public function configureDatagridFilters(DatagridMapper $datagridMapper);

--- a/Admin/AdminHookInterface.php
+++ b/Admin/AdminHookInterface.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+interface AdminHookInterface
+{
+    /**
+     * @param mixed $object
+     */
+    public function preValidate($object);
+
+    /**
+     * @param mixed $object
+     */
+    public function preUpdate($object);
+
+    /**
+     * @param mixed $object
+     */
+    public function postUpdate($object);
+
+    /**
+     * @param mixed $object
+     */
+    public function prePersist($object);
+
+    /**
+     * @param mixed $object
+     */
+    public function postPersist($object);
+
+    /**
+     * @param mixed $object
+     */
+    public function preRemove($object);
+
+    /**
+     * @param mixed $object
+     */
+    public function postRemove($object);
+
+    /**
+     * Called before the batch action, allow you to alter the query and the idx.
+     *
+     * @param string              $action
+     * @param ProxyQueryInterface $query
+     * @param array               $idx
+     * @param bool                $allElements
+     */
+    public function preBatchAction($action, ProxyQueryInterface $query, array &$idx, $allElements);
+}


### PR DESCRIPTION
This is just a POC to reduce the admin class.

A admin definition should only contain these methods as a public API. Methods like `generateUrlgenerateUrl` should be moved to some kind of helper class which will be injected in the constructor.

Refs https://github.com/sonata-project/SonataAdminBundle/issues/3947
- All methods in the new `AbstractAdminDefintion` are public, so they can be called from the outside. There is no need to have private or protected methods, because it doesn't contain any advanced logic.
- By default we don't need any constructor parameters in the new `AbstractAdminDefintion`
