### PR TITLE
Fix twig deprecation

### DIFF
--- a/Resources/views/Form/filter_admin_fields.html.twig
+++ b/Resources/views/Form/filter_admin_fields.html.twig
@@ -50,7 +50,9 @@ file that was distributed with this source code.
                 </div>
             {% endif %}
         {% endfor %}
-        {{ block('form_message') }}
+        {% if block('form_message') is defined %}
+            {{ block('form_message') }}
+        {% endif %}
         {% if expanded %}
             </div>
         {% endif %}
@@ -79,7 +81,9 @@ file that was distributed with this source code.
         {% endif %}
         {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes %}
             </div>
-            {{ block('form_message') }}
+            {% if block('form_message') is defined %}
+                {{ block('form_message') }}
+            {% endif %}
         {% endif %}
     {% endspaceless %}
 {% endblock checkbox_widget %}

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/twig-bridge": "^2.3.5 || ^3.0",
         "symfony/validator": "^2.3 || ^3.0",
         "twig/extensions": "^1.0",
-        "twig/twig": "^1.26"
+        "twig/twig": "^1.28"
     },
     "require-dev": {
         "jms/di-extra-bundle": "^1.7",


### PR DESCRIPTION
I am targetting this branch, because it fixes a deprecation with twig 1.29.

## Changelog
```markdown
### Fixed
- "Silent display of undefined block" Twig deprecation
```

## Subject

Fixes the deprecation:

```
Silent display of undefined block "form_message" is deprecated since version 1.29 and will throw an exception in 2.0. Use the "block('form_message') is defined" expression to test for block existence
```

