### PR TITLE
Avoid PHPUnit warnings

### DIFF
--- a/Tests/Admin/AdminHelperTest.php
+++ b/Tests/Admin/AdminHelperTest.php
@@ -13,10 +13,11 @@ namespace Sonata\AdminBundle\Tests\Admin;
 
 use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormView;
 
-class AdminHelperTest extends \PHPUnit_Framework_TestCase
+class AdminHelperTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var AdminHelper
@@ -25,7 +26,7 @@ class AdminHelperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $pool = new Pool($container, 'title', 'logo.png');
         $this->helper = new AdminHelper($pool);
@@ -33,8 +34,8 @@ class AdminHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testGetChildFormBuilder()
     {
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
-        $eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
 
         $formBuilder = new FormBuilder('test', 'stdClass', $eventDispatcher, $formFactory);
 
@@ -58,14 +59,16 @@ class AdminHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testAddNewInstance()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('getNewInstance')->will($this->returnValue(new \stdClass()));
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getAssociationAdmin')->will($this->returnValue($admin));
         $fieldDescription->expects($this->once())->method('getAssociationMapping')->will($this->returnValue(array('fieldName' => 'fooBar')));
 
-        $object = $this->getMock('stdClass', array('addFooBar'));
+        $object = $this->getMockBuilder('stdClass')
+            ->setMethods(array('addFooBar'))
+            ->getMock();
         $object->expects($this->once())->method('addFooBar');
 
         $this->helper->addNewInstance($object, $fieldDescription);
@@ -73,14 +76,16 @@ class AdminHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testAddNewInstancePlural()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('getNewInstance')->will($this->returnValue(new \stdClass()));
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getAssociationAdmin')->will($this->returnValue($admin));
         $fieldDescription->expects($this->once())->method('getAssociationMapping')->will($this->returnValue(array('fieldName' => 'fooBars')));
 
-        $object = $this->getMock('stdClass', array('addFooBar'));
+        $object = $this->getMockBuilder('stdClass')
+            ->setMethods(array('addFooBar'))
+            ->getMock();
         $object->expects($this->once())->method('addFooBar');
 
         $this->helper->addNewInstance($object, $fieldDescription);
@@ -88,14 +93,16 @@ class AdminHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testAddNewInstanceInflector()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('getNewInstance')->will($this->returnValue(new \stdClass()));
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getAssociationAdmin')->will($this->returnValue($admin));
         $fieldDescription->expects($this->once())->method('getAssociationMapping')->will($this->returnValue(array('fieldName' => 'entries')));
 
-        $object = $this->getMock('stdClass', array('addEntry'));
+        $object = $this->getMockBuilder('stdClass')
+            ->setMethods(array('addEntry'))
+            ->getMock();
         $object->expects($this->once())->method('addEntry');
 
         $this->helper->addNewInstance($object, $fieldDescription);
@@ -103,9 +110,15 @@ class AdminHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testGetElementAccessPath()
     {
-        $object = $this->getMock('stdClass', array('getPathToObject'));
-        $subObject = $this->getMock('stdClass', array('getAnother'));
-        $sub2Object = $this->getMock('stdClass', array('getMoreThings'));
+        $object = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getPathToObject'))
+            ->getMock();
+        $subObject = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getAnother'))
+            ->getMock();
+        $sub2Object = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getMoreThings'))
+            ->getMock();
 
         $object->expects($this->atLeastOnce())->method('getPathToObject')->will($this->returnValue(array($subObject)));
         $subObject->expects($this->atLeastOnce())->method('getAnother')->will($this->returnValue($sub2Object));
@@ -119,28 +132,42 @@ class AdminHelperTest extends \PHPUnit_Framework_TestCase
     public function testItThrowsExceptionWhenDoesNotFindTheFullPath()
     {
         $path = 'uniquePartOfId_path_to_object_0_more_calls';
-        $object = $this->getMock('stdClass', array('getPathToObject'));
-        $subObject = $this->getMock('stdClass', array('getMore'));
+        $object = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getPathToObject'))
+            ->getMock();
+        $subObject = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getMore'))
+            ->getMock();
 
         $object->expects($this->atLeastOnce())->method('getPathToObject')->will($this->returnValue(array($subObject)));
         $subObject->expects($this->atLeastOnce())->method('getMore')->will($this->returnValue('Value'));
 
-        $this->setExpectedException('Exception', 'Could not get element id from '.$path.' Failing part: calls');
+        $this->expectException('Exception', 'Could not get element id from '.$path.' Failing part: calls');
 
         $this->helper->getElementAccessPath($path, $object);
     }
 
     public function testAppendFormFieldElementNested()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $object = $this->getMock('stdClass', array('getSubObject'));
-        $simpleObject = $this->getMock('stdClass', array('getSubObject'));
-        $subObject = $this->getMock('stdClass', array('getAnd'));
-        $sub2Object = $this->getMock('stdClass', array('getMore'));
-        $sub3Object = $this->getMock('stdClass', array('getFinalData'));
-        $dataMapper = $this->getMock('Symfony\Component\Form\DataMapperInterface');
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
-        $eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $object = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getSubObject'))
+            ->getMock();
+        $simpleObject = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getSubObject'))
+            ->getMock();
+        $subObject = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getAnd'))
+            ->getMock();
+        $sub2Object = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getMore'))
+            ->getMock();
+        $sub3Object = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getFinalData'))
+            ->getMock();
+        $dataMapper = $this->createMock('Symfony\Component\Form\DataMapperInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $formBuilder = new FormBuilder('test', get_class($simpleObject), $eventDispatcher, $formFactory);
         $childFormBuilder = new FormBuilder('subObject', get_class($subObject), $eventDispatcher, $formFactory);
 
@@ -156,7 +183,7 @@ class AdminHelperTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->once())->method('getFormBuilder')->will($this->returnValue($formBuilder));
         $admin->expects($this->once())->method('getSubject')->will($this->returnValue($object));
 
-        $this->setExpectedException('Exception', 'unknown collection class');
+        $this->expectException('Exception', 'unknown collection class');
 
         $this->helper->appendFormFieldElement($admin, $simpleObject, 'uniquePartOfId_sub_object_0_and_more_0_final_data');
     }

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -27,12 +27,13 @@ use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Tag;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToStringNull;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
-class AdminTest extends \PHPUnit_Framework_TestCase
+class AdminTest extends PHPUnit_Framework_TestCase
 {
     protected $cacheTempFolder;
 
@@ -475,14 +476,14 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     public function testGetBaseRouteNameWithChildAdmin($objFqn, $expected)
     {
         $routeGenerator = new DefaultRouteGenerator(
-            $this->getMock('Symfony\Component\Routing\RouterInterface'),
+            $this->createMock('Symfony\Component\Routing\RouterInterface'),
             new RoutesCache($this->cacheTempFolder, true)
         );
 
         $container = new Container();
         $pool = new Pool($container, 'Sonata Admin', '/path/to/pic.png');
 
-        $pathInfo = new \Sonata\AdminBundle\Route\PathInfoBuilder($this->getMock('Sonata\AdminBundle\Model\AuditManagerInterface'));
+        $pathInfo = new \Sonata\AdminBundle\Route\PathInfoBuilder($this->createMock('Sonata\AdminBundle\Model\AuditManagerInterface'));
         $postAdmin = new PostAdmin('sonata.post.admin.post', $objFqn, 'SonataNewsBundle:PostAdmin');
         $container->set('sonata.post.admin.post', $postAdmin);
         $postAdmin->setConfigurationPool($pool);
@@ -594,7 +595,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($postAdmin->isAclEnabled());
 
         $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
-        $commentAdmin->setSecurityHandler($this->getMock('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface'));
+        $commentAdmin->setSecurityHandler($this->createMock('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface'));
         $this->assertTrue($commentAdmin->isAclEnabled());
     }
 
@@ -707,7 +708,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getLabelTranslatorStrategy());
 
-        $labelTranslatorStrategy = $this->getMock('Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface');
+        $labelTranslatorStrategy = $this->createMock('Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface');
         $admin->setLabelTranslatorStrategy($labelTranslatorStrategy);
         $this->assertSame($labelTranslatorStrategy, $admin->getLabelTranslatorStrategy());
     }
@@ -718,7 +719,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getRouteBuilder());
 
-        $routeBuilder = $this->getMock('Sonata\AdminBundle\Builder\RouteBuilderInterface');
+        $routeBuilder = $this->createMock('Sonata\AdminBundle\Builder\RouteBuilderInterface');
         $admin->setRouteBuilder($routeBuilder);
         $this->assertSame($routeBuilder, $admin->getRouteBuilder());
     }
@@ -729,7 +730,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getMenuFactory());
 
-        $menuFactory = $this->getMock('Knp\Menu\FactoryInterface');
+        $menuFactory = $this->createMock('Knp\Menu\FactoryInterface');
         $admin->setMenuFactory($menuFactory);
         $this->assertSame($menuFactory, $admin->getMenuFactory());
     }
@@ -740,8 +741,8 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(array(), $admin->getExtensions());
 
-        $adminExtension1 = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
-        $adminExtension2 = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $adminExtension1 = $this->createMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $adminExtension2 = $this->createMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
 
         $admin->addExtension($adminExtension1);
         $admin->addExtension($adminExtension2);
@@ -775,7 +776,14 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getValidator());
 
-        $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+        $validatorClass = '\Symfony\Component\Validator\ValidatorInterface';
+
+        if (interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
+            $validatorClass = 'Symfony\Component\Validator\Validator\ValidatorInterface';
+        }
+
+        $validator = $this->getMockForAbstractClass($validatorClass);
+
         $admin->setValidator($validator);
         $this->assertSame($validator, $admin->getValidator());
     }
@@ -786,7 +794,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getSecurityHandler());
 
-        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
+        $securityHandler = $this->createMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
         $admin->setSecurityHandler($securityHandler);
         $this->assertSame($securityHandler, $admin->getSecurityHandler());
     }
@@ -822,7 +830,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getModelManager());
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $admin->setModelManager($modelManager);
         $this->assertSame($modelManager, $admin->getModelManager());
@@ -844,7 +852,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getRouteGenerator());
 
-        $routeGenerator = $this->getMock('Sonata\AdminBundle\Route\RouteGeneratorInterface');
+        $routeGenerator = $this->createMock('Sonata\AdminBundle\Route\RouteGeneratorInterface');
 
         $admin->setRouteGenerator($routeGenerator);
         $this->assertSame($routeGenerator, $admin->getRouteGenerator());
@@ -870,7 +878,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getShowBuilder());
 
-        $showBuilder = $this->getMock('Sonata\AdminBundle\Builder\ShowBuilderInterface');
+        $showBuilder = $this->createMock('Sonata\AdminBundle\Builder\ShowBuilderInterface');
 
         $admin->setShowBuilder($showBuilder);
         $this->assertSame($showBuilder, $admin->getShowBuilder());
@@ -882,7 +890,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getListBuilder());
 
-        $listBuilder = $this->getMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
+        $listBuilder = $this->createMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
 
         $admin->setListBuilder($listBuilder);
         $this->assertSame($listBuilder, $admin->getListBuilder());
@@ -894,7 +902,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getDatagridBuilder());
 
-        $datagridBuilder = $this->getMock('Sonata\AdminBundle\Builder\DatagridBuilderInterface');
+        $datagridBuilder = $this->createMock('Sonata\AdminBundle\Builder\DatagridBuilderInterface');
 
         $admin->setDatagridBuilder($datagridBuilder);
         $this->assertSame($datagridBuilder, $admin->getDatagridBuilder());
@@ -906,7 +914,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getFormContractor());
 
-        $formContractor = $this->getMock('Sonata\AdminBundle\Builder\FormContractorInterface');
+        $formContractor = $this->createMock('Sonata\AdminBundle\Builder\FormContractorInterface');
 
         $admin->setFormContractor($formContractor);
         $this->assertSame($formContractor, $admin->getFormContractor());
@@ -949,7 +957,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($admin->getTranslator());
 
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
 
         $admin->setTranslator($translator);
         $this->assertSame($translator, $admin->getTranslator());
@@ -1093,7 +1101,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $entity = new \stdClass();
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->once())
             ->method('getUrlsafeIdentifier')
             ->with($this->equalTo($entity))
@@ -1130,7 +1138,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $entity = new \stdClass();
 
-        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface');
+        $securityHandler = $this->createMock('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface');
         $securityHandler->expects($this->any())
             ->method('isGranted')
             ->will($this->returnCallback(function (AdminInterface $adminIn, $attributes, $object = null) use ($admin, $entity) {
@@ -1171,7 +1179,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface');
+        $securityHandler = $this->createMock('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface');
         $securityHandler->expects($this->any())
             ->method('isGranted')
             ->will($this->returnCallback(function (AdminInterface $adminIn, $attributes, $object = null) use ($admin) {
@@ -1201,7 +1209,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
         $admin->setTranslationDomain('fooMessageDomain');
 
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
         $admin->setTranslator($translator);
 
         $translator->expects($this->once())
@@ -1219,7 +1227,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
         $admin->setTranslator($translator);
 
         $translator->expects($this->once())
@@ -1235,7 +1243,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
         $admin->setTranslationDomain('fooMessageDomain');
 
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
         $admin->setTranslator($translator);
 
         $translator->expects($this->once())
@@ -1253,7 +1261,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
         $admin->setTranslator($translator);
 
         $translator->expects($this->once())
@@ -1280,7 +1288,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('sonata.post.admin.post', $admin->getRootCode());
 
         $parentAdmin = new PostAdmin('sonata.post.admin.post.parent', 'NewsBundle\Entity\PostParent', 'SonataNewsBundle:PostParentAdmin');
-        $parentFieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $parentFieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $parentFieldDescription->expects($this->once())
             ->method('getAdmin')
             ->will($this->returnValue($parentAdmin));
@@ -1298,7 +1306,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($admin, $admin->getRoot());
 
         $parentAdmin = new PostAdmin('sonata.post.admin.post.parent', 'NewsBundle\Entity\PostParent', 'SonataNewsBundle:PostParentAdmin');
-        $parentFieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $parentFieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $parentFieldDescription->expects($this->once())
             ->method('getAdmin')
             ->will($this->returnValue($parentAdmin));
@@ -1313,7 +1321,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->once())
             ->method('getExportFields')
             ->with($this->equalTo('NewsBundle\Entity\Post'))
@@ -1337,7 +1345,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $extension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $extension = $this->createMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
         $extension->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(null));
 
         $admin->addExtension($extension);
@@ -1353,7 +1361,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $extension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $extension = $this->createMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
         $extension->expects($this->once())->method('getPersistentParameters')->will($this->returnValue($expected));
 
         $admin->addExtension($extension);
@@ -1444,14 +1452,19 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $commentAdmin->setParentAssociationMapping('post.author');
         $commentAdmin->setParent($postAdmin);
 
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request', array('get'));
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request', array('get'));
+        $query = $this->createMock('Symfony\Component\HttpFoundation\ParameterBag', array('get'));
+        $query->expects($this->any())
+            ->method('get')
+            ->will($this->returnValue(array()));
+        $request->query = $query;
         $request->expects($this->any())
             ->method('get')
             ->will($this->returnValue($authorId));
 
         $commentAdmin->setRequest($request);
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->any())
             ->method('getDefaultSortValues')
             ->will($this->returnValue(array()));
@@ -1472,7 +1485,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $barFieldDescription = new FieldDescription();
         $bazFieldDescription = new FieldDescription();
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->exactly(3))
             ->method('getNewFieldDescriptionInstance')
             ->will($this->returnCallback(function ($adminClass, $name, $filterOptions) use ($fooFieldDescription, $barFieldDescription, $bazFieldDescription) {
@@ -1501,14 +1514,14 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $modelAdmin->setModelManager($modelManager);
 
-        $pager = $this->getMock('Sonata\AdminBundle\Datagrid\PagerInterface');
+        $pager = $this->createMock('Sonata\AdminBundle\Datagrid\PagerInterface');
 
-        $datagrid = $this->getMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
         $datagrid->expects($this->once())
             ->method('getPager')
             ->will($this->returnValue($pager));
 
-        $datagridBuilder = $this->getMock('Sonata\AdminBundle\Builder\DatagridBuilderInterface');
+        $datagridBuilder = $this->createMock('Sonata\AdminBundle\Builder\DatagridBuilderInterface');
         $datagridBuilder->expects($this->once())
             ->method('getBaseDatagrid')
             ->with($this->identicalTo($modelAdmin), array())
@@ -1535,7 +1548,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
     public function testGetSubjectNoRequest()
     {
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager
             ->expects($this->never())
             ->method('find');
@@ -1548,7 +1561,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
     public function testGetSideMenu()
     {
-        $item = $this->getMock('Knp\Menu\ItemInterface');
+        $item = $this->createMock('Knp\Menu\ItemInterface');
         $item
             ->expects($this->once())
             ->method('setChildrenAttribute')
@@ -1558,7 +1571,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->method('setExtra')
             ->with('translation_domain', 'foo_bar_baz');
 
-        $menuFactory = $this->getMock('Knp\Menu\FactoryInterface');
+        $menuFactory = $this->createMock('Knp\Menu\FactoryInterface');
         $menuFactory
             ->expects($this->once())
             ->method('createItem')
@@ -1590,7 +1603,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetSubjectFailed($id)
     {
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager
             ->expects($this->once())
             ->method('find')
@@ -1611,7 +1624,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $entity = new Post();
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager
             ->expects($this->once())
             ->method('find')
@@ -1639,7 +1652,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
+        $securityHandler = $this->createMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
         $securityHandler
             ->expects($this->once())
             ->method('isGranted')
@@ -1647,7 +1660,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
         $admin->setSecurityHandler($securityHandler);
 
-        $routeGenerator = $this->getMock('Sonata\AdminBundle\Route\RouteGeneratorInterface');
+        $routeGenerator = $this->createMock('Sonata\AdminBundle\Route\RouteGeneratorInterface');
         $routeGenerator
             ->expects($this->once())
             ->method('hasAdminRoute')
@@ -1667,7 +1680,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
+        $securityHandler = $this->createMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
         $securityHandler
             ->expects($this->once())
             ->method('isGranted')
@@ -1732,10 +1745,10 @@ class AdminTest extends \PHPUnit_Framework_TestCase
      */
     public function testDefaultDashboardActionsArePresent($objFqn, $expected)
     {
-        $pathInfo = new \Sonata\AdminBundle\Route\PathInfoBuilder($this->getMock('Sonata\AdminBundle\Model\AuditManagerInterface'));
+        $pathInfo = new \Sonata\AdminBundle\Route\PathInfoBuilder($this->createMock('Sonata\AdminBundle\Model\AuditManagerInterface'));
 
         $routeGenerator = new DefaultRouteGenerator(
-            $this->getMock('Symfony\Component\Routing\RouterInterface'),
+            $this->createMock('Symfony\Component\Routing\RouterInterface'),
             new RoutesCache($this->cacheTempFolder, true)
         );
 
@@ -1744,7 +1757,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $admin->setRouteGenerator($routeGenerator);
         $admin->initialize();
 
-        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
+        $securityHandler = $this->createMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
         $securityHandler->expects($this->any())
             ->method('isGranted')
             ->will($this->returnCallback(function (AdminInterface $adminIn, $attributes, $object = null) use ($admin) {
@@ -1767,20 +1780,25 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $subjectId = uniqid();
 
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request', array('get'));
-        $request->query->set('filter', array(
-            'a' => array(
-                'value' => 'b',
-            ),
-            'foo' => array(
-                'type' => '1',
-                'value' => 'bar',
-            ),
-            'baz' => array(
-                'type' => '5',
-                'value' => 'test',
-            ),
-        ));
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request', array('get'));
+        $query = $this->createMock('Symfony\Component\HttpFoundation\ParameterBag', array('set', 'get'));
+        $query->expects($this->any())
+            ->method('get')
+            ->with($this->equalTo('filter'))
+            ->will($this->returnValue(array(
+                'a' => array(
+                    'value' => 'b',
+                ),
+                'foo' => array(
+                    'type' => '1',
+                    'value' => 'bar',
+                ),
+                'baz' => array(
+                    'type' => '5',
+                    'value' => 'test',
+                ),
+            )));
+        $request->query = $query;
 
         $request->expects($this->any())
             ->method('get')
@@ -1788,7 +1806,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $admin->setRequest($request);
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->any())
             ->method('getDefaultSortValues')
             ->will($this->returnValue(array()));
@@ -1821,7 +1839,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
      */
     public function testDefaultBreadcrumbsBuilder()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->once())
             ->method('getParameter')
             ->with('sonata.admin.configuration.breadcrumbs')
@@ -1855,7 +1873,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AbstractAdmin', array(
             'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin',
         ));
-        $this->assertSame($admin, $admin->setBreadcrumbsBuilder($builder = $this->getMock(
+        $this->assertSame($admin, $admin->setBreadcrumbsBuilder($builder = $this->createMock(
             'Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface'
         )));
         $this->assertSame($builder, $admin->getBreadcrumbsBuilder());
@@ -1889,7 +1907,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             'Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface'
         );
         $action = 'myaction';
-        $menu = $this->getMock('Knp\Menu\ItemInterface');
+        $menu = $this->createMock('Knp\Menu\ItemInterface');
         $builder->buildBreadcrumbs($admin, $action, $menu)
             ->shouldBeCalledTimes(1)
             ->willReturn($menu);
@@ -1910,7 +1928,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AbstractAdmin', array(
             'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin',
         ));
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->once())
             ->method('createQuery')
             ->with('My\Class')
@@ -1922,10 +1940,10 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDataSourceIterator()
     {
-        $datagrid = $this->getMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
         $datagrid->method('buildPager');
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->method('getExportFields')->will($this->returnValue(array(
             'field',
             'foo',
@@ -1971,7 +1989,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
         $postAdmin->expects($this->any())->method('getObject')->will($this->returnValue($post));
 
-        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
         $formBuilder->expects($this->any())->method('getForm')->will($this->returnValue(null));
 
         $tagAdmin = $this->getMockBuilder('Sonata\AdminBundle\Tests\Fixtures\Admin\TagAdmin')
@@ -1989,7 +2007,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $tag = new Tag();
         $tagAdmin->setSubject($tag);
 
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
         $tagAdmin->setRequest($request);
 
         $configurationPool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')

--- a/Tests/Admin/BaseAdminModelManagerTest.php
+++ b/Tests/Admin/BaseAdminModelManagerTest.php
@@ -12,18 +12,19 @@
 namespace Sonata\AdminBundle\Tests\Admin;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 class BaseAdminModelManager_Admin extends AbstractAdmin
 {
 }
 
-class BaseAdminModelManagerTest extends \PHPUnit_Framework_TestCase
+class BaseAdminModelManagerTest extends PHPUnit_Framework_TestCase
 {
     public function testHook()
     {
-        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
+        $securityHandler = $this->getMockForAbstractClass('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->once())->method('create');
         $modelManager->expects($this->once())->method('update');
         $modelManager->expects($this->once())->method('delete');
@@ -41,7 +42,7 @@ class BaseAdminModelManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testObject()
     {
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->once())->method('find')->will($this->returnCallback(function ($class, $id) {
             if ($class != 'class') {
                 throw new \RuntimeException('Invalid class argument');
@@ -59,7 +60,7 @@ class BaseAdminModelManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateQuery()
     {
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->once())->method('createQuery')->will($this->returnCallback(function ($class) {
             if ($class != 'class') {
                 throw new \RuntimeException('Invalid class argument');
@@ -73,7 +74,7 @@ class BaseAdminModelManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testId()
     {
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->exactly(2))->method('getNormalizedIdentifier');
 
         $admin = new BaseAdminModelManager_Admin('code', 'class', 'controller');

--- a/Tests/Admin/BaseFieldDescriptionTest.php
+++ b/Tests/Admin/BaseFieldDescriptionTest.php
@@ -15,8 +15,9 @@ use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\FieldDescription;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooCall;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
+class BaseFieldDescriptionTest extends PHPUnit_Framework_TestCase
 {
     public function testSetName()
     {
@@ -79,11 +80,11 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
     {
         $description = new FieldDescription();
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $description->setAdmin($admin);
         $this->isInstanceOf('Sonata\AdminBundle\Admin\AdminInterface', $description->getAdmin());
 
-        $associationAdmin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $associationAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $associationAdmin->expects($this->once())->method('setParentFieldDescription');
 
         $this->assertFalse($description->hasAssociationAdmin());
@@ -91,7 +92,7 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($description->hasAssociationAdmin());
         $this->isInstanceOf('Sonata\AdminBundle\Admin\AdminInterface', $description->getAssociationAdmin());
 
-        $parent = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $parent = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $description->setParent($parent);
         $this->isInstanceOf('Sonata\AdminBundle\Admin\AdminInterface', $description->getParent());
     }
@@ -101,7 +102,9 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $description = new FieldDescription();
         $description->setOption('code', 'getFoo');
 
-        $mock = $this->getMock('stdClass', array('getFoo'));
+        $mock = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getFoo'))
+            ->getMock();
         $mock->expects($this->once())->method('getFoo')->will($this->returnValue(42));
 
         $this->assertSame(42, $description->getFieldValue($mock, 'fake'));
@@ -115,7 +118,9 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $description1->setOption('code', 'getWithOneParameter');
         $description1->setOption('parameters', $oneParameter);
 
-        $mock1 = $this->getMock('stdClass', array('getWithOneParameter'));
+        $mock1 = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getWithOneParameter'))
+            ->getMock();
         $returnValue1 = $arg1 + 2;
         $mock1->expects($this->once())->method('getWithOneParameter')->with($this->equalTo($arg1))->will($this->returnValue($returnValue1));
 
@@ -130,7 +135,9 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $description2->setOption('code', 'getWithTwoParameters');
         $description2->setOption('parameters', $twoParameters);
 
-        $mock2 = $this->getMock('stdClass', array('getWithTwoParameters'));
+        $mock2 = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getWithTwoParameters'))
+            ->getMock();
         $returnValue2 = $arg1 + $arg2;
         $mock2->expects($this->any())->method('getWithTwoParameters')->with($this->equalTo($arg1), $this->equalTo($arg2))->will($this->returnValue($returnValue2));
         $this->assertSame(42, $description2->getFieldValue($mock2, 'fake'));
@@ -139,7 +146,9 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
          * Test with underscored attribute name
          */
         $description3 = new FieldDescription();
-        $mock3 = $this->getMock('stdClass', array('getFake'));
+        $mock3 = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getFake'))
+            ->getMock();
 
         $mock3->expects($this->once())->method('getFake')->will($this->returnValue(42));
         $this->assertSame(42, $description3->getFieldValue($mock3, '_fake'));
@@ -151,7 +160,9 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
     public function testGetValueNoValueException()
     {
         $description = new FieldDescription();
-        $mock = $this->getMock('stdClass', array('getFoo'));
+        $mock = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getFoo'))
+            ->getMock();
 
         $description->getFieldValue($mock, 'fake');
     }
@@ -159,7 +170,9 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
     public function testGetVirtualValue()
     {
         $description = new FieldDescription();
-        $mock = $this->getMock('stdClass', array('getFoo'));
+        $mock = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getFoo'))
+            ->getMock();
 
         $description->setOption('virtual_field', true);
         $description->getFieldValue($mock, 'fake');
@@ -179,7 +192,7 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
     {
         $description = new FieldDescription();
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $description->setAdmin($admin);
 
         $admin->expects($this->once())
@@ -212,7 +225,7 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $description = new FieldDescription();
         $this->assertSame('Bar', $description->getFieldValue($foo, 'bar'));
 
-        $this->setExpectedException('Sonata\AdminBundle\Exception\NoValueException');
+        $this->expectException('Sonata\AdminBundle\Exception\NoValueException');
         $description->getFieldValue($foo, 'inexistantMethod');
     }
 
@@ -227,7 +240,7 @@ class BaseFieldDescriptionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('Baz', $description->getFieldValue($foo, 'inexistantMethod'));
 
         $description->setOption('code', 'inexistantMethod');
-        $this->setExpectedException('Sonata\AdminBundle\Exception\NoValueException');
+        $this->expectException('Sonata\AdminBundle\Exception\NoValueException');
         $description->getFieldValue($foo, 'inexistantMethod');
     }
 

--- a/Tests/Admin/BreadcrumbsBuilderTest.php
+++ b/Tests/Admin/BreadcrumbsBuilderTest.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Comment;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\DummySubject;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -24,7 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Grégoire Paris <postmaster@greg0ire.fr>
  */
-class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
+class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @group legacy
@@ -52,19 +53,19 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         $admin->initialize();
         $commentAdmin->setCurrentChild($subCommentAdmin);
 
-        $menuFactory = $this->getMock('Knp\Menu\FactoryInterface');
-        $menu = $this->getMock('Knp\Menu\ItemInterface');
-        $translatorStrategy = $this->getMock(
+        $menuFactory = $this->getMockForAbstractClass('Knp\Menu\FactoryInterface');
+        $menu = $this->getMockForAbstractClass('Knp\Menu\ItemInterface');
+        $translatorStrategy = $this->getMockForAbstractClass(
             'Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface'
         );
-        $routeGenerator = $this->getMock(
+        $routeGenerator = $this->getMockForAbstractClass(
             'Sonata\AdminBundle\Route\RouteGeneratorInterface'
         );
-        $modelManager = $this->getMock(
+        $modelManager = $this->getMockForAbstractClass(
             'Sonata\AdminBundle\Model\ModelManagerInterface'
         );
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())
             ->method('getParameter')
             ->with('sonata.admin.configuration.breadcrumbs')
@@ -225,12 +226,12 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
         $commentAdmin->initialize();
         $admin->initialize();
 
-        $menuFactory = $this->getMock('Knp\Menu\FactoryInterface');
-        $menu = $this->getMock('Knp\Menu\ItemInterface');
-        $translatorStrategy = $this->getMock(
+        $menuFactory = $this->getMockForAbstractClass('Knp\Menu\FactoryInterface');
+        $menu = $this->getMockForAbstractClass('Knp\Menu\ItemInterface');
+        $translatorStrategy = $this->getMockForAbstractClass(
             'Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface'
         );
-        $routeGenerator = $this->getMock(
+        $routeGenerator = $this->getMockForAbstractClass(
             'Sonata\AdminBundle\Route\RouteGeneratorInterface'
         );
 
@@ -274,7 +275,7 @@ class BreadcrumbsBuilderTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue($menu));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())
             ->method('getParameter')
             ->with('sonata.admin.configuration.breadcrumbs')

--- a/Tests/Admin/FieldDescriptionCollectionTest.php
+++ b/Tests/Admin/FieldDescriptionCollectionTest.php
@@ -12,18 +12,19 @@
 namespace Sonata\AdminBundle\Tests\Admin;
 
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class FieldDescriptionCollectionTest extends \PHPUnit_Framework_TestCase
+class FieldDescriptionCollectionTest extends PHPUnit_Framework_TestCase
 {
     public function testMethods()
     {
         $collection = new FieldDescriptionCollection();
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('title'));
         $collection->add($fieldDescription);
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('position'));
         $collection->add($fieldDescription);
 
@@ -72,11 +73,11 @@ class FieldDescriptionCollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = new FieldDescriptionCollection();
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('title'));
         $collection->add($fieldDescription);
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('position'));
         $collection->add($fieldDescription);
 
@@ -91,15 +92,15 @@ class FieldDescriptionCollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = new FieldDescriptionCollection();
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('title'));
         $collection->add($fieldDescription);
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('position'));
         $collection->add($fieldDescription);
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('batch'));
         $collection->add($fieldDescription);
 

--- a/Tests/Admin/PoolTest.php
+++ b/Tests/Admin/PoolTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\AdminBundle\Tests\Admin;
 
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class PoolTest extends \PHPUnit_Framework_TestCase
+class PoolTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var Pool
@@ -54,16 +55,16 @@ class PoolTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDashboardGroups()
     {
-        $admin_group1 = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin_group1 = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin_group1->expects($this->once())->method('showIn')->will($this->returnValue(true));
 
-        $admin_group2 = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin_group2 = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin_group2->expects($this->once())->method('showIn')->will($this->returnValue(false));
 
-        $admin_group3 = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin_group3 = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin_group3->expects($this->once())->method('showIn')->will($this->returnValue(false));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $container->expects($this->any())->method('get')->will($this->onConsecutiveCalls(
             $admin_group1, $admin_group2, $admin_group3
@@ -204,7 +205,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('sonata.news.admin.comment'))
             ->will($this->returnValue('commentAdminClass'));
 
-        $containerMock = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $containerMock = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $containerMock->expects($this->any())
             ->method('get')
             ->will($this->returnValue($adminMock));
@@ -275,7 +276,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
      */
     private function getContainer()
     {
-        $containerMock = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $containerMock = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $containerMock->expects($this->any())
             ->method('get')
             ->will($this->returnCallback(function ($serviceId) {

--- a/Tests/Command/CreateClassCacheCommandTest.php
+++ b/Tests/Command/CreateClassCacheCommandTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\AdminBundle\Tests\Command;
 
 use Sonata\AdminBundle\Command\CreateClassCacheCommand;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class CreateClassCacheCommandTest extends \PHPUnit_Framework_TestCase
+class CreateClassCacheCommandTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var string
@@ -47,8 +48,8 @@ class CreateClassCacheCommandTest extends \PHPUnit_Framework_TestCase
         $this->application = new Application();
         $command = new CreateClassCacheCommand();
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $kernel = $this->createMock('Symfony\Component\HttpKernel\KernelInterface');
 
         $kernel->expects($this->any())
             ->method('getCacheDir')
@@ -92,7 +93,7 @@ class CreateClassCacheCommandTest extends \PHPUnit_Framework_TestCase
 
     public function testExecute()
     {
-        return;
+        $this->markTestSkipped();
         $this->assertFileExists($this->tempDirectory.'/classes.map');
         $this->assertFileNotExists($this->tempDirectory.'/classes.php');
 

--- a/Tests/Command/ExplainAdminCommandTest.php
+++ b/Tests/Command/ExplainAdminCommandTest.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Tests\Command;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Command\ExplainAdminCommand;
 use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Validator\Constraints\Email;
@@ -23,7 +24,7 @@ use Symfony\Component\Validator\Constraints\NotNull;
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
+class ExplainAdminCommandTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var Application
@@ -45,9 +46,9 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
         $this->application = new Application();
         $command = new ExplainAdminCommand();
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
-        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
 
         $this->admin->expects($this->any())
             ->method('getCode')
@@ -69,7 +70,7 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
             ->method('getRoutes')
             ->will($this->returnValue($routeCollection));
 
-        $fieldDescription1 = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription1 = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
 
         $fieldDescription1->expects($this->any())
             ->method('getType')
@@ -79,7 +80,7 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
             ->method('getTemplate')
             ->will($this->returnValue('SonataAdminBundle:CRUD:foo_text.html.twig'));
 
-        $fieldDescription2 = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription2 = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
 
         $fieldDescription2->expects($this->any())
             ->method('getType')
@@ -119,7 +120,7 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         // php 5.3 BC
-        $adminParent = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $adminParent = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $adminParent->expects($this->any())
             ->method('getCode')
             ->will($this->returnValue('foo_child'));
@@ -133,18 +134,18 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
         if (interface_exists(
             'Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface'
         )) { // Prefer Symfony 2.5+ interfaces
-            $this->validatorFactory = $this->getMock(
+            $this->validatorFactory = $this->createMock(
                 'Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface'
             );
 
-            $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+            $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
             $validator->expects($this->any())->method('getMetadataFor')->will(
                 $this->returnValue($this->validatorFactory)
             );
         } else {
-            $this->validatorFactory = $this->getMock('Symfony\Component\Validator\MetadataFactoryInterface');
+            $this->validatorFactory = $this->createMock('Symfony\Component\Validator\MetadataFactoryInterface');
 
-            $validator = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+            $validator = $this->createMock('Symfony\Component\Validator\ValidatorInterface');
             $validator->expects($this->any())->method('getMetadataFactory')->will(
                 $this->returnValue($this->validatorFactory)
             );
@@ -188,9 +189,9 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
     {
         // NEXT_MAJOR: Remove check, when bumping requirements to SF 2.5+
         if (interface_exists('Symfony\Component\Validator\Mapping\MetadataInterface')) { //sf2.5+
-            $metadata = $this->getMock('Symfony\Component\Validator\Mapping\MetadataInterface');
+            $metadata = $this->createMock('Symfony\Component\Validator\Mapping\MetadataInterface');
         } else {
-            $metadata = $this->getMock('Symfony\Component\Validator\MetadataInterface');
+            $metadata = $this->createMock('Symfony\Component\Validator\MetadataInterface');
         }
 
         $this->validatorFactory->expects($this->once())
@@ -222,25 +223,25 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
 
         $metadata->getters = array('email' => $getterMetadata);
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $this->admin->expects($this->any())
             ->method('getModelManager')
             ->will($this->returnValue($modelManager));
 
-        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
 
         $this->admin->expects($this->any())
              ->method('getFormBuilder')
              ->will($this->returnValue($formBuilder));
 
-        $datagridBuilder = $this->getMock('\Sonata\AdminBundle\Builder\DatagridBuilderInterface');
+        $datagridBuilder = $this->createMock('\Sonata\AdminBundle\Builder\DatagridBuilderInterface');
 
         $this->admin->expects($this->any())
             ->method('getDatagridBuilder')
             ->will($this->returnValue($datagridBuilder));
 
-        $listBuilder = $this->getMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
+        $listBuilder = $this->createMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
 
         $this->admin->expects($this->any())
             ->method('getListBuilder')
@@ -263,9 +264,9 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
     public function testExecuteEmptyValidator()
     {
         if (interface_exists('Symfony\Component\Validator\Mapping\MetadataInterface')) { //sf2.5+
-            $metadata = $this->getMock('Symfony\Component\Validator\Mapping\MetadataInterface');
+            $metadata = $this->createMock('Symfony\Component\Validator\Mapping\MetadataInterface');
         } else {
-            $metadata = $this->getMock('Symfony\Component\Validator\MetadataInterface');
+            $metadata = $this->createMock('Symfony\Component\Validator\MetadataInterface');
         }
 
         $this->validatorFactory->expects($this->once())
@@ -276,25 +277,25 @@ class ExplainAdminCommandTest extends \PHPUnit_Framework_TestCase
         $metadata->properties = array();
         $metadata->getters = array();
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $this->admin->expects($this->any())
             ->method('getModelManager')
             ->will($this->returnValue($modelManager));
 
-        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
 
         $this->admin->expects($this->any())
              ->method('getFormBuilder')
              ->will($this->returnValue($formBuilder));
 
-        $datagridBuilder = $this->getMock('\Sonata\AdminBundle\Builder\DatagridBuilderInterface');
+        $datagridBuilder = $this->createMock('\Sonata\AdminBundle\Builder\DatagridBuilderInterface');
 
         $this->admin->expects($this->any())
             ->method('getDatagridBuilder')
             ->will($this->returnValue($datagridBuilder));
 
-        $listBuilder = $this->getMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
+        $listBuilder = $this->createMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
 
         $this->admin->expects($this->any())
             ->method('getListBuilder')

--- a/Tests/Command/GenerateAdminCommandTest.php
+++ b/Tests/Command/GenerateAdminCommandTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Command;
 
 use Sonata\AdminBundle\Command\GenerateAdminCommand;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\DemoAdminBundle;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -24,7 +25,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
+class GenerateAdminCommandTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var Application
@@ -59,7 +60,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         $bundle = new DemoAdminBundle();
         $bundle->setPath($this->tempDirectory);
 
-        $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
+        $kernel = $this->createMock('Symfony\Component\HttpKernel\KernelInterface');
         $kernel->expects($this->any())
             ->method('getBundles')
             ->will($this->returnValue(array($bundle)));
@@ -122,7 +123,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
     public function testExecute()
     {
         $this->command->setContainer($this->container);
-        $this->container->set('sonata.admin.manager.foo', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.foo', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
 
         $command = $this->application->find('sonata:admin:generate');
         $commandTester = new CommandTester($command);
@@ -170,7 +171,7 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
 
     public function testExecuteWithExceptionNoModelManagers()
     {
-        $this->setExpectedException('RuntimeException', 'There are no model managers registered.');
+        $this->expectException('RuntimeException', 'There are no model managers registered.');
 
         $this->command->setContainer($this->container);
 
@@ -193,15 +194,17 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
     public function testExecuteInteractive($modelEntity)
     {
         $this->command->setContainer($this->container);
-        $this->container->set('sonata.admin.manager.foo', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
-        $this->container->set('sonata.admin.manager.bar', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.foo', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.bar', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
 
         $command = $this->application->find('sonata:admin:generate');
 
         // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
         // DialogHelper does not exist in SensioGeneratorBundle 2.5+
         if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
-            $dialog = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper', array('askConfirmation', 'askAndValidate'));
+            $dialog = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')
+                ->setMethods(array('askConfirmation', 'askAndValidate'))
+                ->getMock();
 
             $dialog->expects($this->any())
                 ->method('askConfirmation')
@@ -252,7 +255,9 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
 
             $command->getHelperSet()->set($dialog, 'dialog');
         } else {
-            $questionHelper = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper', array('ask'));
+            $questionHelper = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper')
+                ->setMethods(array('ask'))
+                ->getMock();
 
             $questionHelper->expects($this->any())
                 ->method('ask')
@@ -348,8 +353,8 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
     public function testValidateManagerType($expected, $managerType)
     {
         $this->command->setContainer($this->container);
-        $this->container->set('sonata.admin.manager.foo', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
-        $this->container->set('sonata.admin.manager.bar', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.foo', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.bar', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
 
         $this->assertSame($expected, $this->command->validateManagerType($managerType));
     }
@@ -372,22 +377,22 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
     public function testValidateManagerTypeWithException2()
     {
         $this->command->setContainer($this->container);
-        $this->container->set('sonata.admin.manager.foo', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
-        $this->container->set('sonata.admin.manager.bar', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.foo', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.bar', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
 
-        $this->setExpectedException('InvalidArgumentException', 'Invalid manager type "baz". Available manager types are "foo", "bar".');
+        $this->expectException('InvalidArgumentException', 'Invalid manager type "baz". Available manager types are "foo", "bar".');
         $this->command->validateManagerType('baz');
     }
 
     public function testValidateManagerTypeWithException3()
     {
-        $this->setExpectedException('InvalidArgumentException', 'Invalid manager type "baz". Available manager types are "".');
+        $this->expectException('InvalidArgumentException', 'Invalid manager type "baz". Available manager types are "".');
         $this->command->validateManagerType('baz');
     }
 
     public function testAnswerUpdateServicesWithNo()
     {
-        $this->container->set('sonata.admin.manager.foo', $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.foo', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
 
         $modelEntity = 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo';
 
@@ -396,7 +401,9 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
         // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
         // DialogHelper does not exist in SensioGeneratorBundle 2.5+
         if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
-            $dialog = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper', array('askConfirmation', 'askAndValidate'));
+            $dialog = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')
+                ->setMethods(array('askConfirmation', 'askAndValidate'))
+                ->getMock();
 
             $dialog->expects($this->any())
                 ->method('askConfirmation')
@@ -447,7 +454,9 @@ class GenerateAdminCommandTest extends \PHPUnit_Framework_TestCase
 
             $command->getHelperSet()->set($dialog, 'dialog');
         } else {
-            $questionHelper = $this->getMock('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper', array('ask'));
+            $questionHelper = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper')
+                ->setMethods(array('ask'))
+                ->getMock();
 
             $questionHelper->expects($this->any())
                 ->method('ask')

--- a/Tests/Command/ListAdminCommandTest.php
+++ b/Tests/Command/ListAdminCommandTest.php
@@ -13,27 +13,28 @@ namespace Sonata\AdminBundle\Tests\Command;
 
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Command\ListAdminCommand;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class ListAdminCommandTest extends \PHPUnit_Framework_TestCase
+class ListAdminCommandTest extends PHPUnit_Framework_TestCase
 {
     public function testExecute()
     {
         $application = new Application();
         $command = new ListAdminCommand();
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
-        $admin1 = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin1 = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin1->expects($this->any())
             ->method('getClass')
             ->will($this->returnValue('Acme\Entity\Foo'));
 
-        $admin2 = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin2 = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin2->expects($this->any())
             ->method('getClass')
             ->will($this->returnValue('Acme\Entity\Bar'));

--- a/Tests/Command/SetupAclCommandTest.php
+++ b/Tests/Command/SetupAclCommandTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Command;
 
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Command\SetupAclCommand;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\AdminBundle\Util\AdminAclManipulatorInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -20,16 +21,16 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class SetupAclCommandTest extends \PHPUnit_Framework_TestCase
+class SetupAclCommandTest extends PHPUnit_Framework_TestCase
 {
     public function testExecute()
     {
         $application = new Application();
         $command = new SetupAclCommand();
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $aclManipulator = $this->getMock('Sonata\AdminBundle\Util\AdminAclManipulatorInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $aclManipulator = $this->createMock('Sonata\AdminBundle\Util\AdminAclManipulatorInterface');
 
         $container->expects($this->any())
             ->method('get')
@@ -67,7 +68,7 @@ class SetupAclCommandTest extends \PHPUnit_Framework_TestCase
         $application = new Application();
         $command = new SetupAclCommand();
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $container->expects($this->any())
             ->method('get')
@@ -98,8 +99,8 @@ class SetupAclCommandTest extends \PHPUnit_Framework_TestCase
         $application = new Application();
         $command = new SetupAclCommand();
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
 
         $container->expects($this->any())
             ->method('get')

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -21,6 +21,7 @@ use Sonata\AdminBundle\Exception\LockException;
 use Sonata\AdminBundle\Exception\ModelManagerException;
 use Sonata\AdminBundle\Tests\Fixtures\Controller\BatchAdminController;
 use Sonata\AdminBundle\Tests\Fixtures\Controller\PreCRUDController;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -42,7 +43,7 @@ use Symfony\Component\Security\Csrf\CsrfToken;
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class CRUDControllerTest extends \PHPUnit_Framework_TestCase
+class CRUDControllerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var CRUDController
@@ -119,14 +120,14 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $this->request = new Request();
         $this->pool = new Pool($this->container, 'title', 'logo.png');
         $this->pool->setAdminServiceIds(array('foo.admin'));
         $this->request->attributes->set('_sonata_admin', 'foo.admin');
-        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $this->translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
         $this->parameters = array();
         $this->template = '';
 
@@ -134,11 +135,9 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $params = &$this->parameters;
         $template = &$this->template;
 
-        $templating = $this->getMock(
-            'Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine',
-            array(),
-            array($this->container, array())
-        );
+        $templating = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine')
+            ->setConstructorArgs(array($this->container, array()))
+            ->getMock();
 
         $templating->expects($this->any())
             ->method('renderResponse')
@@ -174,7 +173,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $twigRenderer = $this->getMock('Symfony\Bridge\Twig\Form\TwigRendererInterface');
+        $twigRenderer = $this->createMock('Symfony\Bridge\Twig\Form\TwigRendererInterface');
 
         $formExtension = new FormExtension($twigRenderer);
 
@@ -204,7 +203,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         if (class_exists('Exporter\Exporter')) {
             $exporter = new Exporter(array(new JsonWriter('/tmp/sonataadmin/export.json')));
         } else {
-            $exporter = $this->getMock('Sonata\AdminBundle\Export\Exporter');
+            $exporter = $this->createMock('Sonata\AdminBundle\Export\Exporter');
 
             $exporter->expects($this->any())
                 ->method('getResponse')
@@ -272,7 +271,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         // php 5.3 BC
         $csrfProvider = $this->csrfProvider;
 
-        $this->logger = $this->getMock('Psr\Log\LoggerInterface');
+        $this->logger = $this->createMock('Psr\Log\LoggerInterface');
         $logger = $this->logger; // php 5.3 BC
 
         $requestStack = null;
@@ -281,7 +280,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             $requestStack->push($request);
         }
 
-        $this->kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
+        $this->kernel = $this->createMock('Symfony\Component\HttpKernel\KernelInterface');
         $kernel = $this->kernel; // php 5.3 BC
 
         $this->container->expects($this->any())
@@ -549,7 +548,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('isChild')
             ->will($this->returnValue(true));
 
-        $adminParent = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $adminParent = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $this->admin->expects($this->once())
             ->method('getParent')
             ->will($this->returnValue($adminParent));
@@ -563,7 +562,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testConfigureWithException()
     {
-        $this->setExpectedException(
+        $this->expectException(
             'RuntimeException',
             'There is no `_sonata_admin` defined for the controller `Sonata\AdminBundle\Controller\CRUDController`'
         );
@@ -574,7 +573,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testConfigureWithException2()
     {
-        $this->setExpectedException(
+        $this->expectException(
             'RuntimeException',
             'Unable to find the admin class related to the current controller '.
             '(Sonata\AdminBundle\Controller\CRUDController)'
@@ -668,7 +667,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testListActionAccessDenied()
     {
-        $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -700,7 +699,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testListAction()
     {
-        $datagrid = $this->getMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
 
         $this->admin->expects($this->any())
             ->method('hasRoute')
@@ -718,7 +717,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $form->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($this->getMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
 
         $this->admin->expects($this->once())
             ->method('getDatagrid')
@@ -745,19 +744,19 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testBatchActionDeleteAccessDenied()
     {
-        $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
             ->with($this->equalTo('batchDelete'))
             ->will($this->throwException(new AccessDeniedException()));
 
-        $this->controller->batchActionDelete($this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        $this->controller->batchActionDelete($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
     }
 
     public function testBatchActionDelete()
     {
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -772,7 +771,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getFilterParameters')
             ->will($this->returnValue(array('foo' => 'bar')));
 
-        $result = $this->controller->batchActionDelete($this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        $result = $this->controller->batchActionDelete($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_delete_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -781,7 +780,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testBatchActionDeleteWithModelManagerException()
     {
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $this->assertLoggerLogsModelManagerException($modelManager, 'batchDelete');
 
         $this->admin->expects($this->once())
@@ -792,7 +791,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getFilterParameters')
             ->will($this->returnValue(array('foo' => 'bar')));
 
-        $result = $this->controller->batchActionDelete($this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        $result = $this->controller->batchActionDelete($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_delete_error'), $this->session->getFlashBag()->get('sonata_flash_error'));
@@ -801,8 +800,8 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testBatchActionDeleteWithModelManagerExceptionInDebugMode()
     {
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
-        $this->setExpectedException('Sonata\AdminBundle\Exception\ModelManagerException');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->expectException('Sonata\AdminBundle\Exception\ModelManagerException');
 
         $modelManager->expects($this->once())
             ->method('batchDelete')
@@ -818,12 +817,12 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('isDebug')
             ->will($this->returnValue(true));
 
-        $this->controller->batchActionDelete($this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        $this->controller->batchActionDelete($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
     }
 
     public function testShowActionNotFoundException()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -834,7 +833,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testShowActionAccessDenied()
     {
-        $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -883,7 +882,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('show'))
             ->will($this->returnValue(true));
 
-        $show = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionCollection');
+        $show = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionCollection');
 
         $this->admin->expects($this->once())
             ->method('getShow')
@@ -975,7 +974,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteActionNotFoundException()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -986,7 +985,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteActionAccessDenied()
     {
-        $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -1162,7 +1161,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteActionWithModelManagerExceptionInDebugMode()
     {
-        $this->setExpectedException('Sonata\AdminBundle\Exception\ModelManagerException');
+        $this->expectException('Sonata\AdminBundle\Exception\ModelManagerException');
 
         $object = new \stdClass();
 
@@ -1387,7 +1386,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testEditActionNotFoundException()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -1398,7 +1397,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testEditActionAccessDenied()
     {
-        $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -1455,7 +1454,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getForm')
             ->will($this->returnValue($form));
 
-        $formView = $this->getMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock('Symfony\Component\Form\FormView');
 
         $form->expects($this->any())
             ->method('createView')
@@ -1576,7 +1575,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->request->setMethod('POST');
 
-        $formView = $this->getMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock('Symfony\Component\Form\FormView');
 
         $form->expects($this->any())
             ->method('createView')
@@ -1680,7 +1679,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->setMethod('POST');
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $formView = $this->getMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock('Symfony\Component\Form\FormView');
 
         $form->expects($this->any())
             ->method('createView')
@@ -1744,7 +1743,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
         $this->request->setMethod('POST');
 
-        $formView = $this->getMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock('Symfony\Component\Form\FormView');
 
         $form->expects($this->any())
             ->method('createView')
@@ -1790,7 +1789,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('supportsPreviewMode')
             ->will($this->returnValue(true));
 
-        $formView = $this->getMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock('Symfony\Component\Form\FormView');
 
         $form->expects($this->any())
             ->method('createView')
@@ -1865,7 +1864,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo($object))
             ->will($this->returnValue($class));
 
-        $formView = $this->getMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock('Symfony\Component\Form\FormView');
 
         $form->expects($this->any())
             ->method('createView')
@@ -1882,7 +1881,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateActionAccessDenied()
     {
-        $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -1943,7 +1942,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getForm')
             ->will($this->returnValue($form));
 
-        $formView = $this->getMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock('Symfony\Component\Form\FormView');
 
         $form->expects($this->any())
             ->method('createView')
@@ -2044,7 +2043,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateActionAccessDenied2()
     {
-        $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
         $object = new \stdClass();
 
@@ -2135,7 +2134,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->request->setMethod('POST');
 
-        $formView = $this->getMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock('Symfony\Component\Form\FormView');
 
         $form->expects($this->any())
             ->method('createView')
@@ -2200,7 +2199,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->request->setMethod('POST');
 
-        $formView = $this->getMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock('Symfony\Component\Form\FormView');
 
         $form->expects($this->any())
             ->method('createView')
@@ -2319,7 +2318,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->setMethod('POST');
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $formView = $this->getMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock('Symfony\Component\Form\FormView');
 
         $form->expects($this->any())
             ->method('createView')
@@ -2368,7 +2367,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('supportsPreviewMode')
             ->will($this->returnValue(true));
 
-        $formView = $this->getMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock('Symfony\Component\Form\FormView');
 
         $form->expects($this->any())
             ->method('createView')
@@ -2401,7 +2400,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testExportActionAccessDenied()
     {
-        $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -2413,7 +2412,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testExportActionWrongFormat()
     {
-        $this->setExpectedException('RuntimeException', 'Export in format `csv` is not allowed for class: `Foo`. Allowed formats are: `json`');
+        $this->expectException('RuntimeException', 'Export in format `csv` is not allowed for class: `Foo`. Allowed formats are: `json`');
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -2444,7 +2443,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getExportFormats')
             ->will($this->returnValue(array('json')));
 
-        $dataSourceIterator = $this->getMock('Exporter\Source\SourceIteratorInterface');
+        $dataSourceIterator = $this->createMock('Exporter\Source\SourceIteratorInterface');
 
         $this->admin->expects($this->once())
             ->method('getDataSourceIterator')
@@ -2460,7 +2459,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testHistoryActionAccessDenied()
     {
-        $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
         $this->admin->expects($this->any())
             ->method('getObject')
@@ -2476,7 +2475,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testHistoryActionNotFoundException()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -2487,7 +2486,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testHistoryActionNoReader()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the audit reader for class : Foo');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the audit reader for class : Foo');
 
         $this->request->query->set('id', 123);
 
@@ -2538,7 +2537,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(true));
 
-        $reader = $this->getMock('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $reader = $this->createMock('Sonata\AdminBundle\Model\AuditReaderInterface');
 
         $this->auditManager->expects($this->once())
             ->method('getReader')
@@ -2566,14 +2565,14 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testAclActionAclNotEnabled()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'ACL are not enabled for this admin');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'ACL are not enabled for this admin');
 
         $this->controller->aclAction(null, $this->request);
     }
 
     public function testAclActionNotFoundException()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
         $this->admin->expects($this->once())
             ->method('isAclEnabled')
@@ -2588,7 +2587,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testAclActionAccessDenied()
     {
-        $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
         $this->admin->expects($this->once())
             ->method('isAclEnabled')
@@ -2640,7 +2639,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $aclUsersForm->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($this->getMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
 
         $aclRolesForm = $this->getMockBuilder('Symfony\Component\Form\Form')
             ->disableOriginalConstructor()
@@ -2648,7 +2647,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $aclRolesForm->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($this->getMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
 
         $this->adminObjectAclManipulator->expects($this->once())
             ->method('createAclUsersForm')
@@ -2727,7 +2726,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $aclUsersForm->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($this->getMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
 
         $aclRolesForm = $this->getMockBuilder('Symfony\Component\Form\Form')
             ->disableOriginalConstructor()
@@ -2735,7 +2734,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $aclRolesForm->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($this->getMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
 
         $this->adminObjectAclManipulator->expects($this->once())
             ->method('createAclUsersForm')
@@ -2812,7 +2811,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $aclUsersForm->expects($this->any())
             ->method('createView')
-            ->will($this->returnValue($this->getMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
 
         $aclRolesForm = $this->getMockBuilder('Symfony\Component\Form\Form')
             ->disableOriginalConstructor()
@@ -2820,7 +2819,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $aclRolesForm->expects($this->any())
             ->method('createView')
-            ->will($this->returnValue($this->getMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
 
         $aclRolesForm->expects($this->once())
             ->method('isValid')
@@ -2860,7 +2859,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testHistoryViewRevisionActionAccessDenied()
     {
-        $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
         $this->admin->expects($this->any())
             ->method('getObject')
@@ -2876,7 +2875,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testHistoryViewRevisionActionNotFoundException()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the object with id : 123');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the object with id : 123');
 
         $this->request->query->set('id', 123);
 
@@ -2889,7 +2888,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testHistoryViewRevisionActionNoReader()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the audit reader for class : Foo');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the audit reader for class : Foo');
 
         $this->request->query->set('id', 123);
 
@@ -2918,7 +2917,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testHistoryViewRevisionActionNotFoundRevision()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the targeted object `123` from the revision `456` with classname : `Foo`');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the targeted object `123` from the revision `456` with classname : `Foo`');
 
         $this->request->query->set('id', 123);
 
@@ -2942,7 +2941,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(true));
 
-        $reader = $this->getMock('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $reader = $this->createMock('Sonata\AdminBundle\Model\AuditReaderInterface');
 
         $this->auditManager->expects($this->once())
             ->method('getReader')
@@ -2981,7 +2980,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(true));
 
-        $reader = $this->getMock('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $reader = $this->createMock('Sonata\AdminBundle\Model\AuditReaderInterface');
 
         $this->auditManager->expects($this->once())
             ->method('getReader')
@@ -3022,7 +3021,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testHistoryCompareRevisionsActionAccessDenied()
     {
-        $this->setExpectedException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -3034,7 +3033,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testHistoryCompareRevisionsActionNotFoundException()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the object with id : 123');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the object with id : 123');
 
         $this->request->query->set('id', 123);
 
@@ -3052,7 +3051,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testHistoryCompareRevisionsActionNoReader()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the audit reader for class : Foo');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the audit reader for class : Foo');
 
         $this->request->query->set('id', 123);
 
@@ -3081,7 +3080,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testHistoryCompareRevisionsActionNotFoundBaseRevision()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the targeted object `123` from the revision `456` with classname : `Foo`');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the targeted object `123` from the revision `456` with classname : `Foo`');
 
         $this->request->query->set('id', 123);
 
@@ -3105,7 +3104,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(true));
 
-        $reader = $this->getMock('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $reader = $this->createMock('Sonata\AdminBundle\Model\AuditReaderInterface');
 
         $this->auditManager->expects($this->once())
             ->method('getReader')
@@ -3123,7 +3122,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testHistoryCompareRevisionsActionNotFoundCompareRevision()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the targeted object `123` from the revision `789` with classname : `Foo`');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the targeted object `123` from the revision `789` with classname : `Foo`');
 
         $this->request->query->set('id', 123);
 
@@ -3147,7 +3146,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(true));
 
-        $reader = $this->getMock('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $reader = $this->createMock('Sonata\AdminBundle\Model\AuditReaderInterface');
 
         $this->auditManager->expects($this->once())
             ->method('getReader')
@@ -3195,7 +3194,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(true));
 
-        $reader = $this->getMock('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $reader = $this->createMock('Sonata\AdminBundle\Model\AuditReaderInterface');
 
         $this->auditManager->expects($this->once())
             ->method('getReader')
@@ -3245,7 +3244,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testBatchActionWrongMethod()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid request type "GET", POST expected');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid request type "GET", POST expected');
 
         $this->controller->batchAction($this->request);
     }
@@ -3257,7 +3256,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testBatchActionActionNotDefined()
     {
-        $this->setExpectedException('RuntimeException', 'The `foo` batch action is not defined');
+        $this->expectException('RuntimeException', 'The `foo` batch action is not defined');
 
         $batchActions = array();
 
@@ -3293,7 +3292,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testBatchActionMethodNotExist()
     {
-        $this->setExpectedException('RuntimeException', 'A `Sonata\AdminBundle\Controller\CRUDController::batchActionFoo` method must be callable');
+        $this->expectException('RuntimeException', 'A `Sonata\AdminBundle\Controller\CRUDController::batchActionFoo` method must be callable');
 
         $batchActions = array('foo' => array('label' => 'Foo Bar', 'ask_confirmation' => false));
 
@@ -3301,7 +3300,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->getMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
         $this->admin->expects($this->once())
             ->method('getDatagrid')
             ->will($this->returnValue($datagrid));
@@ -3326,9 +3325,9 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->getMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
 
-        $query = $this->getMock('\Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock('\Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
         $datagrid->expects($this->once())
             ->method('getQuery')
             ->will($this->returnValue($query));
@@ -3337,7 +3336,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getDatagrid')
             ->will($this->returnValue($datagrid));
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -3381,9 +3380,9 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->getMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
 
-        $query = $this->getMock('\Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock('\Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
         $datagrid->expects($this->once())
             ->method('getQuery')
             ->will($this->returnValue($query));
@@ -3392,7 +3391,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getDatagrid')
             ->will($this->returnValue($datagrid));
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -3443,7 +3442,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->request->set('data', json_encode($data));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $datagrid = $this->getMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
 
         $this->admin->expects($this->once())
             ->method('getDatagrid')
@@ -3455,7 +3454,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
 
         $form->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($this->getMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
 
         $datagrid->expects($this->once())
             ->method('getForm')
@@ -3494,7 +3493,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->getMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
 
         $this->admin->expects($this->once())
             ->method('getDatagrid')
@@ -3528,7 +3527,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->getMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
 
         $this->admin->expects($this->once())
             ->method('getDatagrid')
@@ -3559,7 +3558,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->getMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
 
         $this->admin->expects($this->once())
             ->method('getDatagrid')
@@ -3593,9 +3592,9 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->getMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
 
-        $query = $this->getMock('\Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock('\Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
         $datagrid->expects($this->once())
             ->method('getQuery')
             ->will($this->returnValue($query));
@@ -3604,7 +3603,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getDatagrid')
             ->will($this->returnValue($datagrid));
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $this->admin->expects($this->any())
             ->method('getModelManager')
@@ -3638,9 +3637,9 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->getMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
 
-        $query = $this->getMock('\Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock('\Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
         $datagrid->expects($this->once())
             ->method('getQuery')
             ->will($this->returnValue($query));
@@ -3649,7 +3648,7 @@ class CRUDControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getDatagrid')
             ->will($this->returnValue($datagrid));
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $this->admin->expects($this->once())
             ->method('checkAccess')

--- a/Tests/Controller/CoreControllerTest.php
+++ b/Tests/Controller/CoreControllerTest.php
@@ -13,21 +13,22 @@ namespace Sonata\AdminBundle\Tests\Controller;
 
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Controller\CoreController;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class CoreControllerTest extends \PHPUnit_Framework_TestCase
+class CoreControllerTest extends PHPUnit_Framework_TestCase
 {
     public function testdashboardActionStandardRequest()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $pool = new Pool($container, 'title', 'logo.png');
         $pool->setTemplates(array(
             'ajax' => 'ajax.html',
         ));
 
-        $templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
         $request = new Request();
 
         $requestStack = null;
@@ -36,7 +37,7 @@ class CoreControllerTest extends \PHPUnit_Framework_TestCase
             $requestStack->push($request);
         }
 
-        $breadcrumbsBuilder = $this->getMock('BreadcrumbsBuilderInterface');
+        $breadcrumbsBuilder = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface');
 
         $values = array(
             'sonata.admin.breadcrumbs_builder' => $breadcrumbsBuilder,
@@ -83,14 +84,14 @@ class CoreControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testdashboardActionAjaxLayout()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $pool = new Pool($container, 'title', 'logo.png');
         $pool->setTemplates(array(
             'ajax' => 'ajax.html',
         ));
 
-        $templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
         $request = new Request();
         $request->headers->set('X-Requested-With', 'XMLHttpRequest');
 

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Controller\HelperController;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Component\HttpFoundation\Request;
@@ -63,7 +64,7 @@ class AdminControllerHelper_Bar
     }
 }
 
-class HelperControllerTest extends \PHPUnit_Framework_TestCase
+class HelperControllerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var AdminInterface
@@ -80,15 +81,15 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $pool = new Pool($container, 'title', 'logo.png');
         $pool->setAdminServiceIds(array('foo.admin'));
 
-        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
 
-        $twig = new \Twig_Environment($this->getMock('\Twig_LoaderInterface'));
+        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
         $helper = new AdminHelper($pool);
-        $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
         $this->controller = new HelperController($twig, $pool, $helper, $validator);
 
         // php 5.3 BC
@@ -110,8 +111,8 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testgetShortObjectDescriptionActionInvalidAdmin($validatorInterface)
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $twig = new \Twig_Environment($this->getMock('\Twig_LoaderInterface'));
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
         $request = new Request(array(
             'code' => 'sonata.post.admin',
             'objectId' => 42,
@@ -120,7 +121,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(array('sonata.post.admin'));
         $helper = new AdminHelper($pool);
-        $validator = $this->getMock($validatorInterface);
+        $validator = $this->createMock($validatorInterface);
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
         $controller->getShortObjectDescriptionAction($request);
@@ -134,14 +135,14 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testgetShortObjectDescriptionActionObjectDoesNotExist($validatorInterface)
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('setUniqid');
         $admin->expects($this->once())->method('getObject')->will($this->returnValue(false));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
-        $twig = new \Twig_Environment($this->getMock('\Twig_LoaderInterface'));
+        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
         $request = new Request(array(
             'code' => 'sonata.post.admin',
             'objectId' => 42,
@@ -153,7 +154,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->getMock($validatorInterface);
+        $validator = $this->createMock($validatorInterface);
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
         $controller->getShortObjectDescriptionAction($request);
@@ -164,14 +165,14 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testgetShortObjectDescriptionActionEmptyObjectId($validatorInterface)
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('setUniqid');
         $admin->expects($this->once())->method('getObject')->with($this->identicalTo(null))->will($this->returnValue(false));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
-        $twig = new \Twig_Environment($this->getMock('\Twig_LoaderInterface'));
+        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
         $request = new Request(array(
             'code' => 'sonata.post.admin',
             'objectId' => '',
@@ -184,7 +185,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->getMock($validatorInterface);
+        $validator = $this->createMock($validatorInterface);
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
         $controller->getShortObjectDescriptionAction($request);
@@ -197,7 +198,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
     {
         $mockTemplate = 'AdminHelperTest:mock-short-object-description.html.twig';
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('setUniqid');
         $admin->expects($this->once())->method('getTemplate')->will($this->returnValue($mockTemplate));
         $admin->expects($this->once())->method('getObject')->will($this->returnValue(new AdminControllerHelper_Foo()));
@@ -210,7 +211,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
             return '/ok/url';
         }));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
         $twig = $this->getMockBuilder('\Twig_Environment')->disableOriginalConstructor()->getMock();
@@ -233,7 +234,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->getMock($validatorInterface);
+        $validator = $this->createMock($validatorInterface);
 
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
@@ -250,16 +251,16 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
     {
         $object = new AdminControllerHelper_Foo();
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getOption')->will($this->returnValue(true));
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('getObject')->will($this->returnValue($object));
         $admin->expects($this->once())->method('isGranted')->will($this->returnValue(true));
         $admin->expects($this->once())->method('getListFieldDescription')->will($this->returnValue($fieldDescription));
         $fieldDescription->expects($this->exactly(2))->method('getAdmin')->will($this->returnValue($admin));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
         $pool = new Pool($container, 'title', 'logo');
@@ -267,11 +268,11 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $adminExtension = new SonataAdminExtension(
             $pool,
-            $this->getMock('Psr\Log\LoggerInterface'),
-            $this->getMock('Symfony\Component\Translation\TranslatorInterface')
+            $this->createMock('Psr\Log\LoggerInterface'),
+            $this->createMock('Symfony\Component\Translation\TranslatorInterface')
         );
 
-        $loader = $this->getMock('\Twig_LoaderInterface');
+        $loader = $this->createMock('\Twig_LoaderInterface');
         $loader->method('getSource')->will($this->returnValue('<foo />'));
 
         $twig = new \Twig_Environment($loader);
@@ -286,7 +287,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->getMock($validatorInterface);
+        $validator = $this->createMock($validatorInterface);
 
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
@@ -302,20 +303,20 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
     {
         $object = new AdminControllerHelper_Foo();
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->once())->method('find')->will($this->returnValue($object));
 
         $mockTheme = $this->getMockBuilder('Symfony\Component\Form\FormView')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('getModelManager')->will($this->returnValue($modelManager));
         $admin->expects($this->once())->method('setRequest');
         $admin->expects($this->once())->method('setSubject');
         $admin->expects($this->once())->method('getFormTheme')->will($this->returnValue($mockTheme));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
         $mockRenderer = $this->getMockBuilder('Symfony\Bridge\Twig\Form\TwigRendererInterface')
@@ -326,7 +327,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
             ->method('searchAndRenderBlock')
             ->will($this->returnValue(new Response()));
 
-        $twig = new \Twig_Environment($this->getMock('\Twig_LoaderInterface'));
+        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
         $twig->addExtension(new FormExtension($mockRenderer));
 
         if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
@@ -353,7 +354,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(array('sonata.post.admin'));
 
-        $validator = $this->getMock($validatorInterface);
+        $validator = $this->createMock($validatorInterface);
 
         $mockView = $this->getMockBuilder('Symfony\Component\Form\FormView')
             ->disableOriginalConstructor()
@@ -366,9 +367,12 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
             ->method('createView')
             ->will($this->returnValue($mockView));
 
-        $helper = $this->getMock('Sonata\AdminBundle\Admin\AdminHelper', array('appendFormFieldElement', 'getChildFormView'), array($pool));
+        $helper = $this->getMockBuilder('Sonata\AdminBundle\Admin\AdminHelper')
+            ->setMethods(array('appendFormFieldElement', 'getChildFormView'))
+            ->setConstructorArgs(array($pool))
+            ->getMock();
         $helper->expects($this->once())->method('appendFormFieldElement')->will($this->returnValue(array(
-            $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface'),
+            $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface'),
             $mockForm,
         )));
         $helper->expects($this->once())->method('getChildFormView')->will($this->returnValue($mockView));
@@ -386,7 +390,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
     {
         $object = new AdminControllerHelper_Foo();
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->once())->method('find')->will($this->returnValue($object));
 
         $mockView = $this->getMockBuilder('Symfony\Component\Form\FormView')
@@ -405,11 +409,11 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $formBuilder->expects($this->once())->method('getForm')->will($this->returnValue($mockForm));
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('getModelManager')->will($this->returnValue($modelManager));
         $admin->expects($this->once())->method('getFormBuilder')->will($this->returnValue($formBuilder));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
         $mockRenderer = $this->getMockBuilder('Symfony\Bridge\Twig\Form\TwigRendererInterface')
@@ -420,7 +424,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
             ->method('searchAndRenderBlock')
             ->will($this->returnValue(new Response()));
 
-        $twig = new \Twig_Environment($this->getMock('\Twig_LoaderInterface'));
+        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
         $twig->addExtension(new FormExtension($mockRenderer));
         if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
             $runtimeLoader = $this
@@ -445,9 +449,12 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(array('sonata.post.admin'));
 
-        $validator = $this->getMock($validatorInterface);
+        $validator = $this->createMock($validatorInterface);
 
-        $helper = $this->getMock('Sonata\AdminBundle\Admin\AdminHelper', array('getChildFormView'), array($pool));
+        $helper = $this->getMockBuilder('Sonata\AdminBundle\Admin\AdminHelper')
+            ->setMethods(array('getChildFormView'))
+            ->setConstructorArgs(array($pool))
+            ->getMock();
         $helper->expects($this->once())->method('getChildFormView')->will($this->returnValue($mockView));
 
         $controller = new HelperController($twig, $pool, $helper, $validator);
@@ -466,18 +473,18 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
         $object = new AdminControllerHelper_Foo();
         $object->setBar($bar);
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getOption')->will($this->returnValue(true));
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('getObject')->will($this->returnValue($object));
         $admin->expects($this->once())->method('isGranted')->will($this->returnValue(true));
         $admin->expects($this->once())->method('getListFieldDescription')->will($this->returnValue($fieldDescription));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
-        $twig = new \Twig_Environment($this->getMock('\Twig_LoaderInterface'));
+        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
         $request = new Request(array(
             'code' => 'sonata.post.admin',
             'objectId' => 42,
@@ -496,7 +503,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
             new ConstraintViolation('error2', null, array(), null, 'enabled', null),
         ));
 
-        $validator = $this->getMock($validatorInterface);
+        $validator = $this->createMock($validatorInterface);
 
         $validator
             ->expects($this->once())
@@ -572,7 +579,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
 
         $entity = new Foo();
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
 
         $fieldDescription->expects($this->once())
             ->method('getTargetEntity')
@@ -639,7 +646,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
             ->with('CREATE')
             ->will($this->returnValue(true));
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
 
         $fieldDescription->expects($this->once())
             ->method('getTargetEntity')
@@ -649,7 +656,7 @@ class HelperControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getName')
             ->will($this->returnValue('barField'));
 
-        $targetAdmin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $targetAdmin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
 
         $fieldDescription->expects($this->once())
             ->method('getAssociationAdmin')

--- a/Tests/Datagrid/DatagridMapperTest.php
+++ b/Tests/Datagrid/DatagridMapperTest.php
@@ -13,11 +13,12 @@ namespace Sonata\AdminBundle\Tests\Datagrid;
 
 use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class DatagridMapperTest extends \PHPUnit_Framework_TestCase
+class DatagridMapperTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var DatagridMapper
@@ -31,18 +32,18 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $datagridBuilder = $this->getMock('Sonata\AdminBundle\Builder\DatagridBuilderInterface');
+        $datagridBuilder = $this->createMock('Sonata\AdminBundle\Builder\DatagridBuilderInterface');
 
-        $proxyQuery = $this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
-        $pager = $this->getMock('Sonata\AdminBundle\Datagrid\PagerInterface');
-        $fieldDescriptionCollection = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionCollection');
+        $proxyQuery = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $pager = $this->createMock('Sonata\AdminBundle\Datagrid\PagerInterface');
+        $fieldDescriptionCollection = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionCollection');
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')
                      ->disableOriginalConstructor()
                      ->getMock();
 
         $this->datagrid = new Datagrid($proxyQuery, $fieldDescriptionCollection, $pager, $formBuilder, array());
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
 
         // php 5.3 BC
         $filter = $this->getMockForAbstractClass('Sonata\AdminBundle\Filter\Filter');
@@ -61,7 +62,7 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
                 $datagrid->addFilter($filterClone);
             }));
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         // php 5.3 BC
         $fieldDescription = $this->getFieldDescriptionMock();
@@ -190,15 +191,9 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
 
     public function testAddException()
     {
-        try {
-            $this->datagridMapper->add(12345);
-        } catch (\RuntimeException $e) {
-            $this->assertContains('Unknown field name in datagrid mapper. Field name should be either of FieldDescriptionInterface interface or string', $e->getMessage());
+        $this->expectException('\RuntimeException', 'Unknown field name in datagrid mapper. Field name should be either of FieldDescriptionInterface interface or string');
 
-            return;
-        }
-
-        $this->fail('Failed asserting that exception of type "\RuntimeException" is thrown.');
+        $this->datagridMapper->add(12345);
     }
 
     public function testAddDuplicateNameException()
@@ -216,16 +211,10 @@ class DatagridMapperTest extends \PHPUnit_Framework_TestCase
                 return false;
             }));
 
-        try {
-            $this->datagridMapper->add('fooName');
-            $this->datagridMapper->add('fooName');
-        } catch (\RuntimeException $e) {
-            $this->assertContains('Duplicate field name "fooName" in datagrid mapper. Names should be unique.', $e->getMessage());
+        $this->expectException('RuntimeException', 'Duplicate field name "fooName" in datagrid mapper. Names should be unique.');
 
-            return;
-        }
-
-        $this->fail('Failed asserting that exception of type "\RuntimeException" is thrown.');
+        $this->datagridMapper->add('fooName');
+        $this->datagridMapper->add('fooName');
     }
 
     public function testKeys()

--- a/Tests/Datagrid/DatagridTest.php
+++ b/Tests/Datagrid/DatagridTest.php
@@ -15,12 +15,13 @@ use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\FormBuilder;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class DatagridTest extends \PHPUnit_Framework_TestCase
+class DatagridTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var Datagrid
@@ -49,9 +50,9 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->query = $this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $this->query = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
         $this->columns = new FieldDescriptionCollection();
-        $this->pager = $this->getMock('Sonata\AdminBundle\Datagrid\PagerInterface');
+        $this->pager = $this->createMock('Sonata\AdminBundle\Datagrid\PagerInterface');
 
         $this->formTypes = array();
 
@@ -73,8 +74,8 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             }));
 
         // php 5.3 BC
-        $eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
 
         $this->formBuilder->expects($this->any())
             ->method('add')
@@ -110,7 +111,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->datagrid->hasFilter('foo'));
         $this->assertNull($this->datagrid->getFilter('foo'));
 
-        $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -130,17 +131,17 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertSame(array(), $this->datagrid->getFilters());
 
-        $filter1 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter1 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter1->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
 
-        $filter2 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter2 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter2->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
 
-        $filter3 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter3 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter3->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('baz'));
@@ -160,17 +161,17 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertSame(array(), $this->datagrid->getFilters());
 
-        $filter1 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter1 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter1->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
 
-        $filter2 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter2 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter2->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
 
-        $filter3 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter3 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter3->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('baz'));
@@ -211,7 +212,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->datagrid->hasActiveFilters());
 
-        $filter1 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter1 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter1->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -223,7 +224,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->datagrid->hasActiveFilters());
 
-        $filter2 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter2 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter2->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
@@ -243,7 +244,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
     public function testHasDisplayableFiltersNotActive()
     {
-        $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -261,7 +262,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
     public function testHasDisplayableFiltersActive()
     {
-        $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
@@ -279,7 +280,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
     public function testHasDisplayableFiltersAlwaysShow()
     {
-        $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
@@ -314,7 +315,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildPager()
     {
-        $filter1 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter1 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter1->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -330,7 +331,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->datagrid->addFilter($filter1);
 
-        $filter2 = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter2 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter2->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
@@ -365,7 +366,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
      */
     public function testBuildPagerWithException()
     {
-        $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -385,7 +386,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildPagerWithSortBy()
     {
-        $sortBy = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $sortBy = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $sortBy->expects($this->once())
             ->method('isSortable')
             ->will($this->returnValue(true));
@@ -402,7 +403,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, array('_sort_by' => $sortBy));
 
-        $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -434,7 +435,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
      */
     public function testBuildPagerWithPage($page, $perPage)
     {
-        $sortBy = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $sortBy = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $sortBy->expects($this->once())
             ->method('isSortable')
             ->will($this->returnValue(true));
@@ -451,7 +452,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, array('_sort_by' => $sortBy, '_page' => $page, '_per_page' => $perPage));
 
-        $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));

--- a/Tests/Datagrid/ListMapperTest.php
+++ b/Tests/Datagrid/ListMapperTest.php
@@ -15,12 +15,13 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class ListMapperTest extends \PHPUnit_Framework_TestCase
+class ListMapperTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var ListMapper
@@ -39,9 +40,9 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $listBuilder = $this->getMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
+        $listBuilder = $this->createMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
         $this->fieldDescriptionCollection = new FieldDescriptionCollection();
-        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
 
         $listBuilder->expects($this->any())
             ->method('addField')
@@ -49,7 +50,7 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
                 $list->add($fieldDescription);
             }));
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         // php 5.3 BC
         $fieldDescription = $this->getFieldDescriptionMock();
@@ -179,29 +180,17 @@ class ListMapperTest extends \PHPUnit_Framework_TestCase
                 return false;
             }));
 
-        try {
-            $this->listMapper->add('fooName');
-            $this->listMapper->add('fooName');
-        } catch (\RuntimeException $e) {
-            $this->assertContains('Duplicate field name "fooName" in list mapper. Names should be unique.', $e->getMessage());
+        $this->expectException('RuntimeException', 'Duplicate field name "fooName" in list mapper. Names should be unique.');
 
-            return;
-        }
-
-        $this->fail('Failed asserting that exception of type "\RuntimeException" is thrown.');
+        $this->listMapper->add('fooName');
+        $this->listMapper->add('fooName');
     }
 
     public function testAddWrongTypeException()
     {
-        try {
-            $this->listMapper->add(12345);
-        } catch (\RuntimeException $e) {
-            $this->assertContains('Unknown field name in list mapper. Field name should be either of FieldDescriptionInterface interface or string.', $e->getMessage());
+        $this->expectException('RuntimeException', 'Unknown field name in list mapper. Field name should be either of FieldDescriptionInterface interface or string.');
 
-            return;
-        }
-
-        $this->fail('Failed asserting that exception of type "\RuntimeException" is thrown.');
+        $this->listMapper->add(12345);
     }
 
     public function testAutoAddVirtualOption()

--- a/Tests/Datagrid/PagerTest.php
+++ b/Tests/Datagrid/PagerTest.php
@@ -12,11 +12,12 @@
 namespace Sonata\AdminBundle\Tests\Datagrid;
 
 use Sonata\AdminBundle\Datagrid\Pager;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class PagerTest extends \PHPUnit_Framework_TestCase
+class PagerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var Pager
@@ -137,7 +138,7 @@ class PagerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetQuery()
     {
-        $query = $this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
 
         $this->pager->setQuery($query);
         $this->assertSame($query, $this->pager->getQuery());
@@ -359,7 +360,7 @@ class PagerTest extends \PHPUnit_Framework_TestCase
 
         $this->callMethod($this->pager, 'setNbResults', array(3));
 
-        $query = $this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
 
         $query->expects($this->any())
             ->method('setFirstResult')
@@ -487,7 +488,7 @@ class PagerTest extends \PHPUnit_Framework_TestCase
 
         $this->callMethod($this->pager, 'setNbResults', array(3));
 
-        $query = $this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
 
         $query->expects($this->any())
             ->method('setFirstResult')
@@ -545,7 +546,7 @@ class PagerTest extends \PHPUnit_Framework_TestCase
 
         $this->callMethod($this->pager, 'setNbResults', array(3));
 
-        $query = $this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
 
         $query->expects($this->any())
             ->method('setFirstResult')

--- a/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -13,13 +13,14 @@ namespace Sonata\AdminBundle\Tests\DependencyInjection;
 
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
 /**
  * @author Tiago Garcia
  */
-class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
+class AddDependencyCallsCompilerPassTest extends PHPUnit_Framework_TestCase
 {
     /** @var SonataAdminExtension $extension */
     private $extension;
@@ -37,7 +38,7 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslatorDisabled()
     {
-        $this->setExpectedException(
+        $this->expectException(
           'RuntimeException', 'The "translator" service is not yet enabled.
                 It\'s required by SonataAdmin to display all labels properly.
 
@@ -337,15 +338,9 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
 
         $compilerPass = new AddDependencyCallsCompilerPass();
 
-        try {
-            $compilerPass->process($container);
-        } catch (\RuntimeException $e) {
-            $this->assertSame('You can\'t use "on_top" option with multiple same name groups.', $e->getMessage());
+        $this->expectException('\RuntimeException', 'You can\'t use "on_top" option with multiple same name groups.');
 
-            return;
-        }
-
-        $this->fail('An expected exception has not been raised.');
+        $compilerPass->process($container);
     }
 
     public function testProcessMultipleOnTopOptionsAdditionalGroup()
@@ -379,15 +374,9 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
 
         $compilerPass = new AddDependencyCallsCompilerPass();
 
-        try {
-            $compilerPass->process($container);
-        } catch (\RuntimeException $e) {
-            $this->assertSame('You can\'t use "on_top" option with multiple same name groups.', $e->getMessage());
+        $this->expectException('\RuntimeException', 'You can\'t use "on_top" option with multiple same name groups.');
 
-            return;
-        }
-
-        $this->fail('An expected exception has not been raised.');
+        $compilerPass->process($container);
     }
 
     public function testProcessMultipleOnTopOptionsInServiceDefinition()
@@ -406,15 +395,9 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->setArguments(array('', 'Sonata\AdminBundle\Tests\DependencyInjection\ReportOne', 'SonataAdminBundle:CRUD'))
             ->addTag('sonata.admin', array('group' => 'sonata_report_group', 'manager_type' => 'orm', 'on_top' => true));
 
-        try {
-            $compilerPass->process($container);
-        } catch (\RuntimeException $e) {
-            $this->assertSame('You can\'t use "on_top" option with multiple same name groups.', $e->getMessage());
+        $this->expectException('\RuntimeException', 'You can\'t use "on_top" option with multiple same name groups.');
 
-            return;
-        }
-
-        $this->fail('An expected exception has not been raised.');
+        $compilerPass->process($container);
     }
 
     public function testProcessMultipleOnTopOptionsInServiceDefinition1()
@@ -433,15 +416,9 @@ class AddDependencyCallsCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->setArguments(array('', 'Sonata\AdminBundle\Tests\DependencyInjection\ReportOne', 'SonataAdminBundle:CRUD'))
             ->addTag('sonata.admin', array('group' => 'sonata_report_group', 'manager_type' => 'orm', 'on_top' => false));
 
-        try {
-            $compilerPass->process($container);
-        } catch (\RuntimeException $e) {
-            $this->assertSame('You can\'t use "on_top" option with multiple same name groups.', $e->getMessage());
+        $this->expectException('\RuntimeException', 'You can\'t use "on_top" option with multiple same name groups.');
 
-            return;
-        }
-
-        $this->fail('An expected exception has not been raised.');
+        $compilerPass->process($container);
     }
 
     public function testProcessMultipleOnTopOptionsInServiceDefinition2()

--- a/Tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\AdminBundle\Tests\DependencyInjection;
 
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class AddFilterTypeCompilerPassTest extends \PHPUnit_Framework_TestCase
+class AddFilterTypeCompilerPassTest extends PHPUnit_Framework_TestCase
 {
     private $filterFactory;
 
@@ -23,14 +24,14 @@ class AddFilterTypeCompilerPassTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->filterFactory = $this->getMock('Symfony\Component\DependencyInjection\Definition');
-        $this->fooFilter = $this->getMock('Symfony\Component\DependencyInjection\Definition');
-        $this->barFilter = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $this->filterFactory = $this->createMock('Symfony\Component\DependencyInjection\Definition');
+        $this->fooFilter = $this->createMock('Symfony\Component\DependencyInjection\Definition');
+        $this->barFilter = $this->createMock('Symfony\Component\DependencyInjection\Definition');
     }
 
     public function testProcess()
     {
-        $containerBuilderMock = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $containerBuilderMock = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
 
         $containerBuilderMock->expects($this->any())
             ->method('getDefinition')

--- a/Tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
@@ -13,8 +13,9 @@ namespace Sonata\AdminBundle\Tests\DependencyInjection;
 
 use JMS\DiExtraBundle\Metadata\ClassMetadata;
 use Sonata\AdminBundle\Annotation\Admin;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class AnnotationCompilerPassTest extends \PHPUnit_Framework_TestCase
+class AnnotationCompilerPassTest extends PHPUnit_Framework_TestCase
 {
     public function testInvalidAdminAnnotation()
     {
@@ -22,7 +23,7 @@ class AnnotationCompilerPassTest extends \PHPUnit_Framework_TestCase
          * @Admin(class="Sonata\AdminBundle\Tests\Fixtures\Foo")
          */
 
-        $this->setExpectedException(
+        $this->expectException(
             'LogicException',
             'Unable to generate admin group and label for class Sonata\AdminBundle\Tests\Fixtures\Foo.'
         );

--- a/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -14,9 +14,10 @@ namespace Sonata\AdminBundle\Tests\DependencyInjection;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
+class ExtensionCompilerPassTest extends PHPUnit_Framework_TestCase
 {
     /** @var SonataAdminExtension $extension */
     private $extension;
@@ -46,12 +47,12 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
         $this->root = 'sonata.admin';
         $this->hasTraits = version_compare(PHP_VERSION, '5.4.0', '>=');
 
-        $this->publishExtension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
-        $this->historyExtension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
-        $this->orderExtension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
-        $this->securityExtension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
-        $this->filterExtension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
-        $this->timestampExtension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $this->publishExtension = $this->createMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $this->historyExtension = $this->createMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $this->orderExtension = $this->createMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $this->securityExtension = $this->createMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $this->filterExtension = $this->createMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $this->timestampExtension = $this->createMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
     }
 
     /**
@@ -274,7 +275,7 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
     public function testProcessThrowsExceptionIfTraitsAreNotAvailable()
     {
         if (!$this->hasTraits) {
-            $this->setExpectedException('\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException', 'PHP >= 5.4.0 is required to use traits.');
+            $this->expectException('\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException', 'PHP >= 5.4.0 is required to use traits.');
         }
 
         $config = array(

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -12,9 +12,10 @@
 namespace Sonata\AdminBundle\Tests;
 
 use Sonata\AdminBundle\DependencyInjection\Configuration;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Config\Definition\Processor;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends PHPUnit_Framework_TestCase
 {
     public function testOptions()
     {
@@ -35,7 +36,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testOptionsWithInvalidFormat()
     {
-        $this->setExpectedException('Symfony\Component\Config\Definition\Exception\InvalidTypeException');
+        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidTypeException');
 
         $config = $this->process(array(array(
             'options' => array(
@@ -188,7 +189,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testDashboardGroupsWithBadItemsParams()
     {
-        $this->setExpectedException('\InvalidArgumentException', 'Expected either parameters "route" and "label" for array items');
+        $this->expectException('\InvalidArgumentException', 'Expected either parameters "route" and "label" for array items');
 
         $config = $this->process(array(array(
             'dashboard' => array(

--- a/Tests/Event/AdminEventExtensionTest.php
+++ b/Tests/Event/AdminEventExtensionTest.php
@@ -14,15 +14,16 @@ namespace Sonata\AdminBundle\Tests\Event;
 use Sonata\AdminBundle\Event\AdminEventExtension;
 use Sonata\AdminBundle\Event\ConfigureEvent;
 use Sonata\AdminBundle\Event\PersistenceEvent;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
+class AdminEventExtensionTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @return AdminEventExtension
      */
     public function getExtension($args)
     {
-        $eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $stub = $eventDispatcher->expects($this->once())->method('dispatch');
         call_user_func_array(array($stub, 'with'), $args);
 
@@ -32,7 +33,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
     public function getMapper($class)
     {
         $mapper = $this->getMockBuilder($class)->disableOriginalConstructor()->getMock();
-        $mapper->expects($this->once())->method('getAdmin')->will($this->returnValue($this->getMock('Sonata\AdminBundle\Admin\AdminInterface')));
+        $mapper->expects($this->once())->method('getAdmin')->will($this->returnValue($this->createMock('Sonata\AdminBundle\Admin\AdminInterface')));
 
         return $mapper;
     }
@@ -122,14 +123,14 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
         $this->getExtension(array(
             $this->equalTo('sonata.admin.event.persistence.pre_update'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_UPDATE)),
-        ))->preUpdate($this->getMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
+        ))->preUpdate($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
     }
 
     public function testConfigureQuery()
     {
         $this->getExtension(array(
             $this->equalTo('sonata.admin.event.configure.query'),
-        ))->configureQuery($this->getMock('Sonata\AdminBundle\Admin\AdminInterface'), $this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        ))->configureQuery($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
     }
 
     public function testPostUpdate()
@@ -137,7 +138,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
         $this->getExtension(array(
             $this->equalTo('sonata.admin.event.persistence.post_update'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_UPDATE)),
-        ))->postUpdate($this->getMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
+        ))->postUpdate($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
     }
 
     public function testPrePersist()
@@ -145,7 +146,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
         $this->getExtension(array(
             $this->equalTo('sonata.admin.event.persistence.pre_persist'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_PERSIST)),
-        ))->prePersist($this->getMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
+        ))->prePersist($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
     }
 
     public function testPostPersist()
@@ -153,7 +154,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
         $this->getExtension(array(
             $this->equalTo('sonata.admin.event.persistence.post_persist'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_PERSIST)),
-        ))->postPersist($this->getMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
+        ))->postPersist($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
     }
 
     public function testPreRemove()
@@ -161,7 +162,7 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
         $this->getExtension(array(
             $this->equalTo('sonata.admin.event.persistence.pre_remove'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_REMOVE)),
-        ))->preRemove($this->getMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
+        ))->preRemove($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
     }
 
     public function testPostRemove()
@@ -169,6 +170,6 @@ class AdminEventExtensionTest extends \PHPUnit_Framework_TestCase
         $this->getExtension(array(
             $this->equalTo('sonata.admin.event.persistence.post_remove'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_REMOVE)),
-        ))->postRemove($this->getMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
+        ))->postRemove($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
     }
 }

--- a/Tests/Event/ConfigureEventTest.php
+++ b/Tests/Event/ConfigureEventTest.php
@@ -14,8 +14,9 @@ namespace Sonata\AdminBundle\Tests\Event;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Event\ConfigureEvent;
 use Sonata\AdminBundle\Mapper\BaseMapper;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ConfigureEventTest extends \PHPUnit_Framework_TestCase
+class ConfigureEventTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var ConfigureEvent
@@ -34,7 +35,7 @@ class ConfigureEventTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $this->mapper = $this->getMockBuilder('Sonata\AdminBundle\Mapper\BaseMapper')
             ->disableOriginalConstructor()
             ->getMock();

--- a/Tests/Event/ConfigureQueryEventTest.php
+++ b/Tests/Event/ConfigureQueryEventTest.php
@@ -14,8 +14,9 @@ namespace Sonata\AdminBundle\Tests\Event;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Event\ConfigureQueryEvent;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ConfigureQueryEventTest extends \PHPUnit_Framework_TestCase
+class ConfigureQueryEventTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var ConfigureQueryEvent
@@ -34,8 +35,8 @@ class ConfigureQueryEventTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $this->proxyQuery = $this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->proxyQuery = $this->getMockForAbstractClass('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
 
         $this->event = new ConfigureQueryEvent($this->admin, $this->proxyQuery, 'Foo');
     }

--- a/Tests/Event/PersistenceEventTest.php
+++ b/Tests/Event/PersistenceEventTest.php
@@ -13,8 +13,9 @@ namespace Sonata\AdminBundle\Tests\Event;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Event\PersistenceEvent;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class PersistenceEventTest extends \PHPUnit_Framework_TestCase
+class PersistenceEventTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var PersistenceEvent
@@ -33,7 +34,7 @@ class PersistenceEventTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $this->object = new \stdClass();
 
         $this->event = new PersistenceEvent($this->admin, $this->object, 'Foo');

--- a/Tests/Export/ExporterTest.php
+++ b/Tests/Export/ExporterTest.php
@@ -13,18 +13,19 @@ namespace Sonata\AdminBundle\Tests\Filter;
 
 use Exporter\Source\ArraySourceIterator;
 use Sonata\AdminBundle\Export\Exporter;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @group legacy
  */
-class ExporterTest extends \PHPUnit_Framework_TestCase
+class ExporterTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \RuntimeException
      */
     public function testFilter()
     {
-        $source = $this->getMock('Exporter\Source\SourceIteratorInterface');
+        $source = $this->createMock('Exporter\Source\SourceIteratorInterface');
 
         $exporter = new Exporter();
         $exporter->getResponse('foo', 'foo', $source);

--- a/Tests/Filter/FilterFactoryTest.php
+++ b/Tests/Filter/FilterFactoryTest.php
@@ -12,14 +12,15 @@
 namespace Sonata\AdminBundle\Tests\Filter;
 
 use Sonata\AdminBundle\Filter\FilterFactory;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class FilterFactoryTest extends \PHPUnit_Framework_TestCase
+class FilterFactoryTest extends PHPUnit_Framework_TestCase
 {
     public function testEmptyType()
     {
-        $this->setExpectedException('\RuntimeException', 'The type must be defined');
+        $this->expectException('\RuntimeException', 'The type must be defined');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $filter = new FilterFactory($container, array());
         $filter->create('test', null);
@@ -27,9 +28,9 @@ class FilterFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testUnknownType()
     {
-        $this->setExpectedException('\RuntimeException', 'No attached service to type named `mytype`');
+        $this->expectException('\RuntimeException', 'No attached service to type named `mytype`');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $filter = new FilterFactory($container, array());
         $filter->create('test', 'mytype');
@@ -37,9 +38,9 @@ class FilterFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testUnknownClassType()
     {
-        $this->setExpectedException('\RuntimeException', 'No attached service to type named `Sonata\AdminBundle\Form\Type\Filter\FooType`');
+        $this->expectException('\RuntimeException', 'No attached service to type named `Sonata\AdminBundle\Form\Type\Filter\FooType`');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $filter = new FilterFactory($container, array());
         $filter->create('test', 'Sonata\AdminBundle\Form\Type\Filter\FooType');
@@ -47,9 +48,9 @@ class FilterFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testClassType()
     {
-        $this->setExpectedException('\RuntimeException', 'The service `Sonata\AdminBundle\Form\Type\Filter\DefaultType` must implement `FilterInterface`');
+        $this->expectException('\RuntimeException', 'The service `Sonata\AdminBundle\Form\Type\Filter\DefaultType` must implement `FilterInterface`');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $filter = new FilterFactory($container, array());
         $filter->create('test', 'Sonata\AdminBundle\Form\Type\Filter\DefaultType');
@@ -57,9 +58,9 @@ class FilterFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidTypeInstance()
     {
-        $this->setExpectedException('\RuntimeException', 'The service `mytype` must implement `FilterInterface`');
+        $this->expectException('\RuntimeException', 'The service `mytype` must implement `FilterInterface`');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->once())
             ->method('get')
             ->will($this->returnValue(false));
@@ -70,11 +71,11 @@ class FilterFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateFilter()
     {
-        $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->getMockForAbstractClass('Sonata\AdminBundle\Filter\FilterInterface');
         $filter->expects($this->once())
             ->method('initialize');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->once())
             ->method('get')
             ->will($this->returnValue($filter));

--- a/Tests/Form/ChoiceList/ModelChoiceListTest.php
+++ b/Tests/Form/ChoiceList/ModelChoiceListTest.php
@@ -13,8 +13,9 @@ namespace Sonata\AdminBundle\Tests\Form\ChoiceList;
 
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ModelChoiceListTest extends \PHPUnit_Framework_TestCase
+class ModelChoiceListTest extends PHPUnit_Framework_TestCase
 {
     private $modelManager = null;
 
@@ -24,7 +25,7 @@ class ModelChoiceListTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Test only available for < SF3.0');
         }
 
-        $this->modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $this->modelManager->expects($this->any())
             ->method('getIdentifierFieldNames')

--- a/Tests/Form/ChoiceList/ModelChoiceLoaderTest.php
+++ b/Tests/Form/ChoiceList/ModelChoiceLoaderTest.php
@@ -13,8 +13,9 @@ namespace Sonata\AdminBundle\Tests\Form\ChoiceList;
 
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ModelChoiceLoaderTest extends \PHPUnit_Framework_TestCase
+class ModelChoiceLoaderTest extends PHPUnit_Framework_TestCase
 {
     private $modelManager = null;
 
@@ -24,7 +25,7 @@ class ModelChoiceLoaderTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Test only available for > SF2.7');
         }
 
-        $this->modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
     }
 
     public function testLoadFromEntityWithSamePropertyValues()

--- a/Tests/Form/DataTransformer/ArrayToModelTransformerTest.php
+++ b/Tests/Form/DataTransformer/ArrayToModelTransformerTest.php
@@ -13,17 +13,18 @@ namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
 
 use Sonata\AdminBundle\Form\DataTransformer\ArrayToModelTransformer;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class ArrayToModelTransformerTest extends \PHPUnit_Framework_TestCase
+class ArrayToModelTransformerTest extends PHPUnit_Framework_TestCase
 {
     private $modelManager = null;
 
     public function setUp()
     {
-        $this->modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
     }
 
     public function testReverseTransformEntity()

--- a/Tests/Form/DataTransformer/LegacyModelsToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/LegacyModelsToArrayTransformerTest.php
@@ -14,15 +14,14 @@ namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\AdminBundle\Form\DataTransformer\LegacyModelsToArrayTransformer;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class LegacyModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
+class LegacyModelsToArrayTransformerTest extends PHPUnit_Framework_TestCase
 {
     private $choiceList;
-    private $modelChoiceList;
-
     private $modelManager;
 
     /**
@@ -38,7 +37,7 @@ class LegacyModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         // php 5.3 BC
         $modelManager = $this->modelManager;
@@ -95,7 +94,7 @@ class LegacyModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testReverseTransformWithException1()
     {
-        $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException', 'Expected argument of type "\ArrayAccess", "NULL" given');
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException', 'Expected argument of type "\ArrayAccess", "NULL" given');
 
         $transformer = new LegacyModelsToArrayTransformer($this->choiceList);
 
@@ -108,7 +107,7 @@ class LegacyModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testReverseTransformWithException2()
     {
-        $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException', 'Expected argument of type "array", "integer" given');
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException', 'Expected argument of type "array", "integer" given');
 
         $transformer = new LegacyModelsToArrayTransformer($this->choiceList);
 
@@ -178,7 +177,7 @@ class LegacyModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testReverseTransformWithNonexistentEntityKey()
     {
-        $this->setExpectedException('Symfony\Component\Form\Exception\TransformationFailedException', 'The entities with keys "nonexistent" could not be found');
+        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException', 'The entities with keys "nonexistent" could not be found');
 
         $transformer = new LegacyModelsToArrayTransformer($this->choiceList);
 

--- a/Tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
@@ -15,14 +15,15 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdPropertyTransformer;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooArrayAccess;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ModelToIdPropertyTransformerTest extends \PHPUnit_Framework_TestCase
+class ModelToIdPropertyTransformerTest extends PHPUnit_Framework_TestCase
 {
     private $modelManager = null;
 
     public function setUp()
     {
-        $this->modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
     }
 
     public function testReverseTransform()

--- a/Tests/Form/DataTransformer/ModelToIdTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelToIdTransformerTest.php
@@ -12,14 +12,15 @@
 namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
 
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ModelToIdTransformerTest extends \PHPUnit_Framework_TestCase
+class ModelToIdTransformerTest extends PHPUnit_Framework_TestCase
 {
     private $modelManager = null;
 
     public function setUp()
     {
-        $this->modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
     }
 
     public function testReverseTransformWhenPassing0AsId()

--- a/Tests/Form/Extension/ChoiceTypeExtensionTest.php
+++ b/Tests/Form/Extension/ChoiceTypeExtensionTest.php
@@ -12,15 +12,16 @@
 namespace Sonata\AdminBundle\Tests\Form\Extension;
 
 use Sonata\AdminBundle\Form\Extension\ChoiceTypeExtension;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\CoreBundle\Form\Extension\DependencyInjectionExtension;
 use Symfony\Component\Form\Forms;
 
-class ChoiceTypeExtensionTest extends \PHPUnit_Framework_TestCase
+class ChoiceTypeExtensionTest extends PHPUnit_Framework_TestCase
 {
     protected function setup()
     {
         if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+            $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
             $container->expects($this->any())->method('has')->will($this->returnValue(true));
             $container->expects($this->any())->method('get')
                 ->with($this->equalTo('sonata.admin.form.choice_extension'))

--- a/Tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
+++ b/Tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
@@ -12,12 +12,13 @@
 namespace Sonata\AdminBundle\Tests\Form\Extension\Field\Type;
 
 use Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormConfigBuilder;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
+class FormTypeFieldExtensionTest extends PHPUnit_Framework_TestCase
 {
     public function testExtendedType()
     {
@@ -55,7 +56,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testbuildViewWithNoSonataAdminArray()
     {
-        $eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
 
         $parentFormView = new FormView();
         $parentFormView->vars['sonata_admin_enabled'] = false;
@@ -91,10 +92,10 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testbuildViewWithWithSonataAdmin()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->exactly(2))->method('getCode')->will($this->returnValue('my.admin.reference'));
 
-        $eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
 
         $formView = new FormView();
         $options = array();
@@ -137,7 +138,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testbuildViewWithNestedForm()
     {
-        $eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
 
         $formView = new FormView();
         $formView->vars['name'] = 'format';
@@ -195,7 +196,7 @@ class FormTypeFieldExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testbuildViewWithNestedFormWithNoParent()
     {
-        $eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
 
         $formView = new FormView();
         $options = array();

--- a/Tests/Form/FormMapperTest.php
+++ b/Tests/Form/FormMapperTest.php
@@ -13,9 +13,10 @@ namespace Sonata\AdminBundle\Tests\Form;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CleanAdmin;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\FormBuilder;
 
-class FormMapperTest extends \PHPUnit_Framework_TestCase
+class FormMapperTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var \Sonata\AdminBundle\Builder\FormContractorInterface
@@ -39,16 +40,16 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->contractor = $this->getMock('Sonata\AdminBundle\Builder\FormContractorInterface');
+        $this->contractor = $this->getMockForAbstractClass('Sonata\AdminBundle\Builder\FormContractorInterface');
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
-        $eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
+        $eventDispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
 
         $formBuilder = new FormBuilder('test', 'stdClass', $eventDispatcher, $formFactory);
 
         $this->admin = new CleanAdmin('code', 'class', 'controller');
 
-        $this->modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         // php 5.3 BC
         $fieldDescription = $this->getFieldDescriptionMock();
@@ -65,7 +66,7 @@ class FormMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->admin->setModelManager($this->modelManager);
 
-        $labelTranslatorStrategy = $this->getMock('Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface');
+        $labelTranslatorStrategy = $this->getMockForAbstractClass('Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface');
         $this->admin->setLabelTranslatorStrategy($labelTranslatorStrategy);
 
         $this->formMapper = new FormMapper(

--- a/Tests/Form/Type/AclMatrixTypeTest.php
+++ b/Tests/Form/Type/AclMatrixTypeTest.php
@@ -23,7 +23,7 @@ class AclMatrixTypeTest extends TypeTestCase
     public function testGetDefaultOptions()
     {
         $type = new AclMatrixType();
-        $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $user = $this->getMockForAbstractClass('Symfony\Component\Security\Core\User\UserInterface');
 
         $permissions = array(
             'OWNER' => array(

--- a/Tests/Form/Type/Filter/DateTimeRangeTypeTest.php
+++ b/Tests/Form/Type/Filter/DateTimeRangeTypeTest.php
@@ -19,7 +19,7 @@ class DateTimeRangeTypeTest extends TypeTestCase
 {
     public function testGetDefaultOptions()
     {
-        $stub = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $stub = $this->getMockForAbstractClass('Symfony\Component\Translation\TranslatorInterface');
 
         $type = new DateTimeRangeType($stub);
 

--- a/Tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/Tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -20,7 +20,7 @@ class ModelAutocompleteTypeTest extends TypeTestCase
     public function testGetDefaultOptions()
     {
         $type = new ModelAutocompleteType();
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $optionResolver = new OptionsResolver();
 
         if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {

--- a/Tests/Form/Type/ModelHiddenTypeTest.php
+++ b/Tests/Form/Type/ModelHiddenTypeTest.php
@@ -20,7 +20,7 @@ class ModelHiddenTypeTest extends TypeTestCase
     public function testGetDefaultOptions()
     {
         $type = new ModelHiddenType();
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $optionResolver = new OptionsResolver();
 
         if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {

--- a/Tests/Form/Type/ModelTypeTest.php
+++ b/Tests/Form/Type/ModelTypeTest.php
@@ -29,7 +29,7 @@ class ModelTypeTest extends TypeTestCase
 
     public function testGetDefaultOptions()
     {
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $optionResolver = new OptionsResolver();
 
@@ -67,7 +67,7 @@ class ModelTypeTest extends TypeTestCase
      */
     public function testCompoundOption($expectedCompound, $multiple, $expanded)
     {
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $optionResolver = new OptionsResolver();
 
         if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {

--- a/Tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
+++ b/Tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
@@ -79,7 +79,7 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
         );
 
         $extensions = parent::getExtensions();
-        $guesser = $this->getMock('Symfony\Component\Form\FormTypeGuesserInterface');
+        $guesser = $this->getMockForAbstractClass('Symfony\Component\Form\FormTypeGuesserInterface');
         $extension = new TestExtension($guesser);
         $type = new ChoiceType($mock);
         $extension->addType($type);

--- a/Tests/Form/Widget/FormSonataNativeCollectionWidgetTest.php
+++ b/Tests/Form/Widget/FormSonataNativeCollectionWidgetTest.php
@@ -54,7 +54,7 @@ class FormSonataNativeCollectionWidgetTest extends BaseWidgetTest
     protected function getExtensions()
     {
         $extensions = parent::getExtensions();
-        $guesser = $this->getMock('Symfony\Component\Form\FormTypeGuesserInterface');
+        $guesser = $this->getMockForAbstractClass('Symfony\Component\Form\FormTypeGuesserInterface');
         $extension = new TestExtension($guesser);
         if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
             $extension->addType(new CollectionType());

--- a/Tests/Generator/AdminGeneratorTest.php
+++ b/Tests/Generator/AdminGeneratorTest.php
@@ -13,13 +13,14 @@ namespace Sonata\AdminBundle\Tests\Generator;
 
 use Sonata\AdminBundle\Generator\AdminGenerator;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 /**
  * @author Marek Stipek <mario.dweller@seznam.cz>
  */
-class AdminGeneratorTest extends \PHPUnit_Framework_TestCase
+class AdminGeneratorTest extends PHPUnit_Framework_TestCase
 {
     /** @var AdminGenerator */
     private $adminGenerator;
@@ -60,15 +61,9 @@ class AdminGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('ModelAdmin.php', basename($file));
         $this->assertFileEquals(__DIR__.'/../Fixtures/Admin/ModelAdmin.php', $file);
 
-        try {
-            $this->adminGenerator->generate($this->bundleMock, 'ModelAdmin', 'Model');
-        } catch (\RuntimeException $e) {
-            $this->assertContains('already exists', $e->getMessage());
+        $this->expectException('\RuntimeException', 'already exists');
 
-            return;
-        }
-
-        $this->fail('Failed asserting that exception of type "\RuntimeException" is thrown.');
+        $this->adminGenerator->generate($this->bundleMock, 'ModelAdmin', 'Model');
     }
 
     /**
@@ -76,7 +71,7 @@ class AdminGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     private function createModelManagerMock()
     {
-        $modelManagerMock = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManagerMock = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManagerMock
             ->expects($this->any())
             ->method('getExportFields')
@@ -92,7 +87,7 @@ class AdminGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     private function createBundleMock()
     {
-        $bundleMock = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundleMock = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Bundle\BundleInterface');
         $bundleMock
             ->expects($this->any())
             ->method('getNamespace')

--- a/Tests/Generator/ControllerGeneratorTest.php
+++ b/Tests/Generator/ControllerGeneratorTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\AdminBundle\Tests\Generator;
 
 use Sonata\AdminBundle\Generator\ControllerGenerator;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 /**
  * @author Marek Stipek <mario.dweller@seznam.cz>
  */
-class ControllerGeneratorTest extends \PHPUnit_Framework_TestCase
+class ControllerGeneratorTest extends PHPUnit_Framework_TestCase
 {
     /** @var ControllerGenerator */
     private $controllerGenerator;
@@ -59,15 +60,9 @@ class ControllerGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('ModelAdminController.php', basename($file));
         $this->assertFileEquals(__DIR__.'/../Fixtures/Controller/ModelAdminController.php', $file);
 
-        try {
-            $this->controllerGenerator->generate($this->bundleMock, 'ModelAdminController');
-        } catch (\RuntimeException $e) {
-            $this->assertContains('already exists', $e->getMessage());
+        $this->expectException('\RuntimeException', 'already exists');
 
-            return;
-        }
-
-        $this->fail('Failed asserting that exception of type "\RuntimeException" is thrown.');
+        $this->controllerGenerator->generate($this->bundleMock, 'ModelAdminController');
     }
 
     /**
@@ -75,7 +70,7 @@ class ControllerGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     private function createBundleMock()
     {
-        $bundleMock = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundleMock = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Bundle\BundleInterface');
         $bundleMock
             ->expects($this->any())
             ->method('getNamespace')

--- a/Tests/Guesser/TypeGuesserChainTest.php
+++ b/Tests/Guesser/TypeGuesserChainTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Tests\Guesser;
 
 use Sonata\AdminBundle\Guesser\TypeGuesserChain;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
@@ -20,11 +21,11 @@ use Symfony\Component\Form\Guess\TypeGuess;
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class TypeGuesserChainTest extends \PHPUnit_Framework_TestCase
+class TypeGuesserChainTest extends PHPUnit_Framework_TestCase
 {
     public function testConstructorWithException()
     {
-        $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
+        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
 
         $typeGuesserChain = new TypeGuesserChain(array(new \stdClass()));
     }
@@ -32,24 +33,24 @@ class TypeGuesserChainTest extends \PHPUnit_Framework_TestCase
     public function testGuessType()
     {
         $typeGuess1 = new TypeGuess('foo1', array(), Guess::MEDIUM_CONFIDENCE);
-        $guesser1 = $this->getMock('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+        $guesser1 = $this->getMockForAbstractClass('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
         $guesser1->expects($this->any())
                 ->method('guessType')
                 ->will($this->returnValue($typeGuess1));
 
         $typeGuess2 = new TypeGuess('foo2', array(), Guess::HIGH_CONFIDENCE);
-        $guesser2 = $this->getMock('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+        $guesser2 = $this->getMockForAbstractClass('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
         $guesser2->expects($this->any())
                 ->method('guessType')
                 ->will($this->returnValue($typeGuess2));
 
         $typeGuess3 = new TypeGuess('foo3', array(), Guess::LOW_CONFIDENCE);
-        $guesser3 = $this->getMock('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+        $guesser3 = $this->getMockForAbstractClass('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
         $guesser3->expects($this->any())
                 ->method('guessType')
                 ->will($this->returnValue($typeGuess3));
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $class = '\stdClass';
         $property = 'firstName';
@@ -58,7 +59,7 @@ class TypeGuesserChainTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($typeGuess2, $typeGuesserChain->guessType($class, $property, $modelManager));
 
         $typeGuess4 = new TypeGuess('foo4', array(), Guess::LOW_CONFIDENCE);
-        $guesser4 = $this->getMock('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+        $guesser4 = $this->getMockForAbstractClass('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
         $guesser4->expects($this->any())
                 ->method('guessType')
                 ->will($this->returnValue($typeGuess4));

--- a/Tests/Helpers/PHPUnit_Framework_TestCase.php
+++ b/Tests/Helpers/PHPUnit_Framework_TestCase.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Helpers;
+
+/**
+ * This is helpers class for supporting old and new PHPUnit versions.
+ *
+ * @todo NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ *
+ * @author Oleksandr Savchenko <savchenko.oleksandr.ua@gmail.com>
+ */
+class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function expectException($exception, $message = '', $code = null)
+    {
+        if (is_callable('parent::expectException')) {
+            parent::expectException($exception);
+
+            if ($message !== '') {
+                parent::expectExceptionMessage($message);
+            }
+
+            if ($code !== null) {
+                parent::expectExceptionCode($code);
+            }
+        }
+
+        return parent::setExpectedException($exception, $message, $code);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createMock($originalClassName)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($originalClassName);
+        }
+
+        return parent::getMock($originalClassName);
+    }
+}

--- a/Tests/Mapper/BaseGroupedMapperTest.php
+++ b/Tests/Mapper/BaseGroupedMapperTest.php
@@ -30,8 +30,8 @@ class BaseGroupedMapperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $builder = $this->getMock('Sonata\AdminBundle\Builder\BuilderInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $builder = $this->getMockForAbstractClass('Sonata\AdminBundle\Builder\BuilderInterface');
 
         $this->baseGroupedMapper = $this->getMockForAbstractClass('Sonata\AdminBundle\Mapper\BaseGroupedMapper', array($builder, $admin));
 

--- a/Tests/Mapper/BaseMapperTest.php
+++ b/Tests/Mapper/BaseMapperTest.php
@@ -33,8 +33,8 @@ class BaseMapperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $builder = $this->getMock('Sonata\AdminBundle\Builder\BuilderInterface');
+        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $builder = $this->getMockForAbstractClass('Sonata\AdminBundle\Builder\BuilderInterface');
 
         $this->baseMapper = $this->getMockForAbstractClass('Sonata\AdminBundle\Mapper\BaseMapper', array($builder, $this->admin));
     }

--- a/Tests/Menu/Integration/BaseMenuTest.php
+++ b/Tests/Menu/Integration/BaseMenuTest.php
@@ -51,7 +51,7 @@ abstract class BaseMenuTest extends \PHPUnit_Framework_TestCase
         $this->renderer = new TwigRenderer(
             $this->environment,
             $this->getTemplate(),
-            $this->getMock('Knp\Menu\Matcher\MatcherInterface')
+            $this->getMockForAbstractClass('Knp\Menu\Matcher\MatcherInterface')
         );
 
         return $this->renderer->render($item, $options);

--- a/Tests/Menu/Matcher/Voter/ActiveVoterTest.php
+++ b/Tests/Menu/Matcher/Voter/ActiveVoterTest.php
@@ -43,7 +43,7 @@ class ActiveVoterTest extends AbstractVoterTest
      */
     protected function createItem($data)
     {
-        $item = $this->getMock('Knp\Menu\ItemInterface');
+        $item = $this->getMockForAbstractClass('Knp\Menu\ItemInterface');
         $item->expects($this->any())
              ->method('getExtra')
              ->with('active')

--- a/Tests/Menu/Matcher/Voter/AdminVoterTest.php
+++ b/Tests/Menu/Matcher/Voter/AdminVoterTest.php
@@ -53,7 +53,7 @@ class AdminVoterTest extends AbstractVoterTest
      */
     protected function createItem($data)
     {
-        $item = $this->getMock('Knp\Menu\ItemInterface');
+        $item = $this->getMockForAbstractClass('Knp\Menu\ItemInterface');
         $item->expects($this->any())
              ->method('getExtra')
              ->with($this->logicalOr(
@@ -71,7 +71,7 @@ class AdminVoterTest extends AbstractVoterTest
      */
     private function getAdmin($code, $list = false, $granted = false)
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin
             ->expects($this->any())
             ->method('hasRoute')

--- a/Tests/Menu/Matcher/Voter/ChildrenVoterTest.php
+++ b/Tests/Menu/Matcher/Voter/ChildrenVoterTest.php
@@ -46,14 +46,14 @@ class ChildrenVoterTest extends AbstractVoterTest
     {
         $childItems = array();
         foreach ($data as $childData) {
-            $childItem = $this->getMock('Knp\Menu\ItemInterface');
+            $childItem = $this->getMockForAbstractClass('Knp\Menu\ItemInterface');
             $childItem->expects($this->any())
                 ->method('isCurrent')
                 ->willReturn($childData);
             $childItems[] = $childItem;
         }
 
-        $item = $this->getMock('Knp\Menu\ItemInterface');
+        $item = $this->getMockForAbstractClass('Knp\Menu\ItemInterface');
         $item->expects($this->any())
             ->method('getChildren')
             ->will($this->returnValue($childItems));

--- a/Tests/Menu/MenuBuilderTest.php
+++ b/Tests/Menu/MenuBuilderTest.php
@@ -28,9 +28,9 @@ class MenuBuilderTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
-        $this->provider = $this->getMock('Knp\Menu\Provider\MenuProviderInterface');
+        $this->provider = $this->getMockForAbstractClass('Knp\Menu\Provider\MenuProviderInterface');
         $this->factory = new MenuFactory();
-        $this->eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->eventDispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
 
         $this->builder = new MenuBuilder($this->pool, $this->factory, $this->provider, $this->eventDispatcher);
     }

--- a/Tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/Tests/Menu/Provider/GroupMenuProviderTest.php
@@ -18,8 +18,9 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Menu\Provider\GroupMenuProvider;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class GroupMenuProviderTest extends \PHPUnit_Framework_TestCase
+class GroupMenuProviderTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var MockObject|Pool
@@ -102,7 +103,7 @@ class GroupMenuProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGroupMenuProviderThrowsExceptionWithInvalidArgument()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         new GroupMenuProvider($this->factory, $this->pool, 'foo');
     }
 
@@ -330,7 +331,7 @@ class GroupMenuProviderTest extends \PHPUnit_Framework_TestCase
      */
     private function getAdminMock($hasRoute = true, $isGranted = true)
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())
             ->method('hasRoute')
             ->with($this->equalTo('list'))

--- a/Tests/Model/AuditManagerTest.php
+++ b/Tests/Model/AuditManagerTest.php
@@ -12,20 +12,21 @@
 namespace Sonata\AdminBundle\Tests\Model;
 
 use Sonata\AdminBundle\Model\AuditManager;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * Test for AuditManager.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class AuditManagerTest extends \PHPUnit_Framework_TestCase
+class AuditManagerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetReader()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
 
-        $fooReader = $this->getMock('Sonata\AdminBundle\Model\AuditReaderInterface');
-        $barReader = $this->getMock('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $fooReader = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $barReader = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\AuditReaderInterface');
 
         $container->expects($this->any())
             ->method('get')
@@ -53,9 +54,9 @@ class AuditManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetReaderWithException()
     {
-        $this->setExpectedException('\RuntimeException', 'The class "Foo\Foo" does not have any reader manager');
+        $this->expectException('\RuntimeException', 'The class "Foo\Foo" does not have any reader manager');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
         $auditManager = new AuditManager($container);
 
         $auditManager->getReader('Foo\Foo');

--- a/Tests/Route/AdminPoolLoaderTest.php
+++ b/Tests/Route/AdminPoolLoaderTest.php
@@ -21,8 +21,11 @@ class AdminPoolLoaderTest extends \PHPUnit_Framework_TestCase
 {
     public function testSupports()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $pool = $this->getMock('Sonata\AdminBundle\Admin\Pool', array(), array($container, 'title', 'logoTitle'));
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
+            ->setMethods(array())
+            ->setConstructorArgs(array($container, 'title', 'logoTitle'))
+            ->getMock();
 
         $adminPoolLoader = new AdminPoolLoader($pool, array('foo_admin', 'bar_admin'), $container);
 
@@ -32,8 +35,11 @@ class AdminPoolLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoad()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $pool = $this->getMock('Sonata\AdminBundle\Admin\Pool', array(), array($container, 'title', 'logoTitle'));
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
+            ->setMethods(array())
+            ->setConstructorArgs(array($container, 'title', 'logoTitle'))
+            ->getMock();
 
         $adminPoolLoader = new AdminPoolLoader($pool, array('foo_admin', 'bar_admin'), $container);
 
@@ -44,12 +50,12 @@ class AdminPoolLoaderTest extends \PHPUnit_Framework_TestCase
         $routeCollection2->add('bar');
         $routeCollection2->add('baz');
 
-        $admin1 = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin1 = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin1->expects($this->once())
             ->method('getRoutes')
             ->will($this->returnValue($routeCollection1));
 
-        $admin2 = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin2 = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin2->expects($this->once())
             ->method('getRoutes')
             ->will($this->returnValue($routeCollection2));

--- a/Tests/Route/DefaultRouteGeneratorTest.php
+++ b/Tests/Route/DefaultRouteGeneratorTest.php
@@ -14,9 +14,10 @@ namespace Sonata\AdminBundle\Tests\Route;
 use Sonata\AdminBundle\Route\DefaultRouteGenerator;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Route\RoutesCache;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Routing\Route;
 
-class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
+class DefaultRouteGeneratorTest extends PHPUnit_Framework_TestCase
 {
     protected $cacheTempFolder;
 
@@ -29,7 +30,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testGenerate()
     {
-        $router = $this->getMock('\Symfony\Component\Routing\RouterInterface');
+        $router = $this->getMockForAbstractClass('\Symfony\Component\Routing\RouterInterface');
         $router->expects($this->once())->method('generate')->will($this->returnValue('/foo/bar'));
 
         $cache = new RoutesCache($this->cacheTempFolder, true);
@@ -51,7 +52,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $collection->add('foo');
         $collection->addCollection($childCollection);
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(false));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Foo'));
         $admin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(false));
@@ -62,7 +63,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
-        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->getMockForAbstractClass('Symfony\Component\Routing\RouterInterface');
         $router->expects($this->once())
             ->method('generate')
             ->will($this->returnCallback(function ($name, array $parameters = array()) {
@@ -98,9 +99,9 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testGenerateUrlWithException()
     {
-        $this->setExpectedException('RuntimeException', 'unable to find the route `base.Code.Route.foo`');
+        $this->expectException('RuntimeException', 'unable to find the route `base.Code.Route.foo`');
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(false));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Route'));
         $admin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(false));
@@ -109,7 +110,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->exactly(2))->method('getRoutes')->will($this->returnValue(new RouteCollection('base.Code.Route', 'baseRouteName', 'baseRoutePattern', 'BundleName:ControllerName')));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
-        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->getMockForAbstractClass('Symfony\Component\Routing\RouterInterface');
 
         $cache = new RoutesCache($this->cacheTempFolder, true);
 
@@ -129,7 +130,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $collection->add('foo');
         $collection->addCollection($childCollection);
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Child'));
         $admin->expects($this->any())->method('getBaseCodeRoute')->will($this->returnValue('base.Code.Parent|base.Code.Child'));
@@ -142,7 +143,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($childCollection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
-        $parentAdmin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $parentAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $parentAdmin->expects($this->any())->method('getIdParameter')->will($this->returnValue('childId'));
         $parentAdmin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
         $parentAdmin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Parent'));
@@ -151,8 +152,8 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         // no request attached in this test, so this will not be used
         $parentAdmin->expects($this->never())->method('getPersistentParameters')->will($this->returnValue(array('from' => 'parent')));
 
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-        $request->attributes = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $request->attributes = $this->createMock('Symfony\Component\HttpFoundation\ParameterBag');
         $request->attributes->expects($this->any())->method('has')->will($this->returnValue(true));
         $request->attributes->expects($this->any())
             ->method('get')
@@ -167,7 +168,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->any())->method('getRequest')->will($this->returnValue($request));
         $admin->expects($this->any())->method('getParent')->will($this->returnValue($parentAdmin));
 
-        $router = $this->getMock('\Symfony\Component\Routing\RouterInterface');
+        $router = $this->getMockForAbstractClass('\Symfony\Component\Routing\RouterInterface');
         $router->expects($this->once())
             ->method('generate')
             ->will($this->returnCallback(function ($name, array $parameters = array()) {
@@ -214,7 +215,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $collection->add('foo');
         $collection->addCollection($childCollection);
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(false));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Parent'));
         // embeded admin (not nested ...)
@@ -226,7 +227,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
 
-        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->getMockForAbstractClass('Symfony\Component\Routing\RouterInterface');
         $router->expects($this->once())
             ->method('generate')
             ->will($this->returnCallback(function ($name, array $parameters = array()) {
@@ -245,10 +246,10 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
                 return;
             }));
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getOption')->will($this->returnValue(array()));
 
-        $parentAdmin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $parentAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $parentAdmin->expects($this->any())->method('getUniqid')->will($this->returnValue('parent_foo_uniqueid'));
         $parentAdmin->expects($this->any())->method('getCode')->will($this->returnValue('parent_foo_code'));
         $parentAdmin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
@@ -287,7 +288,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $standaloneCollection = new RouteCollection('base.Code.Child', 'admin_acme_child_standalone', '/', 'BundleName:ControllerName');
         $standaloneCollection->add('bar');
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Child'));
         $admin->expects($this->any())->method('getBaseCodeRoute')->will($this->returnValue('base.Code.Parent|base.Code.Child'));
@@ -299,7 +300,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($childCollection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
-        $parentAdmin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $parentAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $parentAdmin->expects($this->any())->method('getIdParameter')->will($this->returnValue('childId'));
         $parentAdmin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
         $parentAdmin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Parent'));
@@ -308,8 +309,8 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         // no request attached in this test, so this will not be used
         $parentAdmin->expects($this->never())->method('getPersistentParameters')->will($this->returnValue(array('from' => 'parent')));
 
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-        $request->attributes = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $request->attributes = $this->createMock('Symfony\Component\HttpFoundation\ParameterBag');
         $request->attributes->expects($this->any())->method('has')->will($this->returnValue(true));
         $request->attributes->expects($this->any())
             ->method('get')
@@ -324,7 +325,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $admin->expects($this->any())->method('getRequest')->will($this->returnValue($request));
         $admin->expects($this->any())->method('getParent')->will($this->returnValue($parentAdmin));
 
-        $standaloneAdmin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $standaloneAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $standaloneAdmin->expects($this->any())->method('isChild')->will($this->returnValue(false));
         $standaloneAdmin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Child'));
         $standaloneAdmin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(false));
@@ -334,7 +335,7 @@ class DefaultRouteGeneratorTest extends \PHPUnit_Framework_TestCase
         $standaloneAdmin->expects($this->any())->method('getRoutes')->will($this->returnValue($standaloneCollection));
         $standaloneAdmin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
-        $router = $this->getMock('\Symfony\Component\Routing\RouterInterface');
+        $router = $this->getMockForAbstractClass('\Symfony\Component\Routing\RouterInterface');
         $router->expects($this->exactly(2))
             ->method('generate')
             ->will($this->returnCallback(function ($name, array $parameters = array()) {

--- a/Tests/Route/PathInfoBuilderTest.php
+++ b/Tests/Route/PathInfoBuilderTest.php
@@ -18,10 +18,10 @@ class PathInfoBuilderTest extends \PHPUnit_Framework_TestCase
 {
     public function testBuild()
     {
-        $audit = $this->getMock('Sonata\AdminBundle\Model\AuditManagerInterface');
+        $audit = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\AuditManagerInterface');
         $audit->expects($this->once())->method('hasReader')->will($this->returnValue(true));
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('getChildren')->will($this->returnValue(array()));
         $admin->expects($this->once())->method('isAclEnabled')->will($this->returnValue(true));
 

--- a/Tests/Route/QueryStringBuilderTest.php
+++ b/Tests/Route/QueryStringBuilderTest.php
@@ -21,10 +21,10 @@ class QueryStringBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testBuild(array $expectedRoutes, $hasReader, $aclEnabled, $getParent)
     {
-        $audit = $this->getMock('Sonata\AdminBundle\Model\AuditManagerInterface');
+        $audit = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\AuditManagerInterface');
         $audit->expects($this->once())->method('hasReader')->will($this->returnValue($hasReader));
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('getParent')->will($this->returnValue($getParent));
         $admin->expects($this->any())->method('getChildren')->will($this->returnValue(array()));
         $admin->expects($this->once())->method('isAclEnabled')->will($this->returnValue($aclEnabled));
@@ -54,7 +54,7 @@ class QueryStringBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildWithChildren()
     {
-        $audit = $this->getMock('Sonata\AdminBundle\Model\AuditManagerInterface');
+        $audit = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\AuditManagerInterface');
         $audit->expects($this->once())->method('hasReader')->will($this->returnValue(true));
 
         $childRouteCollection1 = new RouteCollection('child1.Code.Route', 'child1RouteName', 'child1RoutePattern', 'child1ControllerName');
@@ -64,13 +64,13 @@ class QueryStringBuilderTest extends \PHPUnit_Framework_TestCase
         $childRouteCollection2 = new RouteCollection('child2.Code.Route', 'child2RouteName', 'child2RoutePattern', 'child2ControllerName');
         $childRouteCollection2->add('baz');
 
-        $child1 = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $child1 = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $child1->expects($this->once())->method('getRoutes')->will($this->returnValue($childRouteCollection1));
 
-        $child2 = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $child2 = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $child2->expects($this->once())->method('getRoutes')->will($this->returnValue($childRouteCollection2));
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('getParent')->will($this->returnValue(null));
         $admin->expects($this->once())->method('getChildren')->will($this->returnValue(array($child1, $child2)));
         $admin->expects($this->once())->method('isAclEnabled')->will($this->returnValue(true));

--- a/Tests/Route/RouteCollectionTest.php
+++ b/Tests/Route/RouteCollectionTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\AdminBundle\Tests\Route;
 
 use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class RouteCollectionTest extends \PHPUnit_Framework_TestCase
+class RouteCollectionTest extends PHPUnit_Framework_TestCase
 {
     public function testGetter()
     {
@@ -88,7 +89,7 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetWithException()
     {
-        $this->setExpectedException('\InvalidArgumentException', 'Element "foo" does not exist.');
+        $this->expectException('\InvalidArgumentException', 'Element "foo" does not exist.');
 
         $routeCollection = new RouteCollection('base.Code.Route', 'baseRouteName', 'baseRoutePattern', 'baseControllerName');
         $routeCollection->get('foo');

--- a/Tests/Search/SearchHandlerTest.php
+++ b/Tests/Search/SearchHandlerTest.php
@@ -25,7 +25,7 @@ class SearchHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function getPool(AdminInterface $admin = null)
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('get')->will($this->returnCallback(function ($id) use ($admin) {
             if ($id == 'fake') {
                 throw new ServiceNotFoundException('Fake service does not exist');
@@ -39,13 +39,13 @@ class SearchHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildPagerWithNoGlobalSearchField()
     {
-        $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->getMockForAbstractClass('Sonata\AdminBundle\Filter\FilterInterface');
         $filter->expects($this->once())->method('getOption')->will($this->returnValue(false));
 
-        $datagrid = $this->getMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->getMockForAbstractClass('Sonata\AdminBundle\Datagrid\DatagridInterface');
         $datagrid->expects($this->once())->method('getFilters')->will($this->returnValue(array($filter)));
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('getDatagrid')->will($this->returnValue($datagrid));
 
         $handler = new SearchHandler($this->getPool($admin));
@@ -54,19 +54,19 @@ class SearchHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildPagerWithGlobalSearchField()
     {
-        $filter = $this->getMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->getMockForAbstractClass('Sonata\AdminBundle\Filter\FilterInterface');
         $filter->expects($this->once())->method('getOption')->will($this->returnValue(true));
 
-        $pager = $this->getMock('Sonata\AdminBundle\Datagrid\PagerInterface');
+        $pager = $this->getMockForAbstractClass('Sonata\AdminBundle\Datagrid\PagerInterface');
         $pager->expects($this->once())->method('setPage');
         $pager->expects($this->once())->method('setMaxPerPage');
 
-        $datagrid = $this->getMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->getMockForAbstractClass('Sonata\AdminBundle\Datagrid\DatagridInterface');
         $datagrid->expects($this->once())->method('getFilters')->will($this->returnValue(array($filter)));
         $datagrid->expects($this->once())->method('setValue');
         $datagrid->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('getDatagrid')->will($this->returnValue($datagrid));
 
         $handler = new SearchHandler($this->getPool($admin));

--- a/Tests/Security/Handler/AclSecurityHandlerTest.php
+++ b/Tests/Security/Handler/AclSecurityHandlerTest.php
@@ -21,11 +21,11 @@ class AclSecurityHandlerTest extends \PHPUnit_Framework_TestCase
         // Set the SecurityContext for Symfony <2.6
         // TODO: Remove conditional return when bumping requirements to SF 2.6+
         if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
-            return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
-            $this->authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+            return $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+            $this->authorizationChecker = $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         }
 
-        return $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        return $this->getMockForAbstractClass('Symfony\Component\Security\Core\SecurityContextInterface');
     }
 
     public function getAuthorizationCheckerMock()
@@ -33,15 +33,15 @@ class AclSecurityHandlerTest extends \PHPUnit_Framework_TestCase
         // Set the SecurityContext for Symfony <2.6
         // TODO: Remove conditional return when bumping requirements to SF 2.6+
         if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
-            return $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+            return $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         }
 
-        return $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        return $this->getMockForAbstractClass('Symfony\Component\Security\Core\SecurityContextInterface');
     }
 
     public function testAcl()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())
             ->method('getCode')
             ->will($this->returnValue('test'));
@@ -51,7 +51,7 @@ class AclSecurityHandlerTest extends \PHPUnit_Framework_TestCase
             ->method('isGranted')
             ->will($this->returnValue(true));
 
-        $aclProvider = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
+        $aclProvider = $this->getMockForAbstractClass('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
 
         $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, 'Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder', array());
 
@@ -76,7 +76,7 @@ class AclSecurityHandlerTest extends \PHPUnit_Framework_TestCase
         );
 
         $authorizationChecker = $this->getAuthorizationCheckerMock();
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())
             ->method('getCode')
             ->will($this->returnValue('test'));
@@ -85,7 +85,7 @@ class AclSecurityHandlerTest extends \PHPUnit_Framework_TestCase
             ->method('getSecurityInformation')
             ->will($this->returnValue($informations));
 
-        $aclProvider = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
+        $aclProvider = $this->getMockForAbstractClass('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
 
         $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, 'Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder', array());
 
@@ -96,14 +96,14 @@ class AclSecurityHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testWithAuthenticationCredentialsNotFoundException()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
 
         $authorizationChecker = $this->getAuthorizationCheckerMock();
         $authorizationChecker->expects($this->any())
             ->method('isGranted')
             ->will($this->throwException(new AuthenticationCredentialsNotFoundException('FAIL')));
 
-        $aclProvider = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
+        $aclProvider = $this->getMockForAbstractClass('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
 
         $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, 'Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder', array());
 
@@ -115,14 +115,14 @@ class AclSecurityHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithNonAuthenticationCredentialsNotFoundException()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
 
         $authorizationChecker = $this->getAuthorizationCheckerMock();
         $authorizationChecker->expects($this->any())
             ->method('isGranted')
             ->will($this->throwException(new \RuntimeException('FAIL')));
 
-        $aclProvider = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
+        $aclProvider = $this->getMockForAbstractClass('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
 
         $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, 'Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder', array());
 

--- a/Tests/Security/Handler/NoopSecurityHandlerTest.php
+++ b/Tests/Security/Handler/NoopSecurityHandlerTest.php
@@ -57,6 +57,6 @@ class NoopSecurityHandlerTest extends \PHPUnit_Framework_TestCase
      */
     private function getSonataAdminObject()
     {
-        return $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        return $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
     }
 }

--- a/Tests/Security/Handler/RoleSecurityHandlerTest.php
+++ b/Tests/Security/Handler/RoleSecurityHandlerTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Security\Handler;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Security\Handler\RoleSecurityHandler;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\SecurityContextInterface;
@@ -22,7 +23,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class RoleSecurityHandlerTest extends \PHPUnit_Framework_TestCase
+class RoleSecurityHandlerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var AdminInterface
@@ -38,12 +39,12 @@ class RoleSecurityHandlerTest extends \PHPUnit_Framework_TestCase
     {
         // Set the SecurityContext for Symfony <2.6
         if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
-            $this->authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+            $this->authorizationChecker = $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         } else {
-            $this->authorizationChecker = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+            $this->authorizationChecker = $this->getMockForAbstractClass('Symfony\Component\Security\Core\SecurityContextInterface');
         }
 
-        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
     }
 
     /**
@@ -186,7 +187,7 @@ class RoleSecurityHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testIsGrantedWithException()
     {
-        $this->setExpectedException('RuntimeException', 'Something is wrong');
+        $this->expectException('RuntimeException', 'Something is wrong');
 
         $this->admin->expects($this->any())
             ->method('getCode')
@@ -233,6 +234,6 @@ class RoleSecurityHandlerTest extends \PHPUnit_Framework_TestCase
      */
     private function getSonataAdminObject()
     {
-        return $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        return $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
     }
 }

--- a/Tests/Show/ShowMapperTest.php
+++ b/Tests/Show/ShowMapperTest.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CleanAdmin;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
 
 /**
@@ -23,7 +24,7 @@ use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class ShowMapperTest extends \PHPUnit_Framework_TestCase
+class ShowMapperTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var ShowMapper
@@ -57,9 +58,9 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->showBuilder = $this->getMock('Sonata\AdminBundle\Builder\ShowBuilderInterface');
+        $this->showBuilder = $this->getMockForAbstractClass('Sonata\AdminBundle\Builder\ShowBuilderInterface');
         $this->fieldDescriptionCollection = new FieldDescriptionCollection();
-        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
 
         $this->admin->expects($this->any())
             ->method('getLabel')
@@ -96,7 +97,7 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
                 $groups = $showGroups;
             }));
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         // php 5.3 BC
         $fieldDescription = $this->getFieldDescriptionMock();
@@ -326,31 +327,18 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
 
     public function testAddException()
     {
-        try {
-            $this->showMapper->add(12345);
-        } catch (\RuntimeException $e) {
-            $this->assertContains('invalid state', $e->getMessage());
+        $this->expectException('\RuntimeException', 'invalid state');
 
-            return;
-        }
-
-        $this->fail('Failed asserting that exception of type "\RuntimeException" is thrown.');
+        $this->showMapper->add(12345);
     }
 
     public function testAddDuplicateFieldNameException()
     {
         $name = 'name';
+        $this->expectException('\RuntimeException', sprintf('Duplicate field %s "name" in show mapper. Names should be unique.', $name));
 
-        try {
-            $this->showMapper->add($name);
-            $this->showMapper->add($name);
-        } catch (\RuntimeException $e) {
-            $this->assertContains(sprintf('Duplicate field name "%s" in show mapper. Names should be unique.', $name), $e->getMessage());
-
-            return;
-        }
-
-        $this->fail('Failed asserting that duplicate field name exception of type "\RuntimeException" is thrown.');
+        $this->showMapper->add($name);
+        $this->showMapper->add($name);
     }
 
     public function testKeys()
@@ -449,7 +437,7 @@ class ShowMapperTest extends \PHPUnit_Framework_TestCase
 
     private function cleanShowMapper()
     {
-        $this->showBuilder = $this->getMock('Sonata\AdminBundle\Builder\ShowBuilderInterface');
+        $this->showBuilder = $this->getMockForAbstractClass('Sonata\AdminBundle\Builder\ShowBuilderInterface');
         $this->fieldDescriptionCollection = new FieldDescriptionCollection();
         $this->admin = new CleanAdmin('code', 'class', 'controller');
         $this->showMapper = new ShowMapper($this->showBuilder, $this->fieldDescriptionCollection, $this->admin);

--- a/Tests/SonataAdminBundleTest.php
+++ b/Tests/SonataAdminBundleTest.php
@@ -28,7 +28,9 @@ class SonataAdminBundleTest extends \PHPUnit_Framework_TestCase
 {
     public function testBuild()
     {
-        $containerBuilder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder', array('addCompilerPass'));
+        $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('addCompilerPass'))
+            ->getMock();
 
         $containerBuilder->expects($this->exactly(4))
             ->method('addCompilerPass')

--- a/Tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
+++ b/Tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Tests\Translator\Extractor\JMSTranslatorBundle;
 use JMS\TranslationBundle\Model\Message;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\AdminBundle\Translator\Extractor\JMSTranslatorBundle\AdminExtractor;
 
 /**
@@ -21,7 +22,7 @@ use Sonata\AdminBundle\Translator\Extractor\JMSTranslatorBundle\AdminExtractor;
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class AdminExtractorTest extends \PHPUnit_Framework_TestCase
+class AdminExtractorTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var AdminExtractor
@@ -54,14 +55,14 @@ class AdminExtractorTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('JMS Translator Bundle does not exist');
         }
 
-        $this->fooAdmin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $this->barAdmin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->fooAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->barAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
 
         // php 5.3 BC
         $fooAdmin = $this->fooAdmin;
         $barAdmin = $this->barAdmin;
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())
             ->method('get')
             ->will($this->returnCallback(function ($id) use ($fooAdmin, $barAdmin) {
@@ -75,7 +76,7 @@ class AdminExtractorTest extends \PHPUnit_Framework_TestCase
                 return;
             }));
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->getMockForAbstractClass('Psr\Log\LoggerInterface');
 
         $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
             ->disableOriginalConstructor()
@@ -95,7 +96,7 @@ class AdminExtractorTest extends \PHPUnit_Framework_TestCase
         $this->adminExtractor = new AdminExtractor($this->pool, $logger);
         $this->adminExtractor->setLogger($logger);
 
-        $this->breadcrumbsBuilder = $this->getMock('Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface');
+        $this->breadcrumbsBuilder = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface');
         $this->adminExtractor->setBreadcrumbsBuilder($this->breadcrumbsBuilder);
     }
 
@@ -147,7 +148,7 @@ class AdminExtractorTest extends \PHPUnit_Framework_TestCase
 
     public function testExtractWithException()
     {
-        $this->setExpectedException('RuntimeException', 'Foo throws exception');
+        $this->expectException('RuntimeException', 'Foo throws exception');
 
         $this->fooAdmin->expects($this->any())
             ->method('getShow')

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Exception\NoValueException;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
@@ -35,7 +36,7 @@ use Symfony\Component\Translation\TranslatorInterface;
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
+class SonataAdminExtensionTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var SonataAdminExtension
@@ -91,13 +92,13 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
     {
         date_default_timezone_set('Europe/London');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $this->pool = new Pool($container, '', '');
         $this->pool->setAdminServiceIds(array('sonata_admin_foo_service'));
         $this->pool->setAdminClasses(array('fooClass' => array('sonata_admin_foo_service')));
 
-        $this->logger = $this->getMock('Psr\Log\LoggerInterface');
+        $this->logger = $this->getMockForAbstractClass('Psr\Log\LoggerInterface');
         $this->xEditableTypeMapping = array(
             'choice' => 'select',
             'boolean' => 'select',
@@ -160,7 +161,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
         $this->object = new \stdClass();
 
         // initialize admin
-        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
 
         $this->admin->expects($this->any())
             ->method('getCode')
@@ -182,7 +183,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
                 return $translator->trans($id, $parameters, $domain);
             }));
 
-        $this->adminBar = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->adminBar = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $this->adminBar->expects($this->any())
             ->method('isGranted')
             ->will($this->returnValue(true));
@@ -208,7 +209,7 @@ class SonataAdminExtensionTest extends \PHPUnit_Framework_TestCase
             }));
 
         // initialize field description
-        $this->fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $this->fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
 
         $this->fieldDescription->expects($this->any())
             ->method('getName')
@@ -1910,7 +1911,7 @@ EOT
     public function testGetValueFromFieldDescription()
     {
         $object = new \stdClass();
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
 
         $fieldDescription->expects($this->any())
             ->method('getValue')
@@ -1921,27 +1922,21 @@ EOT
 
     public function testGetValueFromFieldDescriptionWithRemoveLoopException()
     {
-        $object = $this->getMock('\ArrayAccess');
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $object = $this->createMock('\ArrayAccess');
+        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
 
-        try {
-            $this->assertSame(
-                'anything',
-                $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription, array('loop' => true))
-            );
-        } catch (\RuntimeException $e) {
-            $this->assertContains('remove the loop requirement', $e->getMessage());
+        $this->expectException('\RuntimeException', 'remove the loop requirement');
 
-            return;
-        }
-
-        $this->fail('Failed asserting that exception of type "\RuntimeException" is thrown.');
+        $this->assertSame(
+            'anything',
+            $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription, array('loop' => true))
+        );
     }
 
     public function testGetValueFromFieldDescriptionWithNoValueException()
     {
         $object = new \stdClass();
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
 
         $fieldDescription->expects($this->any())
             ->method('getValue')
@@ -1959,7 +1954,7 @@ EOT
     public function testGetValueFromFieldDescriptionWithNoValueExceptionNewAdminInstance()
     {
         $object = new \stdClass();
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
 
         $fieldDescription->expects($this->any())
             ->method('getValue')
@@ -2083,7 +2078,9 @@ EOT
                 }
             }));
 
-        $element = $this->getMock('stdClass', array('customToString'));
+        $element = $this->getMockBuilder('stdClass')
+            ->setMethods(array('customToString'))
+            ->getMock();
         $element->expects($this->any())
             ->method('customToString')
             ->will($this->returnValue('fooBar'));
@@ -2106,19 +2103,9 @@ EOT
             }));
 
         $element = new \stdClass();
+        $this->expectException('\RuntimeException', 'You must define an `associated_property` option or create a `stdClass::__toString');
 
-        try {
-            $this->twigExtension->renderRelationElement($element, $this->fieldDescription);
-        } catch (\RuntimeException $e) {
-            $this->assertContains(
-                'You must define an `associated_property` option or create a `stdClass::__toString',
-                $e->getMessage()
-            );
-
-            return;
-        }
-
-        $this->fail('Failed asserting that exception of type "\RuntimeException" is thrown.');
+        $this->twigExtension->renderRelationElement($element, $this->fieldDescription);
     }
 
     public function testRenderRelationElementWithPropertyPath()
@@ -2239,7 +2226,7 @@ EOT
      */
     public function testGetXEditableChoicesIsIdempotent(array $input)
     {
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->exactly(2))
             ->method('getOption')
             ->withConsecutive(

--- a/Tests/Twig/GlobalVariablesTest.php
+++ b/Tests/Twig/GlobalVariablesTest.php
@@ -11,12 +11,13 @@
 
 namespace Sonata\AdminBundle\Tests\Twig;
 
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\AdminBundle\Twig\GlobalVariables;
 
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
  */
-class GlobalVariablesTest extends \PHPUnit_Framework_TestCase
+class GlobalVariablesTest extends PHPUnit_Framework_TestCase
 {
     private $code;
     private $action;
@@ -27,7 +28,7 @@ class GlobalVariablesTest extends \PHPUnit_Framework_TestCase
     {
         $this->code = 'sonata.page.admin.page|sonata.page.admin.snapshot';
         $this->action = 'list';
-        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
     }
 
@@ -81,7 +82,7 @@ class GlobalVariablesTest extends \PHPUnit_Framework_TestCase
             ->with('sonata.page.admin.page')
             ->willReturn($this->admin);
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->once())
             ->method('get')
             ->with('sonata.admin.pool')
@@ -97,7 +98,7 @@ class GlobalVariablesTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidArgumentException()
     {
-        $this->setExpectedException(
+        $this->expectException(
             'InvalidArgumentException',
             '$adminPool should be an instance of Sonata\AdminBundle\Admin\Pool'
         );

--- a/Tests/Util/AdminObjectAclDataTest.php
+++ b/Tests/Util/AdminObjectAclDataTest.php
@@ -44,7 +44,9 @@ class AdminObjectAclDataTest extends \PHPUnit_Framework_TestCase
 
     public function testSetAcl()
     {
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Domain\Acl', array(), array(), '', false);
+        $acl = $this->getMockBuilder('Symfony\Component\Security\Acl\Domain\Acl')
+            ->disableOriginalConstructor()
+            ->getMock();
         $adminObjectAclData = $this->createAdminObjectAclData();
         $ret = $adminObjectAclData->setAcl($acl);
 
@@ -77,7 +79,9 @@ class AdminObjectAclDataTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetForm()
     {
-        $form = $this->getMock('\Symfony\Component\Form\Form', array(), array(), '', false);
+        $form = $this->getMockBuilder('\Symfony\Component\Form\Form')
+            ->disableOriginalConstructor()
+            ->getMock();
         $adminObjectAclData = $this->createAdminObjectAclData();
         $ret = $adminObjectAclData->setAclUsersForm($form);
 
@@ -98,7 +102,9 @@ class AdminObjectAclDataTest extends \PHPUnit_Framework_TestCase
 
     public function testSetAclUsersForm()
     {
-        $form = $this->getMock('\Symfony\Component\Form\Form', array(), array(), '', false);
+        $form = $this->getMockBuilder('\Symfony\Component\Form\Form')
+            ->disableOriginalConstructor()
+            ->getMock();
         $adminObjectAclData = $this->createAdminObjectAclData();
         $ret = $adminObjectAclData->setAclUsersForm($form);
 
@@ -117,7 +123,9 @@ class AdminObjectAclDataTest extends \PHPUnit_Framework_TestCase
 
     public function testSetAclRolesForm()
     {
-        $form = $this->getMock('\Symfony\Component\Form\Form', array(), array(), '', false);
+        $form = $this->getMockBuilder('\Symfony\Component\Form\Form')
+            ->disableOriginalConstructor()
+            ->getMock();
         $adminObjectAclData = $this->createAdminObjectAclData();
         $ret = $adminObjectAclData->setAclRolesForm($form);
 
@@ -207,7 +215,7 @@ class AdminObjectAclDataTest extends \PHPUnit_Framework_TestCase
 
     protected function createAdmin($isOwner = true)
     {
-        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface');
+        $securityHandler = $this->getMockForAbstractClass('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface');
 
         $securityHandler->expects($this->any())
             ->method('getObjectPermissions')
@@ -220,7 +228,7 @@ class AdminObjectAclDataTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(array()))
         ;
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
 
         $admin->expects($this->any())
             ->method('isGranted')

--- a/Tests/Util/AdminObjectAclManipulatorTest.php
+++ b/Tests/Util/AdminObjectAclManipulatorTest.php
@@ -28,6 +28,6 @@ class AdminObjectAclManipulatorTest extends \PHPUnit_Framework_TestCase
 
     protected function createAdminObjectAclManipulator()
     {
-        return new AdminObjectAclManipulator($this->getMock('Symfony\Component\Form\FormFactoryInterface'), self::MASK_BUILDER_CLASS);
+        return new AdminObjectAclManipulator($this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface'), self::MASK_BUILDER_CLASS);
     }
 }

--- a/Tests/Util/FormBuilderIteratorTest.php
+++ b/Tests/Util/FormBuilderIteratorTest.php
@@ -38,8 +38,8 @@ class FormBuilderIteratorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $this->dispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->factory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $this->builder = new TestFormBuilder('name', null, $this->dispatcher, $this->factory);
         $this->factory->expects($this->any())->method('createNamedBuilder')->willReturn($this->builder);
     }


### PR DESCRIPTION
I am targetting this branch, because we discuss it in #4286.

Closes #4286

## Changelog

### Changed
- Removed deprecated calls in PHPunit tests to avoid warnings.

## To do

- [x] Finish Admin tests
- [ ] Finish Block tests (blocked by SonataBlockBundle https://github.com/sonata-project/SonataBlockBundle/pull/357)
- [x] Finish Command tests
- [x] Finish Controller tests
- [x] Finish Datagrid tests
- [x] Finish DependencyInjection tests
- [x] Finish Event tests
- [x] Finish Export tests
- [x] Finish Filter tests
- [ ] Finish Form tests (blocked by SonataCoreBundle)
- [x] Finish Generator tests
- [x] Finish Guesser tests
- [x] Finish Manipulator tests
- [x] Finish Mapper tests
- [x] Finish Menu tests
- [x] Finish Model tests
- [x] Finish Resources tests
- [x] Finish Route tests
- [x] Finish Search tests
- [x] Finish Security tests
- [x] Finish Show tests
- [x] Finish Translator tests
- [x] Finish Twig tests
- [x] Finish Util tests

## Subject

This PR is **still in progress**. Currently I want to show my progress.

**If you want to help work with this PR feel free to contact me here.**
