### PR TITLE
#4036 Add priority support for admin extensions

### DIFF
--- a/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -73,7 +73,6 @@ class ExtensionCompilerPass implements CompilerPassInterface
                 }
 
                 $this->addExtension($targets, $id, $extension, $attributes);
-
             }
         }
 

--- a/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -78,7 +78,7 @@ class ExtensionCompilerPass implements CompilerPassInterface
 
         foreach ($targets as $target => $extensions) {
             $extensions = iterator_to_array($extensions);
-            ksort($extensions);
+            krsort($extensions);
             $admin = $container->getDefinition($target);
 
             foreach (array_values($extensions) as $extension) {

--- a/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -38,19 +38,14 @@ class ExtensionCompilerPass implements CompilerPassInterface
                 }
 
                 if (isset($attributes['global']) && $attributes['global']) {
-                    $universalExtensions[] = $id;
+                    $universalExtensions[$id] = $attributes;
                 }
 
                 if (!$target || !$container->hasDefinition($target)) {
                     continue;
                 }
 
-                if (!isset($targets[$target])) {
-                    $targets[$target] = new \SplPriorityQueue();
-                }
-
-                $priority = isset($attributes['priority']) ? $attributes['priority'] : 0;
-                $targets[$target]->insert(new Reference($id), $priority);
+                $this->addExtension($targets, $target, $id, $attributes);
             }
         }
 
@@ -64,9 +59,8 @@ class ExtensionCompilerPass implements CompilerPassInterface
                 $targets[$id] = new \SplPriorityQueue();
             }
 
-            foreach ($universalExtensions as $extension) {
-                $priority = isset($attributes['priority']) ? $attributes['priority'] : 0;
-                $targets[$id]->insert(new Reference($extension), $priority);
+            foreach ($universalExtensions as $extension => $extensionAttributes) {
+                $this->addExtension($targets, $id, $extension, $extensionAttributes);
             }
 
             $extensions = $this->getExtensionsForAdmin($id, $admin, $container, $extensionMap);
@@ -78,8 +72,8 @@ class ExtensionCompilerPass implements CompilerPassInterface
                     );
                 }
 
-                $priority = isset($attributes['priority']) ? $attributes['priority'] : 0;
-                $targets[$id]->insert(new Reference($extension), $priority);
+                $this->addExtension($targets, $id, $extension, $attributes);
+
             }
         }
 
@@ -218,5 +212,23 @@ class ExtensionCompilerPass implements CompilerPassInterface
         }
 
         return $this->hasTrait($parentClass, $traitName);
+    }
+
+    /**
+     * Add extension configuration to the targets array.
+     *
+     * @param array  $targets
+     * @param string $target
+     * @param string $extension
+     * @param array  $attributes
+     */
+    private function addExtension(array &$targets, $target, $extension, $attributes)
+    {
+        if (!isset($targets[$target])) {
+            $targets[$target] = new \SplPriorityQueue();
+        }
+
+        $priority = isset($attributes['priority']) ? $attributes['priority'] : 0;
+        $targets[$target]->insert(new Reference($extension), $priority);
     }
 }

--- a/Resources/doc/reference/extensions.rst
+++ b/Resources/doc/reference/extensions.rst
@@ -52,6 +52,11 @@ Set the *global* attribute to *true* and the extension will be added to all admi
                 tags:
                     - { name: sonata.admin.extension, global: true }
 
+            app.important.extension:
+                class: AppBundle\Admin\Extension\ImportantAdminExtension
+                tags:
+                    - { name: sonata.admin.extension, priority: 5 }
+
 The second option is to add it to your config.yml file.
 
 .. configuration-block::

--- a/Resources/doc/reference/extensions.rst
+++ b/Resources/doc/reference/extensions.rst
@@ -35,6 +35,8 @@ You can include this information in the service definition of your extension.
 Add the tag *sonata.admin.extension* and use the *target* attribute to point to
 the admin you want to modify. Please note you can specify as many tags you want.
 Set the *global* attribute to *true* and the extension will be added to all admins.
+The *priority* attribute is *0* by default and can be a positive or negative integer.
+The higher the priority, the earlier it's executed.
 
 .. configuration-block::
 

--- a/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -250,7 +250,7 @@ class ExtensionCompilerPassTest extends PHPUnit_Framework_TestCase
         $extensions = $def->getExtensions();
         $this->assertCount(4, $extensions);
 
-        $this->assertInstanceOf(get_class($this->securityExtension), $extensions[0]);
+        $this->assertInstanceOf(get_class($this->securityExtension), $extensions[1]);
         $this->assertInstanceOf(get_class($this->publishExtension), $extensions[2]);
         $this->assertInstanceOf(get_class($this->historyExtension), $extensions[3]);
 
@@ -259,7 +259,7 @@ class ExtensionCompilerPassTest extends PHPUnit_Framework_TestCase
         $this->assertCount(5, $extensions);
 
         $this->assertInstanceOf(get_class($this->securityExtension), $extensions[0]);
-        $this->assertInstanceOf(get_class($this->publishExtension), $extensions[1]);
+        $this->assertInstanceOf(get_class($this->publishExtension), $extensions[2]);
         $this->assertInstanceOf(get_class($this->orderExtension), $extensions[3]);
         $this->assertInstanceOf(get_class($this->filterExtension), $extensions[4]);
 
@@ -267,7 +267,7 @@ class ExtensionCompilerPassTest extends PHPUnit_Framework_TestCase
         $extensions = $def->getExtensions();
         $this->assertCount(5, $extensions);
         $this->assertInstanceOf(get_class($this->securityExtension), $extensions[0]);
-        $this->assertInstanceOf(get_class($this->orderExtension), $extensions[1]);
+        $this->assertInstanceOf(get_class($this->orderExtension), $extensions[2]);
         $this->assertInstanceOf(get_class($this->historyExtension), $extensions[3]);
         $this->assertInstanceOf(get_class($this->filterExtension), $extensions[4]);
     }

--- a/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -250,25 +250,25 @@ class ExtensionCompilerPassTest extends PHPUnit_Framework_TestCase
         $extensions = $def->getExtensions();
         $this->assertCount(4, $extensions);
 
-        $this->assertInstanceOf(get_class($this->securityExtension), $extensions[1]);
-        $this->assertInstanceOf(get_class($this->publishExtension), $extensions[2]);
-        $this->assertInstanceOf(get_class($this->historyExtension), $extensions[3]);
+        $this->assertInstanceOf(get_class($this->securityExtension), $extensions[0]);
+        $this->assertInstanceOf(get_class($this->publishExtension), $extensions[1]);
+        $this->assertInstanceOf(get_class($this->historyExtension), $extensions[2]);
 
         $def = $container->get('sonata_article_admin');
         $extensions = $def->getExtensions();
         $this->assertCount(5, $extensions);
 
         $this->assertInstanceOf(get_class($this->securityExtension), $extensions[0]);
-        $this->assertInstanceOf(get_class($this->publishExtension), $extensions[2]);
-        $this->assertInstanceOf(get_class($this->orderExtension), $extensions[3]);
+        $this->assertInstanceOf(get_class($this->publishExtension), $extensions[1]);
+        $this->assertInstanceOf(get_class($this->orderExtension), $extensions[2]);
         $this->assertInstanceOf(get_class($this->filterExtension), $extensions[4]);
 
         $def = $container->get('sonata_news_admin');
         $extensions = $def->getExtensions();
         $this->assertCount(5, $extensions);
         $this->assertInstanceOf(get_class($this->securityExtension), $extensions[0]);
-        $this->assertInstanceOf(get_class($this->orderExtension), $extensions[2]);
-        $this->assertInstanceOf(get_class($this->historyExtension), $extensions[3]);
+        $this->assertInstanceOf(get_class($this->orderExtension), $extensions[1]);
+        $this->assertInstanceOf(get_class($this->historyExtension), $extensions[2]);
         $this->assertInstanceOf(get_class($this->filterExtension), $extensions[4]);
     }
 


### PR DESCRIPTION
(Screwed up last PR so here is a new one)

I am targetting this branch, because i currently have no reason to believe there are extensions that rely on a specific order.

Closes #4036

```markdown
### Added
- Added support for priority attribute in the Extension compiler pass.
```

## To do

- [x] Update the tests
- [x] Update the documentation

## Subject

This pull request should add support for priority when tagging admin extensions.
There should not be any BC breaks, in case there is please leave a comment.
