### PR TITLE
title_show - add polish translation

### DIFF
--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -88,7 +88,7 @@
             </trans-unit>
             <trans-unit id="title_show">
                 <source>title_show</source>
-                <target>title_show</target>
+                <target>Pokaż "%name%"</target>
             </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>


### PR DESCRIPTION
I am targeting this branch, because BC.

## Changelog
```markdown
### Added
add polish translation of `title_show`
```

## Subject
I added the missing phrase