### PR TITLE
Deprecated ModelsToArrayTransformer::$choiceList

### DIFF
--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -51,7 +51,6 @@ class ModelType extends AbstractType
         if ($options['multiple']) {
             if (array_key_exists('choice_loader', $options) && $options['choice_loader'] !== null) { // SF2.7+
                 $builder->addViewTransformer(new ModelsToArrayTransformer(
-                    $options['choice_loader'],
                     $options['model_manager'],
                     $options['class']), true);
             } else {

--- a/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
+
+use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
+
+class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    private $modelManager;
+
+    protected function setUp()
+    {
+        $this->modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface')->reveal();
+    }
+
+    public function testConstructor()
+    {
+        $transformer = new ModelsToArrayTransformer(
+            $this->modelManager,
+            'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo'
+        );
+
+        $this->assertInstanceOf('Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer', $transformer);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyConstructor()
+    {
+        $choiceListClass = interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')
+            ? 'Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader'
+            : 'Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList'
+        ;
+
+        $choiceList = $this->prophesize($choiceListClass)->reveal();
+
+        $transformer = new ModelsToArrayTransformer(
+            $choiceList,
+            $this->modelManager,
+            'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo'
+        );
+
+        $this->assertInstanceOf('Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer', $transformer);
+    }
+}

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated ModelsToArrayTransformer::$choiceList property
+
+When instantiating a ModelsToArrayTransformer object, please use the 2 parameter signature ($modelManager, $class).
+
 ## Deprecated Sonata\AdminBundle\Controller\CoreController::getRequest()
 
 Inject `Symfony\Component\HttpFoundation\Request` in your actions directly as an argument.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because there is not BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4283

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Deprecated
- `ModelToArrayTransformer::$choiceList` property 
- `ModelToArrayTransformer::$choiceList::__construct()` three-argument-signature is deprecated
```

## To do
- [x] Tests (as soon as i find time for it)
<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->