### PR TITLE
Removed exporter class from classes to compile

### DIFF
--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -249,7 +249,6 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
             'Sonata\\AdminBundle\\Datagrid\\ProxyQueryInterface',
             'Sonata\\AdminBundle\\Exception\\ModelManagerException',
             'Sonata\\AdminBundle\\Exception\\NoValueException',
-            'Sonata\\AdminBundle\\Export\\Exporter',
             'Sonata\\AdminBundle\\Filter\\Filter',
             'Sonata\\AdminBundle\\Filter\\FilterFactory',
             'Sonata\\AdminBundle\\Filter\\FilterFactoryInterface',


### PR DESCRIPTION
I am targetting this branch, because it's about removing sonata deprecation warning that gets populated on each page.

## Changelog
```markdown
## Fixed
- Remove `Sonata\CoreBundle\Exporter\Exporter` from classes to compile to cache to avoid deprecation warning
```

## Subject

Remove deprecation warnings for sonata version >= 3.1
Here's the current deprecation message: 
```
The Sonata\CoreBundle\Exporter\Exporter class is deprecated since version 3.1 and will be removed in 4.0. Use Exporter\Exporter instead
```