### PR TITLE
Method change to verify access to the object

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -1080,7 +1080,7 @@ class CRUDController extends Controller
 
         if (!$url) {
             foreach (array('edit', 'show') as $route) {
-                if ($this->admin->hasRoute($route) && $this->admin->isGranted(strtoupper($route), $object)) {
+                if ($this->admin->hasRoute($route) && $this->admin->hasAccess($route, $object)) {
                     $url = $this->admin->generateObjectUrl($route, $object);
                     break;
                 }

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -13,7 +13,7 @@ namespace Sonata\AdminBundle\Tests\Controller;
 
 use Exporter\Exporter;
 use Exporter\Writer\JsonWriter;
-use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Controller\CRUDController;
@@ -56,7 +56,7 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
     private $request;
 
     /**
-     * @var AdminInterface
+     * @var AbstractAdmin
      */
     private $admin;
 
@@ -126,7 +126,9 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
         $this->pool = new Pool($this->container, 'title', 'logo.png');
         $this->pool->setAdminServiceIds(array('foo.admin'));
         $this->request->attributes->set('_sonata_admin', 'foo.admin');
-        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->getMockBuilder('Sonata\AdminBundle\Admin\AbstractAdmin')
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
         $this->parameters = array();
         $this->template = '';
@@ -548,7 +550,9 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->method('isChild')
             ->will($this->returnValue(true));
 
-        $adminParent = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $adminParent = $this->getMockBuilder('Sonata\AdminBundle\Admin\AbstractAdmin')
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->admin->expects($this->once())
             ->method('getParent')
             ->will($this->returnValue($adminParent));
@@ -923,8 +927,8 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $this->admin->expects($this->any())
-            ->method('isGranted')
-            ->with($this->equalTo(strtoupper($route)))
+            ->method('hasAccess')
+            ->with($this->equalTo($route))
             ->will($this->returnValue(true));
 
         $response = $this->protectedTestedMethods['redirectTo']->invoke($this->controller, $object, $this->request);
@@ -946,8 +950,8 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $this->admin->expects($this->any())
-            ->method('isGranted')
-            ->with($this->equalTo(strtoupper('edit')), $object)
+            ->method('hasAccess')
+            ->with($this->equalTo('edit'), $object)
             ->will($this->returnValue(false));
 
         $response = $this->protectedTestedMethods['redirectTo']->invoke($this->controller, $object, $this->request);
@@ -1498,8 +1502,8 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $this->admin->expects($this->once())
-            ->method('isGranted')
-            ->with($this->equalTo('EDIT'))
+            ->method('hasAccess')
+            ->with($this->equalTo('edit'))
             ->will($this->returnValue(true));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')
@@ -1993,8 +1997,8 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $this->admin->expects($this->once())
-            ->method('isGranted')
-            ->with($this->equalTo('EDIT'))
+            ->method('hasAccess')
+            ->with($this->equalTo('edit'))
             ->will($this->returnValue(true));
 
         $this->admin->expects($this->once())


### PR DESCRIPTION
I am targeting this branch, because BC.

## Changelog

```markdown
### Fixed
- use `hasAccess` instead of `isGranted`
```

## Subject
Method change to verify access to the object
referer PR #4370 

I think it will be nice to clean up the buttons in the view `base_edit_form.html.twig` in block `sonata_form_actions`.