### PR TITLE
fix #4292 add conditions for default jms_extra_di

### DIFF
--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -215,14 +215,24 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $bundles = $container->getParameter('kernel.bundles');
 
         if (isset($bundles['JMSDiExtraBundle'])) {
-            $container->prependExtensionConfig(
-                'jms_di_extra',
-                array(
-                    'annotation_patterns' => array(
-                        'Sonata\AdminBundle\Annotation',
-                    ),
-                )
-            );
+            if (!$container->hasParameter('jms_di_extra.annotation_patterns')){
+                $container->setParameter(
+                    'jms_di_extra.annotation_patterns',
+                    array(
+                        'JMS\DiExtraBundle\Annotation',
+                        'Sonata\AdminBundle\Annotation'
+                    )
+                );
+            }else{
+                $container->prependExtensionConfig(
+                    'jms_di_extra',
+                    array(
+                        'annotation_patterns' => array(
+                            'Sonata\AdminBundle\Annotation',
+                        ),
+                    )
+                );
+            }
         }
     }
 

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -215,15 +215,15 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $bundles = $container->getParameter('kernel.bundles');
 
         if (isset($bundles['JMSDiExtraBundle'])) {
-            if (!$container->hasParameter('jms_di_extra.annotation_patterns')){
+            if (!$container->hasParameter('jms_di_extra.annotation_patterns')) {
                 $container->setParameter(
                     'jms_di_extra.annotation_patterns',
                     array(
                         'JMS\DiExtraBundle\Annotation',
-                        'Sonata\AdminBundle\Annotation'
+                        'Sonata\AdminBundle\Annotation',
                     )
                 );
-            }else{
+            } else {
                 $container->prependExtensionConfig(
                     'jms_di_extra',
                     array(


### PR DESCRIPTION
I am targetting this branch, because it fixes the issue #4292.

Closes #4292

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed

- fixed #4292, add condition to resolve conflict with JMSDiExtraBundle
```

## Subject

As suggested @gremo 

> I can't check right now (in phone) but I would do the following. Please correct me if I'm wrong.
> 
> In prependExtensionConfig just check for annotation_pattern. If key doesn't exist, that would mean we need to prepend the default pattern from JMSDiExtraBundle plus the SonataAdminBundle pattern, this way we don't break the bundle.
> 
> If key actualy exists it means that those values come from config.yml and not from defaults. Just prepend the sonata pattern, it's the developer responsibility to add any other pattern (including the default ones).
> 
> This is a temporary fix but it's necessary because how symfony and jms do merging/prepending is not going to chance in the near future.