### PR TITLE
Fix ModelsToArrayTransformer::getIdentifierValues error messages

### DIFF
--- a/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Form\DataTransformer;
 
+use Doctrine\Common\Util\ClassUtils;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
@@ -107,7 +108,12 @@ class ModelsToArrayTransformer implements DataTransformerInterface
         }
 
         if (count($notFound) > 0) {
-            throw new TransformationFailedException(sprintf('The entities with keys "%s" could not be found', implode('", "', $notFound)));
+            throw new TransformationFailedException(
+                sprintf(
+                    'The entities with keys "%s" could not be found',
+                    implode('", "', $notFound)
+                )
+            );
         }
 
         return $collection;

--- a/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -126,10 +126,25 @@ class ModelsToArrayTransformer implements DataTransformerInterface
      */
     private function getIdentifierValues($entity)
     {
+        if (!is_object($entity)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Expected an entity class, received %s',
+                    var_export($entity, true)
+                )
+            );
+        }
         try {
             return $this->modelManager->getIdentifierValues($entity);
         } catch (\Exception $e) {
-            throw new \InvalidArgumentException(sprintf('Unable to retrieve the identifier values for entity %s', ClassUtils::getClass($entity)), 0, $e);
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Unable to retrieve the identifier values for entity %s',
+                    ClassUtils::getClass($entity)
+                ),
+                0,
+                $e
+            );
         }
     }
 }

--- a/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
+
+use Prophecy\Promise\ThrowPromise;
+use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
+use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity;
+use Symfony\Component\Config\Definition\Exception\Exception;
+
+class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ModelManagerInterface
+     */
+    private $modelManager;
+
+    /**
+     * @var ModelChoiceLoader
+     */
+    private $choiceList;
+
+    private $class;
+    private $entity;
+
+    public function setUp()
+    {
+        $this->modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
+
+        $this->choiceList = $this->prophesize('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader');
+
+        $this->class = 'Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity';
+        $this->entity = new FooEntity();
+    }
+
+    public function testGetIdentifierValues()
+    {
+        $transformer = new ModelsToArrayTransformer(
+            $this->choiceList->reveal(),
+            $this->modelManager->reveal(),
+            $this->class
+        );
+        $identityObject = new \stdClass();
+
+        $this->modelManager
+            ->getIdentifierValues($this->entity)
+            ->willReturn($identityObject);
+
+        $this->assertEquals(
+            $this->invokeMethod(
+                $transformer,
+                'getIdentifierValues',
+                array($this->entity)
+            ),
+            $identityObject,
+            'Should return identified values via modelManager'
+        );
+
+        $exceptionObject = new Exception('test exception');
+        $this->modelManager
+            ->getIdentifierValues($this->entity)
+            ->will(new ThrowPromise($exceptionObject));
+
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Unable to retrieve the identifier values for entity '.$this->class
+        );
+
+        $this->invokeMethod($transformer, 'getIdentifierValues', array($this->entity));
+    }
+
+    /**
+     * Invoke a private or protected method for sakes of testing.
+     *
+     * @link https://jtreminio.com/2013/03/unit-testing-tutorial-part-3-testing-protected-private-methods-coverage-reports-and-crap/#targeting-private%2Fprotected-methods-directly Pulled from post by Juan Treminio
+     *
+     * @param object $object     to invoke method on
+     * @param string $methodName to invoke
+     * @param array  $parameters to pass to the method
+     *
+     * @return mixed the result
+     */
+    private function invokeMethod($object, $methodName, array $parameters = array())
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+}

--- a/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -79,6 +79,22 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
         $this->invokeMethod($transformer, 'getIdentifierValues', array($this->entity));
     }
 
+    public function testGetIdentifierValuesHandlesNull()
+    {
+        $transformer = new ModelsToArrayTransformer(
+            $this->choiceList->reveal(),
+            $this->modelManager->reveal(),
+            $this->class
+        );
+
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Expected an entity class, received NULL'
+        );
+
+        $this->invokeMethod($transformer, 'getIdentifierValues', array(null));
+    }
+
     /**
      * Invoke a private or protected method for sakes of testing.
      *


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targeting the 3.x branch, because the use statement is missing and adding it is not a BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4015 
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Fixed
- Added missing use statement to `ModelsToArrayTransformer`
- Added falsy check to `ModelsToArrayTransformer::getIdentifierValues`
```
## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
- [x] Update the tests
## Subject

<!-- Describe your Pull Request content here -->

Was missing use statement for `Doctrine\Common\Util\ClassUtils` when
generating an exception inside the `ModelsToArrayTransformer` class
