### PR TITLE
Refactor translation units

### DIFF
--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -79,7 +79,7 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
             $menu = $admin->getMenuFactory()->createItem('root');
 
             $menu = $menu->addChild(
-                'breadcrumb.link_dashboard',
+                'link_breadcrumb_dashboard',
                 array(
                     'uri' => $admin->getRouteGenerator()->generate('sonata_admin_dashboard'),
                     'extras' => array('translation_domain' => 'SonataAdminBundle'),

--- a/Resources/translations/SonataAdminBundle.ar.xliff
+++ b/Resources/translations/SonataAdminBundle.ar.xliff
@@ -191,7 +191,7 @@
                 <target>form_not_available</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.bg.xliff
+++ b/Resources/translations/SonataAdminBundle.bg.xliff
@@ -191,7 +191,7 @@
                 <target>Формулярът не е достъпен.</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target>Начална страница</target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/Resources/translations/SonataAdminBundle.ca.xliff
@@ -191,7 +191,7 @@
                 <target>form_not_available</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/Resources/translations/SonataAdminBundle.cs.xliff
@@ -191,7 +191,7 @@
                 <target>Formulář není k dispozici</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -191,7 +191,7 @@
                 <target>Form nicht verfügbar.</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -191,7 +191,7 @@
                 <target>Form is not available.</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.es.xliff
+++ b/Resources/translations/SonataAdminBundle.es.xliff
@@ -191,7 +191,7 @@
                 <target>form_not_available</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.eu.xliff
+++ b/Resources/translations/SonataAdminBundle.eu.xliff
@@ -191,7 +191,7 @@
                 <target>form_not_available</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.fa.xliff
+++ b/Resources/translations/SonataAdminBundle.fa.xliff
@@ -191,7 +191,7 @@
                 <target>فرم موجود نیست.</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -191,7 +191,7 @@
                 <target>Formulaire non disponible</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -191,7 +191,7 @@
                 <target>form_not_available</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target>Početna stranica</target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.hu.xliff
+++ b/Resources/translations/SonataAdminBundle.hu.xliff
@@ -191,7 +191,7 @@
                 <target>Az űrlap nem elérhető.</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target>&lt;i class="fa fa-home"&gt;&lt;/i&gt;</target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -191,7 +191,7 @@
                 <target>Form non disponibile</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/Resources/translations/SonataAdminBundle.ja.xliff
@@ -191,7 +191,7 @@
                 <target>form_not_available</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/Resources/translations/SonataAdminBundle.lb.xliff
@@ -191,7 +191,7 @@
                 <target>form_not_available</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.lt.xliff
+++ b/Resources/translations/SonataAdminBundle.lt.xliff
@@ -191,7 +191,7 @@
                 <target>form_not_available</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -191,7 +191,7 @@
                 <target>Form is niet beschikbaar</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.no.xliff
+++ b/Resources/translations/SonataAdminBundle.no.xliff
@@ -191,7 +191,7 @@
                 <target>form_not_available</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -191,7 +191,7 @@
                 <target>Formularz niedostępny</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.pt.xliff
+++ b/Resources/translations/SonataAdminBundle.pt.xliff
@@ -191,7 +191,7 @@
                 <target>form_not_available</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target>Visão Geral</target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -191,7 +191,7 @@
                 <target>O formulário não está disponível</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.ro.xliff
+++ b/Resources/translations/SonataAdminBundle.ro.xliff
@@ -191,7 +191,7 @@
                 <target>form_not_available</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -191,7 +191,7 @@
                 <target>Форма не доступна.</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/Resources/translations/SonataAdminBundle.sk.xliff
@@ -191,7 +191,7 @@
                 <target>Formulár nie je k dispozícii.</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/Resources/translations/SonataAdminBundle.sl.xliff
@@ -191,7 +191,7 @@
                 <target>Obrazec ni na voljo.</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.sv_SE.xliff
+++ b/Resources/translations/SonataAdminBundle.sv_SE.xliff
@@ -191,7 +191,7 @@
                 <target>form_not_available</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/Resources/translations/SonataAdminBundle.uk.xliff
@@ -191,7 +191,7 @@
                 <target>Форма не доступна.</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -191,7 +191,7 @@
                 <target>form_not_available</target>
             </trans-unit>
             <trans-unit id="link_breadcrumb_dashboard">
-                <source>breadcrumb.link_dashboard</source>
+                <source>link_breadcrumb_dashboard</source>
                 <target><![CDATA[<i class="fa fa-home"></i>]]></target>
             </trans-unit>
             <trans-unit id="title_delete">

--- a/Tests/Admin/BreadcrumbsBuilderTest.php
+++ b/Tests/Admin/BreadcrumbsBuilderTest.php
@@ -153,30 +153,30 @@ class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
         $menu->expects($this->exactly(24))
             ->method('addChild')
             ->withConsecutive(
-                array('breadcrumb.link_dashboard'),
+                array('link_breadcrumb_dashboard'),
                 array('someOtherLabel'),
                 array('dummy subject representation'),
                 array('someInterestingLabel'),
                 array('someFancyLabel'),
 
-                array('breadcrumb.link_dashboard'),
+                array('link_breadcrumb_dashboard'),
                 array('someTipTopLabel'),
                 array('dummy subject representation'),
                 array('someFunkyLabel'),
                 array('someAwesomeLabel'),
 
-                array('breadcrumb.link_dashboard'),
+                array('link_breadcrumb_dashboard'),
                 array('someMildlyInterestingLabel'),
                 array('dummy subject representation'),
                 array('someWTFLabel'),
                 array('someBadLabel'),
 
-                array('breadcrumb.link_dashboard'),
+                array('link_breadcrumb_dashboard'),
                 array('someLongLabel'),
                 array('dummy subject representation'),
                 array('someEndlessLabel'),
 
-                array('breadcrumb.link_dashboard'),
+                array('link_breadcrumb_dashboard'),
                 array('someOriginalLabel'),
                 array('dummy subject representation'),
                 array('someOkayishLabel'),
@@ -252,11 +252,11 @@ class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
         $menu->expects($this->any())
             ->method('addChild')
             ->withConsecutive(
-                array('breadcrumb.link_dashboard'),
+                array('link_breadcrumb_dashboard'),
                 array('someOtherLabel'),
                 array('someInterestingLabel'),
 
-                array('breadcrumb.link_dashboard'),
+                array('link_breadcrumb_dashboard'),
                 array('someCoolLabel'),
                 array('dummy subject representation')
             )
@@ -318,7 +318,7 @@ class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
         $routeGenerator->generate('sonata_admin_dashboard')->willReturn('/dashboard');
 
         $admin->getRouteGenerator()->willReturn($routeGenerator->reveal());
-        $menu->addChild('breadcrumb.link_dashboard', array(
+        $menu->addChild('link_breadcrumb_dashboard', array(
             'uri' => '/dashboard',
             'extras' => array(
                 'translation_domain' => 'SonataAdminBundle',
@@ -439,7 +439,7 @@ class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
         $routeGenerator = $this->prophesize('Sonata\AdminBundle\Route\RouteGeneratorInterface');
         $routeGenerator->generate('sonata_admin_dashboard')->willReturn('/dashboard');
         $admin->getRouteGenerator()->willReturn($routeGenerator->reveal());
-        $menu->addChild('breadcrumb.link_dashboard', array(
+        $menu->addChild('link_breadcrumb_dashboard', array(
             'uri' => '/dashboard',
             'extras' => array(
                 'translation_domain' => 'SonataAdminBundle',


### PR DESCRIPTION
I am targeting this branch, because this seems like a somewhat backward compatible patch. Well in fact some one may have had a custom translation for the `breadcrumb.link_dashboard` but it's broken anyway in the current release.

## Changelog

```markdown
### Changed
Changed inconsistent translation unit name.
```
## Subject

Ranamed source translation of the `link_breadcrumb_dashboard` form `breadcrumb.link_dashboard` to `link_breadcrumb_dashboard` to be consistent with other translation units.