### PR TITLE
Add configuration options to define the template of buttons

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2795,7 +2795,7 @@ EOT;
             && $this->hasRoute('create')
         ) {
             $list['create'] = array(
-                'template' => 'SonataAdminBundle:Button:create_button.html.twig',
+                'template' => $this->getConfigurationPool()->getTemplate('button_create'),
             );
         }
 
@@ -2804,7 +2804,7 @@ EOT;
             && $this->hasRoute('edit')
         ) {
             $list['edit'] = array(
-                'template' => 'SonataAdminBundle:Button:edit_button.html.twig',
+                'template' => $this->getConfigurationPool()->getTemplate('button_edit'),
             );
         }
 
@@ -2813,7 +2813,7 @@ EOT;
             && $this->hasRoute('history')
         ) {
             $list['history'] = array(
-                'template' => 'SonataAdminBundle:Button:history_button.html.twig',
+                'template' => $this->getConfigurationPool()->getTemplate('button_history'),
             );
         }
 
@@ -2823,7 +2823,7 @@ EOT;
             && $this->hasRoute('acl')
         ) {
             $list['acl'] = array(
-                'template' => 'SonataAdminBundle:Button:acl_button.html.twig',
+                'template' => $this->getConfigurationPool()->getTemplate('button_acl'),
             );
         }
 
@@ -2833,7 +2833,7 @@ EOT;
             && $this->hasRoute('show')
         ) {
             $list['show'] = array(
-                'template' => 'SonataAdminBundle:Button:show_button.html.twig',
+                'template' => $this->getConfigurationPool()->getTemplate('button_show'),
             );
         }
 
@@ -2842,7 +2842,7 @@ EOT;
             && $this->hasRoute('list')
         ) {
             $list['list'] = array(
-                'template' => 'SonataAdminBundle:Button:list_button.html.twig',
+                'template' => $this->getConfigurationPool()->getTemplate('button_list'),
             );
         }
 
@@ -2882,7 +2882,7 @@ EOT;
             $actions['create'] = array(
                 'label' => 'link_add',
                 'translation_domain' => 'SonataAdminBundle',
-                'template' => 'SonataAdminBundle:CRUD:dashboard__action_create.html.twig',
+                'template' => $this->getConfigurationPool()->getTemplate('action_create'),
                 'url' => $this->generateUrl('create'),
                 'icon' => 'plus-circle',
             );

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2795,7 +2795,7 @@ EOT;
             && $this->hasRoute('create')
         ) {
             $list['create'] = array(
-                'template' => $this->getConfigurationPool()->getTemplate('button_create'),
+                'template' => $this->getTemplate('button_create'),
             );
         }
 
@@ -2804,7 +2804,7 @@ EOT;
             && $this->hasRoute('edit')
         ) {
             $list['edit'] = array(
-                'template' => $this->getConfigurationPool()->getTemplate('button_edit'),
+                'template' => $this->getTemplate('button_edit'),
             );
         }
 
@@ -2813,7 +2813,7 @@ EOT;
             && $this->hasRoute('history')
         ) {
             $list['history'] = array(
-                'template' => $this->getConfigurationPool()->getTemplate('button_history'),
+                'template' => $this->getTemplate('button_history'),
             );
         }
 
@@ -2823,7 +2823,7 @@ EOT;
             && $this->hasRoute('acl')
         ) {
             $list['acl'] = array(
-                'template' => $this->getConfigurationPool()->getTemplate('button_acl'),
+                'template' => $this->getTemplate('button_acl'),
             );
         }
 
@@ -2833,7 +2833,7 @@ EOT;
             && $this->hasRoute('show')
         ) {
             $list['show'] = array(
-                'template' => $this->getConfigurationPool()->getTemplate('button_show'),
+                'template' => $this->getTemplate('button_show'),
             );
         }
 
@@ -2842,7 +2842,7 @@ EOT;
             && $this->hasRoute('list')
         ) {
             $list['list'] = array(
-                'template' => $this->getConfigurationPool()->getTemplate('button_list'),
+                'template' => $this->getTemplate('button_list'),
             );
         }
 
@@ -2882,7 +2882,7 @@ EOT;
             $actions['create'] = array(
                 'label' => 'link_add',
                 'translation_domain' => 'SonataAdminBundle',
-                'template' => $this->getConfigurationPool()->getTemplate('action_create'),
+                'template' => $this->getTemplate('action_create'),
                 'url' => $this->generateUrl('create'),
                 'icon' => 'plus-circle',
             );

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -288,6 +288,13 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('pager_results')->defaultValue('SonataAdminBundle:Pager:results.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('tab_menu_template')->defaultValue('SonataAdminBundle:Core:tab_menu_template.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('knp_menu_template')->defaultValue('SonataAdminBundle:Menu:sonata_menu.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('action_create')->defaultValue('SonataAdminBundle:CRUD:dashboard__action_create.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('button_acl')->defaultValue('SonataAdminBundle:Button:acl_button.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('button_create')->defaultValue('SonataAdminBundle:Button:create_button.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('button_edit')->defaultValue('SonataAdminBundle:Button:edit_button.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('button_history')->defaultValue('SonataAdminBundle:Button:history_button.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('button_list')->defaultValue('SonataAdminBundle:Button:list_button.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('button_show')->defaultValue('SonataAdminBundle:Button:show_button.html.twig')->cannotBeEmpty()->end()
                     ->end()
                 ->end()
 

--- a/Resources/doc/reference/templates.rst
+++ b/Resources/doc/reference/templates.rst
@@ -140,6 +140,13 @@ You can specify your templates in the config.yml file, like so:
                 history_revision_timestamp:     SonataAdminBundle:CRUD:history_revision_timestamp.html.twig
                 short_object_description:       SonataAdminBundle:Helper:short-object-description.html.twig
                 search_result_block:            SonataAdminBundle:Block:block_search_result.html.twig
+                action_create:                  SonataAdminBundle:CRUD:dashboard__action_create.html.twig
+                button_acl:                     SonataAdminBundle:Button:acl_button.html.twig
+                button_create:                  SonataAdminBundle:Button:create_button.html.twig
+                button_edit:                    SonataAdminBundle:Button:edit_button.html.twig
+                button_history:                 SonataAdminBundle:Button:history_button.html.twig
+                button_list:                    SonataAdminBundle:Button:list_button.html.twig
+                button_show:                    SonataAdminBundle:Button:show_button.html.twig
 
 Notice that this is a global change, meaning it will affect all model mappings automatically,
 both for ``Admin`` mappings defined by you and by other bundles.

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1624,7 +1624,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $expected = array(
             'create' => array(
-                'template' => 'SonataAdminBundle:Button:create_button.html.twig',
+                'template' => 'Foo.html.twig',
             ),
         );
 
@@ -1645,6 +1645,15 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->with($admin, 'create')
             ->will($this->returnValue(true));
         $admin->setRouteGenerator($routeGenerator);
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $pool = $this->getMock('Sonata\AdminBundle\Admin\Pool', array(), array($container, 'Sonata Admin', '/path/to/pic.png', array('foo' => 'bar')));
+        $pool
+            ->expects($this->once())
+            ->method('getTemplate')
+            ->with('button_create')
+            ->will($this->returnValue('Foo.html.twig'));
+        $admin->setConfigurationPool($pool);
 
         $this->assertSame($expected, $admin->getActionButtons('list', null));
     }
@@ -1745,6 +1754,10 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             }));
 
         $admin->setSecurityHandler($securityHandler);
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $pool = $this->getMock('Sonata\AdminBundle\Admin\Pool', array(), array($container, 'Sonata Admin', '/path/to/pic.png', array('foo' => 'bar')));
+        $admin->setConfigurationPool($pool);
 
         $this->assertArrayHasKey('list', $admin->getDashboardActions());
         $this->assertArrayHasKey('create', $admin->getDashboardActions());

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1646,14 +1646,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
         $admin->setRouteGenerator($routeGenerator);
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $pool = $this->getMock('Sonata\AdminBundle\Admin\Pool', array(), array($container, 'Sonata Admin', '/path/to/pic.png', array('foo' => 'bar')));
-        $pool
-            ->expects($this->once())
-            ->method('getTemplate')
-            ->with('button_create')
-            ->will($this->returnValue('Foo.html.twig'));
-        $admin->setConfigurationPool($pool);
+        $admin->setTemplate('button_create', 'Foo.html.twig');
 
         $this->assertSame($expected, $admin->getActionButtons('list', null));
     }
@@ -1754,10 +1747,6 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             }));
 
         $admin->setSecurityHandler($securityHandler);
-
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $pool = $this->getMock('Sonata\AdminBundle\Admin\Pool', array(), array($container, 'Sonata Admin', '/path/to/pic.png', array('foo' => 'bar')));
-        $admin->setConfigurationPool($pool);
 
         $this->assertArrayHasKey('list', $admin->getDashboardActions());
         $this->assertArrayHasKey('create', $admin->getDashboardActions());

--- a/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -254,6 +254,7 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
                 case 'setTemplates':
                     $this->assertSame('foobar.twig.html', $parameters[0]['user_block']);
                     $this->assertSame('SonataAdminBundle:Pager:results.html.twig', $parameters[0]['pager_results']);
+                    $this->assertSame('SonataAdminBundle:Button:create_button.html.twig', $parameters[0]['button_create']);
                     break;
 
                 case 'setLabel':


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this PR is full compatible with previous versions.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Moved the raw references of buttons templates from `Admin\AbstractAdmin` to configuration options
```

## Subject

The templates used to render the buttons (create, update, ...) are not configurable. This make impossible or at least hard to override from a third part bundle. For exemple, i'm working on a [bundle that provide a Gentellela theme](https://github.com/kinulab/sonata-gentellela-theme-bundle), but does files are not overwrittable without putting them in `app/Resources`.

So this PR move the hard linked references to configurable options in the templates part.

