### PR TITLE
Remove checks for existing translator

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2109,10 +2109,6 @@ EOT;
     {
         $domain = $domain ?: $this->getTranslationDomain();
 
-        if (!$this->translator) {
-            return $id;
-        }
-
         return $this->translator->trans($id, $parameters, $domain, $locale);
     }
 
@@ -2130,10 +2126,6 @@ EOT;
     public function transChoice($id, $count, array $parameters = array(), $domain = null, $locale = null)
     {
         $domain = $domain ?: $this->getTranslationDomain();
-
-        if (!$this->translator) {
-            return $id;
-        }
 
         return $this->translator->transChoice($id, $count, $parameters, $domain, $locale);
     }

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1648,7 +1648,7 @@ which is not the one registered with this admin class ("%s").
 This is deprecated since 3.x and will no longer be supported in 4.0.
 EOT;
 
-            trigger_error(
+            @trigger_error(
                 sprintf($message, get_class($subject), $this->class),
                 E_USER_DEPRECATED
             ); // NEXT_MAJOR : throw an exception instead

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1192,13 +1192,6 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('sonata.post.admin.post', $admin->getObjectIdentifier());
     }
 
-    public function testTransWithNoTranslator()
-    {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-
-        $this->assertSame('foo', $admin->trans('foo'));
-    }
-
     public function testTrans()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
@@ -1228,13 +1221,6 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('fooTranslated'));
 
         $this->assertSame('fooTranslated', $admin->trans('foo', array('name' => 'Andrej'), 'fooMessageDomain'));
-    }
-
-    public function testTransChoiceWithNoTranslator()
-    {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-
-        $this->assertSame('foo', $admin->transChoice('foo', 2));
     }
 
     public function testTransChoice()

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -315,7 +315,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
                     return true;
                 }
 
-                if ($id == 'security.csrf.token_manager' && Kernel::MAJOR_VERSION >= 3  && $tthis->getCsrfProvider() !== null) {
+                if ($id == 'security.csrf.token_manager' && Kernel::MAJOR_VERSION >= 3 && $tthis->getCsrfProvider() !== null) {
                     return true;
                 }
 


### PR DESCRIPTION
I am targetting this branch, because I think this is BC

## Changelog

```markdown
### Removed
- The admin no longer checks for the `translator` service before translating.
```
## Subject

To use SonataAdminBundle, the translator service has to be enabled. It
is always injected in the admin by a compiler pass, which means there is
no point (anymore?) in checking it exists.

Closes #4089