### PR TITLE
Made more flexible spanElement in menu template

### DIFF
--- a/Resources/views/Menu/sonata_menu.html.twig
+++ b/Resources/views/Menu/sonata_menu.html.twig
@@ -41,9 +41,16 @@
         <a href="#">
             {% set translation_domain = item.extra('label_catalogue') %}
             {% set icon = item.extra('icon')|default('') %}
+            {% set spanElement_parent = parent() %}
             {{ icon|raw }}
-            {{ parent() }}
-            <span class="pull-right-container"><i class="fa pull-right fa-angle-left"></i></span>
+            {% block spanElementContent %}
+                {{ spanElement_parent|raw }}
+            {% endblock %}
+            <span class="pull-right-container">
+                {% block spanElementPull %}
+                    <i class="fa pull-right fa-angle-left"></i>
+                {% endblock %}
+            </span>
         </a>
     {% endspaceless %}
 {% endblock %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added blocks spanElementContent and spanElementPull in menu template for more flexibility of spanElement
```

## Subject

<!-- Describe your Pull Request content here -->
It provides adding additional elements to admin's group label in sidebar menu. For example, adding badges to group label (adding badges to admin label can be made with extending 'label' block). Without the proposed blocks, it is necessary to extend whole 'spanElement' block.