### PR TITLE
Determine service config dir/file

### DIFF
--- a/Command/GenerateAdminCommand.php
+++ b/Command/GenerateAdminCommand.php
@@ -249,13 +249,15 @@ class GenerateAdminCommand extends ContainerAwareCommand
     }
 
     /**
+     * Returns the absolute path to the services config-dir
+     *
      * @param string $bundleName
      *
      * @return string
      */
     private function determineConfigDir($bundleName)
     {
-        $bundleConfigDir = $this->getBundle($bundleName)->getPath().'/Resources/config/';
+        $bundleConfigDir = $this->getBundle($bundleName)->getPath() . '/Resources/config/';
 
         if (!is_dir($bundleConfigDir)) {
             return $this->getKernel()->getRootDir() . '/config';
@@ -272,7 +274,7 @@ class GenerateAdminCommand extends ContainerAwareCommand
     /**
      * @param string $configDir
      *
-     * @return Finder|SplFileInfo[]
+     * @return SplFileInfo[]
      */
     private function findServicesConfigFiles($configDir)
     {

--- a/Command/GenerateAdminCommand.php
+++ b/Command/GenerateAdminCommand.php
@@ -257,18 +257,19 @@ class GenerateAdminCommand extends ContainerAwareCommand
      */
     private function determineConfigDir($bundleName)
     {
+        $applicationConfigDir = $this->getKernel()->getRootDir() . '/config';
         $bundleConfigDir = $this->getBundle($bundleName)->getPath() . '/Resources/config/';
 
-        if (!is_dir($bundleConfigDir)) {
-            return $this->getKernel()->getRootDir() . '/config';
-        }
-
-        $configFiles = $this->findServicesConfigFiles($bundleConfigDir);
-        if (count($configFiles) !== 0) {
+        if (!is_dir($applicationConfigDir)) {
             return $bundleConfigDir;
         }
 
-        return $this->getKernel()->getRootDir() . '/config';
+        $configFiles = $this->findServicesConfigFiles($applicationConfigDir);
+        if (count($configFiles) !== 0) {
+            return $applicationConfigDir;
+        }
+
+        return $bundleConfigDir;
     }
 
     /**

--- a/Manipulator/ServicesManipulator.php
+++ b/Manipulator/ServicesManipulator.php
@@ -154,7 +154,7 @@ XML;
      * @param string $controllerName
      * @param string $managerType
      *
-     * @return string mixed
+     * @return string
      */
     private function createServiceDefinitionXmlNode($servicesContent, $serviceId, $adminClass, $modelClass, $controllerName, $managerType)
     {

--- a/Manipulator/ServicesManipulator.php
+++ b/Manipulator/ServicesManipulator.php
@@ -35,15 +35,29 @@ class ServicesManipulator
             - { name: sonata.admin, manager_type: %s, group: admin, label: %s }
 ';
 
-    private $xmlTemplate = '
-        <service id="%s" class="%s">
+    private $emptyXmlServiceDefinition = <<<XML
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+    </services>
+</container>
+XML;
+
+    private $xmlServiceDefinitionTemplate = <<<XML
+    <service id="%s" class="%s">
             <argument />
             <argument>%s</argument>
             <argument>%s</argument>
 
-            <tag name="sonata.admin" manager_type="%s" group="%s" label="%s" />
-        </service>    
-';
+            <tag name="sonata.admin" manager_type="%s" group="admin" label="%s" />
+        </service>
+        
+    </services>
+XML;
+
 
     /**
      * @param string $file
@@ -65,31 +79,13 @@ class ServicesManipulator
     public function addResource($serviceId, $modelClass, $adminClass, $controllerName, $managerType)
     {
         if (preg_match('/\.xml/', $this->file) !== 0) {
-//            $dom = new \DOMDocument();
-//            $dom->preserveWhiteSpace = false;
-//            $dom->formatOutput = true;
-//            $dom->load($this->file);
-//
-//            $servicesTag = $dom->childNodes->item(0)->childNodes->item(0);
-//
-//            $serviceTag = $this->createServiceDefinitionXmlNode(
-//                $dom,
-//                $serviceId,
-//                $modelClass,
-//                $adminClass,
-//                $controllerName,
-//                $managerType
-//            );
-//
-//            $lineNode = $dom->createElement('empty', '\n');
-//            $servicesTag->appendChild($lineNode);
-//            $servicesTag->appendChild($serviceTag);
-//
-//            $servicesTag->removeChild($lineNode);
-//
-//            $xml = str_replace("  ", "    ", $dom->saveXML());
 
-            $servicesContent = file_get_contents($this->file);
+            if (is_file($this->file)) {
+                $servicesContent = file_get_contents($this->file);
+            } else {
+                fopen($this->file, 'x+');
+                $servicesContent = $this->emptyXmlServiceDefinition;
+            }
             $servicesContent = $this->createServiceDefinitionXmlNode(
                 $servicesContent,
                 $serviceId,
@@ -150,48 +146,23 @@ class ServicesManipulator
         }
     }
 
+    /**
+     * @param string $servicesContent
+     * @param string $serviceId
+     * @param string $adminClass
+     * @param string $modelClass
+     * @param string $controllerName
+     * @param string $managerType
+     *
+     * @return string mixed
+     */
     private function createServiceDefinitionXmlNode($servicesContent, $serviceId, $adminClass, $modelClass, $controllerName, $managerType)
     {
-$template = <<<XML
-    <service id="%s" class="%s">
-            <argument />
-            <argument>%s</argument>
-            <argument>%s</argument>
 
-            <tag name="sonata.admin" manager_type="%s" group="admin" label="%s" />
-        </service>
-        
-    </services>
-XML;
-
-        $template = sprintf($template, $serviceId, $adminClass, $modelClass, $controllerName, $managerType, current(array_slice(explode('\\', $modelClass), -1)));
+        $template = sprintf($this->xmlServiceDefinitionTemplate, $serviceId, $adminClass, $modelClass, $controllerName, $managerType, current(array_slice(explode('\\', $modelClass), -1)));
 
         $content = str_replace('</services>', $template, $servicesContent);
 
-//        $serviceElement = $dom->createElement('service');
-//        $serviceElement->setAttribute('id', $serviceId);
-//        $serviceElement->setAttribute('class', $adminClass);
-//
-//        $argumentElement1 = $dom->createElement('argument');
-//        $argumentElement2 = $dom->createElement('argument');
-//        $argumentElement2->nodeValue = $modelClass;
-//        $argumentElement3 = $dom->createElement('argument');
-//        $argumentElement3->nodeValue = $controllerName;
-//
-//        $tagElement = $dom->createElement('tag');
-//        $tagElement->setAttribute('name', 'sonata.admin');
-//        $tagElement->setAttribute('manager_type', $managerType);
-//        $tagElement->setAttribute('group', 'admin');
-//        $tagElement->setAttribute('label', current(array_slice(explode('\\', $modelClass), -1)));
-//
-//        $serviceElement->appendChild($argumentElement1);
-//        $serviceElement->appendChild($argumentElement2);
-//        $serviceElement->appendChild($argumentElement3);
-//        $serviceElement->appendChild($tagElement);
-
         return $content;
-
-
-
     }
 }

--- a/Manipulator/ServicesManipulator.php
+++ b/Manipulator/ServicesManipulator.php
@@ -147,6 +147,8 @@ XML;
     }
 
     /**
+     * Replaces all service-definition placeholders with the given values and appends it to a existing services definition
+     *
      * @param string $servicesContent
      * @param string $serviceId
      * @param string $adminClass
@@ -158,11 +160,16 @@ XML;
      */
     private function createServiceDefinitionXmlNode($servicesContent, $serviceId, $adminClass, $modelClass, $controllerName, $managerType)
     {
+        $serviceDefinition = sprintf(
+            $this->xmlServiceDefinitionTemplate,
+            $serviceId,
+            $adminClass,
+            $modelClass,
+            $controllerName,
+            $managerType,
+            current(array_slice(explode('\\', $modelClass), -1))
+        );
 
-        $template = sprintf($this->xmlServiceDefinitionTemplate, $serviceId, $adminClass, $modelClass, $controllerName, $managerType, current(array_slice(explode('\\', $modelClass), -1)));
-
-        $content = str_replace('</services>', $template, $servicesContent);
-
-        return $content;
+        return str_replace('</services>', $serviceDefinition, $servicesContent);
     }
 }

--- a/Tests/Command/GenerateAdminCommandTest.php
+++ b/Tests/Command/GenerateAdminCommandTest.php
@@ -208,6 +208,8 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function testExecuteInteractive($modelEntity)
     {
+        mkdir($this->tempDirectory . '/Resources/config', 0777, true);
+
         $this->command->setContainer($this->container);
         $this->container->set('sonata.admin.manager.foo', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
         $this->container->set('sonata.admin.manager.bar', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
@@ -401,12 +403,21 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         $this->command->validateManagerType('baz');
     }
 
-    /**
-     * @group xml
-     */
     public function testWriteXMLServiceDefinitionToApplicationConfigs()
     {
         mkdir($this->tempDirectory . '/config');
+        $emptyServiceDefinition = <<<XML
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+    </services>
+</container>
+XML;
+
+        file_put_contents($this->tempDirectory . '/config/services.xml', $emptyServiceDefinition);
 
         $this->command->setContainer($this->container);
         $this->container->set('sonata.admin.manager.foo', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
@@ -450,18 +461,6 @@ XML;
     public function testWriteXMLServiceDefinitionToBundleConfigs()
     {
         mkdir($this->tempDirectory . '/Resources/config', 0777, true);
-        $emptyServiceDefinition = <<<XML
-<?xml version="1.0" ?>
-<container xmlns="http://symfony.com/schema/dic/services"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <services>
-    </services>
-</container>
-XML;
-
-        file_put_contents($this->tempDirectory . '/Resources/config/services.xml', $emptyServiceDefinition);
 
         $this->command->setContainer($this->container);
         $this->container->set('sonata.admin.manager.foo', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));

--- a/Tests/Command/GenerateAdminCommandTest.php
+++ b/Tests/Command/GenerateAdminCommandTest.php
@@ -442,7 +442,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
                             return $modelEntity;
 
                         case 'The bundle name':
-                            return 'AcmeDemoBundle';
+                            return 'DemoAdminBundle';
 
                         case 'The admin class basename':
                             return 'FooAdmin';
@@ -485,7 +485,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
                             return $modelEntity;
 
                         case 'The bundle name':
-                            return 'AcmeDemoBundle';
+                            return 'DemoAdminBundle';
 
                         case 'The admin class basename':
                             return 'FooAdmin';

--- a/Tests/Command/GenerateAdminCommandTest.php
+++ b/Tests/Command/GenerateAdminCommandTest.php
@@ -69,12 +69,16 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
 
         $kernel->expects($this->any())
             ->method('getBundle')
-            ->with($this->equalTo('AcmeDemoBundle'))
+            ->with($this->equalTo('DemoAdminBundle'))
             ->will($this->returnValue($bundle));
 
         $kernel->expects($this->any())
             ->method('getContainer')
             ->will($this->returnValue($this->container));
+
+        $kernel->expects($this->any())
+            ->method('getRootDir')
+            ->will($this->returnValue($this->tempDirectory));
 
         $this->application = new Application($kernel);
         $this->command = new GenerateAdminCommand();
@@ -97,6 +101,14 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
                 unlink($this->tempDirectory.'/Resources/config/admin.yml');
             }
 
+            if (file_exists($this->tempDirectory.'/Resources/config/services.xml')) {
+                unlink($this->tempDirectory.'/Resources/config/services.xml');
+            }
+
+            if (file_exists($this->tempDirectory.'/config/services.xml')) {
+                unlink($this->tempDirectory.'/config/services.xml');
+            }
+
             if (is_dir($this->tempDirectory.'/Controller')) {
                 rmdir($this->tempDirectory.'/Controller');
             }
@@ -111,6 +123,10 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
 
             if (is_dir($this->tempDirectory.'/Resources')) {
                 rmdir($this->tempDirectory.'/Resources');
+            }
+
+            if (is_dir($this->tempDirectory.'/config')) {
+                rmdir($this->tempDirectory.'/config');
             }
 
             if (file_exists($this->tempDirectory) && is_dir($this->tempDirectory)) {
@@ -129,7 +145,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         $commandTester->execute(array(
             'command' => $command->getName(),
             'model' => 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo',
-            '--bundle' => 'AcmeDemoBundle',
+            '--bundle' => 'DemoAdminBundle',
             '--admin' => 'FooAdmin',
             '--controller' => 'FooAdminController',
             '--services' => 'admin.yml',
@@ -179,7 +195,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         $commandTester->execute(array(
             'command' => $command->getName(),
             'model' => 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo',
-            '--bundle' => 'AcmeDemoBundle',
+            '--bundle' => 'DemoAdminBundle',
             '--admin' => 'FooAdmin',
             '--controller' => 'FooAdminController',
             '--services' => 'admin.yml',
@@ -229,7 +245,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
                             return $modelEntity;
 
                         case 'The bundle name':
-                            return 'AcmeDemoBundle';
+                            return 'DemoAdminBundle';
 
                         case 'The admin class basename':
                             return 'FooAdmin';
@@ -272,7 +288,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
                             return $modelEntity;
 
                         case 'The bundle name':
-                            return 'AcmeDemoBundle';
+                            return 'DemoAdminBundle';
 
                         case 'The admin class basename':
                             return 'FooAdmin';
@@ -383,5 +399,217 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('InvalidArgumentException', 'Invalid manager type "baz". Available manager types are "".');
         $this->command->validateManagerType('baz');
+    }
+
+    /**
+     * @group xml
+     */
+    public function testWriteXMLServiceDefinitionToApplicationConfigs()
+    {
+        mkdir($this->tempDirectory . '/config');
+
+        $this->command->setContainer($this->container);
+        $this->container->set('sonata.admin.manager.foo', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.bar', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+
+        $commandTester = $this->setupAndRunCommandTester('services.xml');
+
+        $expectedOutput = PHP_EOL.str_pad('', 41, ' ').PHP_EOL.'  Welcome to the Sonata admin generator  '.PHP_EOL.str_pad('', 41, ' ').PHP_EOL.PHP_EOL;
+        $expectedOutput .= sprintf('%3$sThe admin class "Sonata\AdminBundle\Tests\Fixtures\Bundle\Admin\FooAdmin" has been generated under the file "%1$s%2$sAdmin%2$sFooAdmin.php".%3$s', $this->tempDirectory, DIRECTORY_SEPARATOR, PHP_EOL);
+        $expectedOutput .= sprintf('%3$sThe controller class "Sonata\AdminBundle\Tests\Fixtures\Bundle\Controller\FooAdminController" has been generated under the file "%1$s%2$sController%2$sFooAdminController.php".%3$s', $this->tempDirectory, DIRECTORY_SEPARATOR, PHP_EOL);
+        $expectedOutput .= sprintf('%3$sThe service "acme_demo_admin.admin.foo" has been appended to the file "%1$s%2$sconfig%2$sservices.xml".%3$s', $this->tempDirectory, DIRECTORY_SEPARATOR, PHP_EOL);
+
+        $this->assertSame($expectedOutput, str_replace("\n", PHP_EOL, str_replace(PHP_EOL, "\n", $commandTester->getDisplay())));
+
+        $this->assertFileExists($this->tempDirectory.'/config/services.xml');
+
+        $expectedServiceDefnition = <<<XML
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="acme_demo_admin.admin.foo" class="Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo">
+            <argument />
+            <argument>Sonata\AdminBundle\Tests\Fixtures\Bundle\Admin\FooAdmin</argument>
+            <argument>DemoAdminBundle:FooAdmin</argument>
+
+            <tag name="sonata.admin" manager_type="foo" group="admin" label="FooAdmin" />
+        </service>
+        
+    </services>
+</container>
+XML;
+
+        $configServiceContent = file_get_contents($this->tempDirectory.'/config/services.xml');
+
+        $this->assertSame($expectedServiceDefnition, $configServiceContent);
+    }
+
+    public function testWriteXMLServiceDefinitionToBundleConfigs()
+    {
+        mkdir($this->tempDirectory . '/Resources/config', 0777, true);
+        $emptyServiceDefinition = <<<XML
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+    </services>
+</container>
+XML;
+
+        file_put_contents($this->tempDirectory . '/Resources/config/services.xml', $emptyServiceDefinition);
+
+        $this->command->setContainer($this->container);
+        $this->container->set('sonata.admin.manager.foo', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.bar', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+
+        $this->setupAndRunCommandTester('services.xml');
+
+        $this->assertFileExists($this->tempDirectory.'/Resources/config/services.xml');
+
+        $expectedServiceDefnition = <<<XML
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="acme_demo_admin.admin.foo" class="Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo">
+            <argument />
+            <argument>Sonata\AdminBundle\Tests\Fixtures\Bundle\Admin\FooAdmin</argument>
+            <argument>DemoAdminBundle:FooAdmin</argument>
+
+            <tag name="sonata.admin" manager_type="foo" group="admin" label="FooAdmin" />
+        </service>
+        
+    </services>
+</container>
+XML;
+
+        $configServiceContent = file_get_contents($this->tempDirectory.'/Resources/config/services.xml');
+
+        $this->assertSame($expectedServiceDefnition, $configServiceContent);
+    }
+
+    /**
+     * @param string $targetConfigFileName
+     *
+     * @return CommandTester
+     */
+    private function setupAndRunCommandTester($targetConfigFileName)
+    {
+        $command = $this->application->find('sonata:admin:generate');
+
+        $modelEntity = 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo';
+
+        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
+        // DialogHelper does not exist in SensioGeneratorBundle 2.5+
+        if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
+            $dialog = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper', array('askConfirmation', 'askAndValidate'));
+
+            $dialog->expects($this->any())
+                ->method('askConfirmation')
+                ->will($this->returnCallback(function (OutputInterface $output, $question, $default) {
+                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
+
+                    switch ($questionClean) {
+                        case 'Do you want to generate a controller':
+                            return 'yes';
+
+                        case 'Do you want to update the services YAML configuration file':
+                            return 'yes';
+                    }
+
+                    return $default;
+                }));
+
+            $dialog->expects($this->any())
+                ->method('askAndValidate')
+                ->will($this->returnCallback(function (OutputInterface $output, $question, $validator, $attempts = false, $default = null) use ($modelEntity, $targetConfigFileName) {
+                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
+
+                    switch ($questionClean) {
+                        case 'The fully qualified model class':
+                            return $modelEntity;
+
+                        case 'The bundle name':
+                            return 'DemoAdminBundle';
+
+                        case 'The admin class basename':
+                            return 'FooAdmin';
+
+                        case 'The controller class basename':
+                            return 'FooAdminController';
+
+                        case 'The services YAML configuration file':
+                            return $targetConfigFileName;
+
+                        case 'The admin service ID':
+                            return 'acme_demo_admin.admin.foo';
+
+                        case 'The manager type':
+                            return 'foo';
+                    }
+
+                    return $default;
+                }));
+
+            $command->getHelperSet()->set($dialog, 'dialog');
+        } else {
+            $questionHelper = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper', array('ask'));
+
+            $questionHelper->expects($this->any())
+                ->method('ask')
+                ->will($this->returnCallback(function (InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity, $targetConfigFileName) {
+                    $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>') - 6);
+
+                    switch ($questionClean) {
+                        // confirmations
+                        case 'Do you want to generate a controller':
+                            return 'yes';
+
+                        case 'Do you want to update the services YAML configuration file':
+                            return 'yes';
+
+                        // inputs
+                        case 'The fully qualified model class':
+                            return $modelEntity;
+
+                        case 'The bundle name':
+                            return 'DemoAdminBundle';
+
+                        case 'The admin class basename':
+                            return 'FooAdmin';
+
+                        case 'The controller class basename':
+                            return 'FooAdminController';
+
+                        case 'The services YAML configuration file':
+                            return $targetConfigFileName;
+
+                        case 'The admin service ID':
+                            return 'acme_demo_admin.admin.foo';
+
+                        case 'The manager type':
+                            return 'foo';
+                    }
+
+                    return false;
+                }));
+
+            $command->getHelperSet()->set($questionHelper, 'question');
+        }
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'model' => $modelEntity,
+        ));
+
+        return $commandTester;
     }
 }

--- a/Tests/Manipulator/ServicesManipulatorTest.php
+++ b/Tests/Manipulator/ServicesManipulatorTest.php
@@ -12,9 +12,11 @@
 namespace Sonata\AdminBundle\Tests\Generator;
 
 use Sonata\AdminBundle\Manipulator\ServicesManipulator;
+use Symfony\Component\Config\Util\XmlUtils;
 
 /**
  * @author Marek Stipek <mario.dweller@seznam.cz>
+ * @group xml-services
  */
 class ServicesManipulatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -124,5 +126,49 @@ class ServicesManipulatorTest extends \PHPUnit_Framework_TestCase
             - { name: sonata.admin, manager_type: manager_type, group: admin, label: class }\n",
             file_get_contents($this->file)
         );
+    }
+
+    public function testAddXmlServiceDefinition()
+    {
+        $emptyServicesXmlFile ='<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="test-service" class="\stdClass"></service>
+
+    </services>
+
+</container>        
+';
+        $this->file = __DIR__ . '/services.xml';
+        file_put_contents($this->file, $emptyServicesXmlFile);
+
+        $this->servicesManipulator = new ServicesManipulator($this->file);
+
+        $this->servicesManipulator->addResource(
+            'service_id',
+            'class',
+            'admin_class',
+            'controller_name',
+            'manager_type'
+        );
+
+        $servicesDocument = XmlUtils::loadFile($this->file);
+
+        $servicesNode = $servicesDocument->childNodes->item(0)->childNodes->item(1);
+
+        $registeredServices = array();
+        foreach ($servicesNode->childNodes as $node) {
+            if ($node instanceof \DOMElement) {
+                $registeredServices[] = $node;
+            }
+        }
+
+        $this->assertEquals(2, count($registeredServices));
+
+
     }
 }

--- a/Tests/Manipulator/ServicesManipulatorTest.php
+++ b/Tests/Manipulator/ServicesManipulatorTest.php
@@ -16,7 +16,6 @@ use Symfony\Component\Config\Util\XmlUtils;
 
 /**
  * @author Marek Stipek <mario.dweller@seznam.cz>
- * @group xml-services
  */
 class ServicesManipulatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -130,7 +129,8 @@ class ServicesManipulatorTest extends \PHPUnit_Framework_TestCase
 
     public function testAddXmlServiceDefinition()
     {
-        $emptyServicesXmlFile ='<?xml version="1.0" ?>
+$emptyServicesXmlFile = <<<XML
+<?xml version="1.0" ?>
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
@@ -141,8 +141,8 @@ class ServicesManipulatorTest extends \PHPUnit_Framework_TestCase
 
     </services>
 
-</container>        
-';
+</container>
+XML;
         $this->file = __DIR__ . '/services.xml';
         file_put_contents($this->file, $emptyServicesXmlFile);
 
@@ -156,19 +156,64 @@ class ServicesManipulatorTest extends \PHPUnit_Framework_TestCase
             'manager_type'
         );
 
-        $servicesDocument = XmlUtils::loadFile($this->file);
+$expectedServiceDefinition = <<<XML
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-        $servicesNode = $servicesDocument->childNodes->item(0)->childNodes->item(1);
+    <services>
 
-        $registeredServices = array();
-        foreach ($servicesNode->childNodes as $node) {
-            if ($node instanceof \DOMElement) {
-                $registeredServices[] = $node;
-            }
-        }
+        <service id="test-service" class="\stdClass"></service>
 
-        $this->assertEquals(2, count($registeredServices));
+        <service id="service_id" class="class">
+            <argument />
+            <argument>admin_class</argument>
+            <argument>controller_name</argument>
 
+            <tag name="sonata.admin" manager_type="manager_type" group="admin" label="admin_class" />
+        </service>
+        
+    </services>
 
+</container>
+XML;
+
+        $this->assertEquals($expectedServiceDefinition, file_get_contents($this->file));
+    }
+
+    public function testCreateServicesXmlFileIfNotExists()
+    {
+        $this->file = __DIR__ . '/services.xml';
+        $this->servicesManipulator = new ServicesManipulator($this->file);
+
+        $this->servicesManipulator->addResource(
+            'service_id',
+            'class',
+            'admin_class',
+            'controller_name',
+            'manager_type'
+        );
+
+        $expectedServiceDefinition = <<<XML
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="service_id" class="class">
+            <argument />
+            <argument>admin_class</argument>
+            <argument>controller_name</argument>
+
+            <tag name="sonata.admin" manager_type="manager_type" group="admin" label="admin_class" />
+        </service>
+        
+    </services>
+</container>
+XML;
+
+        $this->assertEquals($expectedServiceDefinition, file_get_contents($this->file));
     }
 }

--- a/Tests/Manipulator/ServicesManipulatorTest.php
+++ b/Tests/Manipulator/ServicesManipulatorTest.php
@@ -156,7 +156,7 @@ XML;
             'manager_type'
         );
 
-$expectedServiceDefinition = <<<XML
+        $expectedServiceDefinition = <<<XML
 <?xml version="1.0" ?>
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
I am targetting this branch, because to improve the admin-generator command. 

## Changelog
```markdown
### Changed
- `ServiceManipulator` now supports XML service definitions

### Added
- `GenerateAdminCommand::determineConfigDir()` returns the path of the config-directory depending on which dir is really used.
- `GenerateAdminCommand::findServicesConfigFiles` returns a list of files which are matching with pattern `admin.yml|xml` or `services.yml|xml`
```
## To do

- [x] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

The admin generator commands always adds/appends the service-definition to `AppBundle/Resources/config/services.yml`. This is not very user friendly if you using `services.xml` for your service definition, have your config-files under `app/config` or both. Now the command checks which config-dir is used (bundle config-dir or app config-dir) and with type is used (YAML or XML).

If no config-file exists an new `services.yml` file will be created under `app/config`.
