### PR TITLE
Add note to documentation when creating a custom action

### DIFF
--- a/Resources/doc/cookbook/recipe_custom_action.rst
+++ b/Resources/doc/cookbook/recipe_custom_action.rst
@@ -257,3 +257,7 @@ The full ``CarAdmin.php`` example looks like this:
             // ...
         }
     }
+
+.. note::
+
+    If you want to render a custom controller action in a template by using the render function in twig you need to add `_sonata_admin` as an attribute. For example; `{{ render(controller('AppBundle:XxxxCRUD:comment', { '_sonata_admin': 'sonata.admin.xxxx' })) }}`. This has to be done because the moment the rendering should happen no routing is involved yet, and then you will get an error 'There is no _sonata_admin defined for the controller AppBundle\Controller\XxxxCRUDController and the current route ''.'


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is an important note for when users want to create a custom action and render it directly into the template.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added a note to the recipe_custom_action.rst file

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
recipe_custom_action.rst file to document a note for when a user want to render a custom action directly into a template.