### PR TITLE
Only vote on menu items created by SonataAdminBundle

### DIFF
--- a/Menu/Matcher/Voter/ActiveVoter.php
+++ b/Menu/Matcher/Voter/ActiveVoter.php
@@ -26,6 +26,10 @@ class ActiveVoter implements VoterInterface
      */
     public function matchItem(ItemInterface $item)
     {
+        if (!$item->getExtra('sonata_admin', false)) {
+            return;
+        }
+
         return $item->getExtra('active', null);
     }
 }

--- a/Menu/Matcher/Voter/ChildrenVoter.php
+++ b/Menu/Matcher/Voter/ChildrenVoter.php
@@ -42,6 +42,10 @@ class ChildrenVoter implements VoterInterface
      */
     public function matchItem(ItemInterface $item)
     {
+        if (!$item->getExtra('sonata_admin', false)) {
+            return;
+        }
+
         $children = $item->getChildren();
         $match = null;
         foreach ($children as $child) {

--- a/Menu/MenuBuilder.php
+++ b/Menu/MenuBuilder.php
@@ -74,6 +74,7 @@ class MenuBuilder
                 'icon' => $group['icon'],
                 'label_catalogue' => $group['label_catalogue'],
                 'roles' => $group['roles'],
+                'sonata_admin' => true,
             );
 
             $menuProvider = isset($group['provider']) ? $group['provider'] : 'sonata_group_menu';

--- a/Tests/Menu/Matcher/Voter/ActiveVoterTest.php
+++ b/Tests/Menu/Matcher/Voter/ActiveVoterTest.php
@@ -46,8 +46,17 @@ class ActiveVoterTest extends AbstractVoterTest
         $item = $this->getMockForAbstractClass('Knp\Menu\ItemInterface');
         $item->expects($this->any())
              ->method('getExtra')
-             ->with('active')
-             ->will($this->returnValue($data))
+             ->with($this->logicalOr(
+                $this->equalTo('active'),
+                $this->equalTo('sonata_admin')
+             ))
+             ->will($this->returnCallback(function ($name) use ($data) {
+                 if ('active' === $name) {
+                     return $data;
+                 }
+
+                 return true;
+             }))
         ;
 
         return $item;

--- a/Tests/Menu/Matcher/Voter/ChildrenVoterTest.php
+++ b/Tests/Menu/Matcher/Voter/ChildrenVoterTest.php
@@ -58,6 +58,11 @@ class ChildrenVoterTest extends AbstractVoterTest
             ->method('getChildren')
             ->will($this->returnValue($childItems));
 
+        $item->expects($this->any())
+             ->method('getExtra')
+             ->with('sonata_admin')
+             ->will($this->returnValue(true));
+
         return $item;
     }
 }


### PR DESCRIPTION
Closes #4254 

## Changelog

```markdown
### Changed
- Changed `ActiveVoter` and `ChildrenVoter` to only work with menu items having the `SonataAdminBundle` extra set.
```

## Subject

This avoids incorrectly matching items outside the admin dashboard. See #4254 for a more detailed description of what happends when this PR is not applied.
