### PR TITLE
Setting subject data form on retrieve form field element

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -153,6 +153,7 @@ class HelperController
         $formBuilder = $admin->getFormBuilder();
 
         $form = $formBuilder->getForm();
+        $form->setData($subject);
         $form->handleRequest($request);
 
         $view = $this->helper->getChildFormView($form->createView(), $elementId);

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -389,8 +389,17 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
     public function testRetrieveFormFieldElementAction($validatorInterface)
     {
         $object = new AdminControllerHelper_Foo();
+        
+        $request = new Request(array(
+            'code' => 'sonata.post.admin',
+            'objectId' => 42,
+            'field' => 'enabled',
+            'value' => 1,
+            'context' => 'list',
+        ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'POST'));
 
         $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->once())->method('find')->will($this->returnValue($object));
 
         $mockView = $this->getMockBuilder('Symfony\Component\Form\FormView')
@@ -400,6 +409,15 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
         $mockForm = $this->getMockBuilder('Symfony\Component\Form\Form')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $mockForm->expects($this->once())
+            ->method('setData')
+            ->with($object);
+
+        $mockForm->expects($this->once())
+            ->method('handleRequest')
+            ->with($request);
+
         $mockForm->expects($this->once())
             ->method('createView')
             ->will($this->returnValue($mockView));
@@ -438,13 +456,6 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
 
             $twig->addRuntimeLoader($runtimeLoader);
         }
-        $request = new Request(array(
-            'code' => 'sonata.post.admin',
-            'objectId' => 42,
-            'field' => 'enabled',
-            'value' => 1,
-            'context' => 'list',
-        ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'POST'));
 
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(array('sonata.post.admin'));

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -389,7 +389,7 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
     public function testRetrieveFormFieldElementAction($validatorInterface)
     {
         $object = new AdminControllerHelper_Foo();
-        
+
         $request = new Request(array(
             'code' => 'sonata.post.admin',
             'objectId' => 42,
@@ -399,7 +399,6 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
         ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'POST'));
 
         $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->once())->method('find')->will($this->returnValue($object));
 
         $mockView = $this->getMockBuilder('Symfony\Component\Form\FormView')


### PR DESCRIPTION
I am targetting this branch, because it is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Setting data form on update form field element by using ``sonata_type_model``
```

## Subject

`AdminInterface::getFormBuilder` signature doesn't accept any argument currently (it do nothing with `$subject`) so, before that, the form does not have a binded data (`$subject`).

Currently this leads to null `$form->getParent()->getData()` inside any child form type when a new element is added/updating through `sonata_type_model`. This PR try to solve it. (copied from https://github.com/sonata-project/SonataAdminBundle/blob/3.x/Admin/AdminHelper.php#L112-L115)
