### PR TITLE
Added fallback for batch labels

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1101,6 +1101,16 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
             }
         }
 
+        foreach ($actions  as $name => &$action) {
+            if (!array_key_exists('label', $action)) {
+                $action['label'] = $this->getTranslationLabel($name, 'batch', 'label');
+            }
+
+            if (!array_key_exists('translation_domain', $action)) {
+                $action['translation_domain'] = $this->getTranslationDomain();
+            }
+        }
+
         return $actions;
     }
 

--- a/Resources/doc/reference/batch_actions.rst
+++ b/Resources/doc/reference/batch_actions.rst
@@ -9,10 +9,13 @@ Defining new actions
 
 To create a new custom batch action which appears in the list view follow these steps:
 
-Override ``getBatchActions()`` in your ``Admin`` class to define the new batch actions
-by adding them to the ``$actions`` array. Each entry has two settings:
+Override ``configureBatchActions()`` in your ``Admin`` class to define the new batch actions
+by adding them to the ``$actions`` array. Each key represent a batch action and could contain these settings:
 
 - **label**: The name to use when offering this option to users, should be passed through the translator
+  (default: the label is generated via the labelTranslatorStrategy)
+- **translation_domain**: The domain which will be used to translate the key.
+  (default: the translation domain of the admin)
 - **ask_confirmation**: defaults to true and means that the user will be asked
   for confirmation before the batch action is processed
 
@@ -27,18 +30,13 @@ merges them onto a single target item. It should only be available when two cond
     <?php
     // in your Admin class
 
-    public function getBatchActions()
+    public function configureBatchActions($actions)
     {
-        // retrieve the default batch actions (currently only delete)
-        $actions = parent::getBatchActions();
-
         if (
           $this->hasRoute('edit') && $this->isGranted('EDIT') && 
           $this->hasRoute('delete') && $this->isGranted('DELETE')
         ) {
             $actions['merge'] = array(
-                'label' => 'action_merge',
-                'translation_domain' => 'SonataAdminBundle'
                 'ask_confirmation' => true
             );
 

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1694,22 +1694,63 @@ class AdminTest extends PHPUnit_Framework_TestCase
     /**
      * @covers \Sonata\AdminBundle\Admin\AbstractAdmin::configureBatchActions
      */
-    public function getBatchActions()
+    public function testGetBatchActions()
     {
         $expected = array(
-            'action' => array(
+            'delete' => array(
                 'label' => 'action_delete',
                 'translation_domain' => 'SonataAdminBundle',
                 'ask_confirmation' => true, // by default always true
             ),
             'foo' => array(
                 'label' => 'action_foo',
+                'translation_domain' => 'SonataAdminBundle',
+            ),
+            'bar' => array(
+                'label' => 'batch.label_bar',
+                'translation_domain' => 'SonataAdminBundle',
+            ),
+            'baz' => array(
+                'label' => 'action_baz',
+                'translation_domain' => 'AcmeAdminBundle',
             ),
         );
 
-        $modelAdmin = new PostAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'SonataFooBundle:ModelAdmin');
+        $pathInfo = new \Sonata\AdminBundle\Route\PathInfoBuilder($this->createMock('Sonata\AdminBundle\Model\AuditManagerInterface'));
 
-        $this->assertSame($expected, $modelAdmin->getBatchActions());
+        $labelTranslatorStrategy = $this->createMock('Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface');
+        $labelTranslatorStrategy->expects($this->any())
+            ->method('getLabel')
+            ->will($this->returnCallback(function ($label, $context = '', $type = '') {
+                return $context.'.'.$type.'_'.$label;
+            }));
+
+        $admin = new PostAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'SonataFooBundle:ModelAdmin');
+        $admin->setRouteBuilder($pathInfo);
+        $admin->setTranslationDomain('SonataAdminBundle');
+        $admin->setLabelTranslatorStrategy($labelTranslatorStrategy);
+
+        $routeGenerator = $this->createMock('Sonata\AdminBundle\Route\RouteGeneratorInterface');
+        $routeGenerator
+            ->expects($this->once())
+            ->method('hasAdminRoute')
+            ->with($admin, 'delete')
+            ->will($this->returnValue(true));
+        $admin->setRouteGenerator($routeGenerator);
+
+        $securityHandler = $this->createMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
+        $securityHandler->expects($this->any())
+            ->method('isGranted')
+            ->will($this->returnCallback(function (AdminInterface $adminIn, $attributes, $object = null) use ($admin) {
+                if ($admin == $adminIn && $attributes == 'DELETE') {
+                    return true;
+                }
+
+                return false;
+            }));
+        $admin->setSecurityHandler($securityHandler);
+
+        $this->assertSame($expected, $admin->getBatchActions());
     }
 
     /**

--- a/Tests/Fixtures/Admin/PostAdmin.php
+++ b/Tests/Fixtures/Admin/PostAdmin.php
@@ -37,6 +37,12 @@ class PostAdmin extends AbstractAdmin
         $actions['foo'] = array(
             'label' => 'action_foo',
         );
+        $actions['bar'] = array(
+        );
+        $actions['baz'] = array(
+            'label' => 'action_baz',
+            'translation_domain' => 'AcmeAdminBundle',
+        );
 
         return $actions;
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `label` fallback for batch actions
- Added `translation_domain` fallback for batch actions

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [x] Update the documentation

## Subject

Use the existing label generator and translation domain to translate labels in batch actions.