### PR TITLE
Fix wrong context on Select2 v4 field width calculation

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -77,7 +77,7 @@ var Admin = {
                     width: function(){
                         // Select2 v3 and v4 BC. If window.Select2 is defined, then the v3 is installed.
                         // NEXT_MAJOR: Remove Select2 v3 support.
-                        return Admin.get_select2_width(window.Select2 ? this.element : jQuery(this));
+                        return Admin.get_select2_width(window.Select2 ? this.element : select);
                     },
                     dropdownAutoWidth: true,
                     minimumResultsForSearch: 10,
@@ -453,7 +453,7 @@ var Admin = {
             width: function(){
                 // Select2 v3 and v4 BC. If window.Select2 is defined, then the v3 is installed.
                 // NEXT_MAJOR: Remove Select2 v3 support.
-                return Admin.get_select2_width(window.Select2 ? this.element : jQuery(this));
+                return Admin.get_select2_width(window.Select2 ? this.element : subject);
             },
             dropdownAutoWidth: true,
             data: transformedData,

--- a/Resources/views/Menu/sonata_menu.html.twig
+++ b/Resources/views/Menu/sonata_menu.html.twig
@@ -43,7 +43,7 @@
             {% set icon = item.extra('icon')|default('') %}
             {{ icon|raw }}
             {{ parent() }}
-            <i class="fa pull-right fa-angle-left"></i>
+            <span class="pull-right-container"><i class="fa pull-right fa-angle-left"></i></span>
         </a>
     {% endspaceless %}
 {% endblock %}


### PR DESCRIPTION
Fix select2 width calculation when using select2 4.

I am targetting this branch, because I am fix bug, and kept BC.

## Changelog
```markdown
### Fixed
- Fixed select2 width calculation when using select2 v4
```

## Subject
Fix select2 width calculation when using select2 4.