### PR TITLE
Used classname in form type name

### DIFF
--- a/Form/Type/ChoiceFieldMaskType.php
+++ b/Form/Type/ChoiceFieldMaskType.php
@@ -77,7 +77,10 @@ class ChoiceFieldMaskType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+            : 'choice';
     }
 
     /**

--- a/Form/Type/Filter/DateRangeType.php
+++ b/Form/Type/Filter/DateRangeType.php
@@ -92,7 +92,10 @@ class DateRangeType extends AbstractType
         }
 
         $builder
-            ->add('type', 'choice', $choiceOptions)
+            // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            ->add('type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+                : 'choice', $choiceOptions)
             ->add('value', $options['field_type'], $options['field_options'])
         ;
     }

--- a/Form/Type/Filter/DateTimeRangeType.php
+++ b/Form/Type/Filter/DateTimeRangeType.php
@@ -92,7 +92,10 @@ class DateTimeRangeType extends AbstractType
         }
 
         $builder
-            ->add('type', 'choice', $choiceOptions)
+            // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            ->add('type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+                : 'choice', $choiceOptions)
             ->add('value', $options['field_type'], $options['field_options'])
         ;
     }

--- a/Form/Type/Filter/DateTimeType.php
+++ b/Form/Type/Filter/DateTimeType.php
@@ -108,7 +108,10 @@ class DateTimeType extends AbstractType
         }
 
         $builder
-            ->add('type', 'choice', $choiceOptions)
+            // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            ->add('type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+                : 'choice', $choiceOptions)
             ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))
         ;
     }

--- a/Form/Type/Filter/DateType.php
+++ b/Form/Type/Filter/DateType.php
@@ -108,7 +108,10 @@ class DateType extends AbstractType
         }
 
         $builder
-            ->add('type', 'choice', $choiceOptions)
+            // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            ->add('type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+                : 'choice', $choiceOptions)
             ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))
         ;
     }

--- a/Form/Type/Filter/DefaultType.php
+++ b/Form/Type/Filter/DefaultType.php
@@ -68,9 +68,13 @@ class DefaultType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'operator_type' => 'hidden',
+            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+                : 'hidden', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
             'operator_options' => array(),
-            'field_type' => 'text',
+            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                : 'text', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
             'field_options' => array(),
         ));
     }

--- a/Form/Type/Filter/NumberType.php
+++ b/Form/Type/Filter/NumberType.php
@@ -103,7 +103,10 @@ class NumberType extends AbstractType
         }
 
         $builder
-            ->add('type', 'choice', $choiceOptions)
+            // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            ->add('type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+                : 'choice', $choiceOptions)
             ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))
         ;
     }

--- a/Form/Type/ModelHiddenType.php
+++ b/Form/Type/ModelHiddenType.php
@@ -60,7 +60,10 @@ class ModelHiddenType extends AbstractType
      */
     public function getParent()
     {
-        return 'hidden';
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+            : 'hidden';
     }
 
     /**

--- a/Form/Type/ModelListType.php
+++ b/Form/Type/ModelListType.php
@@ -96,7 +96,10 @@ class ModelListType extends AbstractType
      */
     public function getParent()
     {
-        return 'text';
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+            : 'text';
     }
 
     /**

--- a/Form/Type/ModelReferenceType.php
+++ b/Form/Type/ModelReferenceType.php
@@ -59,7 +59,10 @@ class ModelReferenceType extends AbstractType
      */
     public function getParent()
     {
-        return 'text';
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+            : 'text';
     }
 
     /**

--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -171,7 +171,10 @@ class ModelType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+            : 'choice';
     }
 
     /**

--- a/Tests/Form/Type/ChoiceFieldMaskTypeTest.php
+++ b/Tests/Form/Type/ChoiceFieldMaskTypeTest.php
@@ -49,6 +49,9 @@ class ChoiceFieldMaskTypeTest extends TypeTestCase
     public function testGetParent()
     {
         $type = new ChoiceFieldMaskType();
-        $this->assertSame('choice', $type->getParent());
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        $this->assertSame(method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+            : 'choice', $type->getParent());
     }
 }

--- a/Tests/Form/Type/ModelHiddenTypeTest.php
+++ b/Tests/Form/Type/ModelHiddenTypeTest.php
@@ -45,6 +45,9 @@ class ModelHiddenTypeTest extends TypeTestCase
     public function testGetParent()
     {
         $type = new ModelHiddenType();
-        $this->assertSame('hidden', $type->getParent());
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        $this->assertSame(method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+            : 'hidden', $type->getParent());
     }
 }


### PR DESCRIPTION
I am targetting this branch, because it's about avoiding deprecation warnings when using Sf >= 2.8, while keeping the old behavior.

## Changelog
```markdown
## Fixed
- Use class name when referencing `Form Type` to be compatible with Symfony 2.8+
```

## Subject

Remove deprecation warnings when using Sf >= 2.8