### PR TITLE
Add ShowMapper::removeGroup method

### DIFF
--- a/Resources/doc/reference/action_show.rst
+++ b/Resources/doc/reference/action_show.rst
@@ -58,6 +58,33 @@ To specify options, do as follow:
             ;
     }
 
+When extending an existing Admin, you may want to remove some fields, groups or tabs.
+Here is an example of how to achieve this :
+
+.. code-block:: php
+
+    <?php
+    // src/AppBundle/Admin/PersonAdmin.php
+
+    class PersonAdmin extends ParentAdmin
+    {
+        public function configureShowFields(ShowMapper $showMapper)
+        {
+            parent::configureShowFields($showMapper);
+
+            // remove just one field
+            $showMapper->remove('field_to_remove');
+
+            // remove a group from the "default" tab
+            $showMapper->removeGroup('GroupToRemove1');
+
+            // remove a group from a specific tab
+            $showMapper->removeGroup('GroupToRemove2', 'Tab2');
+
+            // remove a group from a specific tab and also remove the tab if it ends up being empty
+            $showMapper->removeGroup('GroupToRemove3', 'Tab3', true);
+    }
+
 Customising the query used to show the object from within your Admin class
 --------------------------------------------------------------------------
 

--- a/Show/ShowMapper.php
+++ b/Show/ShowMapper.php
@@ -114,6 +114,48 @@ class ShowMapper extends BaseGroupedMapper
     }
 
     /**
+     * Removes a group.
+     *
+     * @param string $group          The group to delete
+     * @param string $tab            The tab the group belongs to, defaults to 'default'
+     * @param bool   $deleteEmptyTab Whether or not the parent Tab should be deleted too,
+     *                               when the deleted group leaves the tab empty after deletion
+     *
+     * @return $this
+     */
+    public function removeGroup($group, $tab = 'default', $deleteEmptyTab = false)
+    {
+        $groups = $this->getGroups();
+
+        // When the default tab is used, the tabname is not prepended to the index in the group array
+        if ($tab !== 'default') {
+            $group = $tab.'.'.$group;
+        }
+
+        if (isset($groups[$group])) {
+            foreach ($groups[$group]['fields'] as $field) {
+                $this->remove($field);
+            }
+        }
+        unset($groups[$group]);
+
+        $tabs = $this->getTabs();
+        $key = array_search($group, $tabs[$tab]['groups']);
+
+        if (false !== $key) {
+            unset($tabs[$tab]['groups'][$key]);
+        }
+        if ($deleteEmptyTab && count($tabs[$tab]['groups']) == 0) {
+            unset($tabs[$tab]);
+        }
+
+        $this->setTabs($tabs);
+        $this->setGroups($groups);
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     final public function keys()

--- a/Tests/Show/ShowMapperTest.php
+++ b/Tests/Show/ShowMapperTest.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\CleanAdmin;
 use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
 
 /**
@@ -402,6 +403,56 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
                 'box_class' => 'box box-primary',
                 'fields' => array('fooName3' => 'fooName3', 'fooName2' => 'fooName2', 'fooName1' => 'fooName1', 'fooName4' => 'fooName4'),
             ), ), true), print_r($this->admin->getShowGroups(), true));
+    }
+
+    public function testGroupRemovingWithoutTab()
+    {
+        $this->cleanShowMapper();
+
+        $this->showMapper->with('groupfoo1');
+        $this->showMapper->removeGroup('groupfoo1');
+
+        $this->assertSame(array(), $this->admin->getShowGroups());
+    }
+
+    public function testGroupRemovingWithTab()
+    {
+        $this->cleanShowMapper();
+
+        $this->showMapper->tab('mytab')->with('groupfoo2');
+        $this->showMapper->removeGroup('groupfoo2', 'mytab');
+
+        $this->assertSame(array(), $this->admin->getShowGroups());
+    }
+
+    public function testGroupRemovingWithoutTabAndWithTabRemoving()
+    {
+        $this->cleanShowMapper();
+
+        $this->showMapper->with('groupfoo3');
+        $this->showMapper->removeGroup('groupfoo3', 'default', true);
+
+        $this->assertSame(array(), $this->admin->getShowGroups());
+        $this->assertSame(array(), $this->admin->getShowTabs());
+    }
+
+    public function testGroupRemovingWithTabAndWithTabRemoving()
+    {
+        $this->cleanShowMapper();
+
+        $this->showMapper->tab('mytab2')->with('groupfoo4');
+        $this->showMapper->removeGroup('groupfoo4', 'mytab2', true);
+
+        $this->assertSame(array(), $this->admin->getShowGroups());
+        $this->assertSame(array(), $this->admin->getShowTabs());
+    }
+
+    private function cleanShowMapper()
+    {
+        $this->showBuilder = $this->getMock('Sonata\AdminBundle\Builder\ShowBuilderInterface');
+        $this->fieldDescriptionCollection = new FieldDescriptionCollection();
+        $this->admin = new CleanAdmin('code', 'class', 'controller');
+        $this->showMapper = new ShowMapper($this->showBuilder, $this->fieldDescriptionCollection, $this->admin);
     }
 
     private function getFieldDescriptionMock($name = null, $label = null)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is a new feature

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `ShowMapper::removeGroup` method

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [x] Update the documentation

## Subject

<!-- Describe your Pull Request content here -->
Add ShowMapper::removeGroup method, similar to Add FormlMapper::removeGroup method