### PR TITLE
Added additional extension points for standard_layout

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -64,23 +64,21 @@ file that was distributed with this source code.
                 {% endfor %}
             {% endblock %}
 
-            {% block javascripts_sonata_l10n %}
-                {% set locale = app.request.locale %}
-                {# localize moment #}
+            {% set locale = app.request.locale %}
+            {# localize moment #}
+            {% if locale[:2] != 'en' %}
+                <script src="{{ asset('bundles/sonatacore/vendor/moment/locale/' ~ locale|replace({'_':'-'}) ~ '.js') }}"></script>
+            {% endif %}
+
+            {# localize select2 #}
+            {% if sonata_admin.adminPool.getOption('use_select2') %}
+                {% if locale == 'pt' %}{% set locale = 'pt_PT' %}{% endif %}
+
+                {# omit default EN locale #}
                 {% if locale[:2] != 'en' %}
-                    <script src="{{ asset('bundles/sonatacore/vendor/moment/locale/' ~ locale|replace({'_':'-'}) ~ '.js') }}"></script>
+                    <script src="{{ asset('bundles/sonatacore/vendor/select2/select2_locale_' ~ locale|replace({'_':'-'}) ~ '.js') }}"></script>
                 {% endif %}
-
-                {# localize select2 #}
-                {% if sonata_admin.adminPool.getOption('use_select2') %}
-                    {% if locale == 'pt' %}{% set locale = 'pt_PT' %}{% endif %}
-
-                    {# omit default EN locale #}
-                    {% if locale[:2] != 'en' %}
-                        <script src="{{ asset('bundles/sonatacore/vendor/select2/select2_locale_' ~ locale|replace({'_':'-'}) ~ '.js') }}"></script>
-                    {% endif %}
-                {% endif %}
-            {% endblock %}
+            {% endif %}
         {% endblock %}
 
         <title>

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
         {% endblock %}
 
         {% block javascripts %}
-            {% block javascripts_sonata_config %}
+            {% block sonata_javascript_config %}
                 <script>
                     window.SONATA_CONFIG = {
                         CONFIRM_EXIT: {% if sonata_admin.adminPool.getOption('confirm_exit') %}true{% else %}false{% endif %},
@@ -58,7 +58,7 @@ file that was distributed with this source code.
                 </script>
             {% endblock %}
 
-            {% block javascripts_sonata_pool %}
+            {% block sonata_javascript_pool %}
                 {% for javascript in sonata_admin.adminPool.getOption('javascripts', []) %}
                     <script src="{{ asset(javascript) }}"></script>
                 {% endfor %}

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -64,7 +64,7 @@ file that was distributed with this source code.
                 {% endfor %}
             {% endblock %}
 
-            {% block javascripts_sonata_localised %}
+            {% block javascripts_sonata_l10n %}
                 {% set locale = app.request.locale %}
                 {# localize moment #}
                 {% if locale[:2] != 'en' %}

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -37,44 +37,50 @@ file that was distributed with this source code.
         {% endblock %}
 
         {% block javascripts %}
-            <script>
-                window.SONATA_CONFIG = {
-                    CONFIRM_EXIT: {% if sonata_admin.adminPool.getOption('confirm_exit') %}true{% else %}false{% endif %},
-                    USE_SELECT2: {% if sonata_admin.adminPool.getOption('use_select2') %}true{% else %}false{% endif %},
-                    USE_ICHECK: {% if sonata_admin.adminPool.getOption('use_icheck') %}true{% else %}false{% endif %},
-                    USE_STICKYFORMS: {% if sonata_admin.adminPool.getOption('use_stickyforms') %}true{% else %}false{% endif %}
-                };
-                window.SONATA_TRANSLATIONS = {
-                    CONFIRM_EXIT:  '{{ 'confirm_exit'|trans({}, 'SonataAdminBundle')|escape('js') }}'
-                };
+            {% block javascripts_sonata_config %}
+                <script>
+                    window.SONATA_CONFIG = {
+                        CONFIRM_EXIT: {% if sonata_admin.adminPool.getOption('confirm_exit') %}true{% else %}false{% endif %},
+                        USE_SELECT2: {% if sonata_admin.adminPool.getOption('use_select2') %}true{% else %}false{% endif %},
+                        USE_ICHECK: {% if sonata_admin.adminPool.getOption('use_icheck') %}true{% else %}false{% endif %},
+                        USE_STICKYFORMS: {% if sonata_admin.adminPool.getOption('use_stickyforms') %}true{% else %}false{% endif %}
+                    };
+                    window.SONATA_TRANSLATIONS = {
+                        CONFIRM_EXIT:  '{{ 'confirm_exit'|trans({}, 'SonataAdminBundle')|escape('js') }}'
+                    };
 
-                // http://getbootstrap.com/getting-started/#support-ie10-width
-                if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
-                    var msViewportStyle = document.createElement('style');
-                    msViewportStyle.appendChild(document.createTextNode('@-ms-viewport{width:auto!important}'));
-                    document.querySelector('head').appendChild(msViewportStyle);
-                }
-            </script>
+                    // http://getbootstrap.com/getting-started/#support-ie10-width
+                    if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
+                        var msViewportStyle = document.createElement('style');
+                        msViewportStyle.appendChild(document.createTextNode('@-ms-viewport{width:auto!important}'));
+                        document.querySelector('head').appendChild(msViewportStyle);
+                    }
+                </script>
+            {% endblock %}
 
-            {% for javascript in sonata_admin.adminPool.getOption('javascripts', []) %}
-                <script src="{{ asset(javascript) }}"></script>
-            {% endfor %}
+            {% block javascripts_sonata_pool %}
+                {% for javascript in sonata_admin.adminPool.getOption('javascripts', []) %}
+                    <script src="{{ asset(javascript) }}"></script>
+                {% endfor %}
+            {% endblock %}
 
-            {% set locale = app.request.locale %}
-            {# localize moment #}
-            {% if locale[:2] != 'en' %}
-                <script src="{{ asset('bundles/sonatacore/vendor/moment/locale/' ~ locale|replace({'_':'-'}) ~ '.js') }}"></script>
-            {% endif %}
-
-            {# localize select2 #}
-            {% if sonata_admin.adminPool.getOption('use_select2') %}
-                {% if locale == 'pt' %}{% set locale = 'pt_PT' %}{% endif %}
-
-                {# omit default EN locale #}
+            {% block javascripts_sonata_localised %}
+                {% set locale = app.request.locale %}
+                {# localize moment #}
                 {% if locale[:2] != 'en' %}
-                    <script src="{{ asset('bundles/sonatacore/vendor/select2/select2_locale_' ~ locale|replace({'_':'-'}) ~ '.js') }}"></script>
+                    <script src="{{ asset('bundles/sonatacore/vendor/moment/locale/' ~ locale|replace({'_':'-'}) ~ '.js') }}"></script>
                 {% endif %}
-            {% endif %}
+
+                {# localize select2 #}
+                {% if sonata_admin.adminPool.getOption('use_select2') %}
+                    {% if locale == 'pt' %}{% set locale = 'pt_PT' %}{% endif %}
+
+                    {# omit default EN locale #}
+                    {% if locale[:2] != 'en' %}
+                        <script src="{{ asset('bundles/sonatacore/vendor/select2/select2_locale_' ~ locale|replace({'_':'-'}) ~ '.js') }}"></script>
+                    {% endif %}
+                {% endif %}
+            {% endblock %}
         {% endblock %}
 
         <title>


### PR DESCRIPTION
I am targetting this branch, because the change is backward compatible

## Changelog
```markdown
### Added
- Added three new sub-blocks to standard_layouts javascript block
```

## Subject
Added three new sub-blocks to standard_layouts javascript block. This allows for more granular extension without breaking BC

## Questions
- I wondered what's the reason that the loading of the localised versions of moment.js and select2 are not registered and loaded via the admin pool? Doing so would make the template simpler and we would not need the block javascripts_sonata_l10n at all. We could then also move the logic of generating the proper localised names to PHP instead of Twig (f.e. for respecting the fact that the portuguese version of select2 is called 'pt_PT' and not 'pt'). I didn't include this in the PR because I wanted to hear your opinion on it first? This might also need to have get it's own PR
