### PR TITLE
Fix bug The helper "dialog" is not defined (Undefined DialogHelper Class)

### DIFF
--- a/Command/GenerateAdminCommand.php
+++ b/Command/GenerateAdminCommand.php
@@ -350,5 +350,4 @@ class GenerateAdminCommand extends QuestionableCommand
 
         return $application->getKernel();
     }
-
 }

--- a/Command/GenerateAdminCommand.php
+++ b/Command/GenerateAdminCommand.php
@@ -11,20 +11,15 @@
 
 namespace Sonata\AdminBundle\Command;
 
-use Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper;
-use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 use Sonata\AdminBundle\Generator\AdminGenerator;
 use Sonata\AdminBundle\Generator\ControllerGenerator;
 use Sonata\AdminBundle\Manipulator\ServicesManipulator;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
-use Symfony\Component\Console\Question\Question;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -33,7 +28,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
  * @author Marek Stipek <mario.dweller@seznam.cz>
  * @author Simon Cosandey <simon.cosandey@simseo.ch>
  */
-class GenerateAdminCommand extends ContainerAwareCommand
+class GenerateAdminCommand extends QuestionableCommand
 {
     /**
      * @var string[]
@@ -278,66 +273,6 @@ class GenerateAdminCommand extends ContainerAwareCommand
     }
 
     /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     * @param string          $questionText
-     * @param mixed           $default
-     * @param callable        $validator
-     *
-     * @return mixed
-     */
-    private function askAndValidate(InputInterface $input, OutputInterface $output, $questionText, $default, $validator)
-    {
-        $questionHelper = $this->getQuestionHelper();
-
-        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
-        if ($questionHelper instanceof DialogHelper) {
-            return $questionHelper->askAndValidate(
-                $output,
-                $questionHelper->getQuestion($questionText, $default),
-                $validator,
-                false,
-                $default
-            );
-        }
-
-        $question = new Question($questionHelper->getQuestion($questionText, $default), $default);
-
-        $question->setValidator($validator);
-
-        return $questionHelper->ask($input, $output, $question);
-    }
-
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     * @param string          $questionText
-     * @param string          $default
-     * @param string          $separator
-     *
-     * @return string
-     */
-    private function askConfirmation(InputInterface $input, OutputInterface $output, $questionText, $default, $separator)
-    {
-        $questionHelper = $this->getQuestionHelper();
-
-        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
-        if ($questionHelper instanceof DialogHelper) {
-            $question = $questionHelper->getQuestion($questionText, $default, $separator);
-
-            return $questionHelper->askConfirmation($output, $question, ($default === 'no' ? false : true));
-        }
-
-        $question = new ConfirmationQuestion($questionHelper->getQuestion(
-            $questionText,
-            $default,
-            $separator
-        ), ($default === 'no' ? false : true));
-
-        return $questionHelper->ask($input, $output, $question);
-    }
-
-    /**
      * @return string
      *
      * @throws \RuntimeException
@@ -416,28 +351,4 @@ class GenerateAdminCommand extends ContainerAwareCommand
         return $application->getKernel();
     }
 
-    /**
-     * @return QuestionHelper|DialogHelper
-     */
-    private function getQuestionHelper()
-    {
-        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
-        if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
-            $questionHelper = $this->getHelper('dialog');
-
-            if (!$questionHelper instanceof DialogHelper) {
-                $questionHelper = new DialogHelper();
-                $this->getHelperSet()->set($questionHelper);
-            }
-        } else {
-            $questionHelper = $this->getHelper('question');
-
-            if (!$questionHelper instanceof QuestionHelper) {
-                $questionHelper = new QuestionHelper();
-                $this->getHelperSet()->set($questionHelper);
-            }
-        }
-
-        return $questionHelper;
-    }
 }

--- a/Command/GenerateObjectAclCommand.php
+++ b/Command/GenerateObjectAclCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class GenerateObjectAclCommand extends ContainerAwareCommand
+class GenerateObjectAclCommand extends QuestionableCommand
 {
     /**
      * @var string
@@ -47,9 +47,6 @@ class GenerateObjectAclCommand extends ContainerAwareCommand
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var $dialog \Symfony\Component\Console\Helper\DialogHelper */
-        $dialog = $this->getHelperSet()->get('dialog');
-
         $output->writeln('Welcome to the AdminBundle object ACL generator');
         $output->writeln(array(
                 '',
@@ -79,13 +76,13 @@ class GenerateObjectAclCommand extends ContainerAwareCommand
                 continue;
             }
 
-            if ($input->getOption('step') && !$dialog->askConfirmation($output, sprintf("<question>Generate ACLs for the object instances handled by \"%s\"?</question>\n", $id), false)) {
+            if ($input->getOption('step') && !$this->askConfirmation($input, $output, sprintf("<question>Generate ACLs for the object instances handled by \"%s\"?</question>\n", $id), 'no', '?')) {
                 continue;
             }
 
             $securityIdentity = null;
-            if ($input->getOption('step') && $dialog->askConfirmation($output, "<question>Set an object owner?</question>\n", false)) {
-                $username = $dialog->askAndValidate($output, 'Please enter the username: ', 'Sonata\AdminBundle\Command\Validators::validateUsername');
+            if ($input->getOption('step') && $this->askConfirmation($input, $output, "<question>Set an object owner?</question>\n", 'no', '?')) {
+                $username = $this->askAndValidate($input, $output, 'Please enter the username: ', '', 'Sonata\AdminBundle\Command\Validators::validateUsername');
 
                 $securityIdentity = new UserSecurityIdentity($username, $this->getUserEntityClass($input, $output));
             }
@@ -121,7 +118,7 @@ class GenerateObjectAclCommand extends ContainerAwareCommand
                 list($userBundle, $userEntity) = Validators::validateEntityName($input->getOption('user_entity'));
                 $this->userEntityClass = $this->getContainer()->get('doctrine')->getEntityNamespace($userBundle).'\\'.$userEntity;
             } else {
-                list($userBundle, $userEntity) = $this->getHelperSet()->get('dialog')->askAndValidate($output, 'Please enter the User Entity shortcut name: ', 'Sonata\AdminBundle\Command\Validators::validateEntityName');
+                list($userBundle, $userEntity) = $this->askAndValidate($input, $output, 'Please enter the User Entity shortcut name: ', '', 'Sonata\AdminBundle\Command\Validators::validateEntityName');
 
                 // Entity exists?
                 $this->userEntityClass = $this->getContainer()->get('doctrine')->getEntityNamespace($userBundle).'\\'.$userEntity;

--- a/Command/GenerateObjectAclCommand.php
+++ b/Command/GenerateObjectAclCommand.php
@@ -12,7 +12,6 @@
 namespace Sonata\AdminBundle\Command;
 
 use Sonata\AdminBundle\Util\ObjectAclManipulatorInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/Command/QuestionableCommand.php
+++ b/Command/QuestionableCommand.php
@@ -30,7 +30,7 @@ abstract class QuestionableCommand extends ContainerAwareCommand
      *
      * @return mixed
      */
-    protected function askAndValidate(InputInterface $input, OutputInterface $output, $questionText, $default, $validator)
+    final protected function askAndValidate(InputInterface $input, OutputInterface $output, $questionText, $default, $validator)
     {
         $questionHelper = $this->getQuestionHelper();
 
@@ -61,7 +61,7 @@ abstract class QuestionableCommand extends ContainerAwareCommand
      *
      * @return string
      */
-    protected function askConfirmation(InputInterface $input, OutputInterface $output, $questionText, $default, $separator)
+    final protected function askConfirmation(InputInterface $input, OutputInterface $output, $questionText, $default, $separator)
     {
         $questionHelper = $this->getQuestionHelper();
 
@@ -84,7 +84,7 @@ abstract class QuestionableCommand extends ContainerAwareCommand
     /**
      * @return QuestionHelper|DialogHelper
      */
-    protected function getQuestionHelper()
+    final protected function getQuestionHelper()
     {
         // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
         if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {

--- a/Command/QuestionableCommand.php
+++ b/Command/QuestionableCommand.php
@@ -21,7 +21,6 @@ use Symfony\Component\Console\Question\Question;
 
 abstract class QuestionableCommand extends ContainerAwareCommand
 {
-
     /**
      * @param InputInterface  $input
      * @param OutputInterface $output

--- a/Command/QuestionableCommand.php
+++ b/Command/QuestionableCommand.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Command;
+
+use Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper;
+use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+
+abstract class QuestionableCommand extends ContainerAwareCommand {
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     * @param string          $questionText
+     * @param mixed           $default
+     * @param callable        $validator
+     *
+     * @return mixed
+     */
+    protected function askAndValidate(InputInterface $input, OutputInterface $output, $questionText, $default, $validator)
+    {
+        $questionHelper = $this->getQuestionHelper();
+
+        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
+        if ($questionHelper instanceof DialogHelper) {
+            return $questionHelper->askAndValidate(
+                $output,
+                $questionHelper->getQuestion($questionText, $default),
+                $validator,
+                false,
+                $default
+            );
+        }
+
+        $question = new Question($questionHelper->getQuestion($questionText, $default), $default);
+
+        $question->setValidator($validator);
+
+        return $questionHelper->ask($input, $output, $question);
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     * @param string          $questionText
+     * @param string          $default
+     * @param string          $separator
+     *
+     * @return string
+     */
+    protected function askConfirmation(InputInterface $input, OutputInterface $output, $questionText, $default, $separator)
+    {
+        $questionHelper = $this->getQuestionHelper();
+
+        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
+        if ($questionHelper instanceof DialogHelper) {
+            $question = $questionHelper->getQuestion($questionText, $default, $separator);
+
+            return $questionHelper->askConfirmation($output, $question, ($default === 'no' ? false : true));
+        }
+
+        $question = new ConfirmationQuestion($questionHelper->getQuestion(
+            $questionText,
+            $default,
+            $separator
+        ), ($default === 'no' ? false : true));
+
+        return $questionHelper->ask($input, $output, $question);
+    }
+
+    /**
+     * @return QuestionHelper|DialogHelper
+     */
+    protected function getQuestionHelper()
+    {
+        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
+        if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
+            $questionHelper = $this->getHelper('dialog');
+
+            if (!$questionHelper instanceof DialogHelper) {
+                $questionHelper = new DialogHelper();
+                $this->getHelperSet()->set($questionHelper);
+            }
+        } else {
+            $questionHelper = $this->getHelper('question');
+
+            if (!$questionHelper instanceof QuestionHelper) {
+                $questionHelper = new QuestionHelper();
+                $this->getHelperSet()->set($questionHelper);
+            }
+        }
+
+        return $questionHelper;
+    }
+
+}

--- a/Command/QuestionableCommand.php
+++ b/Command/QuestionableCommand.php
@@ -19,7 +19,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 
-abstract class QuestionableCommand extends ContainerAwareCommand {
+abstract class QuestionableCommand extends ContainerAwareCommand
+{
 
     /**
      * @param InputInterface  $input
@@ -105,5 +106,4 @@ abstract class QuestionableCommand extends ContainerAwareCommand {
 
         return $questionHelper;
     }
-
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because I found bug The helper "dialog" is not defined (Undefined DialogHelper Class)

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4327

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->
<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed the bug that caused an error "The helper "dialog" is not defined." on Symfony3 with new `\Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper` when you run command "sonata:admin:generate-object-acl". 
```

## To do
Delete or re-right Command/QuestionableCommand.php

<!-- Describe your Pull Request content here -->
https://github.com/sonata-project/SonataAdminBundle/issues/4327