### PR TITLE
Add missing Russian translations

### DIFF
--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -468,11 +468,11 @@
             </trans-unit>
             <trans-unit id="read_more">
                 <source>read_more</source>
-                <target>read_more</target>
+                <target>Читать далее</target>
             </trans-unit>
             <trans-unit id="read_less">
                 <source>read_less</source>
-                <target>read_less</target>
+                <target>Закрыть</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
I am targeting this branch, because this is a BC patch.

The `read_less` snippet is a bit tricky. It should be translated literally as `Read less` but the English version reads as `Close`. I translated consistently to the English version.