### PR TITLE
avoid whitespace in rendered html output

### DIFF
--- a/Resources/views/Pager/base_results.html.twig
+++ b/Resources/views/Pager/base_results.html.twig
@@ -24,7 +24,7 @@ file that was distributed with this source code.
     <select class="per-page small form-control" id="{{ admin.uniqid }}_per_page" style="width: auto">
         {% for per_page in admin.getperpageoptions %}
             <option {% if per_page == admin.datagrid.pager.maxperpage %}selected="selected"{% endif %} value="{{ admin.generateUrl('list', {'filter': admin.datagrid.values|merge({'_page': 1, '_per_page': per_page})}) }}">
-                {{ per_page }}
+                {{- per_page -}}
             </option>
         {% endfor %}
     </select>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

I am targetting this branch, because this is BC.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- whitespace in HTML output for `entries per page` dropdown
```

## Subject

It is much easier for tests, Behat for example

## Screenshots

### Before
![bildschirmfoto 2016-09-06 um 16 21 11](https://cloud.githubusercontent.com/assets/995707/18277849/3143b240-7450-11e6-8402-a549e46ae4f5.png)

### After
![bildschirmfoto 2016-09-06 um 16 33 37](https://cloud.githubusercontent.com/assets/995707/18277851/36893414-7450-11e6-9090-e09d56d974ba.png)


