### PR TITLE
Add note for actions rendered directly into a template.

### DIFF
--- a/Resources/doc/cookbook/recipe_custom_action.rst
+++ b/Resources/doc/cookbook/recipe_custom_action.rst
@@ -257,3 +257,14 @@ The full ``CarAdmin.php`` example looks like this:
             // ...
         }
     }
+
+.. note::
+
+If you want to render a custom controller action in a template by using the
+render function in twig you need to add ``_sonata_admin`` as an attribute. For
+example; ``{{ render(controller('AppBundle:XxxxCRUD:comment', {
+'_sonata_admin': 'sonata.admin.xxxx' })) }}``. This has to be done because the
+moment the rendering should happen the routing, which usually sets the value of
+this parameter, is not involved at all, and then you will get an error 'There
+is no _sonata_admin defined for the controller
+AppBundle\Controller\XxxxCRUDController and the current route ''.'

--- a/Resources/doc/cookbook/recipe_custom_action.rst
+++ b/Resources/doc/cookbook/recipe_custom_action.rst
@@ -260,11 +260,11 @@ The full ``CarAdmin.php`` example looks like this:
 
 .. note::
 
-If you want to render a custom controller action in a template by using the
-render function in twig you need to add ``_sonata_admin`` as an attribute. For
-example; ``{{ render(controller('AppBundle:XxxxCRUD:comment', {
-'_sonata_admin': 'sonata.admin.xxxx' })) }}``. This has to be done because the
-moment the rendering should happen the routing, which usually sets the value of
-this parameter, is not involved at all, and then you will get an error 'There
-is no _sonata_admin defined for the controller
-AppBundle\Controller\XxxxCRUDController and the current route ''.'
+    If you want to render a custom controller action in a template by using the
+    render function in twig you need to add ``_sonata_admin`` as an attribute. For
+    example; ``{{ render(controller('AppBundle:XxxxCRUD:comment', {'_sonata_admin':
+    'sonata.admin.xxxx' })) }}``. This has to be done because the moment the
+    rendering should happen the routing, which usually sets the value of this
+    parameter, is not involved at all, and then you will get an error "There is no
+    _sonata_admin defined for the controller
+    AppBundle\Controller\XxxxCRUDController and the current route ''."

--- a/Resources/doc/cookbook/recipe_custom_action.rst
+++ b/Resources/doc/cookbook/recipe_custom_action.rst
@@ -267,4 +267,4 @@ The full ``CarAdmin.php`` example looks like this:
     rendering should happen the routing, which usually sets the value of this
     parameter, is not involved at all, and then you will get an error "There is no
     _sonata_admin defined for the controller
-    AppBundle\Controller\XxxxCRUDController and the current route ''."
+    AppBundle\Controller\XxxxCRUDController and the current route ' '."


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is just a little documentation change.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added a note to the 'Create a custom admin action' cookbook.

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->
Modified recipe_custom_action.rst file to document a note for when a user want to render a custom action directly into a template.
