### PR TITLE
Fix permission name - not show, but view

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -1080,7 +1080,9 @@ class CRUDController extends Controller
 
         if (!$url) {
             foreach (array('edit', 'show') as $route) {
-                if ($this->admin->hasRoute($route) && $this->admin->isGranted(strtoupper($route), $object)) {
+                if ($this->admin->hasRoute($route) 
+                    && $this->admin->isGranted(strtoupper(str_replace('show', 'view', $route)), $object)
+                ) {
                     $url = $this->admin->generateObjectUrl($route, $object);
                     break;
                 }


### PR DESCRIPTION
I am targeting this branch, because BC.

## Changelog

```markdown
### Fixed
- name of permission, use `VIEW` instead of `SHOW`
```

## Subject
In `isGranted` param should be name of permission, not action name.

similar PR #4360 