### PR TITLE
Dropdown arrows position corrected

### DIFF
--- a/Resources/views/Menu/sonata_menu.html.twig
+++ b/Resources/views/Menu/sonata_menu.html.twig
@@ -43,7 +43,7 @@
             {% set icon = item.extra('icon')|default('') %}
             {{ icon|raw }}
             {{ parent() }}
-            <i class="fa pull-right fa-angle-left"></i>
+            <span class="pull-right-container"><i class="fa pull-right fa-angle-left"></i></span>
         </a>
     {% endspaceless %}
 {% endblock %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch

-->
I am targetting this branch, because its a bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4218

## Changelog
<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- a bug with the side menu arrow position was fixed
```

## Screenshots

### Before
![actual](https://cloud.githubusercontent.com/assets/6814451/20787599/08a87cf8-b7ad-11e6-9e79-dfa117722d4f.png)

### After
![with-span pull-right-container](https://cloud.githubusercontent.com/assets/6814451/20787606/1255c8fa-b7ad-11e6-8ca3-214833fdb1b1.png)


## Subject

<!-- Describe your Pull Request content here -->

https://github.com/sonata-project/SonataAdminBundle/issues/4218