### PR TITLE
Deprecate translation in Admin class

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -280,7 +280,11 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     /**
      * The translator component.
      *
+     * NEXT_MAJOR: remove this property
+     *
      * @var \Symfony\Component\Translation\TranslatorInterface
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     protected $translator;
 
@@ -2108,6 +2112,11 @@ EOT;
      */
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.'.
+            E_USER_DEPRECATED
+        );
+
         $domain = $domain ?: $this->getTranslationDomain();
 
         return $this->translator->trans($id, $parameters, $domain, $locale);
@@ -2116,6 +2125,8 @@ EOT;
     /**
      * Translate a message id.
      *
+     * NEXT_MAJOR: remove this method
+     *
      * @param string      $id
      * @param int         $count
      * @param array       $parameters
@@ -2123,9 +2134,16 @@ EOT;
      * @param string|null $locale
      *
      * @return string the translated string
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     public function transChoice($id, $count, array $parameters = array(), $domain = null, $locale = null)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.'.
+            E_USER_DEPRECATED
+        );
+
         $domain = $domain ?: $this->getTranslationDomain();
 
         return $this->translator->transChoice($id, $count, $parameters, $domain, $locale);
@@ -2149,17 +2167,35 @@ EOT;
 
     /**
      * {@inheritdoc}
+     *
+     * NEXT_MAJOR: remove this method
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     public function setTranslator(TranslatorInterface $translator)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.'.
+            E_USER_DEPRECATED
+        );
+
         $this->translator = $translator;
     }
 
     /**
      * {@inheritdoc}
+     *
+     * NEXT_MAJOR: remove this method
+     *
+     * @deprecated since 3.x, to be removed with 4.0
      */
     public function getTranslator()
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.'.
+            E_USER_DEPRECATED
+        );
+
         return $this->translator;
     }
 

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -268,12 +268,16 @@ interface AdminInterface
     /**
      * translate a message id.
      *
+     * NEXT_MAJOR: remove this method
+     *
      * @param string $id
      * @param array  $parameters
      * @param null   $domain
      * @param null   $locale
      *
      * @return string the translated string
+     *
+     * @deprecated since 3.x, to be removed in 4.0
      */
     public function trans($id, array $parameters = array(), $domain = null, $locale = null);
 

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -185,7 +185,7 @@ class CRUDController extends Controller
 
                 $this->addFlash(
                     'sonata_flash_success',
-                    $this->admin->trans(
+                    $this->trans(
                         'flash_delete_success',
                         array('%name%' => $this->escapeHtml($objectName)),
                         'SonataAdminBundle'
@@ -200,7 +200,7 @@ class CRUDController extends Controller
 
                 $this->addFlash(
                     'sonata_flash_error',
-                    $this->admin->trans(
+                    $this->trans(
                         'flash_delete_error',
                         array('%name%' => $this->escapeHtml($objectName)),
                         'SonataAdminBundle'
@@ -277,7 +277,7 @@ class CRUDController extends Controller
 
                     $this->addFlash(
                         'sonata_flash_success',
-                        $this->admin->trans(
+                        $this->trans(
                             'flash_edit_success',
                             array('%name%' => $this->escapeHtml($this->admin->toString($object))),
                             'SonataAdminBundle'
@@ -291,7 +291,7 @@ class CRUDController extends Controller
 
                     $isFormValid = false;
                 } catch (LockException $e) {
-                    $this->addFlash('sonata_flash_error', $this->admin->trans('flash_lock_error', array(
+                    $this->addFlash('sonata_flash_error', $this->trans('flash_lock_error', array(
                         '%name%' => $this->escapeHtml($this->admin->toString($object)),
                         '%link_start%' => '<a href="'.$this->admin->generateObjectUrl('edit', $object).'">',
                         '%link_end%' => '</a>',
@@ -304,7 +304,7 @@ class CRUDController extends Controller
                 if (!$this->isXmlHttpRequest()) {
                     $this->addFlash(
                         'sonata_flash_error',
-                        $this->admin->trans(
+                        $this->trans(
                             'flash_edit_error',
                             array('%name%' => $this->escapeHtml($this->admin->toString($object))),
                             'SonataAdminBundle'
@@ -526,7 +526,7 @@ class CRUDController extends Controller
 
                     $this->addFlash(
                         'sonata_flash_success',
-                        $this->admin->trans(
+                        $this->trans(
                             'flash_create_success',
                             array('%name%' => $this->escapeHtml($this->admin->toString($object))),
                             'SonataAdminBundle'
@@ -547,7 +547,7 @@ class CRUDController extends Controller
                 if (!$this->isXmlHttpRequest()) {
                     $this->addFlash(
                         'sonata_flash_error',
-                        $this->admin->trans(
+                        $this->trans(
                             'flash_create_error',
                             array('%name%' => $this->escapeHtml($this->admin->toString($object))),
                             'SonataAdminBundle'
@@ -1363,5 +1363,22 @@ class CRUDController extends Controller
      */
     protected function preList(Request $request)
     {
+    }
+
+    /**
+     * Translate a message id.
+     *
+     * @param string $id
+     * @param array  $parameters
+     * @param string $domain
+     * @param string $locale
+     *
+     * @return string translated string
+     */
+    final protected function trans($id, array $parameters = array(), $domain = null, $locale = null)
+    {
+        $domain = $domain ?: $this->admin->getTranslationDomain();
+
+        return $this->get('translator')->trans($id, $parameters, $domain, $locale);
     }
 }

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -24,6 +24,7 @@
             <tag name="twig.extension"/>
             <argument type="service" id="sonata.admin.pool"/>
             <argument type="service" id="logger" on-invalid="ignore"/>
+            <argument type="service" id="translator"/>
             <call method="setXEditableTypeMapping">
                 <argument>%sonata.admin.twig.extension.x_editable_type_mapping%</argument>
             </call>

--- a/Resources/doc/reference/translation.rst
+++ b/Resources/doc/reference/translation.rst
@@ -49,10 +49,10 @@ translate messages within the ``configureFields`` method or in templates.
     {{ 'message_create_snapshots'|trans({}, 'SonataPageBundle') }}
 
     {# by using the admin trans method with hardcoded catalogue #}
-    {{ admin.trans('message_create_snapshots', {}, 'SonataPageBundle') }}
+    {{ 'message_create_snapshots'|trans({}, 'SonataPageBundle') }}
 
     {# by using the admin trans with the configured catalogue #}
-    {{ admin.trans('message_create_snapshots') }}
+    {{ 'message_create_snapshots'|trans({}, admin.translationdomain) }}
 
 The last solution is most flexible, as no catalogue parameters are hardcoded, and is the recommended one to use.
 

--- a/Resources/views/Block/block_admin_list.html.twig
+++ b/Resources/views/Block/block_admin_list.html.twig
@@ -30,7 +30,7 @@ file that was distributed with this source code.
                                 {% if admin.dashboardActions|length > 0 %}
                                             <tr>
                                                 <td class="sonata-ba-list-label" width="40%">
-                                                    {{ admin.label|trans({}, admin.translationdomain) }}
+                                                    {{ label|trans({}, admin.translationdomain) }}
                                                 </td>
                                                 <td>
                                                     <div class="btn-group">

--- a/Resources/views/Block/block_search_result.html.twig
+++ b/Resources/views/Block/block_search_result.html.twig
@@ -18,7 +18,7 @@ file that was distributed with this source code.
                 {% set icon = settings.icon|default('') %}
                 {{ icon|raw }}
                 <h3 class="box-title">
-                    {{ admin.label|trans({}, admin.translationdomain) }}
+                    {{ label|trans({}, admin.translationdomain) }}
                 </h3>
 
                 <div class="box-tools pull-right">

--- a/Resources/views/CRUD/base_edit_form.html.twig
+++ b/Resources/views/CRUD/base_edit_form.html.twig
@@ -32,7 +32,7 @@
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">
                                 {% for name, form_tab in admin.formtabs %}
-                                    <li{% if loop.index == 1 %} class="active"{% endif %}><a href="#tab_{{ admin.uniqid }}_{{ loop.index }}" data-toggle="tab"><i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i> {{ admin.trans(name, {}, form_tab.translation_domain) }}</a></li>
+                                    <li{% if loop.index == 1 %} class="active"{% endif %}><a href="#tab_{{ admin.uniqid }}_{{ loop.index }}" data-toggle="tab"><i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i> {{ name|trans({}, form_tab.translation_domain) }}</a></li>
                                 {% endfor %}
                             </ul>
                             <div class="tab-content">

--- a/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -8,7 +8,7 @@
             <div class="{{ form_group.box_class }}">
                 <div class="box-header">
                     <h4 class="box-title">
-                        {{ admin.trans(form_group.name, {}, form_group.translation_domain) }}
+                        {{ form_group.name|trans({}, form_group.translation_domain) }}
                     </h4>
                 </div>
                 <div class="box-body">

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -61,7 +61,7 @@ file that was distributed with this source code.
                                             {% spaceless %}
                                                 <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.options.header_class is defined %} {{ field_description.options.header_class }}{% endif %}"{% if field_description.options.header_style is defined %} style="{{ field_description.options.header_style }}"{% endif %}>
                                                     {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters) }}">{% endif %}
-                                                    {{ admin.trans(field_description.label, {}, field_description.translationDomain) }}
+                                                    {{ field_description.label|trans({}, field_description.translationDomain) }}
                                                     {% if sortable %}</a>{% endif %}
                                                 </th>
                                             {% endspaceless %}
@@ -220,7 +220,7 @@ file that was distributed with this source code.
                         {% set filterActive = ((filter.isActive() or filter.options['show_filter']) and not admin.isDefaultFilter(filter.formName)) %}
                         <li>
                             <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
-                                <i class="fa {{ filterActive ? 'fa-check-square-o' : 'fa-square-o' }}"></i>{{ admin.trans(filter.label, {}, filter.translationDomain) }}
+                                <i class="fa {{ (filter.isActive() or filter.options['show_filter']) ? 'fa-check-square-o' : 'fa-square-o' }}"></i>{{ filter.label|trans({}, filter.translationDomain) }}
                             </a>
                         </li>
                     {% endfor %}
@@ -248,7 +248,7 @@ file that was distributed with this source code.
                                     {% set filterVisible = filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null %}
                                     <div class="form-group {% block sonata_list_filter_group_class %}{% endblock %}" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ filterVisible ? 'true' : 'false' }}" style="display: {% if filterActive %}block{% else %}none{% endif %}">
                                         {% if filter.label is not same as(false) %}
-                                            <label for="{{ form.children[filter.formName].children['value'].vars.id }}" class="col-sm-3 control-label">{{ admin.trans(filter.label, {}, filter.translationDomain) }}</label>
+                                            <label for="{{ form.children[filter.formName].children['value'].vars.id }}" class="col-sm-3 control-label">{{ filter.label|trans({}, filter.translationDomain) }}</label>
                                         {% endif %}
                                         {% set attr = form.children[filter.formName].children['type'].vars.attr|default({}) %}
 

--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -38,7 +38,7 @@ file that was distributed with this source code.
                         <li{% if loop.first %} class="active"{% endif %}>
                             <a href="#tab_{{ admin.uniqid }}_{{ loop.index }}" data-toggle="tab">
                                 <i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i>
-                                {{ admin.trans(name, {}, show_tab.translation_domain) }}
+                                {{ name|trans({}, show_tab.translation_domain) }}
                             </a>
                         </li>
                     {% endfor %}

--- a/Resources/views/CRUD/base_show_compare.html.twig
+++ b/Resources/views/CRUD/base_show_compare.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends 'SonataAdminBundle:CRUD:base_show.html.twig' %}
 
 {% block show_title %}
-    {{ admin.trans(name) }}
+    {{ name|trans({}, admin.translationdomain) }}
 {% endblock %}
 
 {% block show_field %}

--- a/Resources/views/CRUD/base_show_field.html.twig
+++ b/Resources/views/CRUD/base_show_field.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-<th{% if(is_diff|default(false)) %} class="diff"{% endif %}>{% block name %}{{ admin.trans(field_description.label, {}, field_description.translationDomain) }}{% endblock %}</th>
+<th{% if(is_diff|default(false)) %} class="diff"{% endif %}>{% block name %}{{ field_description.label|trans({}, field_description.translationDomain) }}{% endblock %}</th>
 <td>{% block field %}{% if field_description.options.safe %}{{ value|raw }}{% else %}{{ value|nl2br }}{% endif %}{% endblock %}</td>
 
 {% block field_compare %}

--- a/Resources/views/CRUD/base_show_macro.html.twig
+++ b/Resources/views/CRUD/base_show_macro.html.twig
@@ -13,7 +13,7 @@
                 <div class="box-header">
                     <h4 class="box-title">
                         {% block show_title %}
-                            {{ admin.trans(show_group.name, {}, show_group.translation_domain) }}
+                            {{ show_group.name|trans({}, show_group.translation_domain) }}
                         {% endblock %}
                     </h4>
                 </div>

--- a/Resources/views/CRUD/preview.html.twig
+++ b/Resources/views/CRUD/preview.html.twig
@@ -35,7 +35,7 @@ file that was distributed with this source code.
                 {% if name %}
                     <tr class="sonata-ba-view-title">
                         <td colspan="2">
-                            {{ admin.trans(name) }}
+                            {{ name|trans({}, admin.translationdomain) }}
                         </td>
                     </tr>
                 {% endif %}

--- a/Resources/views/CRUD/tree.html.twig
+++ b/Resources/views/CRUD/tree.html.twig
@@ -50,7 +50,7 @@ file that was distributed with this source code.
         <div class="box box-primary">
             <div class="box-header">
                 <h1 class="box-title">
-                    {{ admin.trans('element.tree_site_label') }}
+                    {{ 'element.tree_site_label'|trans({}, admin.translationdomain) }}
                     <div class="btn-group">
                         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                             <strong class="text-info">{{ currentSite.name }}</strong> <span class="caret"></span>

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -134,7 +134,7 @@ file that was distributed with this source code.
             {% if not sonata_admin.admin %}
                 {{- label|trans({}, translation_domain) -}}
             {% else %}
-                {{ sonata_admin.admin.trans(label, {}, sonata_admin.field_description.translationDomain) }}
+                {{ label|trans({}, sonata_admin.field_description.translationDomain) }}
             {% endif %}
         </label>
     {% endif %}
@@ -358,7 +358,7 @@ file that was distributed with this source code.
             {% endif %}
 
             {% if sonata_admin is defined and sonata_admin_enabled and sonata_admin.field_description.help|default(false) %}
-                <span class="help-block sonata-ba-field-help">{{ sonata_admin.admin.trans(sonata_admin.field_description.help, {}, sonata_admin.field_description.translationDomain)|raw }}</span>
+                <span class="help-block sonata-ba-field-help">{{ sonata_admin.field_description.help|trans({}, sonata_admin.field_description.translationDomain)|raw }}</span>
             {% endif %}
         </div>
     </div>

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1209,6 +1209,9 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('fooTranslated', $admin->trans('foo'));
     }
 
+    /**
+     * @group Legacy
+     */
     public function testTransWithMessageDomain()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
@@ -1240,6 +1243,9 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('fooTranslated', $admin->transChoice('foo', 2));
     }
 
+    /**
+     * @group Legacy
+     */
     public function testTransChoiceWithMessageDomain()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -110,6 +110,11 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
     private $kernel;
 
     /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
      * {@inheritdoc}
      */
     protected function setUp()
@@ -121,6 +126,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->pool->setAdminServiceIds(array('foo.admin'));
         $this->request->attributes->set('_sonata_admin', 'foo.admin');
         $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $this->parameters = array();
         $this->template = '';
 
@@ -162,6 +168,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $request = $this->request;
         $admin = $this->admin;
         $session = $this->session;
+        $translator = $this->translator;
 
         $twig = $this->getMockBuilder('Twig_Environment')
             ->disableOriginalConstructor()
@@ -279,7 +286,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
                 $requestStack,
                 $csrfProvider,
                 $logger,
-                $kernel
+                $kernel,
+                $translator
             ) {
                 switch ($id) {
                     case 'sonata.admin.pool':
@@ -309,6 +317,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
                         return $logger;
                     case 'kernel':
                         return $kernel;
+                    case 'translator':
+                        return $translator;
                 }
             }));
 
@@ -335,6 +345,10 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
                 }
 
                 if ($id == 'templating') {
+                    return true;
+                }
+
+                if ($id == 'translator') {
                     return true;
                 }
 
@@ -3694,7 +3708,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     private function expectTranslate($id, array $parameters = array(), $domain = null, $locale = null)
     {
-        $this->admin->expects($this->once())
+        $this->translator->expects($this->once())
             ->method('trans')
             ->with($this->equalTo($id), $this->equalTo($parameters), $this->equalTo($domain), $this->equalTo($locale))
             ->will($this->returnValue($id));

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
 use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Test for SonataAdminExtension.
@@ -81,6 +82,11 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
      */
     private $xEditableTypeMapping;
 
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
     public function setUp()
     {
         date_default_timezone_set('Europe/London');
@@ -109,7 +115,19 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
             'url' => 'url',
         );
 
-        $this->twigExtension = new SonataAdminExtension($this->pool, $this->logger);
+        // translation extension
+        $translator = new Translator('en', new MessageSelector());
+        $translator->addLoader('xlf', new XliffFileLoader());
+        $translator->addResource(
+            'xlf',
+            __DIR__.'/../../../Resources/translations/SonataAdminBundle.en.xliff',
+            'en',
+            'SonataAdminBundle'
+        );
+
+        $this->translator = $translator;
+
+        $this->twigExtension = new SonataAdminExtension($this->pool, $this->logger, $this->translator);
         $this->twigExtension->setXEditableTypeMapping($this->xEditableTypeMapping);
 
         $loader = new StubFilesystemLoader(array(
@@ -123,16 +141,6 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
             'optimizations' => 0,
         ));
         $this->environment->addExtension($this->twigExtension);
-
-        // translation extension
-        $translator = new Translator('en', new MessageSelector());
-        $translator->addLoader('xlf', new XliffFileLoader());
-        $translator->addResource(
-            'xlf',
-            __DIR__.'/../../../Resources/translations/SonataAdminBundle.en.xliff',
-            'en',
-            'SonataAdminBundle'
-        );
         $this->environment->addExtension(new TranslationExtension($translator));
 
         // routing extension
@@ -963,7 +971,7 @@ EOT
         data-title="Data"
         data-pk="12345"
         data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=xyz"
-        data-source="[{&quot;value&quot;:&quot;Foo&quot;,&quot;text&quot;:&quot;Delete&quot;},{&quot;value&quot;:&quot;Status2&quot;,&quot;text&quot;:&quot;Alias2&quot;},{&quot;value&quot;:&quot;Status3&quot;,&quot;text&quot;:&quot;Alias3&quot;}]" >
+        data-source="[{&quot;value&quot;:&quot;Foo&quot;,&quot;text&quot;:&quot;action_delete&quot;},{&quot;value&quot;:&quot;Status2&quot;,&quot;text&quot;:&quot;Alias2&quot;},{&quot;value&quot;:&quot;Status3&quot;,&quot;text&quot;:&quot;Alias3&quot;}]" >
          Delete
     </span>
 </td>

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,11 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated admin translator
+
+The `$translator` property and the corresponding methods (`setTranslator`, `getTranslator`, `trans` and `transChoice`) in `AbstractAdmin` are deprecated.
+Please use `CRUDController::trans` or twig templates instead.
+
 UPGRADE FROM 3.4 to 3.5
 =======================
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4072
Rebase of #4089

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `CRUDController::trans` method

### Changed
- translation in twig templates uses the twig translation filter

### Deprecated
- deprecated `AdminInterface::trans` method
- deprecated `AbstractAdmin::$translator` property
- deprecated `AbstractAdmin::trans` method
- deprecated `AbstractAdmin::transChoice` method
- deprecated `AbstractAdmin::getTranslator` method
- deprecated `AbstractAdmin::setTranslator` method
```


## Subject

This change deprecates the translator in the `AbstractAdmin` and moves all translation logic to the templates and the CRUDController.

