### PR TITLE
fix missing title for nested admin

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -17,6 +17,21 @@ file that was distributed with this source code.
 
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
 
+{% block title %}
+    {#
+        The list template can be used in nested mode,
+        so we define the title corresponding to the parent's admin.
+    #}
+    
+    {% if admin.isChild and admin.parent.subject %}
+        {{ "title_edit"|trans({'%name%': admin.parent.toString(admin.parent.subject)|truncate(15) }, 'SonataAdminBundle') }}
+    {% endif %}
+{% endblock %}
+
+{% block navbar_title %}
+    {{ block('title') }}
+{% endblock %}
+
 {% block list_table %}
     <div class="col-xs-12 col-md-12">
         {% set batchactions = admin.batchactions %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because it is a bug fix.
## Changelog

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Fixed
- Missing title for nested admin
```

Before:
<img width="741" alt="screen shot 2016-09-05 at 10 19 08" src="https://cloud.githubusercontent.com/assets/14672/18241579/3904d90e-7352-11e6-990d-819763fe3b9f.PNG">

After:
<img width="771" alt="screen shot 2016-09-05 at 10 18 53" src="https://cloud.githubusercontent.com/assets/14672/18241577/38ee34c4-7352-11e6-9150-8e489b0969c0.PNG">
