### PR TITLE
Create admin builder class

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -294,23 +294,35 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     protected $formContractor;
 
     /**
+     * NEXT_MAJOR: move property to AdminBuilder.
+     *
      * The related list builder.
      *
      * @var ListBuilderInterface
+     *
+     * @deprecated since 3.x, to be removed in 4.0
      */
     protected $listBuilder;
 
     /**
+     * NEXT_MAJOR: move property to AdminBuilder.
+     *
      * The related view builder.
      *
      * @var ShowBuilderInterface
+     *
+     * @deprecated since 3.x, to be removed in 4.0
      */
     protected $showBuilder;
 
     /**
+     * NEXT_MAJOR: move property to AdminBuilder.
+     *
      * The related datagrid builder.
      *
      * @var DatagridBuilderInterface
+     *
+     * @deprecated since 3.x, to be removed in 4.0
      */
     protected $datagridBuilder;
 
@@ -2287,7 +2299,11 @@ EOT;
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * {@inheritdoc}
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     public function setDatagridBuilder(DatagridBuilderInterface $datagridBuilder)
     {
@@ -2295,7 +2311,11 @@ EOT;
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * {@inheritdoc}
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     public function getDatagridBuilder()
     {
@@ -2303,7 +2323,11 @@ EOT;
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * {@inheritdoc}
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     public function setListBuilder(ListBuilderInterface $listBuilder)
     {
@@ -2311,7 +2335,11 @@ EOT;
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * {@inheritdoc}
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     public function getListBuilder()
     {
@@ -2319,7 +2347,11 @@ EOT;
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * @param ShowBuilderInterface $showBuilder
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     public function setShowBuilder(ShowBuilderInterface $showBuilder)
     {
@@ -2327,7 +2359,11 @@ EOT;
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * @return ShowBuilderInterface
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     public function getShowBuilder()
     {

--- a/Admin/AdminBuilder.php
+++ b/Admin/AdminBuilder.php
@@ -11,6 +11,9 @@
 
 namespace Sonata\AdminBundle\Admin;
 
+use Sonata\AdminBundle\Builder\ListBuilderInterface;
+use Sonata\AdminBundle\Builder\ShowBuilderInterface;
+use Sonata\AdminBundle\Builder\DatagridBuilderInterface as DatagridBuilder;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
@@ -21,6 +24,33 @@ use Symfony\Component\PropertyAccess\PropertyPath;
  */
 final class AdminBuilder implements FormBuilderInterface, DatagridBuilderInterface
 {
+    /**
+     * @var ShowBuilderInterface
+     */
+    private $showBuilder;
+
+    /**
+     * @var ListBuilderInterface
+     */
+    private $listBuilder;
+
+    /**
+     * @var DatagridBuilder
+     */
+    private $datagridBuilder;
+
+    /**
+     * @param ShowBuilderInterface $showBuilder
+     * @param ListBuilderInterface $listBuilder
+     * @param DatagridBuilder      $datagridBuilder
+     */
+    public function __construct(ShowBuilderInterface $showBuilder, ListBuilderInterface $listBuilder,  DatagridBuilder $datagridBuilder)
+    {
+        $this->showBuilder = $showBuilder;
+        $this->listBuilder = $listBuilder;
+        $this->datagridBuilder = $datagridBuilder;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/Admin/AdminBuilder.php
+++ b/Admin/AdminBuilder.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Show\ShowMapper;
+use Symfony\Component\PropertyAccess\PropertyPath;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+final class AdminBuilder implements FormBuilderInterface, DatagridBuilderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getCreateForm(AdminInterface $admin)
+    {
+        return $this->getEditForm($admin);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEditForm(AdminInterface $admin)
+    {
+        // append parent object if any
+        // todo : clean the way the Admin class can retrieve set the object
+        if ($admin->isChild() && $admin->getParentAssociationMapping()) {
+            $parent = $admin->getParent()->getObject($admin->getRequest()->get($admin->getParent()->getIdParameter()));
+
+            $propertyAccessor = $admin->getConfigurationPool()->getPropertyAccessor();
+            $propertyPath = new PropertyPath($admin->getParentAssociationMapping());
+
+            $object = $admin->getSubject();
+
+            $value = $propertyAccessor->getValue($object, $propertyPath);
+
+            if (is_array($value) || ($value instanceof \Traversable && $value instanceof \ArrayAccess)) {
+                $value[] = $parent;
+                $propertyAccessor->setValue($object, $propertyPath, $value);
+            } else {
+                $propertyAccessor->setValue($object, $propertyPath, $parent);
+            }
+        }
+
+        // NEXT_MAJOR: Move AbstractAdmin::getFormBuilder method to AdminBuilder
+        return $admin->getFormBuilder()->getForm();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getShowForm(AdminInterface $admin)
+    {
+        $show = new FieldDescriptionCollection();
+        $mapper = new ShowMapper($admin->getShowBuilder(), $show, $admin);
+
+        // NEXT_MAJOR: increase visiblity of configureShowFields method
+        $reflection = new \ReflectionMethod($admin, 'configureShowFields');
+        $reflection->setAccessible(true);
+        $reflection->invoke($admin, $mapper);
+
+        foreach ($admin->getExtensions() as $extension) {
+            $extension->configureShowFields($mapper);
+        }
+
+        return $show;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDatagrid(AdminInterface $admin)
+    {
+        $filterParameters = $admin->getFilterParameters();
+
+        // transform _sort_by from a string to a FieldDescriptionInterface for the datagrid.
+        if (isset($filterParameters['_sort_by']) && is_string($filterParameters['_sort_by'])) {
+            if ($admin->hasListFieldDescription($filterParameters['_sort_by'])) {
+                $filterParameters['_sort_by'] = $admin->getListFieldDescription($filterParameters['_sort_by']);
+            } else {
+                $filterParameters['_sort_by'] = $admin->getModelManager()->getNewFieldDescriptionInstance(
+                    $admin->getClass(),
+                    $filterParameters['_sort_by'],
+                    array()
+                );
+
+                $admin->getListBuilder()->buildField(null, $filterParameters['_sort_by'], $admin);
+            }
+        }
+
+        // initialize the datagrid
+        $datagrid = $admin->getDatagridBuilder()->getBaseDatagrid($admin, $filterParameters);
+
+        $datagrid->getPager()->setMaxPageLinks($admin->getMaxPageLinks());
+
+        $mapper = new DatagridMapper($admin->getDatagridBuilder(), $datagrid, $admin);
+
+        // build the datagrid filter
+
+        // NEXT_MAJOR: increase visiblity of configureDatagridFilters method
+        $reflection = new \ReflectionMethod($admin, 'configureDatagridFilters');
+        $reflection->setAccessible(true);
+        $reflection->invoke($admin, $mapper);
+
+        // ok, try to limit to add parent filter
+        if ($admin->isChild() && $admin->getParentAssociationMapping() && !$mapper->has($admin->getParentAssociationMapping())) {
+            // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+            $modelHiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\AdminBundle\Form\Type\ModelHiddenType'
+                : 'sonata_type_model_hidden';
+
+            // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+            $hiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+                : 'hidden';
+
+            $mapper->add($admin->getParentAssociationMapping(), null, array(
+                'show_filter' => false,
+                'label' => false,
+                'field_type' => $modelHiddenType,
+                'field_options' => array(
+                    'model_manager' => $admin->getModelManager(),
+                ),
+                'operator_type' => $hiddenType,
+            ), null, null, array(
+                'admin_code' => $admin->getParent()->getCode(),
+            ));
+        }
+
+        foreach ($admin->getExtensions() as $extension) {
+            $extension->configureDatagridFilters($mapper);
+        }
+
+        return $datagrid;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getList(AdminInterface $admin)
+    {
+        $list = $admin->getListBuilder()->getBaseList();
+
+        $mapper = new ListMapper($admin->getListBuilder(), $list, $admin);
+
+        if (count($admin->getBatchActions()) > 0) {
+            $fieldDescription = $admin->getModelManager()->getNewFieldDescriptionInstance($admin->getClass(), 'batch', array(
+                'label' => 'batch',
+                'code' => '_batch',
+                'sortable' => false,
+                'virtual_field' => true,
+            ));
+
+            $fieldDescription->setAdmin($admin);
+            $fieldDescription->setTemplate($admin->getTemplate('batch'));
+
+            $mapper->add($fieldDescription, 'batch');
+        }
+
+        // NEXT_MAJOR: increase visiblity of configureListFields method
+        $reflection = new \ReflectionMethod($admin, 'configureListFields');
+        $reflection->setAccessible(true);
+        $reflection->invoke($admin, $mapper);
+
+        foreach ($admin->getExtensions() as $extension) {
+            $extension->configureListFields($mapper);
+        }
+
+        if ($admin->hasRequest() && $admin->getRequest()->isXmlHttpRequest()) {
+            $fieldDescription = $admin->getModelManager()->getNewFieldDescriptionInstance($admin->getClass(), 'select', array(
+                'label' => false,
+                'code' => '_select',
+                'sortable' => false,
+                'virtual_field' => false,
+            ));
+
+            $fieldDescription->setAdmin($admin);
+            $fieldDescription->setTemplate($admin->getTemplate('select'));
+
+            $mapper->add($fieldDescription, 'select');
+        }
+
+        return $list;
+    }
+}

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -114,7 +114,11 @@ interface AdminInterface
     public function attachAdminClass(FieldDescriptionInterface $fieldDescription);
 
     /**
+     * NEXT_MAJOR: remove this signature.
+     *
      * @return \Sonata\AdminBundle\Datagrid\DatagridInterface
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     public function getDatagrid();
 
@@ -205,9 +209,13 @@ interface AdminInterface
     public function getFormFieldDescriptions();
 
     /**
+     * NEXT_MAJOR: remove this signature.
+     *
      * Returns a form depend on the given $object.
      *
      * @return Form
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     public function getForm();
 
@@ -406,9 +414,13 @@ interface AdminInterface
     public function getFilterFieldDescription($name);
 
     /**
+     * NEXT_MAJOR: remove this signature.
+     *
      * Returns a list depend on the given $object.
      *
      * @return FieldDescriptionCollection
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     public function getList();
 
@@ -464,7 +476,11 @@ interface AdminInterface
     public function getValidator();
 
     /**
+     * NEXT_MAJOR: remove this signature.
+     *
      * @return array
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     public function getShow();
 

--- a/Admin/DatagridBuilderInterface.php
+++ b/Admin/DatagridBuilderInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
+
+/**
+ * Builds admin datagrids.
+ *
+ * @author Christian Gripp <mail@core23.de>
+ */
+interface DatagridBuilderInterface
+{
+    /**
+     * @param AdminInterface $admin
+     *
+     * @return DatagridInterface
+     */
+    public function getDatagrid(AdminInterface $admin);
+
+    /**
+     * @param AdminInterface $admin
+     *
+     * @return FieldDescriptionCollection
+     */
+    public function getList(AdminInterface $admin);
+}

--- a/Admin/FormBuilderInterface.php
+++ b/Admin/FormBuilderInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * Builds admin forms. There is a dependency on the AdminInterface because
+ * this object holds useful object to deal with this task, but there is
+ * probably a better design.
+ *
+ * @author Christian Gripp <mail@core23.de>
+ */
+interface FormBuilderInterface
+{
+    /**
+     * @param AdminInterface $admin
+     *
+     * @return FormInterface
+     */
+    public function getCreateForm(AdminInterface $admin);
+
+    /**
+     * @param AdminInterface $admin
+     *
+     * @return FormInterface
+     */
+    public function getEditForm(AdminInterface $admin);
+
+    /**
+     * @param AdminInterface $admin
+     *
+     * @return FormInterface
+     */
+    public function getShowForm(AdminInterface $admin);
+}

--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -27,6 +27,7 @@
         <service id="sonata.admin.breadcrumbs_builder" class="Sonata\AdminBundle\Admin\BreadcrumbsBuilder">
             <argument>%sonata.admin.configuration.breadcrumbs%</argument>
         </service>
+        <service id="sonata.admin.admin_builder" class="Sonata\AdminBundle\Admin\AdminBuilder"/>
         <!-- Services used to format the label, default is sonata.admin.label.strategy.noop -->
         <service id="sonata.admin.label.strategy.bc" class="Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy"/>
         <service id="sonata.admin.label.strategy.native" class="Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy"/>

--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -27,7 +27,8 @@
         <service id="sonata.admin.breadcrumbs_builder" class="Sonata\AdminBundle\Admin\BreadcrumbsBuilder">
             <argument>%sonata.admin.configuration.breadcrumbs%</argument>
         </service>
-        <service id="sonata.admin.admin_builder" class="Sonata\AdminBundle\Admin\AdminBuilder"/>
+        <service id="sonata.admin.admin_builder" class="Sonata\AdminBundle\Admin\AdminBuilder">
+        </service>
         <!-- Services used to format the label, default is sonata.admin.label.strategy.noop -->
         <service id="sonata.admin.label.strategy.bc" class="Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy"/>
         <service id="sonata.admin.label.strategy.native" class="Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy"/>

--- a/Tests/Admin/AdminBuilderTest.php
+++ b/Tests/Admin/AdminBuilderTest.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Admin;
+
+class AdminBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+    }
+}

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -33,6 +33,12 @@ Please use `Pager::getFirstIndex()` and `Pager::getLastIndex()` instead!
 UPGRADE FROM 3.9 to 3.10
 ========================
 
+## Deprecated AbstractAdmin methods
+
+- `buildDatagrid`, `buildShow`, `buildForm` and `buildList` are deprecated, and no replacement is given, they will become internal methods.
+- `getShow`, `getList`, `getForm` and `getDatagrid` are deprecated in favor of the homonym method of the `sonata.admin.admin_builder` service.
+- The admin builder accessors are deprecated, the `sonata.admin.admin_builder` service should be used directly instead.
+
 ## Deprecated passing no 3rd argument to GroupMenuProvider
 
 Passing no 3rd argument to `Menu\Provider\GroupMenuProvider` is deprecated.

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -36,6 +36,7 @@ UPGRADE FROM 3.9 to 3.10
 ## Deprecated AbstractAdmin methods
 
 - `buildDatagrid`, `buildShow`, `buildForm` and `buildList` are deprecated, and no replacement is given, they will become internal methods.
+- `showBuilder`, `listBuilder` and `datagridBuilder` are deprecated in favor of the homonym properties of the `sonata.admin.admin_builder` service.
 - `getShow`, `getList`, `getForm` and `getDatagrid` are deprecated in favor of the homonym method of the `sonata.admin.admin_builder` service.
 - The admin builder accessors are deprecated, the `sonata.admin.admin_builder` service should be used directly instead.
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is BC (at the moment)

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes  #4104
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Added `AdminBuilder` class to handle admin form / datagrid creation
```
## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
- [ ] Update the tests
- [ ] <s>Move `getShow`, `getList`, `getForm`, `getDatagrid` to `CRUDController`</s>
- [x] Update the documentation
- [ ] Inject default builders in `AdminBuilder`
## Subject

This is another tiny step to reduce the complexity of the admin class. There are still many methods like `buildDatagrid` which should be removed from this class afterwards.
