### PR TITLE
Add missing titles to the CRUD show page

### DIFF
--- a/Resources/translations/SonataAdminBundle.ar.xliff
+++ b/Resources/translations/SonataAdminBundle.ar.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>إنشاء</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>لوحة المشرف</target>

--- a/Resources/translations/SonataAdminBundle.bg.xliff
+++ b/Resources/translations/SonataAdminBundle.bg.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Добавяне на елемент</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Начална страница</target>

--- a/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/Resources/translations/SonataAdminBundle.ca.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Crea</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Tauler</target>

--- a/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/Resources/translations/SonataAdminBundle.cs.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Vytvořit</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Administrační panel</target>

--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Hinzufügen</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>"%name%" betrachten</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Startseite</target>

--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Create</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>Show "%name%"</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Dashboard</target>

--- a/Resources/translations/SonataAdminBundle.es.xliff
+++ b/Resources/translations/SonataAdminBundle.es.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Crear</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Panel principal</target>

--- a/Resources/translations/SonataAdminBundle.eu.xliff
+++ b/Resources/translations/SonataAdminBundle.eu.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Sortu</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Hasiera</target>

--- a/Resources/translations/SonataAdminBundle.fa.xliff
+++ b/Resources/translations/SonataAdminBundle.fa.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>ایجاد</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>داشبورد</target>

--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Créer</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>Afficher "%name%"</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Tableau de bord</target>

--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Novi unos</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Početna stranica</target>

--- a/Resources/translations/SonataAdminBundle.hu.xliff
+++ b/Resources/translations/SonataAdminBundle.hu.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Hozzáadás</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>"%name%" megjelenítése</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Vezérlőpult</target>

--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Crea</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Dashboard</target>

--- a/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/Resources/translations/SonataAdminBundle.ja.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>作成</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>ダッシュボード</target>

--- a/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/Resources/translations/SonataAdminBundle.lb.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Dobäisetzen</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Startsäit</target>

--- a/Resources/translations/SonataAdminBundle.lt.xliff
+++ b/Resources/translations/SonataAdminBundle.lt.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Sukurti</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Titulinis</target>

--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Aanmaken</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Dashboard</target>

--- a/Resources/translations/SonataAdminBundle.no.xliff
+++ b/Resources/translations/SonataAdminBundle.no.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Lag ny</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Dashboard</target>

--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Stwórz</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Pulpit</target>

--- a/Resources/translations/SonataAdminBundle.pt.xliff
+++ b/Resources/translations/SonataAdminBundle.pt.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Criar</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Visão Geral</target>

--- a/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Criar</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Visão Geral</target>

--- a/Resources/translations/SonataAdminBundle.ro.xliff
+++ b/Resources/translations/SonataAdminBundle.ro.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Creați</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Panoul principal</target>

--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Создать</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>Показать "%name%"</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Панель администрирования</target>

--- a/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/Resources/translations/SonataAdminBundle.sk.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Vytvoriť</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Administračný panel</target>

--- a/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/Resources/translations/SonataAdminBundle.sl.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Ustvari</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Kontrolna plošča</target>

--- a/Resources/translations/SonataAdminBundle.sv_SE.xliff
+++ b/Resources/translations/SonataAdminBundle.sv_SE.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Skapa</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Dashboard</target>

--- a/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/Resources/translations/SonataAdminBundle.uk.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>Створити</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>Показати "%name%"</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>Панель</target>

--- a/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -86,6 +86,10 @@
                 <source>title_create</source>
                 <target>创建</target>
             </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>title_show</target>
+            </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>
                 <target>控制面板</target>

--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -11,6 +11,14 @@ file that was distributed with this source code.
 
 {% extends base_template %}
 
+{% block title %}
+    {{ "title_show"|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
+{% endblock %}
+
+{% block navbar_title %}
+    {{ block('title') }}
+{% endblock %}
+
 {%- block actions -%}
     {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
 {%- endblock -%}


### PR DESCRIPTION
I am targeting this branch, because this is a BC fix.

## Changelog

```markdown
### Added
- Added missing titles to the CRUD show page.
```

## To do

- [ ] Add missing translations for other languages