### PR TITLE
Support abstract admin service inheritance

### DIFF
--- a/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -419,6 +419,18 @@ class MockAdmin extends AbstractAdmin
 {
 }
 
+class MockAbstractServiceAdmin extends AbstractAdmin
+{
+    private $extraArgument;
+
+    public function __construct($code, $class, $baseControllerName, $extraArgument)
+    {
+        $this->extraArgument = $extraArgument;
+
+        parent::__construct($code, $class, $baseControllerName);
+    }
+}
+
 class Post
 {
 }


### PR DESCRIPTION

I am targetting 3.x, because it's about adding admin service inheritance. It doesn't break backward compatilibity.

## Changelog
```markdown
### Changed
- Updated compiler pass to support parent definition when using abstract service for admin.
```

## Subject
This PR is about supporting abstract service definition for admin service.
It allows to declare another admin service using the same admin class, with different parameters, but let us avoid redeclaring common arguments for the admin class.
This allow to use this kind of code:
```xml
<?xml version="1.0" encoding="UTF-8"?>

<container xmlns="http://symfony.com/schema/dic/services"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
    <services>
        <service id="admin.base.xxx" abstract="true">
            <argument />
            <argument>Entity</argument>
            <argument>Controller</argument>
            <call method="setXXX">
                <argument type="service" id="xxx" />
            </call>
        </service>
        <service id="admin.xxx" class="XXXAdmin" parent="admin.base.xxx">
            <argument>xxx1</argument>
            <tag name="sonata.admin" manager_type="orm" label="XXX" />
        </service>
        <service id="admin.xxx2" class="XXXAdmin" parent="admin.base.xxx">
            <argument>xxx2</argument>
            <tag name="sonata.admin" manager_type="orm" label="XXX" />
        </service>
    </services>
</container>
```