### PR TITLE
[Form] 'required' option is always true if the type of a field is pas…

### DIFF
--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Form;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
@@ -76,6 +77,19 @@ class FormMapper extends BaseGroupedMapper
 
              // fix the form name
              $fieldName = str_replace('.', '__', $fieldName);
+        }
+
+        $classEntity = $this->admin->getClass();
+        if (!isset($options['required']) && property_exists($classEntity, $name)) {
+            $reflectionProperty = new \ReflectionProperty($classEntity, $name);
+            $annotationReader = new AnnotationReader();
+            $columnAnnotation = $annotationReader->getPropertyAnnotation(
+                $reflectionProperty,
+                'Doctrine\ORM\Mapping\Column'
+            );
+            if (null !== $columnAnnotation && true === $columnAnnotation->nullable) {
+                $options['required'] = false;
+            }
         }
 
         // change `collection` to `sonata_type_native_collection` form type to


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because we have unconvenient form field performance

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #4142
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Changed
- Improve method `FormMapper::add`
```
## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note
## Subject

<!-- Describe your Pull Request content here -->

For now it works with `Doctrine\ORM\Mapping\Column` annotation fields

Now if the field has nullable=true, it will be show as not required field
