### PR TITLE
AbstractAdmin trigger_error punctuation fix

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2113,7 +2113,7 @@ EOT;
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
         @trigger_error(
-            'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.'.
+            'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.',
             E_USER_DEPRECATED
         );
 
@@ -2140,7 +2140,7 @@ EOT;
     public function transChoice($id, $count, array $parameters = array(), $domain = null, $locale = null)
     {
         @trigger_error(
-            'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.'.
+            'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.',
             E_USER_DEPRECATED
         );
 
@@ -2175,7 +2175,7 @@ EOT;
     public function setTranslator(TranslatorInterface $translator)
     {
         @trigger_error(
-            'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.'.
+            'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.',
             E_USER_DEPRECATED
         );
 
@@ -2192,7 +2192,7 @@ EOT;
     public function getTranslator()
     {
         @trigger_error(
-            'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.'.
+            'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.',
             E_USER_DEPRECATED
         );
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is a patch


## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- fixed `trigger_error` calls - `E_USER_DEPRECATED` was concatenated to the sentence, not passed as argument.

```
## Subject

Changing dot `.` to comma `,` in `trigger_error` calls, added in #4124 

