### PR TITLE
update recipe to use request_stack

### DIFF
--- a/Resources/doc/cookbook/recipe_image_previews.rst
+++ b/Resources/doc/cookbook/recipe_image_previews.rst
@@ -58,7 +58,7 @@ we are manipulating form fields we do this from within ``ImageAdmin::configureFo
             if ($image && ($webPath = $image->getWebPath())) {
                 // get the container so the full path to the image can be set
                 $container = $this->getConfigurationPool()->getContainer();
-                $fullPath = $container->get('request')->getBasePath().'/'.$webPath;
+                $fullPath = $container->get('request_stack')->getCurrentRequest()->getBasePath().'/'.$webPath;
 
                 // add a 'help' option containing the preview's img tag
                 $fileFieldOptions['help'] = '<img src="'.$fullPath.'" class="admin-preview" />';


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because {reason}.

## Changelog

update image preview recipe

## Subject

The current version of the recipe uses `request` service which is deprecated since symfony 3.0 and should not be used since 2.4.
