### PR TITLE
[DOC] Fix the render of global errors on the form

### DIFF
--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -181,6 +181,7 @@ Full Configuration Options
                     - bundles/sonataadmin/css/styles.css
                     - bundles/sonataadmin/css/layout.css
                     - bundles/sonataadmin/css/tree.css
+                    - bundles/sonataadmin/css/colors.css
                 javascripts:
 
                     # Defaults:


### PR DESCRIPTION
Targeting 3.x because no BC Break

## Changelog

Update the configuration in the documentation

## Subject

No css is applied without this line, for example when you create a new page on sonata page, and the url unique exception occured.