### PR TITLE
Call AbstractAdmin::configureBatchActions by reference

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1092,7 +1092,16 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
             );
         }
 
-        $actions = $this->configureBatchActions($actions);
+        $confActions = $this->configureBatchActions($actions);
+
+        // NEXT_MAJOR: remove this check
+        if ($confActions != $actions) {
+            @trigger_error(
+                'Calling AbstractAdmin::configureBatchActions by value is deprecated since 3.x and will be changed in 4.0.',
+                E_USER_DEPRECATED
+            );
+            $actions = $confActions;
+        }
 
         foreach ($this->getExtensions() as $extension) {
             // TODO: remove method check in next major release
@@ -3063,7 +3072,7 @@ EOT;
       *
       * @return array
       */
-     protected function configureBatchActions($actions)
+     protected function configureBatchActions(&$actions)
      {
          return $actions;
      }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed 
 - the method `AbstractAdmin::configureBatchActions` is called by value
```

## Subject
Changed it to be consistent with the other `configure*` methods.
