### PR TITLE
Improve Russian translation

### DIFF
--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -208,7 +208,7 @@
             </trans-unit>
             <trans-unit id="title_batch_confirmation">
                 <source>title_batch_confirmation</source>
-                <target>Подтверждение пакетного действия</target>
+                <target>Подтверждение пакетного действия "%action%"</target>
             </trans-unit>
             <trans-unit id="message_batch_confirmation">
                 <source>message_batch_confirmation</source>


### PR DESCRIPTION
I am targeting this branch, because this is a BC patch.

## Changelog

```markdown
### Added
- Added a missing variable placeholder to a translation unit.
```

## To do

- [x] Make sure a colon is actually needed before the action name. Some translations have it there and some not. Not sure how to handle that.

## Subject
Added a missing variable placeholder to a translation unit.