### PR TITLE
Removed wrong styles on an Admin with Subclasses

### DIFF
--- a/Resources/views/Button/create_button.html.twig
+++ b/Resources/views/Button/create_button.html.twig
@@ -15,15 +15,15 @@ file that was distributed with this source code.
             <i class="fa fa-plus-circle" aria-hidden="true"></i>
             {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }}</a>
     {% else %}
-        <li class="divider" role="presentation"></li>
-        {% for subclass in admin.subclasses|keys %}
-            <li>
-                <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
-                    <i class="fa fa-plus-circle" aria-hidden="true"></i>
-                    {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
-                </a>
-            </li>
-        {% endfor %}
-        <li class="divider" role="presentation"></li>
+        <ul class="list-unstyled">
+            {% for subclass in admin.subclasses|keys %}
+                <li>
+                    <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
+                        <i class="fa fa-plus-circle" aria-hidden="true"></i>
+                        {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
     {% endif %}
 {% endif %}


### PR DESCRIPTION
There was a wrong markup when using subclasses, li without an ul
Also wrong styles, fixed markup and removed default li styles.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed markup on list on Admin with subclasses
```

## Subject

<!-- Describe your Pull Request content here -->
Markup on admin with subclasses was broken. There was an li without an ul. I fixed that and also removed default styles on li.

Before:
<img width="1012" alt="captura de pantalla 2017-02-21 a las 13 32 31" src="https://cloud.githubusercontent.com/assets/1137485/23165667/980689fa-f83d-11e6-8e74-848cd6fc6565.png">


After:
<img width="1008" alt="captura de pantalla 2017-02-21 a las 13 32 45" src="https://cloud.githubusercontent.com/assets/1137485/23165672/9ea05340-f83d-11e6-965c-edb377831fb8.png">
