### PR TITLE
Fix translation doesn't work in xEditableChoices

### DIFF
--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -425,7 +425,7 @@ EOT;
                 foreach ($choices as $value => $text) {
                     if ($catalogue) {
                         if (null !== $this->translator) {
-                            $this->translator->trans($text, array(), $catalogue);
+                            $text = $this->translator->trans($text, array(), $catalogue);
                         // NEXT_MAJOR: Remove this check
                         } elseif (method_exists($fieldDescription->getAdmin(), 'trans')) {
                             $text = $fieldDescription->getAdmin()->trans($text, array(), $catalogue);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because I found a bug in xeditable choice form type.
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Fixed
- Assign translated version of the choice label to variable

```
## Subject

<!-- Describe your Pull Request content here -->

Translated version of the choice label was forgotten to assign to `$text` variable.
