### PR TITLE
Standardize the global form error

### DIFF
--- a/Resources/public/css/colors.css
+++ b/Resources/public/css/colors.css
@@ -24,19 +24,6 @@ input.title {
     width: 500px;
 }
 
-div.sonata-ba-form-error {
-    width: 495px;
-    border: 3px solid #CE6F6F;
-    background-color: #F79992;
-    color: #9C2F2F;
-    padding: 5px;
-    margin-bottom: 10px;
-}
-
-div.sonata-ba-form-error ul {
-    margin: 0;
-}
-
 div.sonata-ba-field-error input{
     border: 1px solid #f79992;
 }

--- a/Resources/views/CRUD/base_acl_macro.html.twig
+++ b/Resources/views/CRUD/base_acl_macro.html.twig
@@ -16,11 +16,8 @@ file that was distributed with this source code.
           method="POST"
             {% if not admin_pool.getOption('html5_validate') %}novalidate="novalidate"{% endif %}
             >
-        {% if form.vars.errors|length > 0 %}
-            <div class="sonata-ba-form-error">
-                {{ form_errors(form) }}
-            </div>
-        {% endif %}
+
+        {{ include('SonataAdminBundle:Helper:render_form_dismissable_errors.html.twig') }}
 
         <div class="box box-success">
             <div class="body table-responsive no-padding">

--- a/Resources/views/CRUD/base_edit_form.html.twig
+++ b/Resources/views/CRUD/base_edit_form.html.twig
@@ -17,11 +17,8 @@
               {% if not sonata_admin.adminPool.getOption('html5_validate') %}novalidate="novalidate"{% endif %}
               {% block sonata_form_attributes %}{% endblock %}
               >
-            {% if form.vars.errors|length > 0 %}
-                <div class="sonata-ba-form-error">
-                    {{ form_errors(form) }}
-                </div>
-            {% endif %}
+
+            {{ include('SonataAdminBundle:Helper:render_form_dismissable_errors.html.twig') }}
 
             {% block sonata_pre_fieldsets %}
                 <div class="row">

--- a/Resources/views/Helper/render_form_dismissable_errors.html.twig
+++ b/Resources/views/Helper/render_form_dismissable_errors.html.twig
@@ -1,0 +1,6 @@
+{% for error in form.vars.errors %}
+    <div class="alert alert-danger alert-dismissable">
+        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+        {{ error.message }}
+    </div>
+{% endfor %}


### PR DESCRIPTION
I am targetting 3.x because no BC Break

Close a part of #4099
Fixes a part of #4099 

## Subject

The render of global form error is now a Bootstrap 3 alert dismissible