### PR TITLE
Removed unnecessary autoload-dev entry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,9 +66,6 @@
             "Tests/"
         ]
     },
-    "autoload-dev": {
-        "psr-4": { "Sonata\\AdminBundle\\Tests\\": "Tests/" }
-     },
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDashboardBundle/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a pedantic change.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

There is no reason for this entry, because the `Tests` namespace is already covered by the normal `autoload` entry.
