### PR TITLE
Improve English translation

### DIFF
--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -204,7 +204,7 @@
             </trans-unit>
             <trans-unit id="title_batch_confirmation">
                 <source>title_batch_confirmation</source>
-                <target>Confirm batch action '%action%'</target>
+                <target>Confirm batch action "%action%"</target>
             </trans-unit>
             <trans-unit id="message_batch_confirmation">
                 <source>message_batch_confirmation</source>


### PR DESCRIPTION
I am targeting this branch, because this is a BC patch.

## Changelog

```markdown
### Fixed
- Fixed inconsistent translation placeholder quoting.
```

## To do

- [x] Make sure a colon is not needed before the action name. Some translations have it there and some not. Not sure how to handle that.

## Subject
Fixed inconsistent translation placeholder quoting.