### PR TITLE
Fixed choices_as_values deprecation warning

### DIFF
--- a/Form/Type/Filter/ChoiceType.php
+++ b/Form/Type/Filter/ChoiceType.php
@@ -69,31 +69,30 @@ class ChoiceType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_CONTAINS => 'label_type_contains',
-            self::TYPE_NOT_CONTAINS => 'label_type_not_contains',
-            self::TYPE_EQUAL => 'label_type_equals',
+            'label_type_contains' => self::TYPE_CONTAINS,
+            'label_type_not_contains' => self::TYPE_NOT_CONTAINS,
+            'label_type_equals' => self::TYPE_EQUAL,
         );
-
-        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-            $choices = array_flip($choices);
-        }
-
-        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
-            }
-        }
-
         $operatorChoices = array();
+
         // NEXT_MAJOR: Remove first check (when requirement of Symfony is >= 2.8)
         if ($options['operator_type'] !== 'hidden' && $options['operator_type'] !== 'Symfony\Component\Form\Extension\Core\Type\HiddenType') {
-            $operatorChoices['choices'] = $choices;
-
-            // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
-            if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
+            if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+                $choices = array_flip($choices);
+                foreach ($choices as $key => $value) {
+                    $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
+                }
+            } else {
                 $operatorChoices['choice_translation_domain'] = 'SonataAdminBundle';
+
+                // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+                if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                    $operatorChoices['choices_as_values'] = true;
+                }
             }
+
+            $operatorChoices['choices'] = $choices;
         }
 
         $builder

--- a/Form/Type/Filter/DateRangeType.php
+++ b/Form/Type/Filter/DateRangeType.php
@@ -66,30 +66,29 @@ class DateRangeType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_BETWEEN => 'label_date_type_between',
-            self::TYPE_NOT_BETWEEN => 'label_date_type_not_between',
+            'label_date_type_between' => self::TYPE_BETWEEN,
+            'label_date_type_not_between' => self::TYPE_NOT_BETWEEN,
         );
-
-        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-            $choices = array_flip($choices);
-        }
-
-        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
-            }
-        }
-
         $choiceOptions = array(
-            'choices' => $choices,
             'required' => false,
         );
 
-        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+            $choices = array_flip($choices);
+            foreach ($choices as $key => $value) {
+                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
+            }
+        } else {
             $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+
+            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                $choiceOptions['choices_as_values'] = true;
+            }
         }
+
+        $choiceOptions['choices'] = $choices;
 
         $builder
             ->add('type', 'choice', $choiceOptions)

--- a/Form/Type/Filter/DateTimeRangeType.php
+++ b/Form/Type/Filter/DateTimeRangeType.php
@@ -66,30 +66,29 @@ class DateTimeRangeType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_BETWEEN => 'label_date_type_between',
-            self::TYPE_NOT_BETWEEN => 'label_date_type_not_between',
+            'label_date_type_between' => self::TYPE_BETWEEN,
+            'label_date_type_not_between' => self::TYPE_NOT_BETWEEN,
         );
-
-        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-            $choices = array_flip($choices);
-        }
-
-        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
-            }
-        }
-
         $choiceOptions = array(
-            'choices' => $choices,
             'required' => false,
         );
 
-        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+            $choices = array_flip($choices);
+            foreach ($choices as $key => $value) {
+                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
+            }
+        } else {
             $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+
+            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                $choiceOptions['choices_as_values'] = true;
+            }
         }
+
+        $choiceOptions['choices'] = $choices;
 
         $builder
             ->add('type', 'choice', $choiceOptions)

--- a/Form/Type/Filter/DateTimeType.php
+++ b/Form/Type/Filter/DateTimeType.php
@@ -77,35 +77,34 @@ class DateTimeType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_EQUAL => 'label_date_type_equal',
-            self::TYPE_GREATER_EQUAL => 'label_date_type_greater_equal',
-            self::TYPE_GREATER_THAN => 'label_date_type_greater_than',
-            self::TYPE_LESS_EQUAL => 'label_date_type_less_equal',
-            self::TYPE_LESS_THAN => 'label_date_type_less_than',
-            self::TYPE_NULL => 'label_date_type_null',
-            self::TYPE_NOT_NULL => 'label_date_type_not_null',
+            'label_date_type_equal' => self::TYPE_EQUAL,
+            'label_date_type_greater_equal' => self::TYPE_GREATER_EQUAL,
+            'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
+            'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
+            'label_date_type_less_than' => self::TYPE_LESS_THAN,
+            'label_date_type_null' => self::TYPE_NULL,
+            'label_date_type_not_null' => self::TYPE_NOT_NULL,
         );
-
-        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-            $choices = array_flip($choices);
-        }
-
-        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
-            }
-        }
-
         $choiceOptions = array(
-            'choices' => $choices,
             'required' => false,
         );
 
-        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+            $choices = array_flip($choices);
+            foreach ($choices as $key => $value) {
+                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
+            }
+        } else {
             $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+
+            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                $choiceOptions['choices_as_values'] = true;
+            }
         }
+
+        $choiceOptions['choices'] = $choices;
 
         $builder
             ->add('type', 'choice', $choiceOptions)

--- a/Form/Type/Filter/DateType.php
+++ b/Form/Type/Filter/DateType.php
@@ -77,35 +77,34 @@ class DateType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_EQUAL => 'label_date_type_equal',
-            self::TYPE_GREATER_EQUAL => 'label_date_type_greater_equal',
-            self::TYPE_GREATER_THAN => 'label_date_type_greater_than',
-            self::TYPE_LESS_EQUAL => 'label_date_type_less_equal',
-            self::TYPE_LESS_THAN => 'label_date_type_less_than',
-            self::TYPE_NULL => 'label_date_type_null',
-            self::TYPE_NOT_NULL => 'label_date_type_not_null',
+            'label_date_type_equal' => self::TYPE_EQUAL,
+            'label_date_type_greater_equal' => self::TYPE_GREATER_EQUAL,
+            'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
+            'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
+            'label_date_type_less_than' => self::TYPE_LESS_THAN,
+            'label_date_type_null' => self::TYPE_NULL,
+            'label_date_type_not_null' => self::TYPE_NOT_NULL,
         );
-
-        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-            $choices = array_flip($choices);
-        }
-
-        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
-            }
-        }
-
         $choiceOptions = array(
-            'choices' => $choices,
             'required' => false,
         );
 
-        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+            $choices = array_flip($choices);
+            foreach ($choices as $key => $value) {
+                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
+            }
+        } else {
             $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+
+            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                $choiceOptions['choices_as_values'] = true;
+            }
         }
+
+        $choiceOptions['choices'] = $choices;
 
         $builder
             ->add('type', 'choice', $choiceOptions)

--- a/Form/Type/Filter/NumberType.php
+++ b/Form/Type/Filter/NumberType.php
@@ -74,33 +74,32 @@ class NumberType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = array(
-            self::TYPE_EQUAL => 'label_type_equal',
-            self::TYPE_GREATER_EQUAL => 'label_type_greater_equal',
-            self::TYPE_GREATER_THAN => 'label_type_greater_than',
-            self::TYPE_LESS_EQUAL => 'label_type_less_equal',
-            self::TYPE_LESS_THAN => 'label_type_less_than',
+            'label_type_equal' => self::TYPE_EQUAL,
+            'label_type_greater_equal' => self::TYPE_GREATER_EQUAL,
+            'label_type_greater_than' => self::TYPE_GREATER_THAN,
+            'label_type_less_equal' => self::TYPE_LESS_EQUAL,
+            'label_type_less_than' => self::TYPE_LESS_THAN,
         );
-
-        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-            $choices = array_flip($choices);
-        }
-
-        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
-            }
-        }
-
         $choiceOptions = array(
-            'choices' => $choices,
             'required' => false,
         );
 
-        // NEXT_MAJOR: Remove this hack, when dropping support for symfony <2.7
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+            $choices = array_flip($choices);
+            foreach ($choices as $key => $value) {
+                $choices[$key] = $this->translator->trans($value, array(), 'SonataAdminBundle');
+            }
+        } else {
             $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+
+            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                $choiceOptions['choices_as_values'] = true;
+            }
         }
+
+        $choiceOptions['choices'] = $choices;
 
         $builder
             ->add('type', 'choice', $choiceOptions)


### PR DESCRIPTION
I am targetting this branch, because it's about avoiding deprecation warnings when using Sf >= 2.8, while keeping the old behavior.

## Changelog
```markdown
## Fixed
- Set `choices_as_values` to `true` on choice type based to be compatible with Symfony 3
```

## Subject

Remove deprecation warnings when using Sf >= 2.8
Here's the current deprecation message: 
```
The value "false" for the "choices_as_values" option of the "choice" form type (Symfony\Component\Form\Extension\Core\Type\ChoiceType) is deprecated since version 2.8 and will not be supported anymore in 3.0. Set this option to "true" and flip the contents of the "choices" option instead.
```