### PR TITLE
Revert "don't display action menu if there are no filters"

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -206,7 +206,7 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block list_filters_actions %}
-    {%- if admin.datagrid.hasDisplayableFilters %}
+    {%- if admin.datagrid.filters|length %}
         <ul class="nav navbar-nav navbar-right">
 
             <li class="dropdown sonata-actions">


### PR DESCRIPTION
Changes in #4062 by commit 7056ebbcfeba959539326be3f4dfa8be05db112a are breaking compatibility. I will update the #4062 changelog as things are no longer complete.