### PR TITLE
Fixed AdminType delete checkboxes

### DIFF
--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -46,7 +46,16 @@ class AdminType extends AbstractType
                 $options['delete_options']['type_options']['translation_domain'] = $admin->getTranslationDomain();
             }
 
-            $builder->add('_delete', $options['delete_options']['type'], $options['delete_options']['type_options']);
+            $builder->add(
+                '_delete',
+                $options['delete_options']['type'],
+                array_merge(
+                    $options['delete_options']['type_options'],
+                    array(
+                        'attr' => array('class' => 'sonata-admin-type-delete-checkbox'),
+                    )
+                )
+            );
         }
 
         // hack to make sure the subject is correctly set

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -502,6 +502,9 @@ btn_add and btn_catalogue:
   corresponding button. You can also specify a custom translation catalogue
   for this label, which defaults to ``SonataAdminBundle``.
 
+When using ``edit: inline`` a delete checkbox will be rendered for each element of the collection.
+Checking it will disable the fields but the form needs to be submitted for the element to actually be removed from the collection.
+
 **TIP**: A jQuery event is fired after a row has been added (``sonata-admin-append-form-element``).
 You can listen to this event to trigger custom JavaScript (eg: add a calendar widget to a newly added date field)
 

--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -55,7 +55,7 @@ var Admin = {
             padding: 15,
             overflow: 'auto'
         });
-      
+
         jQuery(modal).trigger('sonata-admin-setup-list-modal');
     },
     setup_select2: function(subject) {
@@ -608,6 +608,17 @@ var Admin = {
                 lessLink: '<a href="#">'+jQuery(this).data('readmore-less')+'</a>'
             });
         });
+    },
+    handle_inline_delete_checkboxes: function() {
+        var eventType = window.SONATA_CONFIG.USE_ICHECK ? 'ifChanged': 'change';
+
+        $('.sonata-ba-form').on(eventType, '.sonata-admin-type-delete-checkbox', function() {
+            var id = jQuery(this).prop('id');
+
+            jQuery('[id^=' + id.split('__')[0] + ']:not("#' + id + '")')
+                .prop('disabled', jQuery(this).is(':checked'))
+            ;
+        });
     }
 };
 
@@ -620,6 +631,7 @@ jQuery(document).ready(function() {
     Admin.setup_per_page_switcher(document);
     Admin.setup_collection_buttons(document);
     Admin.shared_setup(document);
+    Admin.handle_inline_delete_checkboxes();
 });
 
 jQuery(document).on('sonata-admin-append-form-element', function(e) {

--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -41,6 +41,9 @@ file that was distributed with this source code.
                 dropdownAutoWidth: {{ dropdown_auto_width ? 'true' : 'false' }},
                 containerCssClass: '{{ container_css_class ~ ' form-control' }}',
                 dropdownCssClass: '{{ dropdown_css_class }}',
+                initSelection : function (element, callback) {
+                    callback(element.val());
+                },
                 ajax: {
                     url:  '{{ url ?: path(route.name, route.parameters|default([]))|e('js') }}',
                     dataType: 'json',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4348 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
When checking the delete checkbox of an inline child form of `CollectionType` the related fields are now disabled to avoid preventing submission of the form when one of those inputs is required.

```

## Subject

<!-- Describe your Pull Request content here -->

See #4348 