### PR TITLE
Fix example code in docs

### DIFF
--- a/Resources/doc/reference/batch_actions.rst
+++ b/Resources/doc/reference/batch_actions.rst
@@ -68,6 +68,7 @@ granularity), the passed query is ``null``.
     use Sonata\AdminBundle\Controller\CRUDController as BaseController;
     use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
     use Symfony\Component\HttpFoundation\RedirectResponse;
+    use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
     class CRUDController extends BaseController


### PR DESCRIPTION
I am targeting this branch, because this patch doesn't break the BC.

Fixed example code which otherwise threw 

> Type error: Argument 2 passed to AppBundle\Controller\CRUDController::batchActionMerge() must be an instance of AppBundle\Controller\Request or null, instance of Symfony\Component\HttpFoundation\Request given