### PR TITLE
Removed deprecation warning when using filter which don't override de…

### DIFF
--- a/Filter/Filter.php
+++ b/Filter/Filter.php
@@ -95,7 +95,12 @@ abstract class Filter implements FilterInterface
      */
     public function getFieldType()
     {
-        return $this->getOption('field_type', 'text');
+        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
+        // (when requirement of Symfony is >= 2.8)
+        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+            : 'text'
+        );
     }
 
     /**

--- a/Tests/Datagrid/DatagridMapperTest.php
+++ b/Tests/Datagrid/DatagridMapperTest.php
@@ -104,7 +104,9 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Sonata\AdminBundle\Filter\FilterInterface', $filter);
         $this->assertSame('foo.name', $filter->getName());
         $this->assertSame('foo__name', $filter->getFormName());
-        $this->assertSame('text', $filter->getFieldType());
+        $this->assertSame(method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+            : 'text', $filter->getFieldType());
         $this->assertSame('fooLabel', $filter->getLabel());
         $this->assertSame(array('required' => false), $filter->getFieldOptions());
         $this->assertSame(array(

--- a/Tests/Filter/FilterTest.php
+++ b/Tests/Filter/FilterTest.php
@@ -19,7 +19,9 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FooFilter();
 
-        $this->assertSame('text', $filter->getFieldType());
+        $this->assertSame(method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+            : 'text', $filter->getFieldType());
         $this->assertSame(array('required' => false), $filter->getFieldOptions());
         $this->assertNull($filter->getLabel());
 


### PR DESCRIPTION
I am targetting this branch, because it's about avoiding deprecation warnings when using Sf >= 2.8, while keeping the old behavior.

## Changelog
```markdown
## Fixed
- Type for `Filter` to be compatible with Symfony 2.8+
```

## Subject

Remove deprecation warnings when using Sf >= 2.8