### PR TITLE
Avoid deprecation notices

### DIFF
--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\AdminBundle\Tests\Controller;
 
+use Exporter\Exporter;
+use Exporter\Writer\JsonWriter;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\Pool;
@@ -178,11 +180,16 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
                 }
             }));
 
-        $exporter = $this->getMock('Sonata\AdminBundle\Export\Exporter');
+        // NEXT_MAJOR : require sonata/exporter ^1.7 and remove conditional
+        if (class_exists('Exporter\Exporter')) {
+            $exporter = new Exporter(array(new JsonWriter('/tmp/sonataadmin/export.json')));
+        } else {
+            $exporter = $this->getMock('Sonata\AdminBundle\Export\Exporter');
 
-        $exporter->expects($this->any())
-            ->method('getResponse')
-            ->will($this->returnValue(new StreamedResponse()));
+            $exporter->expects($this->any())
+                ->method('getResponse')
+                ->will($this->returnValue(new StreamedResponse()));
+        }
 
         $this->auditManager = $this->getMockBuilder('Sonata\AdminBundle\Model\AuditManager')
             ->disableOriginalConstructor()

--- a/Tests/Export/ExporterTest.php
+++ b/Tests/Export/ExporterTest.php
@@ -14,6 +14,9 @@ namespace Sonata\AdminBundle\Tests\Filter;
 use Exporter\Source\ArraySourceIterator;
 use Sonata\AdminBundle\Export\Exporter;
 
+/**
+ * @group legacy
+ */
 class ExporterTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/Tests/Form/Widget/BaseWidgetTest.php
+++ b/Tests/Form/Widget/BaseWidgetTest.php
@@ -56,7 +56,9 @@ abstract class BaseWidgetTest extends AbstractWidgetTestCase
     {
         $environment = parent::getEnvironment();
         $environment->addGlobal('sonata_admin', $this->getSonataAdmin());
-        $environment->addExtension(new TranslationExtension(new StubTranslator()));
+        if (!$environment->hasExtension('translator')) {
+            $environment->addExtension(new TranslationExtension(new StubTranslator()));
+        }
 
         return $environment;
     }


### PR DESCRIPTION
I am targetting this branch, because this is BC

## Changelog

No changelog, this is only about the test suite (so the users do not care).

## To do

## Subject

This fixes several (but not all) deprecation notices. The only deprecation notice left comes from the SonataCoreBundle, it's about the `initRuntime` call in `AbstractWidgetTestCase` (I think, might actually be wrong b/c the `FormExtension` is marked with an interface that should make that ok).