### PR TITLE
Improved class support for filter factory

### DIFF
--- a/Filter/FilterFactory.php
+++ b/Filter/FilterFactory.php
@@ -51,14 +51,16 @@ class FilterFactory implements FilterFactoryInterface
 
         $id = isset($this->types[$type]) ? $this->types[$type] : false;
 
-        if (!$id) {
+        if ($id) {
+            $filter = $this->container->get($id);
+        } elseif (class_exists($type)) {
+            $filter = new $type();
+        } else {
             throw new \RuntimeException(sprintf('No attached service to type named `%s`', $type));
         }
 
-        $filter = $this->container->get($id);
-
         if (!$filter instanceof FilterInterface) {
-            throw new \RuntimeException(sprintf('The service `%s` must implement `FilterInterface`', $id));
+            throw new \RuntimeException(sprintf('The service `%s` must implement `FilterInterface`', $type));
         }
 
         $filter->initialize($name, $options);

--- a/Tests/Filter/FilterFactoryTest.php
+++ b/Tests/Filter/FilterFactoryTest.php
@@ -15,55 +15,50 @@ use Sonata\AdminBundle\Filter\FilterFactory;
 
 class FilterFactoryTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @expectedException RuntimeException
-     */
     public function testEmptyType()
     {
+        $this->setExpectedException('\RuntimeException', 'The type must be defined');
+
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $filter = new FilterFactory($container, array());
         $filter->create('test', null);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testUnknownType()
     {
+        $this->setExpectedException('\RuntimeException', 'No attached service to type named `mytype`');
+
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $filter = new FilterFactory($container, array());
         $filter->create('test', 'mytype');
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testUnknownClassType()
     {
+        $this->setExpectedException('\RuntimeException', 'No attached service to type named `Sonata\AdminBundle\Form\Type\Filter\FooType`');
+
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $filter = new FilterFactory($container, array());
         $filter->create('test', 'Sonata\AdminBundle\Form\Type\Filter\FooType');
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testClassType()
     {
+        $this->setExpectedException('\RuntimeException', 'The service `Sonata\AdminBundle\Form\Type\Filter\DefaultType` must implement `FilterInterface`');
+
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $filter = new FilterFactory($container, array());
         $filter->create('test', 'Sonata\AdminBundle\Form\Type\Filter\DefaultType');
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testInvalidTypeInstance()
     {
+        $this->setExpectedException('\RuntimeException', 'The service `mytype` must implement `FilterInterface`');
+
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->once())
             ->method('get')

--- a/Tests/Filter/FilterFactoryTest.php
+++ b/Tests/Filter/FilterFactoryTest.php
@@ -40,6 +40,28 @@ class FilterFactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException RuntimeException
      */
+    public function testUnknownClassType()
+    {
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $filter = new FilterFactory($container, array());
+        $filter->create('test', 'Sonata\AdminBundle\Form\Type\Filter\FooType');
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testClassType()
+    {
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $filter = new FilterFactory($container, array());
+        $filter->create('test', 'Sonata\AdminBundle\Form\Type\Filter\DefaultType');
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
     public function testInvalidTypeInstance()
     {
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is a BC feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Improved class support for filter factory
```
## Subject

Added support for filters that doesn't exists as a service.
