### PR TITLE
Fix example code in docs

### DIFF
--- a/Resources/doc/reference/batch_actions.rst
+++ b/Resources/doc/reference/batch_actions.rst
@@ -190,6 +190,7 @@ This method may return three different values:
     namespace AppBundle\Controller;
 
     use Sonata\AdminBundle\Controller\CRUDController as BaseController;
+    use Symfony\Component\HttpFoundation\Request;
 
     class CRUDController extends BaseController
     {


### PR DESCRIPTION
I am targeting this branch, because this patch doesn't break the BC.

Fixed example code which otherwise threw 

> Type error: Argument 3 passed to AppBundle\Controller\CRUDController::batchActionMergeIsRelevant() must be an instance of AppBundle\Controller\Request or null, instance of Symfony\Component\HttpFoundation\Request given