### PR TITLE
Fixed 2 misspellings of "sonata_choice_field_mask"

### DIFF
--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -324,7 +324,7 @@ template
     {% block sonata_type_model_autocomplete_selection_format %}'<b>'+item.label+'</b>'{% endblock %}
 
 sonata_type_choice_field_mask
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Setting a field type of ``sonata_type_choice_field_mask`` will use an instance of
 ``ChoiceFieldMaskType`` to render choice field.

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -323,10 +323,10 @@ template
     {# change the default selection format #}
     {% block sonata_type_model_autocomplete_selection_format %}'<b>'+item.label+'</b>'{% endblock %}
 
-sonata_choice_field_mask
+sonata_type_choice_field_mask
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Setting a field type of ``sonata_choice_field_mask`` will use an instance of
+Setting a field type of ``sonata_type_choice_field_mask`` will use an instance of
 ``ChoiceFieldMaskType`` to render choice field.
 
 According the choice made only associated fields are displayed. The others fields are hidden.


### PR DESCRIPTION
Found some typos in https://sonata-project.org/bundles/admin/master/doc/reference/form_types.html# an fixed them.
