### PR TITLE
Remove duplicated breadcrumb on admin list

### DIFF
--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -123,7 +123,7 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
             return $this->buildBreadcrumbs($childAdmin, $action, $menu);
         }
 
-        if ('list' === $action && $admin->isChild()) {
+        if ('list' === $action) {
             $menu->setUri(false);
         } elseif ('create' !== $action && $admin->hasSubject()) {
             $menu = $menu->addChild($admin->toString($admin->getSubject()), array(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Remove duplicated breadcrumb on admin list
```

## Subject

<!-- Describe your Pull Request content here -->
When you are on any admin list, there is a duplicated breadcrumb (one with link and the other without). This does not apply to list of childs.

Before:
![captura de pantalla 2017-02-27 a las 13 59 48](https://cloud.githubusercontent.com/assets/1137485/23362239/1f1ac3c8-fcf5-11e6-9b0d-3c6a667b5d48.png)

After:
![captura de pantalla 2017-02-27 a las 14 00 19](https://cloud.githubusercontent.com/assets/1137485/23362240/21f3048e-fcf5-11e6-8c5f-9c732d45f53b.png)

