### PR TITLE
Fix internal deprecation notices

### DIFF
--- a/Controller/CoreController.php
+++ b/Controller/CoreController.php
@@ -48,7 +48,7 @@ class CoreController extends Controller
             'blocks' => $blocks,
         );
 
-        if (!$this->getRequest()->isXmlHttpRequest()) {
+        if (!$this->getCurrentRequest()->isXmlHttpRequest()) {
             $parameters['breadcrumbs_builder'] = $this->get('sonata.admin.breadcrumbs_builder');
         }
 
@@ -125,16 +125,13 @@ class CoreController extends Controller
      */
     public function getRequest()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since 3.0 and will be removed in 4.0.'.
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 3.0 and will be removed in 4.0.'.
             ' Inject the Symfony\Component\HttpFoundation\Request into the actions instead.',
             E_USER_DEPRECATED
         );
 
-        if ($this->container->has('request_stack')) {
-            return $this->container->get('request_stack')->getCurrentRequest();
-        }
-
-        return $this->container->get('request');
+        return $this->getCurrentRequest();
     }
 
     /**
@@ -158,10 +155,25 @@ class CoreController extends Controller
      */
     protected function getBaseTemplate()
     {
-        if ($this->getRequest()->isXmlHttpRequest()) {
+        if ($this->getCurrentRequest()->isXmlHttpRequest()) {
             return $this->getAdminPool()->getTemplate('ajax');
         }
 
         return $this->getAdminPool()->getTemplate('layout');
+    }
+
+    /**
+     * Get the request object from the container.
+     *
+     * @return Request
+     */
+    private function getCurrentRequest()
+    {
+        // NEXT_MAJOR: simplify this when dropping sf < 2.4
+        if ($this->container->has('request_stack')) {
+            return $this->container->get('request_stack')->getCurrentRequest();
+        }
+
+        return $this->container->get('request');
     }
 }

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1221,7 +1221,7 @@ class AdminTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group Legacy
+     * @group legacy
      */
     public function testTransWithMessageDomain()
     {
@@ -1255,7 +1255,7 @@ class AdminTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group Legacy
+     * @group legacy
      */
     public function testTransChoiceWithMessageDomain()
     {

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -951,6 +951,9 @@ class AdminTest extends PHPUnit_Framework_TestCase
         $this->assertSame('foo', $admin->getTranslationDomain());
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetTranslator()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
@@ -1204,6 +1207,9 @@ class AdminTest extends PHPUnit_Framework_TestCase
         $this->assertSame('sonata.post.admin.post', $admin->getObjectIdentifier());
     }
 
+    /**
+     * @group legacy
+     */
     public function testTrans()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
@@ -1238,6 +1244,9 @@ class AdminTest extends PHPUnit_Framework_TestCase
         $this->assertSame('fooTranslated', $admin->trans('foo', array('name' => 'Andrej'), 'fooMessageDomain'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testTransChoice()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');


### PR DESCRIPTION
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- deprecation notices that could not be avoided in the `CoreController` class
```



## Subject

There are still deprecation notices, but they come from Symfony. This PR fixes all outstanding internal deprecation notices.
