### PR TITLE
Deprecate legacy class

### DIFF
--- a/Form/DataTransformer/LegacyModelsToArrayTransformer.php
+++ b/Form/DataTransformer/LegacyModelsToArrayTransformer.php
@@ -17,6 +17,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 /**
+ * NEXT_MAJOR: remove this class when dropping Symfony < 2.7 support.
+ *
  * This class should be used with Symfony <2.7 only and will be deprecated with 3.0.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -33,6 +35,13 @@ class LegacyModelsToArrayTransformer implements DataTransformerInterface
      */
     public function __construct(ModelChoiceList $choiceList)
     {
+        if (interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
+            @trigger_error(
+                'The '.__CLASS__.' class is deprecated since 3.x, to be removed in 4.0. '.
+                'Use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer instead.',
+                E_USER_DEPRECATED
+            );
+        }
         $this->choiceList = $choiceList;
     }
 


### PR DESCRIPTION

I am targetting this branch, because this is BC (a new deprecation was introduced).

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `LegacyModelsToArrayTransformer` was deprecated although the name should make it pretty obvious already.
```

## Subject

This should have been setup when creating this class.
