### PR TITLE
Added 'attributes' parameter for 'url' field type

### DIFF
--- a/Resources/doc/reference/field_types.rst
+++ b/Resources/doc/reference/field_types.rst
@@ -118,6 +118,7 @@ Parameter                               Description
 ======================================  ==================================================================
 **hide_protocol**                       remove protocol part from the link text
 **url**                                 URL address (e.g. ``http://example.com``)
+**attributes**                          array of html tag attributes (e.g. ``array('target' => '_blank')``)
 **route.name**                          route name (e.g. ``acme_blog_homepage``)
 **route.parameters**                    array of route parameters (e.g. ``array('type' => 'example', 'display' => 'full')``)
 **route.absolute**                      boolean value, create absolute or relative url address based on ``route.name`` and  ``route.parameters`` (default ``false``)

--- a/Resources/doc/reference/field_types.rst
+++ b/Resources/doc/reference/field_types.rst
@@ -135,6 +135,12 @@ Parameter                               Description
             ->add('targetUrl', 'url')
 
             // Output for value `http://example.com`:
+            // `<a href="http://example.com" target="_blank">example.com</a>`
+            ->add('targetUrl', 'url', array(
+                'attributes' => array('target' => '_blank')
+            ))
+
+            // Output for value `http://example.com`:
             // `<a href="http://example.com">example.com</a>`
             ->add('targetUrl', 'url', array(
                 'hide_protocol' => true

--- a/Resources/views/CRUD/list_url.html.twig
+++ b/Resources/views/CRUD/list_url.html.twig
@@ -42,12 +42,7 @@ file that was distributed with this source code.
             {% set value = value|replace({'http://': '', 'https://': ''}) %}
         {% endif %}
 
-        {% set attributes = "" %}
-        {% for attribute, value in field_description.options.attributes|default([]) %}
-            {% set attributes = attributes ~ ' ' ~ attribute|escape ~ '="' ~ value|escape('html_attr') ~ '"' %}
-        {% endfor %}
-
-        <a href="{{ url_address }}"{{ attributes|raw }}>{{ value }}</a>
+        <a href="{{ url_address }}"{% for attribute, value in field_description.options.attributes|default([]) %} {{ attribute }}="{{ value|escape('html_attr') }}"{% endfor %}>{{ value }}</a>
     {% endif %}
 {% endspaceless %}
 {% endblock %}

--- a/Resources/views/CRUD/list_url.html.twig
+++ b/Resources/views/CRUD/list_url.html.twig
@@ -42,7 +42,12 @@ file that was distributed with this source code.
             {% set value = value|replace({'http://': '', 'https://': ''}) %}
         {% endif %}
 
-        <a href="{{ url_address }}">{{ value }}</a>
+        {% set attributes = "" %}
+        {% for attribute, value in field_description.options.attributes|default([]) %}
+            {% set attributes = attributes ~ ' ' ~ attribute|escape ~ '="' ~ value|escape('html_attr') ~ '"' %}
+        {% endfor %}
+
+        <a href="{{ url_address }}"{{ attributes|raw }}>{{ value }}</a>
     {% endif %}
 {% endspaceless %}
 {% endblock %}

--- a/Resources/views/CRUD/list_url.html.twig
+++ b/Resources/views/CRUD/list_url.html.twig
@@ -42,7 +42,14 @@ file that was distributed with this source code.
             {% set value = value|replace({'http://': '', 'https://': ''}) %}
         {% endif %}
 
-        <a href="{{ url_address }}"{% for attribute, value in field_description.options.attributes|default([]) %} {{ attribute }}="{{ value|escape('html_attr') }}"{% endfor %}>{{ value }}</a>
+        <a
+            href="{{ url_address }}"
+            {%- for attribute, value in field_description.options.attributes|default([]) %}
+                {{ attribute }}="{{ value|escape('html_attr') }}"
+            {%- endfor -%}
+        >
+            {{- value -}}
+        </a>
     {% endif %}
 {% endspaceless %}
 {% endblock %}

--- a/Resources/views/CRUD/show_url.html.twig
+++ b/Resources/views/CRUD/show_url.html.twig
@@ -42,7 +42,12 @@ file that was distributed with this source code.
             {% set value = value|replace({'http://': '', 'https://': ''}) %}
         {% endif %}
 
-        <a href="{{ url_address }}"{% for attribute, value in field_description.options.attributes|default([]) %} {{ attribute }}="{{ value|escape('html_attr') }}"{% endfor %}>
+        <a
+            href="{{ url_address }}"
+            {%- for attribute, value in field_description.options.attributes|default([]) %}
+                {{ attribute }}="{{ value|escape('html_attr') }}"
+            {%- endfor -%}
+        >
             {%- if field_description.options.safe -%}
                 {{- value|raw -}}
             {%- else -%}

--- a/Resources/views/CRUD/show_url.html.twig
+++ b/Resources/views/CRUD/show_url.html.twig
@@ -42,12 +42,7 @@ file that was distributed with this source code.
             {% set value = value|replace({'http://': '', 'https://': ''}) %}
         {% endif %}
 
-        {% set attributes = "" %}
-        {% for attribute, value in field_description.options.attributes|default([]) %}
-            {% set attributes = attributes ~ ' ' ~ attribute|escape ~ '="' ~ value|escape('html_attr') ~ '"' %}
-        {% endfor %}
-
-        <a href="{{ url_address }}"{{ attributes|raw }}>
+        <a href="{{ url_address }}"{% for attribute, value in field_description.options.attributes|default([]) %} {{ attribute }}="{{ value|escape('html_attr') }}"{% endfor %}>
             {%- if field_description.options.safe -%}
                 {{- value|raw -}}
             {%- else -%}

--- a/Resources/views/CRUD/show_url.html.twig
+++ b/Resources/views/CRUD/show_url.html.twig
@@ -42,7 +42,12 @@ file that was distributed with this source code.
             {% set value = value|replace({'http://': '', 'https://': ''}) %}
         {% endif %}
 
-        <a href="{{ url_address }}">
+        {% set attributes = "" %}
+        {% for attribute, value in field_description.options.attributes|default([]) %}
+            {% set attributes = attributes ~ ' ' ~ attribute|escape ~ '="' ~ value|escape('html_attr') ~ '"' %}
+        {% endfor %}
+
+        <a href="{{ url_address }}"{{ attributes|raw }}>
             {%- if field_description.options.safe -%}
                 {{- value|raw -}}
             {%- else -%}

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -1042,6 +1042,14 @@ EOT
             ),
             array(
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
+                <a href="https://example.com" target="_blank" class="fooLink">https://example.com</a>
+                </td>',
+                'url',
+                'https://example.com',
+                array('attributes' => array('target' => '_blank', 'class' => 'fooLink')),
+            ),
+            array(
+                '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="http://example.com">example.com</a>
                 </td>',
                 'url',
@@ -1574,6 +1582,12 @@ EOT
                 'url',
                 'http://example.com',
                 array('safe' => false),
+            ),
+            array(
+                '<th>Data</th> <td><a href="http://example.com" target="_blank">http://example.com</a></td>',
+                'url',
+                'http://example.com',
+                array('safe' => false, 'attributes' => array('target' => '_blank')),
             ),
             array(
                 '<th>Data</th> <td><a href="http://example.com" target="_blank" class="fooLink">http://example.com</a></td>',

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -1034,6 +1034,14 @@ EOT
             ),
             array(
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
+                <a href="https://example.com" target="_blank">https://example.com</a>
+                </td>',
+                'url',
+                'https://example.com',
+                array('attributes' => array('target' => '_blank')),
+            ),
+            array(
+                '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="http://example.com">example.com</a>
                 </td>',
                 'url',
@@ -1566,6 +1574,12 @@ EOT
                 'url',
                 'http://example.com',
                 array('safe' => false),
+            ),
+            array(
+                '<th>Data</th> <td><a href="http://example.com" target="_blank" class="fooLink">http://example.com</a></td>',
+                'url',
+                'http://example.com',
+                array('safe' => false, 'attributes' => array('target' => '_blank', 'class' => 'fooLink')),
             ),
             array(
                 '<th>Data</th> <td><a href="https://example.com">https://example.com</a></td>',


### PR DESCRIPTION
I am targeting this branch, because this is new feature with BC.

## Changelog


```markdown
### Added
- Added 'attributes' parameter for 'url' field type
```

## Subject

We have case, when we want open url in new tab, for this we need set target="_blank" for <a> tag. This PR add generic solution for this and similar use cases.
