### PR TITLE
Fix menu builder listener code sample

### DIFF
--- a/Resources/doc/cookbook/recipe_knp_menu.rst
+++ b/Resources/doc/cookbook/recipe_knp_menu.rst
@@ -151,12 +151,12 @@ You can modify the menu via events easily. You can register as many listeners as
         {
             $menu = $event->getMenu();
 
-            $child = $menu->addChild('reports', array(
+            $child = $menu->addChild('reports', [
+                'label' => 'Daily and monthly reports',
                 'route' => 'app_reports_index',
-                'labelAttributes' => array('icon' => 'fa fa-bar-chart'),
-            ));
-
-            $child->setLabel('Daily and monthly reports');
+            ])->setExtras([
+                'icon' => '<i class="fa fa-bar-chart"></i>',
+            ]);
         }
     }
 


### PR DESCRIPTION
I am targetting this branch, because it's a 3.x doc fix.

## To do

- [ ] Update the documentation

## Subject

The icon is now defined onto the extras options and the label can be set directly from child creation options.
