### PR TITLE
Check Twig blocks exist before rendering them

### DIFF
--- a/Resources/views/ajax_layout.html.twig
+++ b/Resources/views/ajax_layout.html.twig
@@ -10,9 +10,9 @@ file that was distributed with this source code.
 #}
 
 {% block content %}
-    {% set _list_table           = block('list_table')|trim %}
-    {% set _list_filters         = block('list_filters')|trim %}
-    {% set _list_filters_actions = block('list_filters_actions') %}
+    {% set _list_table = block('list_table') is defined ? block('list_table')|trim : null %}
+    {% set _list_filters = block('list_filters') is defined ? block('list_filters')|trim : null %}
+    {% set _list_filters_actions = block('list_filters_actions') is defined ? block('list_filters_actions') : null %}
 
     {% block preview %}{% endblock %}
     {% block form %}{% endblock %}


### PR DESCRIPTION
No idea why this did not fail before. Maybe Twig 2.0 is stricter?
Fixes #4305

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- compatibility of ajax actions with Twig 2.0
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Test this. @Lctrs , can you help?