### PR TITLE
uncomment part of old test case

### DIFF
--- a/Tests/Command/ExplainAdminCommandTest.php
+++ b/Tests/Command/ExplainAdminCommandTest.php
@@ -169,6 +169,7 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
 
     public function testExecute()
     {
+        // NEXT_MAJOR: Remove check, when bumping requirements to SF 2.5+
         if (interface_exists('Symfony\Component\Validator\Mapping\MetadataInterface')) { //sf2.5+
             $metadata = $this->getMock('Symfony\Component\Validator\Mapping\MetadataInterface');
         } else {
@@ -180,6 +181,7 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Acme\Entity\Foo'))
             ->will($this->returnValue($metadata));
 
+        // NEXT_MAJOR: Remove check, when bumping requirements to SF 2.5+
         if (class_exists('Symfony\Component\Validator\Mapping\GenericMetadata')) {
             $class = 'GenericMetadata';
         } else {

--- a/Tests/Command/ExplainAdminCommandTest.php
+++ b/Tests/Command/ExplainAdminCommandTest.php
@@ -203,13 +203,11 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
             ->method('getModelManager')
             ->will($this->returnValue($modelManager));
 
-        // @todo Mock of \Traversable is available since Phpunit 3.8. This should be completed after stable release of Phpunit 3.8.
-        // @see https://github.com/sebastianbergmann/phpunit-mock-objects/issues/103
-        // $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
-        //
-        // $this->admin->expects($this->any())
-        //     ->method('getFormBuilder')
-        //     ->will($this->returnValue($formBuilder));
+        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+
+        $this->admin->expects($this->any())
+             ->method('getFormBuilder')
+             ->will($this->returnValue($formBuilder));
 
         $datagridBuilder = $this->getMock('\Sonata\AdminBundle\Builder\DatagridBuilderInterface');
 
@@ -252,13 +250,11 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
             ->method('getModelManager')
             ->will($this->returnValue($modelManager));
 
-        // @todo Mock of \Traversable is available since Phpunit 3.8. This should be completed after stable release of Phpunit 3.8.
-        // @see https://github.com/sebastianbergmann/phpunit-mock-objects/issues/103
-        // $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
-        //
-        // $this->admin->expects($this->any())
-        //     ->method('getFormBuilder')
-        //     ->will($this->returnValue($formBuilder));
+        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+
+        $this->admin->expects($this->any())
+             ->method('getFormBuilder')
+             ->will($this->returnValue($formBuilder));
 
         $datagridBuilder = $this->getMock('\Sonata\AdminBundle\Builder\DatagridBuilderInterface');
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is BC

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Subject

I found a todo, where the part of the test should be uncommented when PHPUnit 3.8 is released.

Let's see how it works
