### PR TITLE
extend AbstractBlockService instead of deprecated BaseBlockService and increase block-bundle dependency to ^3.2

### DIFF
--- a/Block/AdminListBlockService.php
+++ b/Block/AdminListBlockService.php
@@ -12,8 +12,8 @@
 namespace Sonata\AdminBundle\Block;
 
 use Sonata\AdminBundle\Admin\Pool;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AdminListBlockService extends BaseBlockService
+class AdminListBlockService extends AbstractBlockService
 {
     protected $pool;
 

--- a/Block/AdminSearchBlockService.php
+++ b/Block/AdminSearchBlockService.php
@@ -14,8 +14,8 @@ namespace Sonata\AdminBundle\Block;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Search\SearchHandler;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,7 +25,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AdminSearchBlockService extends BaseBlockService
+class AdminSearchBlockService extends AbstractBlockService
 {
     /**
      * @var Pool

--- a/Block/AdminStatsBlockService.php
+++ b/Block/AdminStatsBlockService.php
@@ -12,8 +12,8 @@
 namespace Sonata\AdminBundle\Block;
 
 use Sonata\AdminBundle\Admin\Pool;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author  Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AdminStatsBlockService extends BaseBlockService
+class AdminStatsBlockService extends AbstractBlockService
 {
     /**
      * @var Pool

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/common": "^2.2",
         "doctrine/inflector": "^1.0",
         "knplabs/knp-menu-bundle": "^2.1.1",
-        "sonata-project/block-bundle": "^3.1.1",
+        "sonata-project/block-bundle": "^3.2",
         "sonata-project/core-bundle": "^3.1",
         "sonata-project/exporter": "^1.0",
         "symfony/class-loader": "^2.3 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #4155

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- extend `AbstractBlockService` instead of deprecated `BaseBlockService`
- block-bundle dependency is now 3.2
```

## Subject

<!-- Describe your Pull Request content here -->

extend AbstractBlockService instead of deprecated BaseBlockService and increase block-bundle dependency to ^3.2

Deprecation was introduced here https://github.com/sonata-project/SonataBlockBundle/pull/328 and released in Block-Bundle 3.2.0