### PR TITLE
extract admin group and label translations

### DIFF
--- a/Tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
+++ b/Tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
@@ -77,8 +77,16 @@ class AdminExtractorTest extends \PHPUnit_Framework_TestCase
 
         $logger = $this->getMock('Psr\Log\LoggerInterface');
 
-        $this->pool = new Pool($container, '', '');
-        $this->pool->setAdminServiceIds(array('foo_admin', 'bar_admin'));
+        $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $this->pool->expects($this->any())
+            ->method('getAdminServiceIds')
+            ->will($this->returnValue(array('foo_admin', 'bar_admin')));
+        $this->pool->expects($this->any())
+            ->method('getContainer')
+            ->will($this->returnValue($container));
 
         $this->adminExtractor = new AdminExtractor($this->pool, $logger);
         $this->adminExtractor->setLogger($logger);

--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -107,8 +107,17 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
 
         $this->catalogue = new MessageCatalogue();
 
+        foreach ($this->adminPool->getAdminGroups() as $name => $group) {
+            $this->trans($name, array(), $group['label_catalogue']);
+        }
+
         foreach ($this->adminPool->getAdminServiceIds() as $id) {
             $admin = $this->getAdmin($id);
+
+            $label = $admin->getLabel();
+            if (!empty($label)) {
+                $this->trans($label, array(), $admin->getTranslationDomain());
+            }
 
             $this->translator = $admin->getTranslator();
             $this->labelStrategy = $admin->getLabelTranslatorStrategy();


### PR DESCRIPTION
I am targetting this branch, because it's a BC feature.

## Changelog

```markdown
### Added
- Extract admin group and label translations.
```

## Subject

When using JMSTranslationBundle to extract translations, neither the admin group nor the admin label are extracted. Those are now extracted allowing full extraction of the admin strings using the JMSTranslationBundle extractor.

## Todo

- [x] Tests
- [x] ~~Extract FormMapper groups and tabs labels~~
- [x] ~~Docs~~
