### PR TITLE
Remove deprecated translation logic

### DIFF
--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -83,7 +83,7 @@ file that was distributed with this source code.
                         <div class="box-header">
                             <h4 class="box-title">
                                 {% block show_title %}
-                                    {{ admin.trans(show_group.name, {}, show_group.translation_domain) }}
+                                    {{ show_group.name|trans({}, show_group.translation_domain) }}
                                 {% endblock %}
                             </h4>
                         </div>


### PR DESCRIPTION
I am targetting this branch, because this is BC.

Partially closes #4229

## Changelog

```markdown
### Changed
- translation in twig templates uses the twig translation filter
```

## Subject

Removes deprecated translations calls from the `AdminInterface::trans` method.

