### PR TITLE
Added 'sonata-admin-setup-list-modal' event trigger

### DIFF
--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -100,6 +100,13 @@ btn_add, btn_list, btn_delete and btn_catalogue:
 
     If you need to use a sortable ``sonata_type_model`` check the :doc:`../cookbook/recipe_sortable_sonata_type_model` page.
 
+.. note::
+
+    When using ``sonata_type_model`` with ``btn_add``, a jQuery event will be
+    triggered when a child form is added to the DOM
+    (``sonata-admin-setup-list-modal`` by default and
+    ``sonata-admin-append-form-element`` when using ``edit:inline``).
+
 sonata_type_model_hidden
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Setting a field type of ``sonata_type_model_hidden`` will use an instance of

--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -55,6 +55,8 @@ var Admin = {
             padding: 15,
             overflow: 'auto'
         });
+      
+        jQuery(modal).trigger('sonata-admin-setup-list-modal');
     },
     setup_select2: function(subject) {
         if (window.SONATA_CONFIG && window.SONATA_CONFIG.USE_SELECT2) {


### PR DESCRIPTION
Admin.setup_list_modal now triggers a 'sonata-admin-setup-list-modal' jQuery event

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4270 

## Changelog

### Added
- JQuery event trigger to Admin.setup_list_modal()

