### PR TITLE
Fix breadcrumb without link

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -155,7 +155,7 @@ file that was distributed with this source code.
                                                             {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
                                                         {%- endif -%}
 
-                                                        {% if not loop.last  %}
+                                                        {% if not loop.last %}
                                                             <li>
                                                                 {% if menu.uri is not empty %}
                                                                     <a href="{{ menu.uri }}">
@@ -166,7 +166,7 @@ file that was distributed with this source code.
                                                                         {% endif %}
                                                                     </a>
                                                                 {% else %}
-                                                                    {{ label }}
+                                                                    <span>{{ label }}</span>
                                                                 {% endif %}
                                                             </li>
                                                         {% else %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Breadcrumb without link are now displayed correctly
```

## Subject

<!-- Describe your Pull Request content here -->
Breadcrumb without link was displayed without an span, which is incorrect visually speaking.

Before:
![captura de pantalla 2017-02-27 a las 15 46 53](https://cloud.githubusercontent.com/assets/1137485/23365706/5261a74c-fd04-11e6-878f-c2633386e872.png)

After:
![captura de pantalla 2017-02-27 a las 15 49 12](https://cloud.githubusercontent.com/assets/1137485/23365711/54ebe1e4-fd04-11e6-9659-a9371297b44e.png)
