### PR TITLE
Changed translations of base breadcrumb

### DIFF
--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -78,14 +78,12 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
         if (!$menu) {
             $menu = $admin->getMenuFactory()->createItem('root');
 
-            $menu = $this->createMenuItem(
-                $admin,
-                $menu,
-                'dashboard',
-                'SonataAdminBundle',
-                array('uri' => $admin->getRouteGenerator()->generate(
-                    'sonata_admin_dashboard'
-                ))
+            $menu = $menu->addChild(
+                'breadcrumb.link_dashboard',
+                array(
+                    'uri' => $admin->getRouteGenerator()->generate('sonata_admin_dashboard'),
+                    'extras' => array('translation_domain' => 'SonataAdminBundle'),
+                )
             );
         }
 

--- a/Tests/Admin/BreadcrumbsBuilderTest.php
+++ b/Tests/Admin/BreadcrumbsBuilderTest.php
@@ -109,53 +109,43 @@ class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
             ->with('sonata_admin_dashboard')
             ->will($this->returnValue('http://somehost.com'));
 
-        $translatorStrategy->expects($this->exactly(18))
+        $translatorStrategy->expects($this->exactly(13))
             ->method('getLabel')
             ->withConsecutive(
-                array('dashboard'),
                 array('DummySubject_list'),
                 array('Comment_list'),
                 array('Comment_repost'),
 
-                array('dashboard'),
                 array('DummySubject_list'),
                 array('Comment_list'),
                 array('Comment_flag'),
 
-                array('dashboard'),
                 array('DummySubject_list'),
                 array('Comment_list'),
                 array('Comment_edit'),
 
-                array('dashboard'),
                 array('DummySubject_list'),
                 array('Comment_list'),
 
-                array('dashboard'),
                 array('DummySubject_list'),
                 array('Comment_list')
             )
             ->will($this->onConsecutiveCalls(
-                'someLabel',
                 'someOtherLabel',
                 'someInterestingLabel',
                 'someFancyLabel',
 
-                'someCoolLabel',
                 'someTipTopLabel',
                 'someFunkyLabel',
                 'someAwesomeLabel',
 
-                'someLikeableLabel',
                 'someMildlyInterestingLabel',
                 'someWTFLabel',
                 'someBadLabel',
 
-                'someBoringLabel',
                 'someLongLabel',
                 'someEndlessLabel',
 
-                'someAlmostThereLabel',
                 'someOriginalLabel',
                 'someOkayishLabel'
             ));
@@ -163,30 +153,30 @@ class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
         $menu->expects($this->exactly(24))
             ->method('addChild')
             ->withConsecutive(
-                array('someLabel'),
+                array('breadcrumb.link_dashboard'),
                 array('someOtherLabel'),
                 array('dummy subject representation'),
                 array('someInterestingLabel'),
                 array('someFancyLabel'),
 
-                array('someCoolLabel'),
+                array('breadcrumb.link_dashboard'),
                 array('someTipTopLabel'),
                 array('dummy subject representation'),
                 array('someFunkyLabel'),
                 array('someAwesomeLabel'),
 
-                array('someLikeableLabel'),
+                array('breadcrumb.link_dashboard'),
                 array('someMildlyInterestingLabel'),
                 array('dummy subject representation'),
                 array('someWTFLabel'),
                 array('someBadLabel'),
 
-                array('someBoringLabel'),
+                array('breadcrumb.link_dashboard'),
                 array('someLongLabel'),
                 array('dummy subject representation'),
                 array('someEndlessLabel'),
 
-                array('someAlmostThereLabel'),
+                array('breadcrumb.link_dashboard'),
                 array('someOriginalLabel'),
                 array('dummy subject representation'),
                 array('someOkayishLabel'),
@@ -247,29 +237,26 @@ class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
         $translatorStrategy->expects($this->any())
             ->method('getLabel')
             ->withConsecutive(
-                array('dashboard'),
                 array('DummySubject_list'),
                 array('DummySubject_repost'),
 
-                array('dashboard'),
                 array('DummySubject_list')
             )
             ->will($this->onConsecutiveCalls(
-                'someLabel',
                 'someOtherLabel',
                 'someInterestingLabel',
-                'someFancyLabel',
+
                 'someCoolLabel'
             ));
 
         $menu->expects($this->any())
             ->method('addChild')
             ->withConsecutive(
-                array('someLabel'),
+                array('breadcrumb.link_dashboard'),
                 array('someOtherLabel'),
                 array('someInterestingLabel'),
-                array('someFancyLabel'),
 
+                array('breadcrumb.link_dashboard'),
                 array('someCoolLabel'),
                 array('dummy subject representation')
             )
@@ -326,17 +313,12 @@ class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
         $labelTranslatorStrategy = $this->prophesize(
             'Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface'
         );
-        $labelTranslatorStrategy->getLabel(
-            'dashboard',
-            'breadcrumb',
-            'link'
-        )->willReturn('Dashboard');
 
         $routeGenerator = $this->prophesize('Sonata\AdminBundle\Route\RouteGeneratorInterface');
         $routeGenerator->generate('sonata_admin_dashboard')->willReturn('/dashboard');
 
         $admin->getRouteGenerator()->willReturn($routeGenerator->reveal());
-        $menu->addChild('Dashboard', array(
+        $menu->addChild('breadcrumb.link_dashboard', array(
             'uri' => '/dashboard',
             'extras' => array(
                 'translation_domain' => 'SonataAdminBundle',
@@ -453,16 +435,11 @@ class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
         $labelTranslatorStrategy = $this->prophesize(
             'Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface'
         );
-        $labelTranslatorStrategy->getLabel(
-            'dashboard',
-            'breadcrumb',
-            'link'
-        )->willReturn('Dashboard');
 
         $routeGenerator = $this->prophesize('Sonata\AdminBundle\Route\RouteGeneratorInterface');
         $routeGenerator->generate('sonata_admin_dashboard')->willReturn('/dashboard');
         $admin->getRouteGenerator()->willReturn($routeGenerator->reveal());
-        $menu->addChild('Dashboard', array(
+        $menu->addChild('breadcrumb.link_dashboard', array(
             'uri' => '/dashboard',
             'extras' => array(
                 'translation_domain' => 'SonataAdminBundle',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Default translation of Base Breadcrumb `Dashboard`
```

## Subject

<!-- Describe your Pull Request content here -->
The thing is, since now, when you are defining an Admin, if you don't set Translator Strategy to `sonata.admin.label.strategy.underscore` you end up having the base breadcrumb without the correct translation. Default behavior should be having a house icon as the base breadcrumb.

I would like to stay on default translator strategy but still have that icon displayed.

Before:
![captura de pantalla 2017-02-27 a las 13 53 59](https://cloud.githubusercontent.com/assets/1137485/23362097/6b506014-fcf4-11e6-9682-5e17886fbd13.png)

After:
![captura de pantalla 2017-02-27 a las 13 54 40](https://cloud.githubusercontent.com/assets/1137485/23362099/70623a00-fcf4-11e6-82ca-c12c6166eae9.png)