### PR TITLE
Fix for #4267

### DIFF
--- a/Command/GenerateAdminCommand.php
+++ b/Command/GenerateAdminCommand.php
@@ -53,7 +53,7 @@ class GenerateAdminCommand extends ContainerAwareCommand
             ->addOption('admin', 'a', InputOption::VALUE_OPTIONAL, 'The admin class basename')
             ->addOption('controller', 'c', InputOption::VALUE_OPTIONAL, 'The controller class basename')
             ->addOption('manager', 'm', InputOption::VALUE_OPTIONAL, 'The model manager type')
-            ->addOption('services', 'y', InputOption::VALUE_OPTIONAL, 'The services YAML file', null)
+            ->addOption('services', 'y', InputOption::VALUE_OPTIONAL, 'The services YAML file', 'services.yml')
             ->addOption('id', 'i', InputOption::VALUE_OPTIONAL, 'The admin service ID')
         ;
     }
@@ -228,6 +228,8 @@ class GenerateAdminCommand extends ContainerAwareCommand
             );
             $input->setOption('services', $servicesFile);
             $input->setOption('id', $id);
+        } else {
+            $input->setOption('services', false);
         }
 
         $input->setArgument('model', $modelClass);

--- a/Command/GenerateAdminCommand.php
+++ b/Command/GenerateAdminCommand.php
@@ -53,7 +53,7 @@ class GenerateAdminCommand extends ContainerAwareCommand
             ->addOption('admin', 'a', InputOption::VALUE_OPTIONAL, 'The admin class basename')
             ->addOption('controller', 'c', InputOption::VALUE_OPTIONAL, 'The controller class basename')
             ->addOption('manager', 'm', InputOption::VALUE_OPTIONAL, 'The model manager type')
-            ->addOption('services', 'y', InputOption::VALUE_OPTIONAL, 'The services YAML file', 'services.yml')
+            ->addOption('services', 'y', InputOption::VALUE_OPTIONAL, 'The services YAML file', null)
             ->addOption('id', 'i', InputOption::VALUE_OPTIONAL, 'The admin service ID')
         ;
     }

--- a/Tests/Command/GenerateAdminCommandTest.php
+++ b/Tests/Command/GenerateAdminCommandTest.php
@@ -397,7 +397,6 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnCallback(function (InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity) {
                 $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>') - 6);
 
-                echo $questionClean . PHP_EOL;
                 switch ($questionClean) {
                     // confirmations
                     case 'Do you want to generate a controller':

--- a/Tests/Command/GenerateAdminCommandTest.php
+++ b/Tests/Command/GenerateAdminCommandTest.php
@@ -385,9 +385,6 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         $this->command->validateManagerType('baz');
     }
 
-    /**
-     * @group admin-gen
-     */
     public function testAnswerUpdateServicesWithNo()
     {
         $this->container->set('sonata.admin.manager.foo', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
@@ -396,6 +393,8 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
 
         $command = $this->application->find('sonata:admin:generate');
 
+        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
+        // DialogHelper does not exist in SensioGeneratorBundle 2.5+
         if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
             $dialog = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper', array('askConfirmation', 'askAndValidate'));
 

--- a/Tests/Command/GenerateAdminCommandTest.php
+++ b/Tests/Command/GenerateAdminCommandTest.php
@@ -49,8 +49,6 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        error_reporting(E_ALL & ~E_STRICT & ~E_DEPRECATED);
-
         // create temp dir
         $tempfile = tempnam(sys_get_temp_dir(), 'sonata_admin');
         if (file_exists($tempfile)) {
@@ -85,7 +83,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         $this->application->add($this->command);
     }
 
-    public function tearown()
+    public function tearDown()
     {
         if ($this->tempDirectory) {
             if (file_exists($this->tempDirectory.'/Controller/FooAdminController.php')) {

--- a/Tests/Command/GenerateAdminCommandTest.php
+++ b/Tests/Command/GenerateAdminCommandTest.php
@@ -23,7 +23,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
- * @group admin-gen
  */
 class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
 {

--- a/Tests/Command/GenerateAdminCommandTest.php
+++ b/Tests/Command/GenerateAdminCommandTest.php
@@ -385,42 +385,100 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         $this->command->validateManagerType('baz');
     }
 
+    /**
+     * @group admin-gen
+     */
     public function testAnswerUpdateServicesWithNo()
     {
-        $questionHelper = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper', array('ask'));
-
         $this->container->set('sonata.admin.manager.foo', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
 
         $modelEntity = 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo';
-        $questionHelper->expects($this->any())
-            ->method('ask')
-            ->will($this->returnCallback(function (InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity) {
-                $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>') - 6);
-
-                switch ($questionClean) {
-                    // confirmations
-                    case 'Do you want to generate a controller':
-                        return false;
-
-                    case 'Do you want to update the services YAML configuration file':
-                        return false;
-
-                    // inputs
-                    case 'The fully qualified model class':
-                        return $modelEntity;
-
-                    case 'The bundle name':
-                        return 'AcmeDemoBundle';
-
-                    case 'The admin class basename':
-                        return 'FooAdmin';
-                }
-
-                return false;
-            }));
 
         $command = $this->application->find('sonata:admin:generate');
-        $command->getHelperSet()->set($questionHelper, 'question');
+
+        if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
+            $dialog = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper', array('askConfirmation', 'askAndValidate'));
+
+            $dialog->expects($this->any())
+                ->method('askConfirmation')
+                ->will($this->returnCallback(function (OutputInterface $output, $question, $default) {
+                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
+
+                    switch ($questionClean) {
+                        case 'Do you want to generate a controller':
+                            return false;
+
+                        case 'Do you want to update the services YAML configuration file':
+                            return false;
+                    }
+
+                    return $default;
+                }));
+
+            $dialog->expects($this->any())
+                ->method('askAndValidate')
+                ->will($this->returnCallback(function (OutputInterface $output, $question, $validator, $attempts = false, $default = null) use ($modelEntity) {
+                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
+
+                    switch ($questionClean) {
+                        case 'The fully qualified model class':
+                            return $modelEntity;
+
+                        case 'The bundle name':
+                            return 'AcmeDemoBundle';
+
+                        case 'The admin class basename':
+                            return 'FooAdmin';
+
+                        case 'The controller class basename':
+                            return 'FooAdminController';
+
+                        case 'The services YAML configuration file':
+                            return 'admin.yml';
+
+                        case 'The admin service ID':
+                            return 'acme_demo_admin.admin.foo';
+
+                        case 'The manager type':
+                            return 'foo';
+                    }
+
+                    return $default;
+                }));
+
+            $command->getHelperSet()->set($dialog, 'dialog');
+        } else {
+            $questionHelper = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper', array('ask'));
+
+            $questionHelper->expects($this->any())
+                ->method('ask')
+                ->will($this->returnCallback(function (InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity) {
+                    $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>') - 6);
+
+                    switch ($questionClean) {
+                        // confirmations
+                        case 'Do you want to generate a controller':
+                            return false;
+
+                        case 'Do you want to update the services YAML configuration file':
+                            return false;
+
+                        // inputs
+                        case 'The fully qualified model class':
+                            return $modelEntity;
+
+                        case 'The bundle name':
+                            return 'AcmeDemoBundle';
+
+                        case 'The admin class basename':
+                            return 'FooAdmin';
+                    }
+
+                    return false;
+                }));
+
+            $command->getHelperSet()->set($questionHelper, 'question');
+        }
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(array(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

I am targetting this branch, because of a bug-fix.

Closes #4267 

## Changelog

Set `services` option default-value to null in command `Sonata\AdminBundle\Command\GenerateAdminCommand`

## To do

- [x] Update the tests

## Subject

Fix for #4267 

If I answer the question `Do you want to update the services YAML configuration file [yes]?` with no, then `interact` sets no value for `services` which is ok. 

Then the command checks in https://github.com/sonata-project/SonataAdminBundle/blob/3.x/Command/GenerateAdminCommand.php#L135 if a service-file is set, which is always true because of the default value `->addOption('services', 'y', InputOption::VALUE_OPTIONAL, 'The services YAML file', 'services.yml')`.