### PR TITLE
Fix xeditable choices translations

### DIFF
--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -980,7 +980,7 @@ EOT
         data-title="Data"
         data-pk="12345"
         data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=xyz"
-        data-source="[{&quot;value&quot;:&quot;Foo&quot;,&quot;text&quot;:&quot;action_delete&quot;},{&quot;value&quot;:&quot;Status2&quot;,&quot;text&quot;:&quot;Alias2&quot;},{&quot;value&quot;:&quot;Status3&quot;,&quot;text&quot;:&quot;Alias3&quot;}]" >
+        data-source="[{&quot;value&quot;:&quot;Foo&quot;,&quot;text&quot;:&quot;Delete&quot;},{&quot;value&quot;:&quot;Status2&quot;,&quot;text&quot;:&quot;Alias2&quot;},{&quot;value&quot;:&quot;Status3&quot;,&quot;text&quot;:&quot;Alias3&quot;}]" >
          Delete
     </span>
 </td>

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -423,7 +423,7 @@ EOT;
                 foreach ($choices as $value => $text) {
                     if ($catalogue) {
                         if (null !== $this->translator) {
-                            $this->translator->trans($text, array(), $catalogue);
+                            $text = $this->translator->trans($text, array(), $catalogue);
                         // NEXT_MAJOR: Remove this check
                         } elseif (method_exists($fieldDescription->getAdmin(), 'trans')) {
                             $text = $fieldDescription->getAdmin()->trans($text, array(), $catalogue);


### PR DESCRIPTION
I am targetting this branch, because it's a BC bugfix.

## Changelog

```markdown
### Fixed
- Xeditable choices are now correctly translated
```

## Subject

Simply add a missing variable affectation when translating xeditable choices.