### PR TITLE
Fixed #4124

### DIFF
--- a/Resources/views/Block/block_admin_list.html.twig
+++ b/Resources/views/Block/block_admin_list.html.twig
@@ -30,7 +30,7 @@ file that was distributed with this source code.
                                 {% if admin.dashboardActions|length > 0 %}
                                             <tr>
                                                 <td class="sonata-ba-list-label" width="40%">
-                                                    {{ label|trans({}, admin.translationdomain) }}
+                                                    {{ admin.label|trans({}, admin.translationdomain) }}
                                                 </td>
                                                 <td>
                                                     <div class="btn-group">

--- a/Resources/views/Block/block_search_result.html.twig
+++ b/Resources/views/Block/block_search_result.html.twig
@@ -18,7 +18,7 @@ file that was distributed with this source code.
                 {% set icon = settings.icon|default('') %}
                 {{ icon|raw }}
                 <h3 class="box-title">
-                    {{ label|trans({}, admin.translationdomain) }}
+                    {{ admin.label|trans({}, admin.translationdomain) }}
                 </h3>
 
                 <div class="box-tools pull-right">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #4124

## Subject

Fixed wrong template replacements for `admin.trans`.

