### PR TITLE
Inverse merge order of persistent parameters in list editables

### DIFF
--- a/Resources/views/CRUD/base_list_field.html.twig
+++ b/Resources/views/CRUD/base_list_field.html.twig
@@ -40,7 +40,15 @@ file that was distributed with this source code.
         {% set xEditableType = field_description.type|sonata_xeditable_type %}
 
         {% if isEditable and xEditableType %}
-            {% set url = path('sonata_admin_set_object_field_value', { 'context': 'list', 'field': field_description.name, 'objectId': admin.id(object), 'code': admin.code(object) }|merge(admin.getPersistentParameters|default([])) )  %}
+            {% set url = path(
+                'sonata_admin_set_object_field_value',
+                admin.getPersistentParameters|default([])|merge({
+                    'context': 'list',
+                    'field': field_description.name,
+                    'objectId': admin.id(object),
+                    'code': admin.code(object)
+                })
+            ) %}
             <span {% block field_span_attributes %}class="x-editable" data-type="{{ xEditableType }}" data-value="{{ field_description.type == 'date' and value is not empty ? value.format('Y-m-d') : value }}" data-title="{{ field_description.label|trans({}, field_description.translationDomain) }}" data-pk="{{ admin.id(object) }}" data-url="{{ url }}" {% endblock %}>
                 {{ block('field') }}
             </span>

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -229,6 +229,10 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
     public function testRenderListElement($expected, $type, $value, array $options)
     {
         $this->admin->expects($this->any())
+            ->method('getPersistentParameters')
+            ->will($this->returnValue(array('context' => 'foo')));
+
+        $this->admin->expects($this->any())
             ->method('isGranted')
             ->will($this->returnValue(true));
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes sonata-project/SonataClassificationBundle#241

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed behaviour of persistent parameters in list editables
```
## Subject
Prevents overwriting parameters set in template. For example classification-bundle introduce `context` parameter which conflicts with `context == 'list'` expected by setObjectFieldValueAction() (see sonata-project/SonataClassificationBundle#241). Overwriting `context` cause "Invalid context" error while editing fields.

Merging with persistent parameters was implemented in #2725. I do not see any discussion about how it should work or the unit test for this case. So I assume that the author's intention was to include parameters from expansions, and no overriding existing ones.
<!-- Describe your Pull Request content here -->
