### PR TITLE
Fix deprecations

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2172,12 +2172,14 @@ EOT;
      *
      * @deprecated since 3.9, to be removed with 4.0
      */
-    public function setTranslator(TranslatorInterface $translator)
+    public function setTranslator(TranslatorInterface $translator, $deprecation = true)
     {
-        @trigger_error(
-            'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.',
-            E_USER_DEPRECATED
-        );
+        if ($deprecation) {
+            @trigger_error(
+                'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.',
+                E_USER_DEPRECATED
+            );
+        }
 
         $this->translator = $translator;
     }

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -2172,9 +2172,10 @@ EOT;
      *
      * @deprecated since 3.9, to be removed with 4.0
      */
-    public function setTranslator(TranslatorInterface $translator, $deprecation = true)
+    public function setTranslator(TranslatorInterface $translator)
     {
-        if ($deprecation) {
+        $args = func_get_args();
+        if (isset($args[1]) && $args[1]) {
             @trigger_error(
                 'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.',
                 E_USER_DEPRECATED

--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -275,7 +275,12 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             $method = 'set'.Inflector::classify($attr);
 
             if (isset($overwriteAdminConfiguration[$attr]) || !$definition->hasMethodCall($method)) {
-                $definition->addMethodCall($method, array(new Reference(isset($overwriteAdminConfiguration[$attr]) ? $overwriteAdminConfiguration[$attr] : $addServiceId)));
+                $args = array(new Reference(isset($overwriteAdminConfiguration[$attr]) ? $overwriteAdminConfiguration[$attr] : $addServiceId));
+                if ('translator' === $attr) {
+                    $args[] = false;
+                }
+
+                $definition->addMethodCall($method, $args);
             }
         }
 

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -8,18 +8,18 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% set _preview              = block('preview') %}
-{% set _form                 = block('form') %}
-{% set _show                 = block('show') %}
-{% set _list_table           = block('list_table') %}
-{% set _list_filters         = block('list_filters') %}
-{% set _tab_menu             = block('tab_menu') %}
-{% set _content              = block('content') %}
-{% set _title                = block('title') %}
-{% set _breadcrumb           = block('breadcrumb') %}
-{% set _actions              = block('actions') %}
-{% set _navbar_title         = block('navbar_title') %}
-{% set _list_filters_actions = block('list_filters_actions') %}
+{% set _preview              = block('preview') is defined ? block('preview') : null %}
+{% set _form                 = block('form') is defined ? block('form') : null %}
+{% set _show                 = block('show') is defined ? block('show') : null %}
+{% set _list_table           = block('list_table') is defined ? block('list_table') : null %}
+{% set _list_filters         = block('list_filters') is defined ? block('list_filters') : null %}
+{% set _tab_menu             = block('tab_menu') is defined ? block('tab_menu') : null %}
+{% set _content              = block('content') is defined ? block('content') : null %}
+{% set _title                = block('title') is defined ? block('title') : null %}
+{% set _breadcrumb           = block('breadcrumb') is defined ? block('breadcrumb') : null %}
+{% set _actions              = block('actions') is defined ? block('actions') : null %}
+{% set _navbar_title         = block('navbar_title') is defined ? block('navbar_title') : null %}
+{% set _list_filters_actions = block('list_filters_actions') is defined ? block('list_filters_actions') : null %}
 
 <!DOCTYPE html>
 <html {% block html_attributes %}class="no-js"{% endblock %}>


### PR DESCRIPTION
I am targetting this branch, because no BC break, bug fix.

Closes #4229

## Changelog

```markdown
### Removed
- a Twig deprecation added in Twig 1.28.0
- a Sonata deprecation called by Sonata itself by adding a way to disable it when called internally
```