### PR TITLE
Expose classes of Sonata KNP Menu Voters as parameters

### DIFF
--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="sonata.admin.menu.matcher.voter.admin.class">Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter</parameter>
+        <parameter key="sonata.admin.menu.matcher.voter.children.class">Sonata\AdminBundle\Menu\Matcher\Voter\ChildrenVoter</parameter>
+        <parameter key="sonata.admin.menu.matcher.voter.active.class">Sonata\AdminBundle\Menu\Matcher\Voter\ActiveVoter</parameter>
+    </parameters>
     <services>
         <service id="sonata.admin.menu_builder" class="Sonata\AdminBundle\Menu\MenuBuilder">
             <argument type="service" id="sonata.admin.pool"/>
@@ -17,14 +22,14 @@
             <argument/>
             <tag name="knp_menu.provider"/>
         </service>
-        <service id="sonata.admin.menu.matcher.voter.admin" class="Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter">
+        <service id="sonata.admin.menu.matcher.voter.admin" class="%sonata.admin.menu.matcher.voter.admin.class%">
             <tag name="knp_menu.voter" request="true"/>
         </service>
-        <service id="sonata.admin.menu.matcher.voter.children" class="Sonata\AdminBundle\Menu\Matcher\Voter\ChildrenVoter">
+        <service id="sonata.admin.menu.matcher.voter.children" class="%sonata.admin.menu.matcher.voter.children.class%">
             <argument type="service" id="knp_menu.matcher"/>
             <tag name="knp_menu.voter"/>
         </service>
-        <service id="sonata.admin.menu.matcher.voter.active" class="Sonata\AdminBundle\Menu\Matcher\Voter\ActiveVoter">
+        <service id="sonata.admin.menu.matcher.voter.active" class="%sonata.admin.menu.matcher.voter.active.class%">
             <tag name="knp_menu.voter"/>
         </service>
     </services>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to #4254

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject
This is a first step about the issue #4254 about Knp Menu voter `ChildrenVoter` that can have side effect on other menu in the project.

This add the ability to easily override and hack Sonata default voter.