### PR TITLE
Show the difference between security properties

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -443,7 +443,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     /**
      * The Access mapping.
      *
-     * @var array
+     * @var array [action1 => requiredRole1, action2 => [requiredRole2, requiredRole3]]
      */
     protected $accessMapping = array();
 

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -797,7 +797,10 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(array(), $admin->getSecurityInformation());
 
-        $securityInformation = array('ROLE_FOO', 'ROLE_BAR');
+        $securityInformation = array(
+            'GUEST' => array('VIEW', 'LIST'),
+            'STAFF' => array('EDIT', 'LIST', 'CREATE'),
+        );
 
         $admin->setSecurityInformation($securityInformation);
         $this->assertSame($securityInformation, $admin->getSecurityInformation());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is very very BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Subject

<!-- Describe your Pull Request content here -->
The test for securityInformation had inaccurate data, and there was no
documentation for the accessMapping. This change helps getting what the
difference between both properties is.

