### PR TITLE
special method for sharing persistent parameters

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1983,6 +1983,14 @@ EOT;
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function sharePersistentParameters($code)
+    {
+        return $this->getPersistentParameters();
+    }
+
+    /**
      * @param string $name
      *
      * @return null|mixed

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -937,6 +937,14 @@ interface AdminInterface
     public function getPersistentParameters();
 
     /**
+     * Returns an array of persistent parameters which will be saved on url generation
+     *
+     * @param string $code
+     * @return array
+     */
+    public function sharePersistentParameters($code);
+
+    /**
      * NEXT_MAJOR: remove this signature
      * Get breadcrumbs for $action.
      *

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -940,6 +940,7 @@ interface AdminInterface
      * Returns an array of persistent parameters which will be saved on url generation
      *
      * @param string $code
+     *
      * @return array
      */
     public function sharePersistentParameters($code);

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -937,7 +937,7 @@ interface AdminInterface
     public function getPersistentParameters();
 
     /**
-     * Returns an array of persistent parameters which will be saved on url generation
+     * Returns an array of persistent parameters which will be saved on url generation.
      *
      * @param string $code
      *

--- a/Route/DefaultRouteGenerator.php
+++ b/Route/DefaultRouteGenerator.php
@@ -105,7 +105,7 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
 
         // allows to define persistent parameters
         if ($admin->hasRequest()) {
-            $parameters = array_merge($admin->getPersistentParameters(), $parameters);
+            $parameters = array_merge($admin->sharePersistentParameters($name), $parameters);
         }
 
         $code = $this->getCode($admin, $name);

--- a/Tests/Route/DefaultRouteGeneratorTest.php
+++ b/Tests/Route/DefaultRouteGeneratorTest.php
@@ -58,7 +58,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->once())->method('hasRequest')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('foo_code'));
-        $admin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
+        $admin->expects($this->once())->method('sharePersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
@@ -105,7 +105,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Route'));
         $admin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(false));
         $admin->expects($this->once())->method('hasRequest')->will($this->returnValue(true));
-        $admin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array()));
+        $admin->expects($this->once())->method('sharePersistentParameters')->will($this->returnValue(array()));
         $admin->expects($this->exactly(2))->method('getRoutes')->will($this->returnValue(new RouteCollection('base.Code.Route', 'baseRouteName', 'baseRoutePattern', 'BundleName:ControllerName')));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
@@ -138,7 +138,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->any())->method('hasRequest')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('foo_code'));
-        $admin->expects($this->any())->method('getPersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
+        $admin->expects($this->any())->method('sharePersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($childCollection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
@@ -149,7 +149,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $parentAdmin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
         // no request attached in this test, so this will not be used
-        $parentAdmin->expects($this->never())->method('getPersistentParameters')->will($this->returnValue(array('from' => 'parent')));
+        $parentAdmin->expects($this->never())->method('sharePersistentParameters')->will($this->returnValue(array('from' => 'parent')));
 
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
         $request->attributes = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
@@ -222,7 +222,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->once())->method('hasRequest')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('foo_code'));
-        $admin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
+        $admin->expects($this->once())->method('sharePersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
 
@@ -295,7 +295,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->any())->method('hasParentFieldDescription')->will($this->returnValue(false));
         $admin->expects($this->any())->method('hasRequest')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
-        $admin->expects($this->any())->method('getPersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
+        $admin->expects($this->any())->method('sharePersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($childCollection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
@@ -306,7 +306,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $parentAdmin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
         // no request attached in this test, so this will not be used
-        $parentAdmin->expects($this->never())->method('getPersistentParameters')->will($this->returnValue(array('from' => 'parent')));
+        $parentAdmin->expects($this->never())->method('sharePersistentParameters')->will($this->returnValue(array('from' => 'parent')));
 
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
         $request->attributes = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
@@ -330,7 +330,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $standaloneAdmin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(false));
         $standaloneAdmin->expects($this->once())->method('hasRequest')->will($this->returnValue(true));
         $standaloneAdmin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
-        $standaloneAdmin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
+        $standaloneAdmin->expects($this->once())->method('sharePersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
         $standaloneAdmin->expects($this->any())->method('getRoutes')->will($this->returnValue($standaloneCollection));
         $standaloneAdmin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a BC fix

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Ability to control which persistent parameters will be in url 
```

## Subject
Currenly, generator is keeping all persistent parameters in new url. They are not necessary for `list` urls for example.

And actually, it causes real problems. 
I got an issue using SonataPageBundle: when we adding a block and clicking `Actions > Add new` - type of block will be saved and user won't be asked for it.
If we save changes using "Update and close" button, we will be redirected to `list` page with `type` parameter, and it also will be saved in url if we will try to create new block (and we won't be asked for type).
I will create PR for this in `SonataPageBundle` as fix if this PR will be merged.