### PR TITLE
Adjust role permission

### DIFF
--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -111,8 +111,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
                         'VIEW' => array('VIEW'),
                         'DELETE' => array('DELETE'),
                         'EXPORT' => array('EXPORT'),
-                        'OPERATOR' => array('OPERATOR'),
-                        'MASTER' => array('MASTER'),
+                        'ALL' => array('ALL'),
                     );
                 }
                 break;


### PR DESCRIPTION
I am targetting this branch, because this is BC since the roles deleted shouldn't be there in the first place AFAIK.

## Changelog
```markdown
### Fixed
- Fixed permissions when setting role for the security handler
```

## Subject
Fixed permissions when setting role for the security handler. Operator and Master should be only for ACL based permission. Also, the role ALL is missing.

Reference: https://sonata-project.org/bundles/admin/3-x/doc/reference/security.html#role-handler

