### PR TITLE
Fixing styles on admin with subclasses

### DIFF
--- a/Resources/views/Button/acl_button.html.twig
+++ b/Resources/views/Button/acl_button.html.twig
@@ -9,7 +9,10 @@ file that was distributed with this source code.
 
 #}
 {% if admin.isAclEnabled() and admin.canAccessObject('acl', object) and admin.hasRoute('acl') %}
-    <a class="sonata-action-element" href="{{ admin.generateObjectUrl('acl', object) }}">
-        <i class="fa fa-users" aria-hidden="true"></i>
-        {{ 'link_action_acl'|trans({}, 'SonataAdminBundle') }}</a>
+    <li>
+        <a class="sonata-action-element" href="{{ admin.generateObjectUrl('acl', object) }}">
+            <i class="fa fa-users" aria-hidden="true"></i>
+            {{ 'link_action_acl'|trans({}, 'SonataAdminBundle') }}
+        </a>
+    </li>
 {% endif %}

--- a/Resources/views/Button/create_button.html.twig
+++ b/Resources/views/Button/create_button.html.twig
@@ -11,19 +11,20 @@ file that was distributed with this source code.
 
 {% if admin.hasAccess('create') and admin.hasRoute('create') %}
     {% if admin.subClasses is empty %}
-        <a class="sonata-action-element" href="{{ admin.generateUrl('create') }}">
-            <i class="fa fa-plus-circle" aria-hidden="true"></i>
-            {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }}</a>
+        <li>
+            <a class="sonata-action-element" href="{{ admin.generateUrl('create') }}">
+                <i class="fa fa-plus-circle" aria-hidden="true"></i>
+                {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }}
+            </a>
+        </li>
     {% else %}
-        <ul class="list-unstyled">
-            {% for subclass in admin.subclasses|keys %}
-                <li>
-                    <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
-                        <i class="fa fa-plus-circle" aria-hidden="true"></i>
-                        {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
+        {% for subclass in admin.subclasses|keys %}
+            <li>
+                <a class="sonata-action-element" href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
+                    <i class="fa fa-plus-circle" aria-hidden="true"></i>
+                    {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
+                </a>
+            </li>
+        {% endfor %}
     {% endif %}
 {% endif %}

--- a/Resources/views/Button/edit_button.html.twig
+++ b/Resources/views/Button/edit_button.html.twig
@@ -10,7 +10,10 @@ file that was distributed with this source code.
 #}
 
 {% if admin.canAccessObject('edit', object) and admin.hasRoute('edit') %}
-    <a class="sonata-action-element" href="{{ admin.generateObjectUrl('edit', object) }}">
-        <i class="fa fa-edit" aria-hidden="true"></i>
-        {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}</a>
+    <li>
+        <a class="sonata-action-element" href="{{ admin.generateObjectUrl('edit', object) }}">
+            <i class="fa fa-edit" aria-hidden="true"></i>
+            {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}
+        </a>
+    </li>
 {% endif %}

--- a/Resources/views/Button/history_button.html.twig
+++ b/Resources/views/Button/history_button.html.twig
@@ -10,7 +10,10 @@ file that was distributed with this source code.
 #}
 
 {% if admin.canAccessObject('history', object) and admin.hasRoute('history') %}
-    <a class="sonata-action-element" href="{{ admin.generateObjectUrl('history', object) }}">
-        <i class="fa fa-archive" aria-hidden="true"></i>
-        {{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}</a>
+    <li>
+        <a class="sonata-action-element" href="{{ admin.generateObjectUrl('history', object) }}">
+            <i class="fa fa-archive" aria-hidden="true"></i>
+            {{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}
+        </a>
+    </li>
 {% endif %}

--- a/Resources/views/Button/list_button.html.twig
+++ b/Resources/views/Button/list_button.html.twig
@@ -10,7 +10,10 @@ file that was distributed with this source code.
 #}
 
 {% if admin.hasAccess('list') and admin.hasRoute('list') %}
-    <a class="sonata-action-element" href="{{ admin.generateUrl('list') }}">
-        <i class="fa fa-list" aria-hidden="true"></i>
-        {{ 'link_action_list'|trans({}, 'SonataAdminBundle') }}</a>
+    <li>
+        <a class="sonata-action-element" href="{{ admin.generateUrl('list') }}">
+            <i class="fa fa-list" aria-hidden="true"></i>
+            {{ 'link_action_list'|trans({}, 'SonataAdminBundle') }}
+        </a>
+    </li>
 {% endif %}

--- a/Resources/views/Button/show_button.html.twig
+++ b/Resources/views/Button/show_button.html.twig
@@ -9,7 +9,10 @@ file that was distributed with this source code.
 
 #}
 {% if admin.canAccessObject('show', object) and admin.show|length > 0 and admin.hasRoute('show') %}
-    <a class="sonata-action-element" href="{{ admin.generateObjectUrl('show', object) }}">
-        <i class="fa fa-eye" aria-hidden="true"></i>
-        {{ 'link_action_show'|trans({}, 'SonataAdminBundle') }}</a>
+    <li>
+        <a class="sonata-action-element" href="{{ admin.generateObjectUrl('show', object) }}">
+            <i class="fa fa-eye" aria-hidden="true"></i>
+            {{ 'link_action_show'|trans({}, 'SonataAdminBundle') }}
+        </a>
+    </li>
 {% endif %}

--- a/Resources/views/CRUD/action_buttons.html.twig
+++ b/Resources/views/CRUD/action_buttons.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 {% spaceless %}
     {% for item in admin.getActionButtons(action, object|default(null)) %}
         {% if item.template is defined %}
-            <li>{% include item.template %}</li>
+            {% include item.template %}
         {% endif %}
     {% endfor %}
 {% endspaceless %}

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -22,7 +22,7 @@ file that was distributed with this source code.
         The list template can be used in nested mode,
         so we define the title corresponding to the parent's admin.
     #}
-    
+
     {% if admin.isChild and admin.parent.subject %}
         {{ "title_edit"|trans({'%name%': admin.parent.toString(admin.parent.subject)|truncate(15) }, 'SonataAdminBundle') }}
     {% endif %}
@@ -106,7 +106,9 @@ file that was distributed with this source code.
                                 </div>
                                 <span class="progress-description">
                                     {% if not app.request.xmlHttpRequest %}
+                                    <ul class="list-unstyled">
                                         {% include 'SonataAdminBundle:Button:create_button.html.twig' %}
+                                    </ul>
                                     {% endif %}
                                 </span>
                             </div><!-- /.info-box-content -->


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC and a continuation of #4337.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Unified styles between admins with subclasses and admins without subclasses
```

## Subject

<!-- Describe your Pull Request content here -->
On my previous PR (#4337) I fixed the visualization of the no results page of an admin list (with subclasses), that broke the side menu:

BEFORE THIS PR:
![captura de pantalla 2017-03-02 a las 18 33 18](https://cloud.githubusercontent.com/assets/1137485/23519340/d0665a4c-ff76-11e6-93bb-1b0b1de85265.png)


AFTER THIS PR:
![captura de pantalla 2017-03-02 a las 18 32 44](https://cloud.githubusercontent.com/assets/1137485/23519346/d3d3a1e4-ff76-11e6-9de0-ec20c23a2bbe.png)
