### PR TITLE
fix permission name - not SHOW, but VIEW;

### DIFF
--- a/Resources/doc/cookbook/recipe_customizing_a_mosaic_list.rst
+++ b/Resources/doc/cookbook/recipe_customizing_a_mosaic_list.rst
@@ -64,7 +64,7 @@ The ``list_outer_rows_mosaic.html.twig`` is the name of one mosaic's tile. You s
     {% block sonata_mosaic_description %}
         {% if admin.isGranted('EDIT', object) and admin.hasRoute('edit') %}
             <a href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|truncate(40) }}</a>
-        {% elseif admin.isGranted('SHOW', object) and admin.hasRoute('show') %}
+        {% elseif admin.isGranted('VIEW', object) and admin.hasRoute('show') %}
             <a href="{{ admin.generateUrl('show', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|truncate(40) }}</a>
         {% else %}
             {{ meta.title|truncate(40) }}

--- a/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
+++ b/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
@@ -60,7 +60,7 @@ This template can be customized to match your needs. You should only extends the
                             {% block sonata_mosaic_description %}
                                 {% if admin.isGranted('EDIT', object) and admin.hasRoute('edit') %}
                                     <a class="mosaic-inner-link" href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|truncate(40) }}</a>
-                                {% elseif admin.isGranted('SHOW', object) and admin.hasRoute('show') %}
+                                {% elseif admin.isGranted('VIEW', object) and admin.hasRoute('show') %}
                                     <a class="mosaic-inner-link" href="{{ admin.generateUrl('show', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|truncate(40) }}</a>
                                 {% else %}
                                     {{ meta.title|truncate(40) }}


### PR DESCRIPTION
I am targetting this branch, because BC.

Closes #4359 

## Changelog

```markdown
### Fixed
- name of permission, use `VIEW` instead of `SHOW`
```

## Subject
SHOW is a name of action, VIEW is a name of permission. In a function isGranted should be name of permission. 

