### PR TITLE
Fix compatibility with Symfony 3.2 form renderer

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -23,6 +23,7 @@ use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -105,7 +106,7 @@ class CRUDController extends Controller
         $formView = $datagrid->getForm()->createView();
 
         // set the theme for the current Admin Form
-        $this->get('twig')->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')->renderer->setTheme($formView, $this->admin->getFilterTheme());
+        $this->setFormTheme($formView);
 
         return $this->render($this->admin->getTemplate('list'), array(
             'action' => 'list',
@@ -318,14 +319,13 @@ class CRUDController extends Controller
             }
         }
 
-        $view = $form->createView();
-
+        $formView = $form->createView();
         // set the theme for the current Admin Form
-        $this->get('twig')->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')->renderer->setTheme($view, $this->admin->getFormTheme());
+        $this->setFormTheme($formView);
 
         return $this->render($this->admin->getTemplate($templateKey), array(
             'action' => 'edit',
-            'form' => $view,
+            'form' => $formView,
             'object' => $object,
         ), null);
     }
@@ -557,14 +557,13 @@ class CRUDController extends Controller
             }
         }
 
-        $view = $form->createView();
-
+        $formView = $form->createView();
         // set the theme for the current Admin Form
-        $this->get('twig')->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')->renderer->setTheme($view, $this->admin->getFormTheme());
+        $this->setFormTheme($formView);
 
         return $this->render($this->admin->getTemplate($templateKey), array(
             'action' => 'create',
-            'form' => $view,
+            'form' => $formView,
             'object' => $object,
         ), null);
     }
@@ -1346,6 +1345,28 @@ class CRUDController extends Controller
      */
     protected function preList(Request $request)
     {
+    }
+
+    /**
+     * Sets the admin form theme to form view. Used for compatibility between Symfony versions.
+     *
+     * @param FormView $formView
+     */
+    protected function setFormTheme(FormView $formView)
+    {
+        $twig = $this->get('twig');
+
+        try {
+            $twig
+                ->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')
+                ->setTheme($formView, $this->admin->getFilterTheme());
+        } catch (\Twig_Error_Runtime $e) {
+            // BC for Symfony < 3.2 where this runtime not exists
+            $twig
+                ->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')
+                ->renderer
+                ->setTheme($formView, $this->admin->getFilterTheme());
+        }
     }
 
     /**

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -1348,28 +1348,6 @@ class CRUDController extends Controller
     }
 
     /**
-     * Sets the admin form theme to form view. Used for compatibility between Symfony versions.
-     *
-     * @param FormView $formView
-     */
-    protected function setFormTheme(FormView $formView)
-    {
-        $twig = $this->get('twig');
-
-        try {
-            $twig
-                ->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')
-                ->setTheme($formView, $this->admin->getFilterTheme());
-        } catch (\Twig_Error_Runtime $e) {
-            // BC for Symfony < 3.2 where this runtime not exists
-            $twig
-                ->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')
-                ->renderer
-                ->setTheme($formView, $this->admin->getFilterTheme());
-        }
-    }
-
-    /**
      * Translate a message id.
      *
      * @param string $id
@@ -1384,5 +1362,27 @@ class CRUDController extends Controller
         $domain = $domain ?: $this->admin->getTranslationDomain();
 
         return $this->get('translator')->trans($id, $parameters, $domain, $locale);
+    }
+
+    /**
+     * Sets the admin form theme to form view. Used for compatibility between Symfony versions.
+     *
+     * @param FormView $formView
+     */
+    private function setFormTheme(FormView $formView)
+    {
+        $twig = $this->get('twig');
+
+        try {
+            $twig
+                ->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')
+                ->setTheme($formView, $this->admin->getFilterTheme());
+        } catch (\Twig_Error_Runtime $e) {
+            // BC for Symfony < 3.2 where this runtime not exists
+            $twig
+                ->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')
+                ->renderer
+                ->setTheme($formView, $this->admin->getFilterTheme());
+        }
     }
 }

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -333,8 +333,6 @@ class CRUDController extends Controller
     /**
      * Batch action.
      *
-     * @param Request $request
-     *
      * @return Response|RedirectResponse
      *
      * @throws NotFoundHttpException If the HTTP method is not POST
@@ -460,8 +458,6 @@ class CRUDController extends Controller
     /**
      * Create action.
      *
-     * @param Request $request
-     *
      * @return Response
      *
      * @throws AccessDeniedException If access is not granted
@@ -577,7 +573,6 @@ class CRUDController extends Controller
      * Show action.
      *
      * @param int|string|null $id
-     * @param Request         $request
      *
      * @return Response
      *
@@ -615,7 +610,6 @@ class CRUDController extends Controller
      * Show history revisions for object.
      *
      * @param int|string|null $id
-     * @param Request         $request
      *
      * @return Response
      *
@@ -663,7 +657,6 @@ class CRUDController extends Controller
      *
      * @param int|string|null $id
      * @param string|null     $revision
-     * @param Request         $request
      *
      * @return Response
      *
@@ -725,7 +718,6 @@ class CRUDController extends Controller
      * @param int|string|null $id
      * @param int|string|null $base_revision
      * @param int|string|null $compare_revision
-     * @param Request         $request
      *
      * @return Response
      *
@@ -842,7 +834,6 @@ class CRUDController extends Controller
      * Returns the Response object associated to the acl action.
      *
      * @param int|string|null $id
-     * @param Request         $request
      *
      * @return Response|RedirectResponse
      *
@@ -1110,8 +1101,6 @@ class CRUDController extends Controller
     /**
      * Returns true if the preview is requested to be shown.
      *
-     * @param Request $request
-     *
      * @return bool
      */
     protected function isPreviewRequested()
@@ -1123,8 +1112,6 @@ class CRUDController extends Controller
 
     /**
      * Returns true if the preview has been approved.
-     *
-     * @param Request $request
      *
      * @return bool
      */
@@ -1141,8 +1128,6 @@ class CRUDController extends Controller
      * That means either a preview is requested or the preview has already been shown
      * and it got approved/declined.
      *
-     * @param Request $request
-     *
      * @return bool
      */
     protected function isInPreviewMode()
@@ -1155,8 +1140,6 @@ class CRUDController extends Controller
 
     /**
      * Returns true if the preview has been declined.
-     *
-     * @param Request $request
      *
      * @return bool
      */

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Filter\FilterInterface;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -108,13 +109,10 @@ class HelperController
         $view = $this->helper->getChildFormView($form->createView(), $elementId);
 
         // render the widget
-        // todo : fix this, the twig environment variable is not set inside the extension ...
+        $renderer = $this->getFormRenderer();
+        $renderer->setTheme($view, $admin->getFormTheme());
 
-        $extension = $this->twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension');
-        $extension->initRuntime($this->twig);
-        $extension->renderer->setTheme($view, $admin->getFormTheme());
-
-        return new Response($extension->renderer->searchAndRenderBlock($view, 'widget'));
+        return new Response($renderer->searchAndRenderBlock($view, 'widget'));
     }
 
     /**
@@ -157,12 +155,10 @@ class HelperController
         $view = $this->helper->getChildFormView($form->createView(), $elementId);
 
         // render the widget
-        // todo : fix this, the twig environment variable is not set inside the extension ...
-        $extension = $this->twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension');
-        $extension->initRuntime($this->twig);
-        $extension->renderer->setTheme($view, $admin->getFormTheme());
+        $renderer = $this->getFormRenderer();
+        $renderer->setTheme($view, $admin->getFormTheme());
 
-        return new Response($extension->renderer->searchAndRenderBlock($view, 'widget'));
+        return new Response($renderer->searchAndRenderBlock($view, 'widget'));
     }
 
     /**
@@ -496,5 +492,24 @@ class HelperController
         }
 
         return $fieldDescription;
+    }
+
+    /**
+     * @return TwigRenderer
+     */
+    private function getFormRenderer()
+    {
+        try {
+            $runtime = $this->twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer');
+            $runtime->setEnvironment($this->twig);
+
+            return $runtime;
+        } catch (\Twig_Error_Runtime $e) {
+            // BC for Symfony < 3.2 where this runtime not exists
+            $extension = $this->twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension');
+            $extension->initRuntime($this->twig);
+
+            return $extension->renderer;
+        }
     }
 }

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -187,6 +187,19 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
                 }
             }));
 
+        $twig->expects($this->any())
+            ->method('getRuntime')
+            ->will($this->returnCallback(function ($name) use ($twigRenderer) {
+                switch ($name) {
+                    case 'Symfony\Bridge\Twig\Form\TwigRenderer':
+                        if (Kernel::MAJOR_VERSION >= 3 && Kernel::MINOR_VERSION >= 2) {
+                            return $twigRenderer;
+                        }
+
+                        throw new \Twig_Error_Runtime('This runtime exists when Symony >= 3.2.');
+                }
+            }));
+
         // NEXT_MAJOR : require sonata/exporter ^1.7 and remove conditional
         if (class_exists('Exporter\Exporter')) {
             $exporter = new Exporter(array(new JsonWriter('/tmp/sonataadmin/export.json')));

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -20,6 +20,7 @@ use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 
@@ -328,6 +329,20 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $twig = new \Twig_Environment($this->getMock('\Twig_LoaderInterface'));
         $twig->addExtension(new FormExtension($mockRenderer));
+
+        if (Kernel::MAJOR_VERSION >= 3 && Kernel::MINOR_VERSION >= 2) {
+            $runtimeLoader = $this
+                ->getMockBuilder('Twig_RuntimeLoaderInterface')
+                ->getMock();
+
+            $runtimeLoader->expects($this->once())
+                ->method('load')
+                ->with($this->equalTo('Symfony\Bridge\Twig\Form\TwigRenderer'))
+                ->will($this->returnValue($mockRenderer));
+
+            $twig->addRuntimeLoader($runtimeLoader);
+        }
+
         $request = new Request(array(
             'code' => 'sonata.post.admin',
             'objectId' => 42,
@@ -368,7 +383,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getValidatorInterfaces
      */
-    public function testretrieveFormFieldElementAction($validatorInterface)
+    public function testRetrieveFormFieldElementAction($validatorInterface)
     {
         $object = new AdminControllerHelper_Foo();
 

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -1297,7 +1297,7 @@ EOT
     }
 
     /**
-     * @expectedException        Twig_Error_Loader
+     * @expectedException        \Twig_Error_Loader
      * @expectedExceptionMessage Unable to find template "base_list_nonexistent_field.html.twig"
      * @group                    legacy
      */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4152, #4154

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added helper method `CRUDController::setFormTheme`.
### Fixed
- Fix compatibility with Symfony 3.2 form renderer.
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->

Proposed sollution in #4154 breaks compatibility with older Symfony versions because `twig.form.renderer` service is private https://github.com/symfony/symfony/blob/2.8/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml#L156 . Also I've updated code in other places.

