### PR TITLE
renamed Pager::getLastIndice() and Pager::getFirstIndice()

### DIFF
--- a/Datagrid/Pager.php
+++ b/Datagrid/Pager.php
@@ -251,7 +251,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      *
      * @return int
      */
-    public function getFirstIndice()
+    public function getFirstIndex()
     {
         if ($this->page == 0) {
             return 1;
@@ -261,11 +261,27 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since 3.x, will be removed in 4.0
+     */
+    public function getFirstIndice()
+    {
+        @trigger_error(
+            'Method '.__METHOD__.' is deprecated since version 3.x and will be removed in 4.0, '.
+            'please use getFirstIndex() instead.',
+            E_USER_DEPRECATED
+        );
+
+        return $this->getFirstIndex();
+    }
+
+    /**
      * Returns the last index on the current page.
      *
      * @return int
      */
-    public function getLastIndice()
+    public function getLastIndex()
     {
         if ($this->page == 0) {
             return $this->nbResults;
@@ -275,6 +291,22 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         }
 
         return $this->page * $this->maxPerPage;
+    }
+
+    /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since 3.x, will be removed in 4.0
+     */
+    public function getLastIndice()
+    {
+        @trigger_error(
+            'Method '.__METHOD__.' is deprecated since version 3.x and will be removed in 4.0, '.
+            'please use getLastIndex() instead.',
+            E_USER_DEPRECATED
+        );
+
+        return $this->getLastIndex();
     }
 
     /**

--- a/Tests/Datagrid/PagerTest.php
+++ b/Tests/Datagrid/PagerTest.php
@@ -433,43 +433,43 @@ class PagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(20, $this->pager->getPreviousPage());
     }
 
-    public function testGetFirstIndice()
+    public function testGetFirstIndex()
     {
-        $this->assertSame(1, $this->pager->getFirstIndice());
+        $this->assertSame(1, $this->pager->getFirstIndex());
 
         $this->pager->setMaxPerPage(0);
         $this->pager->setPage(0);
-        $this->assertSame(1, $this->pager->getFirstIndice());
+        $this->assertSame(1, $this->pager->getFirstIndex());
 
         $this->pager->setPage(2);
         $this->pager->setMaxPerPage(10);
-        $this->assertSame(11, $this->pager->getFirstIndice());
+        $this->assertSame(11, $this->pager->getFirstIndex());
 
         $this->pager->setPage(4);
         $this->pager->setMaxPerPage(7);
-        $this->assertSame(22, $this->pager->getFirstIndice());
+        $this->assertSame(22, $this->pager->getFirstIndex());
     }
 
-    public function testGetLastIndice()
+    public function testGetLastIndex()
     {
-        $this->assertSame(0, $this->pager->getLastIndice());
+        $this->assertSame(0, $this->pager->getLastIndex());
 
         $this->pager->setMaxPerPage(0);
         $this->pager->setPage(0);
-        $this->assertSame(0, $this->pager->getLastIndice());
+        $this->assertSame(0, $this->pager->getLastIndex());
 
         $this->callMethod($this->pager, 'setNbResults', array(100));
 
-        $this->assertSame(100, $this->pager->getLastIndice());
+        $this->assertSame(100, $this->pager->getLastIndex());
 
         $this->pager->setPage(2);
-        $this->assertSame(0, $this->pager->getLastIndice());
+        $this->assertSame(0, $this->pager->getLastIndex());
 
         $this->pager->setMaxPerPage(10);
-        $this->assertSame(20, $this->pager->getLastIndice());
+        $this->assertSame(20, $this->pager->getLastIndex());
 
         $this->pager->setPage(11);
-        $this->assertSame(100, $this->pager->getLastIndice());
+        $this->assertSame(100, $this->pager->getLastIndex());
     }
 
     public function testGetNext()

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+## Renamed Pager::getFirstIndice() and Pager::getLastIndice()
+
+Please use `Pager::getFirstIndex()` and `Pager::getLastIndex()` instead!
+
 UPGRADE FROM 3.9 to 3.10
 ========================
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

**This is a rebase of #4185**

Fixes #3494

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `Pager::getFirstIndex()` and `Pager::getLastIndex()`

### Deprecated
- `Pager::getFirstIndice()` and `Pager::getLastIndice()`
```

## Subject

@see #3494 
