### PR TITLE
removed deprecated translation/translator methods

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -560,22 +560,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
         $datagrid = $this->getDatagrid();
         $datagrid->buildPager();
 
-        $fields = array();
-
-        foreach ($this->getExportFields() as $key => $field) {
-            $label = $this->getTranslationLabel($field, 'export', 'label');
-            $transLabel = $this->trans($label);
-
-            // NEXT_MAJOR: Remove this hack, because all field labels will be translated with the major release
-            // No translation key exists
-            if ($transLabel == $label) {
-                $fields[$key] = $field;
-            } else {
-                $fields[$transLabel] = $field;
-            }
-        }
-
-        return $this->getModelManager()->getDataSourceIterator($datagrid, $fields);
+        return $this->getModelManager()->getDataSourceIterator($datagrid, $this->getExportFields());
     }
 
     /**

--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -43,7 +43,6 @@ use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
@@ -276,17 +275,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
      * @var \Symfony\Component\HttpFoundation\Request
      */
     protected $request;
-
-    /**
-     * The translator component.
-     *
-     * NEXT_MAJOR: remove this property
-     *
-     * @var \Symfony\Component\Translation\TranslatorInterface
-     *
-     * @deprecated since 3.9, to be removed with 4.0
-     */
-    protected $translator;
 
     /**
      * The related form contractor.
@@ -1935,48 +1923,6 @@ EOT;
     /**
      * {@inheritdoc}
      */
-    public function trans($id, array $parameters = array(), $domain = null, $locale = null)
-    {
-        @trigger_error(
-            'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.',
-            E_USER_DEPRECATED
-        );
-
-        $domain = $domain ?: $this->getTranslationDomain();
-
-        return $this->translator->trans($id, $parameters, $domain, $locale);
-    }
-
-    /**
-     * Translate a message id.
-     *
-     * NEXT_MAJOR: remove this method
-     *
-     * @param string      $id
-     * @param int         $count
-     * @param array       $parameters
-     * @param string|null $domain
-     * @param string|null $locale
-     *
-     * @return string the translated string
-     *
-     * @deprecated since 3.9, to be removed with 4.0
-     */
-    public function transChoice($id, $count, array $parameters = array(), $domain = null, $locale = null)
-    {
-        @trigger_error(
-            'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.',
-            E_USER_DEPRECATED
-        );
-
-        $domain = $domain ?: $this->getTranslationDomain();
-
-        return $this->translator->transChoice($id, $count, $parameters, $domain, $locale);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function setTranslationDomain($translationDomain)
     {
         $this->translationDomain = $translationDomain;
@@ -1988,43 +1934,6 @@ EOT;
     public function getTranslationDomain()
     {
         return $this->translationDomain;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * NEXT_MAJOR: remove this method
-     *
-     * @deprecated since 3.9, to be removed with 4.0
-     */
-    public function setTranslator(TranslatorInterface $translator)
-    {
-        $args = func_get_args();
-        if (isset($args[1]) && $args[1]) {
-            @trigger_error(
-                'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.',
-                E_USER_DEPRECATED
-            );
-        }
-
-        $this->translator = $translator;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * NEXT_MAJOR: remove this method
-     *
-     * @deprecated since 3.9, to be removed with 4.0
-     */
-    public function getTranslator()
-    {
-        @trigger_error(
-            'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.',
-            E_USER_DEPRECATED
-        );
-
-        return $this->translator;
     }
 
     /**

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -27,7 +27,6 @@ use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
@@ -68,20 +67,6 @@ interface AdminInterface
      * @return DatagridBuilderInterface
      */
     public function getDatagridBuilder();
-
-    /**
-     * Set translator.
-     *
-     * @param TranslatorInterface $translator
-     */
-    public function setTranslator(TranslatorInterface $translator);
-
-    /**
-     * Get translator.
-     *
-     * @return TranslatorInterface
-     */
-    public function getTranslator();
 
     /**
      * @param Request $request
@@ -284,22 +269,6 @@ interface AdminInterface
      * @return bool
      */
     public function hasParentFieldDescription();
-
-    /**
-     * translate a message id.
-     *
-     * NEXT_MAJOR: remove this method
-     *
-     * @param string $id
-     * @param array  $parameters
-     * @param null   $domain
-     * @param null   $locale
-     *
-     * @return string the translated string
-     *
-     * @deprecated since 3.9, to be removed in 4.0
-     */
-    public function trans($id, array $parameters = array(), $domain = null, $locale = null);
 
     /**
      * Returns the list of available urls.

--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -208,7 +208,6 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
             'show_builder',
             'list_builder',
             'datagrid_builder',
-            'translator',
             'configuration_pool',
             'router',
             'validator',
@@ -258,7 +257,6 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
             'show_builder' => sprintf('sonata.admin.builder.%s_show', $manager_type),
             'list_builder' => sprintf('sonata.admin.builder.%s_list', $manager_type),
             'datagrid_builder' => sprintf('sonata.admin.builder.%s_datagrid', $manager_type),
-            'translator' => 'translator',
             'configuration_pool' => 'sonata.admin.pool',
             'route_generator' => 'sonata.admin.route.default_generator',
             'validator' => 'validator',
@@ -276,10 +274,6 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
             if (isset($overwriteAdminConfiguration[$attr]) || !$definition->hasMethodCall($method)) {
                 $args = array(new Reference(isset($overwriteAdminConfiguration[$attr]) ? $overwriteAdminConfiguration[$attr] : $addServiceId));
-                if ('translator' === $attr) {
-                    $args[] = false;
-                }
-
                 $definition->addMethodCall($method, $args);
             }
         }

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1774,7 +1774,7 @@ class AdminTest extends PHPUnit_Framework_TestCase
 
         $admin = $this->getMockBuilder('Sonata\AdminBundle\Admin\AbstractAdmin')
             ->disableOriginalConstructor()
-            ->setMethods(array('getDatagrid', 'getTranslationLabel', 'trans'))
+            ->setMethods(array('getDatagrid', 'getTranslationLabel'))
             ->getMockForAbstractClass();
         $admin->method('getDatagrid')->will($this->returnValue($datagrid));
         $admin->setModelManager($modelManager);
@@ -1783,15 +1783,6 @@ class AdminTest extends PHPUnit_Framework_TestCase
             ->method('getTranslationLabel')
             ->will($this->returnCallback(function ($label, $context = '', $type = '') {
                 return $context.'.'.$type.'_'.$label;
-            }));
-        $admin->expects($this->any())
-            ->method('trans')
-            ->will($this->returnCallback(function ($label) {
-                if ($label == 'export.label_field') {
-                    return 'Feld';
-                }
-
-                return $label;
             }));
 
         $admin->getDataSourceIterator();

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -950,21 +950,6 @@ class AdminTest extends PHPUnit_Framework_TestCase
         $this->assertSame('foo', $admin->getTranslationDomain());
     }
 
-    /**
-     * @group legacy
-     */
-    public function testGetTranslator()
-    {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-
-        $this->assertNull($admin->getTranslator());
-
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
-
-        $admin->setTranslator($translator);
-        $this->assertSame($translator, $admin->getTranslator());
-    }
-
     public function testGetShowGroups()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
@@ -1204,80 +1189,6 @@ class AdminTest extends PHPUnit_Framework_TestCase
         $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
         $this->assertSame('sonata.post.admin.post', $admin->getObjectIdentifier());
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testTrans()
-    {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-        $admin->setTranslationDomain('fooMessageDomain');
-
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
-        $admin->setTranslator($translator);
-
-        $translator->expects($this->once())
-            ->method('trans')
-            ->with($this->equalTo('foo'), $this->equalTo(array()), $this->equalTo('fooMessageDomain'))
-            ->will($this->returnValue('fooTranslated'));
-
-        $this->assertSame('fooTranslated', $admin->trans('foo'));
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testTransWithMessageDomain()
-    {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
-        $admin->setTranslator($translator);
-
-        $translator->expects($this->once())
-            ->method('trans')
-            ->with($this->equalTo('foo'), $this->equalTo(array('name' => 'Andrej')), $this->equalTo('fooMessageDomain'))
-            ->will($this->returnValue('fooTranslated'));
-
-        $this->assertSame('fooTranslated', $admin->trans('foo', array('name' => 'Andrej'), 'fooMessageDomain'));
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testTransChoice()
-    {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-        $admin->setTranslationDomain('fooMessageDomain');
-
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
-        $admin->setTranslator($translator);
-
-        $translator->expects($this->once())
-            ->method('transChoice')
-            ->with($this->equalTo('foo'), $this->equalTo(2), $this->equalTo(array()), $this->equalTo('fooMessageDomain'))
-            ->will($this->returnValue('fooTranslated'));
-
-        $this->assertSame('fooTranslated', $admin->transChoice('foo', 2));
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testTransChoiceWithMessageDomain()
-    {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
-        $admin->setTranslator($translator);
-
-        $translator->expects($this->once())
-            ->method('transChoice')
-            ->with($this->equalTo('foo'), $this->equalTo(2), $this->equalTo(array('name' => 'Andrej')), $this->equalTo('fooMessageDomain'))
-            ->will($this->returnValue('fooTranslated'));
-
-        $this->assertSame('fooTranslated', $admin->transChoice('foo', 2, array('name' => 'Andrej'), 'fooMessageDomain'));
     }
 
     public function testSetPersistFilters()

--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -43,11 +43,6 @@ final class AdminExtractor implements ExtractorInterface, TranslatorInterface, S
     /**
      * @var string|bool
      */
-    private $translator;
-
-    /**
-     * @var string|bool
-     */
     private $labelStrategy;
 
     /**
@@ -71,7 +66,6 @@ final class AdminExtractor implements ExtractorInterface, TranslatorInterface, S
 
         // state variable
         $this->catalogue = false;
-        $this->translator = false;
         $this->labelStrategy = false;
         $this->domain = false;
     }
@@ -119,11 +113,9 @@ final class AdminExtractor implements ExtractorInterface, TranslatorInterface, S
                 $this->trans($label, array(), $admin->getTranslationDomain());
             }
 
-            $this->translator = $admin->getTranslator();
             $this->labelStrategy = $admin->getLabelTranslatorStrategy();
             $this->domain = $admin->getTranslationDomain();
 
-            $admin->setTranslator($this);
             $admin->setSecurityHandler($this);
             $admin->setLabelTranslatorStrategy($this);
 
@@ -192,42 +184,6 @@ final class AdminExtractor implements ExtractorInterface, TranslatorInterface, S
         $this->catalogue = false;
 
         return $catalogue;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function trans($id, array $parameters = array(), $domain = null, $locale = null)
-    {
-        $this->addMessage($id, $domain);
-
-        return $id;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
-    {
-        $this->addMessage($id, $domain);
-
-        return $id;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setLocale($locale)
-    {
-        $this->translator->setLocale($locale);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getLocale()
-    {
-        return $this->translator->getLocale();
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I removed already deprecated methods.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
