### PR TITLE
Fixed `create_button.html.twig` template issue when there is only a single admin subclass

### DIFF
--- a/Resources/views/Button/create_button.html.twig
+++ b/Resources/views/Button/create_button.html.twig
@@ -11,20 +11,27 @@ file that was distributed with this source code.
 
 {% if admin.hasAccess('create') and admin.hasRoute('create') %}
     {% if admin.subClasses is empty %}
-        <li>
-            <a class="sonata-action-element" href="{{ admin.generateUrl('create') }}">
-                <i class="fa fa-plus-circle" aria-hidden="true"></i>
-                {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }}
-            </a>
-        </li>
+        <a class="sonata-action-element" href="{{ admin.generateUrl('create') }}">
+            <i class="fa fa-plus-circle" aria-hidden="true"></i>
+            {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }}</a>
     {% else %}
-        {% for subclass in admin.subclasses|keys %}
-            <li>
-                <a class="sonata-action-element" href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
-                    <i class="fa fa-plus-circle" aria-hidden="true"></i>
-                    {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
-                </a>
-            </li>
-        {% endfor %}
+        {% if 1 is same as (admin.subclasses|length) %}
+            {% set subclass = admin.subclasses|keys|first %}
+            <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
+                <i class="fa fa-plus-circle" aria-hidden="true"></i>
+                {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
+            </a>
+        {% else %}
+            <ul class="list-unstyled">
+                {% for subclass in admin.subclasses|keys %}
+                    <li>
+                        <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
+                            <i class="fa fa-plus-circle" aria-hidden="true"></i>
+                            {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
     {% endif %}
 {% endif %}

--- a/Resources/views/Button/create_button.html.twig
+++ b/Resources/views/Button/create_button.html.twig
@@ -15,23 +15,13 @@ file that was distributed with this source code.
             <i class="fa fa-plus-circle" aria-hidden="true"></i>
             {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }}</a>
     {% else %}
-        {% if 1 is same as (admin.subclasses|length) %}
-            {% set subclass = admin.subclasses|keys|first %}
-            <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
-                <i class="fa fa-plus-circle" aria-hidden="true"></i>
-                {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
-            </a>
-        {% else %}
-            <ul class="list-unstyled">
-                {% for subclass in admin.subclasses|keys %}
-                    <li>
-                        <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
-                            <i class="fa fa-plus-circle" aria-hidden="true"></i>
-                            {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
-                        </a>
-                    </li>
-                {% endfor %}
-            </ul>
-        {% endif %}
+        {% for subclass in admin.subclasses|keys %}
+            <li>
+                <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
+                    <i class="fa fa-plus-circle" aria-hidden="true"></i>
+                    {{ 'link_action_create'|trans({}, 'SonataAdminBundle') }} {{ subclass|trans({}, admin.translationdomain) }}
+                </a>
+            </li>
+        {% endfor %}
     {% endif %}
 {% endif %}


### PR DESCRIPTION
I am targeting this branch, because this issue just fix a template that it's backwards compatible.

## Changelog

```markdown

### Fixed
Added a validation to add a single `<a>` tag when there is a single admin subclass on `create_button.html.twig` 

```


## Subject
Fixed `create_button.html.twig` template issue when there is only a single admin subclass
