### PR TITLE
Rename pager methods. refs #3494

### DIFF
--- a/Datagrid/Pager.php
+++ b/Datagrid/Pager.php
@@ -251,7 +251,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      *
      * @return int
      */
-    public function getFirstIndice()
+    public function getFirstIndex()
     {
         if ($this->page == 0) {
             return 1;
@@ -265,7 +265,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      *
      * @return int
      */
-    public function getLastIndice()
+    public function getLastIndex()
     {
         if ($this->page == 0) {
             return $this->nbResults;

--- a/Datagrid/Pager.php
+++ b/Datagrid/Pager.php
@@ -247,6 +247,22 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * NEXT_MAJOR: remove this method
+     *
+     * @deprecated
+     */
+
+    public function getFirstIndice()
+    {
+        @trigger_error(
+            'Method ' . __METHOD__ . ' is deprecated since version 3.x and will be removed in 4.0, ' .
+            'please use getFirstIndex() instead.',
+            E_USER_DEPRECATED
+        );
+        return $this->getFirstIndex();
+    }
+
+    /**
      * Returns the first index on the current page.
      *
      * @return int
@@ -258,6 +274,23 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         }
 
         return ($this->page - 1) * $this->maxPerPage + 1;
+    }
+
+
+    /**
+     * NEXT_MAJOR: remove this method
+     *
+     * @deprecated
+     */
+
+    public function getLastIndice()
+    {
+        @trigger_error(
+            'Method ' . __METHOD__ . ' is deprecated since version 3.x and will be removed in 4.0, ' .
+            'please use getLastIndex() instead.',
+            E_USER_DEPRECATED
+        );
+        return $this->getLastIndex();
     }
 
     /**

--- a/Tests/Datagrid/PagerTest.php
+++ b/Tests/Datagrid/PagerTest.php
@@ -435,41 +435,41 @@ class PagerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetFirstIndice()
     {
-        $this->assertSame(1, $this->pager->getFirstIndice());
+        $this->assertSame(1, $this->pager->getFirstIndex());
 
         $this->pager->setMaxPerPage(0);
         $this->pager->setPage(0);
-        $this->assertSame(1, $this->pager->getFirstIndice());
+        $this->assertSame(1, $this->pager->getFirstIndex());
 
         $this->pager->setPage(2);
         $this->pager->setMaxPerPage(10);
-        $this->assertSame(11, $this->pager->getFirstIndice());
+        $this->assertSame(11, $this->pager->getFirstIndex());
 
         $this->pager->setPage(4);
         $this->pager->setMaxPerPage(7);
-        $this->assertSame(22, $this->pager->getFirstIndice());
+        $this->assertSame(22, $this->pager->getFirstIndex());
     }
 
     public function testGetLastIndice()
     {
-        $this->assertSame(0, $this->pager->getLastIndice());
+        $this->assertSame(0, $this->pager->getLastIndex());
 
         $this->pager->setMaxPerPage(0);
         $this->pager->setPage(0);
-        $this->assertSame(0, $this->pager->getLastIndice());
+        $this->assertSame(0, $this->pager->getLastIndex());
 
         $this->callMethod($this->pager, 'setNbResults', array(100));
 
-        $this->assertSame(100, $this->pager->getLastIndice());
+        $this->assertSame(100, $this->pager->getLastIndex());
 
         $this->pager->setPage(2);
-        $this->assertSame(0, $this->pager->getLastIndice());
+        $this->assertSame(0, $this->pager->getLastIndex());
 
         $this->pager->setMaxPerPage(10);
-        $this->assertSame(20, $this->pager->getLastIndice());
+        $this->assertSame(20, $this->pager->getLastIndex());
 
         $this->pager->setPage(11);
-        $this->assertSame(100, $this->pager->getLastIndice());
+        $this->assertSame(100, $this->pager->getLastIndex());
     }
 
     public function testGetNext()

--- a/Tests/Datagrid/PagerTest.php
+++ b/Tests/Datagrid/PagerTest.php
@@ -433,7 +433,7 @@ class PagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(20, $this->pager->getPreviousPage());
     }
 
-    public function testGetFirstIndice()
+    public function testGetFirstIndex()
     {
         $this->assertSame(1, $this->pager->getFirstIndex());
 
@@ -450,7 +450,7 @@ class PagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(22, $this->pager->getFirstIndex());
     }
 
-    public function testGetLastIndice()
+    public function testGetLastIndex()
     {
         $this->assertSame(0, $this->pager->getLastIndex());
 


### PR DESCRIPTION
I am targeting this branch, because changing the names is a BC break.

Fixes #3494
## Changelog

``` markdown
### Changed
- Renamed pager methods `getFirstIndice()` and `getLastIndice()` to
 `getFirstIndex()`, respectively `getLastIndex()`.
```
## To do
- [X] Update the tests
## Subject

Rename the pager methods `getFirstIndice()` and `getLastIndice()`.
