### PR TITLE
Remove non FQCNs on form types on AbstractAdmin

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -838,14 +838,24 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
 
         // ok, try to limit to add parent filter
         if ($this->isChild() && $this->getParentAssociationMapping() && !$mapper->has($this->getParentAssociationMapping())) {
+            // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+            $modelHiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\AdminBundle\Form\Type\ModelHiddenType'
+                : 'sonata_type_model_hidden';
+
+            // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+            $hiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+                : 'hidden';
+
             $mapper->add($this->getParentAssociationMapping(), null, array(
                 'show_filter' => false,
                 'label' => false,
-                'field_type' => 'sonata_type_model_hidden',
+                'field_type' => $modelHiddenType,
                 'field_options' => array(
                     'model_manager' => $this->getModelManager(),
                 ),
-                'operator_type' => 'hidden',
+                'operator_type' => $hiddenType,
             ), null, null, array(
                 'admin_code' => $this->getParent()->getCode(),
             ));


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Removed non FQCNs on form types on AbstractAdmin
```
<!--
## To do


    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.


- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note
-->
## Subject

<!-- Describe your Pull Request content here -->
There was a non FQCN on a form type only visible when using child admins
