### PR TITLE
updated bin paths

### DIFF
--- a/Resources/doc/getting_started/installation.rst
+++ b/Resources/doc/getting_started/installation.rst
@@ -145,8 +145,8 @@ install the assets:
 
 .. code-block:: bash
 
-    $ php app/console cache:clear
-    $ php app/console assets:install
+    $ php bin/console cache:clear
+    $ php bin/console assets:install
 
 The Admin Interface
 -------------------

--- a/Resources/doc/reference/console.rst
+++ b/Resources/doc/reference/console.rst
@@ -14,13 +14,13 @@ cache:create-cache-class
 ------------------------
 
 The ``cache:create-cache-class`` command generates the cache class
-(``app/cache/...env.../classes.php``) from the classes.map file.
+(``var/cache/...env.../classes.php``) from the classes.map file.
 
 Usage example:
 
 .. code-block:: bash
 
-    $ php app/console cache:create-cache-class
+    $ php bin/console cache:create-cache-class
 
 sonata:admin:generate
 ---------------------
@@ -52,7 +52,7 @@ Usage example:
 
 .. code-block:: bash
 
-    $ php app/console sonata:admin:generate AppBundle/Entity/Foo
+    $ php bin/console sonata:admin:generate AppBundle/Entity/Foo
 
 sonata:admin:list
 -----------------
@@ -66,7 +66,7 @@ Usage example:
 
 .. code-block:: bash
 
-    $ php app/console sonata:admin:list
+    $ php bin/console sonata:admin:list
 
 
 .. figure:: ../images/console_admin_list.png
@@ -86,7 +86,7 @@ Usage example:
 
 .. code-block:: bash
 
-    $ php app/console sonata:admin:explain sonata.news.admin.post
+    $ php bin/console sonata:admin:explain sonata.news.admin.post
 
 .. figure:: ../images/console_admin_explain.png
    :align: center
@@ -108,7 +108,7 @@ Usage example:
 
 .. code-block:: bash
 
-    $ php app/console sonata:admin:setup-acl
+    $ php bin/console sonata:admin:setup-acl
 
 sonata:admin:generate-object-acl
 --------------------------------

--- a/Resources/doc/reference/getting_started.rst
+++ b/Resources/doc/reference/getting_started.rst
@@ -282,7 +282,7 @@ Install your assets:
 
 .. code-block:: bash
 
-    $ php app/console assets:install
+    $ php bin/console assets:install
 
 Now you can change your project's main config.yml file:
 

--- a/Resources/doc/reference/routing.rst
+++ b/Resources/doc/reference/routing.rst
@@ -247,13 +247,13 @@ You can view all of the current routes defined for an Admin class by using the c
 
 .. code-block:: bash
 
- $ php app/console sonata:admin:explain <<admin.service.name>>
+ $ php bin/console sonata:admin:explain <<admin.service.name>>
 
 for example if your Admin is called sonata.admin.foo you would run
 
 .. code-block:: bash
 
-    $ php app/console sonata:admin:explain app.admin.foo
+    $ php bin/console sonata:admin:explain app.admin.foo
 
 Sonata internally checks for the existence of a route before linking to it. As a result, removing a
 route will prevent links to that action from appearing in the administrative interface. For example,

--- a/Resources/doc/reference/security.rst
+++ b/Resources/doc/reference/security.rst
@@ -388,13 +388,13 @@ In ``app/config/security.yml``:
             acl:
                 connection: default
 
-- Install the ACL tables ``php app/console init:acl``
+- Install the ACL tables ``php bin/console init:acl``
 
 - Create a new root user:
 
 .. code-block:: bash
 
-    $ php app/console fos:user:create --super-admin
+    $ php bin/console fos:user:create --super-admin
         Please choose a username:root
         Please choose an email:root@domain.com
         Please choose a password:root
@@ -404,7 +404,7 @@ If you have Admin classes, you can install or update the related CRUD ACL rules:
 
 .. code-block:: bash
 
-    $ php app/console sonata:admin:setup-acl
+    $ php bin/console sonata:admin:setup-acl
     Starting ACL AdminBundle configuration
     > install ACL for sonata.media.admin.media
        - add role: ROLE_SONATA_MEDIA_ADMIN_MEDIA_GUEST, permissions: ["VIEW","LIST"]
@@ -418,7 +418,7 @@ object of an admin:
 
 .. code-block:: bash
 
-    $ php app/console sonata:admin:generate-object-acl
+    $ php bin/console sonata:admin:generate-object-acl
 
 Optionally, you can specify an object owner, and step through each admin. See
 the help of the command for more information.
@@ -628,7 +628,7 @@ Usage
 ~~~~~
 
 Every time you create a new ``Admin`` class, you should start with the command
-``php app/console sonata:admin:setup-acl`` so the ACL database will be updated
+``php bin/console sonata:admin:setup-acl`` so the ACL database will be updated
 with the latest roles and permissions.
 
 In the templates, or in your code, you can use the Admin method ``isGranted()``:


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
symfony 3 changed console paths to /bin

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the documentation

## Subject

<!-- Describe your Pull Request content here -->

Simple fix for the documented path to the bin/console

