### PR TITLE
fix uses the twig translation filter

### DIFF
--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -83,7 +83,7 @@ file that was distributed with this source code.
                         <div class="box-header">
                             <h4 class="box-title">
                                 {% block show_title %}
-                                    {{ show_group.name|trans({}, show_group.translation_domain) }}
+                                    {{ show_group.name|trans({}, show_group.translation_domain|default(admin.translationDomain)) }}
                                 {% endblock %}
                             </h4>
                         </div>


### PR DESCRIPTION
I am targetting this branch, because this is BC.

Closes #4230

## Changelog

```markdown
### Fixed
- display correct name of group uses default translation domain
```

## Subject
Set default translation domain.