### PR TITLE
Allow using Twig 2.x version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "sonata-project/admin-bundle",
     "type": "symfony-bundle",
-    "description": "Symfony SonataAdminBundle",
+    "description": "The missing Symfony Admin Generator",
     "keywords": ["Admin Generator", "admin", "sonata", "bootstrap"],
     "homepage": "https://sonata-project.org/bundles/admin",
     "license": "MIT",
@@ -17,36 +17,39 @@
         }
     ],
     "require": {
-        "symfony/http-foundation": "~2.3|~3.0",
-        "symfony/form": "^2.3.5|~3.0",
-        "symfony/validator": "~2.3|~3.0",
-        "symfony/security-bundle": "~2.3|~3.0",
-        "symfony/routing": "~2.3|~3.0",
-        "symfony/config": "^2.3.9|~3.0",
-        "symfony/console": "~2.3|~3.0",
-        "symfony/twig-bridge": "^2.3.5|~3.0",
-        "symfony/class-loader":"~2.3|~3.0",
-        "symfony/expression-language": "~2.4|~3.0",
-        "symfony/templating":"~2.3|~3.0",
-        "symfony/translation":"~2.3|~3.0",
-        "symfony/dependency-injection": "^2.3.3|~3.0",
-        "symfony/property-access": "~2.3|~3.0",
-        "symfony/security-acl": "~2.3|~3.0",
-        "twig/twig": "~1.23",
-        "twig/extensions": "~1.0",
-        "sonata-project/exporter": "~1.0",
-        "sonata-project/block-bundle": "^2.3.9",
-        "sonata-project/core-bundle": "^2.3.10",
-        "doctrine/common": "~2.2",
-        "doctrine/inflector": "~1.0",
-        "knplabs/knp-menu-bundle": "^2.1.1"
+        "php": "^5.3 || ^7.0",
+        "doctrine/common": "^2.2",
+        "doctrine/inflector": "^1.0",
+        "knplabs/knp-menu-bundle": "^2.1.1",
+        "sonata-project/block-bundle": "^3.2",
+        "sonata-project/core-bundle": "^3.1",
+        "sonata-project/exporter": "^1.0",
+        "symfony/class-loader": "^2.3 || ^3.0",
+        "symfony/config": "^2.3.9 || ^3.0",
+        "symfony/console": "^2.3 || ^3.0",
+        "symfony/dependency-injection": "^2.3.3 || ^3.0",
+        "symfony/expression-language": "^2.4 || ^3.0",
+        "symfony/form": "^2.3.5 || ^3.0",
+        "symfony/http-foundation": "^2.3 || ^3.0",
+        "symfony/property-access": "^2.3 || ^3.0",
+        "symfony/routing": "^2.3 || ^3.0",
+        "symfony/security-acl": "^2.3 || ^3.0",
+        "symfony/security-bundle": "^2.3 || ^3.0",
+        "symfony/templating": "^2.3 || ^3.0",
+        "symfony/translation": "^2.3 || ^3.0",
+        "symfony/twig-bridge": "^2.3.5 || ^3.0",
+        "symfony/validator": "^2.3 || ^3.0",
+        "twig/extensions": "^1.0",
+        "twig/twig": "^1.26 || ^2.0"
     },
     "require-dev": {
-        "jms/di-extra-bundle": "~1.7",
-        "sensio/generator-bundle": "~2.3|~3.0",
-        "symfony/yaml": "~2.3|~3.0",
+        "jms/di-extra-bundle": "^1.7",
+        "jms/translation-bundle": "^1.2",
+        "sensio/generator-bundle": "^2.3 || ^3.0",
+        "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/intl-bundle": "^2.2.4",
-        "symfony/phpunit-bridge": "~2.7|~3.0"
+        "symfony/phpunit-bridge": "^2.7 || ^3.0",
+        "symfony/yaml": "^2.3 || ^3.0"
     },
     "conflict": {
         "jms/di-extra-bundle": "<1.7.0"
@@ -58,11 +61,20 @@
         "sonata-project/intl-bundle": "Add localized date and number into the list"
     },
     "autoload": {
-        "psr-4": { "Sonata\\AdminBundle\\": "" }
+        "psr-4": { "Sonata\\AdminBundle\\": "" },
+        "exclude-from-classmap": [
+            "Tests/"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": { "Sonata\\AdminBundle\\Tests\\": "Tests/" }
+     },
+    "config": {
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.4.x-dev"
+            "dev-master": "3.x-dev"
         }
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is not a deprecation removal or a BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes no issue.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

### Changed

Twig dependency.

## To do

Nothing.

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->

Twig 2.0 will probably be released this week. I'm trying to test it in a Symfony app that uses Sonata. I can't install it because:

```
$ composer update twig/twig

Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - sonata-project/admin-bundle 3.10.0 requires twig/twig ^1.26 -> satisfiable by twig/twig[1.x-dev].
    - sonata-project/admin-bundle 3.10.0 requires twig/twig ^1.26 -> satisfiable by twig/twig[1.x-dev].
    - sonata-project/admin-bundle 3.10.0 requires twig/twig ^1.26 -> satisfiable by twig/twig[1.x-dev].
    - Can only install one of: twig/twig[2.x-dev, 1.x-dev].
    - Installation request for twig/twig 2.x-dev -> satisfiable by twig/twig[2.x-dev].
    - Installation request for sonata-project/admin-bundle (locked at 3.10.0, required as ^3.0) -> satisfiable by sonata-project/admin-bundle[3.10.0].
```
