### PR TITLE
better deprecation handling for Sonata\AdminBundle\Controller\CoreController::getRequest()

### DIFF
--- a/Controller/CoreController.php
+++ b/Controller/CoreController.php
@@ -120,13 +120,18 @@ class CoreController extends Controller
      *
      * NEXT_MAJOR: remove this method.
      *
-     * @deprecated Use the Request action argument. This method will be removed
-     *             in SonataAdminBundle 4.0 and the action methods adjusted
+     * @deprecated since 3.0, to be removed in 4.0 and action methods will be adjusted.
+     *             Use Symfony\Component\HttpFoundation\Request as an action argument.
      *
      * @return Request
      */
     public function getRequest()
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since 3.0 and will be removed in 4.0.'.
+            ' Inject the Symfony\Component\HttpFoundation\Request into the actions instead.',
+            E_USER_DEPRECATED
+        );
+
         if ($this->container->has('request_stack')) {
             return $this->container->get('request_stack')->getCurrentRequest();
         }

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated Sonata\AdminBundle\Controller\CoreController::getRequest()
+
+Inject `Symfony\Component\HttpFoundation\Request` in your actions directly as an argument.
+
 UPGRADE FROM 3.10 to 3.11
 =========================
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `Sonata\AdminBundle\Controller\CoreController::getRequest()`
```

