### PR TITLE
note on translator is present twice

### DIFF
--- a/Resources/doc/getting_started/installation.rst
+++ b/Resources/doc/getting_started/installation.rst
@@ -98,16 +98,6 @@ line in the `app/AppKernel.php` file of your project:
 
         $ bower install ./vendor/sonata-project/admin-bundle/bower.json
 
-.. note::
-
-    You must enable translator service in `config.yml`.
-
-    .. code-block:: yaml
-
-        framework:
-            translator: { fallbacks: ["%locale%"] }
-
-    For more information: http://symfony.com/doc/current/translation.html#configuration
 
 Step 3: Configure the Installed Bundles
 ---------------------------------------
@@ -158,6 +148,8 @@ The translator service is required by SonataAdmin to display all labels properly
     # app/config/config.yml
     framework:
         translator: { fallbacks: [en] }
+        
+For more information: http://symfony.com/doc/current/translation.html#configuration
 
 Step 6: Preparing your Environment
 ----------------------------------


### PR DESCRIPTION
I am targetting this branch, because it's one I'm reading.

## Subject

I noticed that on the documentation https://sonata-project.org/bundles/admin/master/doc/getting_started/installation.html the note on translator is present twice