### PR TITLE
Replace isGranted by hasAccess or checkAccess

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1095,7 +1095,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface
     {
         $actions = array();
 
-        if ($this->hasRoute('delete') && $this->isGranted('DELETE')) {
+        if ($this->hasRoute('delete') && $this->hasAccess('delete')) {
             $actions['delete'] = array(
                 'label' => 'action_delete',
                 'translation_domain' => 'SonataAdminBundle',
@@ -2947,7 +2947,7 @@ EOT;
     {
         $actions = array();
 
-        if ($this->hasRoute('create') && $this->isGranted('CREATE')) {
+        if ($this->hasRoute('create') && $this->hasAccess('create')) {
             $actions['create'] = array(
                 'label' => 'link_add',
                 'translation_domain' => 'SonataAdminBundle',
@@ -2957,7 +2957,7 @@ EOT;
             );
         }
 
-        if ($this->hasRoute('list') && $this->isGranted('LIST')) {
+        if ($this->hasRoute('list') && $this->hasAccess('list')) {
             $actions['list'] = array(
                 'label' => 'link_list',
                 'translation_domain' => 'SonataAdminBundle',

--- a/Admin/BreadcrumbsBuilder.php
+++ b/Admin/BreadcrumbsBuilder.php
@@ -93,7 +93,7 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
             sprintf('%s_list', $admin->getClassnameLabel()),
             $admin->getTranslationDomain(),
             array(
-                'uri' => $admin->hasRoute('list') && $admin->isGranted('LIST') ?
+                'uri' => $admin->hasRoute('list') && $admin->hasAccess('list') ?
                 $admin->generateUrl('list') :
                 null,
             )

--- a/Block/AdminSearchBlockService.php
+++ b/Block/AdminSearchBlockService.php
@@ -20,7 +20,6 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -66,9 +65,7 @@ class AdminSearchBlockService extends AbstractBlockService
             throw new \RuntimeException('The requested service is not an Admin instance');
         }
 
-        if (!$admin->isGranted('LIST')) {
-            throw new AccessDeniedException();
-        }
+        $admin->checkAccess('list');
 
         $pager = $this->searchHandler->search(
             $admin,

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -249,7 +249,7 @@ class HelperController
         }
 
         // check user permission
-        if (false === $admin->isGranted('EDIT', $object)) {
+        if (false === $admin->hasAccess('edit', $object)) {
             return new JsonResponse(array('status' => 'KO', 'message' => 'Invalid permissions'));
         }
 
@@ -332,14 +332,9 @@ class HelperController
         $admin->setRequest($request);
         $context = $request->get('_context', '');
 
-        if ($context === 'filter' && false === $admin->isGranted('LIST')) {
-            throw new AccessDeniedException();
-        }
-
-        if ($context !== 'filter'
-            && false === $admin->isGranted('CREATE')
-            && false === $admin->isGranted('EDIT')
-        ) {
+        if ($context === 'filter') {
+            $admin->checkAccess('list');
+        } elseif (!$admin->hasAccess('create') && !$admin->hasAccess('edit')) {
             throw new AccessDeniedException();
         }
 
@@ -381,9 +376,7 @@ class HelperController
         $targetAdmin = $fieldDescription->getAssociationAdmin();
 
         // check user permission
-        if (false === $targetAdmin->isGranted('LIST')) {
-            throw new AccessDeniedException();
-        }
+        $targetAdmin->checkAccess('list');
 
         if (mb_strlen($searchText, 'UTF-8') < $minimumInputLength) {
             return new JsonResponse(array('status' => 'KO', 'message' => 'Too short search string.'), 403);

--- a/Datagrid/ListMapper.php
+++ b/Datagrid/ListMapper.php
@@ -52,7 +52,7 @@ class ListMapper extends BaseMapper
         $fieldDescriptionOptions['identifier'] = true;
 
         if (!isset($fieldDescriptionOptions['route']['name'])) {
-            $routeName = ($this->admin->isGranted('EDIT') && $this->admin->hasRoute('edit')) ? 'edit' : 'show';
+            $routeName = ($this->admin->hasAccess('edit') && $this->admin->hasRoute('edit')) ? 'edit' : 'show';
             $fieldDescriptionOptions['route']['name'] = $routeName;
         }
 

--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -41,7 +41,7 @@ class AdminType extends AbstractType
             $admin->getParentFieldDescription()->setAssociationAdmin($admin);
         }
 
-        if ($options['delete'] && $admin->isGranted('DELETE')) {
+        if ($options['delete'] && $admin->hasAccess('delete')) {
             if (!array_key_exists('translation_domain', $options['delete_options']['type_options'])) {
                 $options['delete_options']['type_options']['translation_domain'] = $admin->getTranslationDomain();
             }

--- a/Menu/Matcher/Voter/AdminVoter.php
+++ b/Menu/Matcher/Voter/AdminVoter.php
@@ -48,7 +48,7 @@ class AdminVoter implements VoterInterface
         $admin = $item->getExtra('admin');
         $match = null;
         if ($admin instanceof AdminInterface
-            && $admin->hasRoute('list') && $admin->isGranted('LIST')
+            && $admin->hasRoute('list') && $admin->hasAccess('list')
             && $this->request && $this->request->get('_sonata_admin') == $admin->getCode()
         ) {
             $match = true;

--- a/Menu/Provider/GroupMenuProvider.php
+++ b/Menu/Provider/GroupMenuProvider.php
@@ -67,7 +67,7 @@ class GroupMenuProvider implements MenuProviderInterface
             && !$checker instanceof \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface
         ) {
             throw new \InvalidArgumentException(
-                'Argument 3 must be an instance of either \Symfony\Component\Security\Core\SecurityContextInterface or 
+                'Argument 3 must be an instance of either \Symfony\Component\Security\Core\SecurityContextInterface or
                 \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
             );
         }
@@ -102,7 +102,7 @@ class GroupMenuProvider implements MenuProviderInterface
                     $admin = $this->pool->getInstance($item['admin']);
 
                     // skip menu item if no `list` url is available or user doesn't have the LIST access rights
-                    if (!$admin->hasRoute('list') || !$admin->isGranted('LIST')) {
+                    if (!$admin->hasRoute('list') || !$admin->hasAccess('list')) {
                         continue;
                     }
 
@@ -145,7 +145,7 @@ class GroupMenuProvider implements MenuProviderInterface
                     $admin = $this->pool->getInstance($item['admin']);
 
                     // skip menu item if no `list` url is available or user doesn't have the LIST access rights
-                    if (!$admin->hasRoute('list') || !$admin->isGranted('LIST')) {
+                    if (!$admin->hasRoute('list') || !$admin->hasAccess('list')) {
                         continue;
                     }
 

--- a/Resources/doc/cookbook/recipe_customizing_a_mosaic_list.rst
+++ b/Resources/doc/cookbook/recipe_customizing_a_mosaic_list.rst
@@ -62,9 +62,9 @@ The ``list_outer_rows_mosaic.html.twig`` is the name of one mosaic's tile. You s
     {% endblock %}
 
     {% block sonata_mosaic_description %}
-        {% if admin.isGranted('EDIT', object) and admin.hasRoute('edit') %}
+        {% if admin.hasAccess('edit', object) and admin.hasRoute('edit') %}
             <a href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|truncate(40) }}</a>
-        {% elseif admin.isGranted('VIEW', object) and admin.hasRoute('show') %}
+        {% elseif admin.hasAccess('show', object) and admin.hasRoute('show') %}
             <a href="{{ admin.generateUrl('show', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|truncate(40) }}</a>
         {% else %}
             {{ meta.title|truncate(40) }}

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -233,7 +233,7 @@ ACL
 ^^^
 
 Though the route linked by a menu may be protected the Tab Menu will not automatically check the ACl for you.
-The link will still appear unless you manually check it using the `isGranted` method:
+The link will still appear unless you manually check it using the `hasAccess` method:
 
 .. code-block:: php
 
@@ -245,7 +245,7 @@ The link will still appear unless you manually check it using the `isGranted` me
         $menu->addChild($this->trans('Show'), array('uri' => $admin->generateUrl('show', array('id' => $id))));
 
         // Link will only appear if access to ACL protected URL is granted
-        if ($this->isGranted('EDIT')) {
+        if ($this->hasAccess('edit')) {
             $menu->addChild($this->trans('Edit'), array('uri' => $admin->generateUrl('edit', array('id' => $id))));
         }
     }

--- a/Resources/doc/reference/batch_actions.rst
+++ b/Resources/doc/reference/batch_actions.rst
@@ -33,8 +33,8 @@ merges them onto a single target item. It should only be available when two cond
     public function configureBatchActions($actions)
     {
         if (
-          $this->hasRoute('edit') && $this->isGranted('EDIT') && 
-          $this->hasRoute('delete') && $this->isGranted('DELETE')
+          $this->hasRoute('edit') && $this->hasAccess('edit') &&
+          $this->hasRoute('delete') && $this->hasAccess('delete')
         ) {
             $actions['merge'] = array(
                 'ask_confirmation' => true
@@ -81,9 +81,8 @@ granularity), the passed query is ``null``.
          */
         public function batchActionMerge(ProxyQueryInterface $selectedModelQuery, Request $request = null)
         {
-            if (!$this->admin->isGranted('EDIT') || !$this->admin->isGranted('DELETE')) {
-                throw new AccessDeniedException();
-            }
+            $this->admin->checkAccess('edit');
+            $this->admin->checkAccess('delete');
 
             $modelManager = $this->admin->getModelManager();
 
@@ -131,8 +130,8 @@ granularity), the passed query is ``null``.
 
 A merge action requires two kinds of selection: a set of source objects to merge from
 and a target object to merge into. By default, batch_actions only let you select one set
-of objects to manipulate. We can override this behavior by changing our list template 
-(``list__batch.html.twig``) and adding a radio button to choose the target object. 
+of objects to manipulate. We can override this behavior by changing our list template
+(``list__batch.html.twig``) and adding a radio button to choose the target object.
 
 .. code-block:: html+jinja
 
@@ -170,9 +169,9 @@ for further explanation of overriding bundle templates.
 
 By default, batch actions are not executed if no object was selected, and the user is notified of
 this lack of selection. If your custom batch action needs more complex logic to determine if
-an action can be performed or not, just define a ``batchAction<MyAction>IsRelevant`` method 
-(e.g. ``batchActionMergeIsRelevant``) in your ``CRUDController`` class. This check is performed 
-before the user is asked for confirmation, to make sure there is actually something to confirm. 
+an action can be performed or not, just define a ``batchAction<MyAction>IsRelevant`` method
+(e.g. ``batchActionMergeIsRelevant``) in your ``CRUDController`` class. This check is performed
+before the user is asked for confirmation, to make sure there is actually something to confirm.
 
 This method may return three different values:
 

--- a/Resources/doc/reference/security.rst
+++ b/Resources/doc/reference/security.rst
@@ -158,7 +158,7 @@ So our ``security.yml`` file may look something like this:
                 ROLE_ADMIN:             [ROLE_STAFF, ROLE_SONATA_FOO_EDITOR, ROLE_SONATA_FOO_ADMIN]
                 ROLE_SUPER_ADMIN:       [ROLE_ADMIN, ROLE_ALLOWED_TO_SWITCH]
 
-                # you could alternatively use for an admin who has all rights 
+                # you could alternatively use for an admin who has all rights
                 ROLE_ALL_ADMIN:         [ROLE_STAFF, ROLE_SONATA_FOO_ALL]
 
             # set access_strategy to unanimous, else you may have unexpected behaviors
@@ -177,7 +177,7 @@ You can now test if a user is authorized from an Admin class:
 
 .. code-block:: php
 
-    if ($this->isGranted('LIST')) {
+    if ($this->hasAccess('list')) {
         // ...
     }
 
@@ -185,7 +185,7 @@ From a controller extending ``Sonata\AdminBundle\Controller\CRUDController``:
 
 .. code-block:: php
 
-    if ($this->admin->isGranted('LIST')) {
+    if ($this->admin->hasAccess('list')) {
         // ...
     }
 
@@ -617,7 +617,7 @@ because for example you want to restrict access using extra rules:
 
 .. code-block:: html+jinja
 
-    {% if admin.isGranted('EDIT', user_object) %}
+    {% if admin.hasAccess('edit', user_object) %}
         {# ... #}
     {% endif %}
 
@@ -635,14 +635,14 @@ Every time you create a new ``Admin`` class, you should start with the command
 ``php app/console sonata:admin:setup-acl`` so the ACL database will be updated
 with the latest roles and permissions.
 
-In the templates, or in your code, you can use the Admin method ``isGranted()``:
+In the templates, or in your code, you can use the Admin method ``hasAccess()``:
 
 - check for an admin that the user is allowed to ``EDIT``:
 
 .. code-block:: html+jinja
 
     {# use the admin security method  #}
-    {% if admin.isGranted('EDIT') %}
+    {% if admin.hasAccess('edit') %}
         {# ... #}
     {% endif %}
 
@@ -657,7 +657,7 @@ In the templates, or in your code, you can use the Admin method ``isGranted()``:
 .. code-block:: html+jinja
 
     {# use the admin security method  #}
-    {% if admin.isGranted('DELETE', object) %}
+    {% if admin.hasAccess('delete', object) %}
         {# ... #}
     {% endif %}
 

--- a/Resources/views/Block/block_search_result.html.twig
+++ b/Resources/views/Block/block_search_result.html.twig
@@ -24,12 +24,12 @@ file that was distributed with this source code.
                 <div class="box-tools pull-right">
                     {% if pager and pager.getNbResults() > 0 %}
                         <span class="badge">{{ pager.getNbResults() }}</span>
-                    {% elseif admin.hasRoute('create') and admin.isGranted('CREATE') %}
+                    {% elseif admin.hasRoute('create') and admin.hasAccess('create') %}
                         <a href="{{ admin.generateUrl('create') }}" class="btn btn-box-tool">
                             <i class="fa fa-plus" aria-hidden="true"></i>
                         </a>
                     {% endif %}
-                    {% if admin.hasRoute('list') and admin.isGranted('LIST') %}
+                    {% if admin.hasRoute('list') and admin.hasAccess('list') %}
                         <a href="{{ admin.generateUrl('list') }}" class="btn btn-box-tool">
                             <i class="fa fa-list" aria-hidden="true"></i>
                         </a>

--- a/Resources/views/CRUD/base_edit_form.html.twig
+++ b/Resources/views/CRUD/base_edit_form.html.twig
@@ -83,23 +83,23 @@
                         {% if admin.id(object) is not null %}
                             <button type="submit" class="btn btn-success" name="btn_update_and_edit"><i class="fa fa-save" aria-hidden="true"></i> {{ 'btn_update_and_edit_again'|trans({}, 'SonataAdminBundle') }}</button>
 
-                            {% if admin.hasroute('list') and admin.isGranted('LIST') %}
+                            {% if admin.hasRoute('list') and admin.hasAccess('list') %}
                                 <button type="submit" class="btn btn-success" name="btn_update_and_list"><i class="fa fa-save"></i> <i class="fa fa-list" aria-hidden="true"></i> {{ 'btn_update_and_return_to_list'|trans({}, 'SonataAdminBundle') }}</button>
                             {% endif %}
 
-                            {% if admin.hasroute('delete') and admin.isGranted('DELETE', object) %}
+                            {% if admin.hasRoute('delete') and admin.hasAccess('delete', object) %}
                                 {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
                                 <a class="btn btn-danger" href="{{ admin.generateObjectUrl('delete', object) }}"><i class="fa fa-minus-circle" aria-hidden="true"></i> {{ 'link_delete'|trans({}, 'SonataAdminBundle') }}</a>
                             {% endif %}
 
-                            {% if admin.isAclEnabled() and admin.hasroute('acl') and admin.isGranted('MASTER', object) %}
+                            {% if admin.isAclEnabled() and admin.hasRoute('acl') and admin.hasAccess('acl', object) %}
                                 <a class="btn btn-info" href="{{ admin.generateObjectUrl('acl', object) }}"><i class="fa fa-users" aria-hidden="true"></i> {{ 'link_edit_acl'|trans({}, 'SonataAdminBundle') }}</a>
                             {% endif %}
                         {% else %}
-                            {% if admin.hasroute('edit') and admin.isGranted('EDIT') %}
+                            {% if admin.hasroute('edit') and admin.hasAccess('edit') %}
                                 <button class="btn btn-success" type="submit" name="btn_create_and_edit"><i class="fa fa-save" aria-hidden="true"></i> {{ 'btn_create_and_edit_again'|trans({}, 'SonataAdminBundle') }}</button>
                             {% endif %}
-                            {% if admin.hasroute('list') and admin.isGranted('LIST') %}
+                            {% if admin.hasroute('list') and admin.hasAccess('list') %}
                                 <button type="submit" class="btn btn-success" name="btn_create_and_list"><i class="fa fa-save"></i> <i class="fa fa-list" aria-hidden="true"></i> {{ 'btn_create_and_return_to_list'|trans({}, 'SonataAdminBundle') }}</button>
                             {% endif %}
                             <button class="btn btn-success" type="submit" name="btn_create_and_create"><i class="fa fa-plus-circle" aria-hidden="true"></i> {{ 'btn_create_and_create_a_new_one'|trans({}, 'SonataAdminBundle') }}</button>

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -180,7 +180,7 @@ file that was distributed with this source code.
                                 {% set export_formats = export_formats|default(admin.exportFormats) %}
 
                                 <div class="pull-right">
-                                    {% if admin.hasRoute('export') and admin.isGranted('EXPORT') and export_formats|length %}
+                                    {% if admin.hasRoute('export') and admin.hasAccess('export') and export_formats|length %}
                                         <div class="btn-group">
                                             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                                                 <i class="fa fa-share-square-o" aria-hidden="true"></i>

--- a/Resources/views/CRUD/base_list_field.html.twig
+++ b/Resources/views/CRUD/base_list_field.html.twig
@@ -11,14 +11,12 @@ file that was distributed with this source code.
 
 <td class="sonata-ba-list-field sonata-ba-list-field-{{ field_description.type }}" objectId="{{ admin.id(object) }}"{% if field_description.options.row_align is defined %} style="text-align:{{ field_description.options.row_align }}"{% endif %}>
     {% set route = field_description.options.route.name|default(null) %}
-    {% set action = route == 'show' ? 'VIEW' : route|upper %}
 
     {% if
         field_description.options.identifier is defined
         and route
-        and action
         and admin.hasRoute(route)
-        and admin.isGranted(action, action in ['VIEW', 'EDIT'] ? object : null)
+        and admin.hasAccess(route, action in ['show', 'edit'] ? object : null)
     %}
         <a class="sonata-link-identifier" href="{{ admin.generateObjectUrl(route, object, field_description.options.route.parameters) }}">
             {%- block field %}
@@ -36,7 +34,7 @@ file that was distributed with this source code.
             {% endblock -%}
         </a>
     {% else %}
-        {% set isEditable = field_description.options.editable is defined and field_description.options.editable and admin.isGranted('EDIT', object) %}
+        {% set isEditable = field_description.options.editable is defined and field_description.options.editable and admin.hasAccess('edit', object) %}
         {% set xEditableType = field_description.type|sonata_xeditable_type %}
 
         {% if isEditable and xEditableType %}

--- a/Resources/views/CRUD/base_list_flat_field.html.twig
+++ b/Resources/views/CRUD/base_list_flat_field.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
     {% if
             field_description.options.identifier is defined
         and field_description.options.route is defined
-        and admin.isGranted(field_description.options.route.name == 'show' ? 'VIEW' : field_description.options.route.name|upper, object)
+        and admin.hasAccess(field_description.options.route.name, object)
         and admin.hasRoute(field_description.options.route.name)
     %}
         <a href="{{ admin.generateObjectUrl(field_description.options.route.name, object, field_description.options.route.parameters) }}">

--- a/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/Resources/views/CRUD/batch_confirmation.html.twig
@@ -45,7 +45,7 @@ file that was distributed with this source code.
 
                     <button type="submit" class="btn btn-danger">{{ 'btn_execute_batch_action'|trans({}, 'SonataAdminBundle') }}</button>
 
-                    {% if admin.hasRoute('list') and admin.isGranted('LIST') %}
+                    {% if admin.hasRoute('list') and admin.hasAccess('list') %}
                         {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
 
                         <a class="btn btn-success" href="{{ admin.generateUrl('list') }}">

--- a/Resources/views/CRUD/delete.html.twig
+++ b/Resources/views/CRUD/delete.html.twig
@@ -33,7 +33,7 @@ file that was distributed with this source code.
                     <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
 
                     <button type="submit" class="btn btn-danger"><i class="fa fa-trash" aria-hidden="true"></i> {{ 'btn_delete'|trans({}, 'SonataAdminBundle') }}</button>
-                    {% if admin.hasRoute('edit') and admin.isGranted('EDIT', object) %}
+                    {% if admin.hasRoute('edit') and admin.hasAccess('edit', object) %}
                         {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
 
                         <a class="btn btn-success" href="{{ admin.generateObjectUrl('edit', object) }}">

--- a/Resources/views/CRUD/list__action_delete.html.twig
+++ b/Resources/views/CRUD/list__action_delete.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% if admin.isGranted('DELETE', object) and admin.hasRoute('delete') %}
+{% if admin.hasAccess('delete', object) and admin.hasRoute('delete') %}
     <a href="{{ admin.generateObjectUrl('delete', object) }}" class="btn btn-sm btn-default delete_link" title="{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}">
         <i class="fa fa-times" aria-hidden="true"></i>
         {{ 'action_delete'|trans({}, 'SonataAdminBundle') }}

--- a/Resources/views/CRUD/list__action_edit.html.twig
+++ b/Resources/views/CRUD/list__action_edit.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% if admin.isGranted('EDIT', object) and admin.hasRoute('edit') %}
+{% if admin.hasAccess('edit', object) and admin.hasRoute('edit') %}
     <a href="{{ admin.generateObjectUrl('edit', object) }}" class="btn btn-sm btn-default edit_link" title="{{ 'action_edit'|trans({}, 'SonataAdminBundle') }}">
         <i class="fa fa-pencil" aria-hidden="true"></i>
         {{ 'action_edit'|trans({}, 'SonataAdminBundle') }}

--- a/Resources/views/CRUD/list__action_show.html.twig
+++ b/Resources/views/CRUD/list__action_show.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% if admin.isGranted('VIEW', object) and admin.hasRoute('show') %}
+{% if admin.hasAccess('show', object) and admin.hasRoute('show') %}
     <a href="{{ admin.generateObjectUrl('show', object) }}" class="btn btn-sm btn-default view_link" title="{{ 'action_show'|trans({}, 'SonataAdminBundle') }}">
         <i class="fa fa-search-plus" aria-hidden="true"></i>
         {{ 'action_show'|trans({}, 'SonataAdminBundle') }}

--- a/Resources/views/CRUD/list_boolean.html.twig
+++ b/Resources/views/CRUD/list_boolean.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% extends admin.getTemplate('base_list_field') %}
 
-{% set isEditable = field_description.options.editable is defined and field_description.options.editable and admin.isGranted('EDIT', object) %}
+{% set isEditable = field_description.options.editable is defined and field_description.options.editable and admin.hasAccess('edit', object) %}
 {% set xEditableType = field_description.type|sonata_xeditable_type %}
 
 {% if isEditable and xEditableType %}

--- a/Resources/views/CRUD/list_choice.html.twig
+++ b/Resources/views/CRUD/list_choice.html.twig
@@ -14,7 +14,7 @@ file that was distributed with this source code.
 {% set is_editable =
     field_description.options.editable is defined and
     field_description.options.editable and
-    admin.isGranted('EDIT', object)
+    admin.hasAccess('edit', object)
 %}
 {% set x_editable_type = field_description.type|sonata_xeditable_type %}
 

--- a/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
+++ b/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
@@ -55,16 +55,16 @@ This template can be customized to match your needs. You should only extends the
                         {% set export_formats = export_formats|default(admin.getExportFormats) %}
 
                         <div class="mosaic-inner-text">
-                            {% if (admin.hasRoute('batch') and batchactions|length > 0) or (admin.hasRoute('export') and admin.isGranted("EXPORT") and export_formats|length) %}
+                            {% if (admin.hasRoute('batch') and batchactions|length > 0) or (admin.hasRoute('export') and admin.hasAccess('export') and export_formats|length) %}
                                 <input type="checkbox" name="idx[]" value="{{ admin.id(object) }}">
                             {% else %}
                                 &nbsp;
                             {% endif %}
 
                             {% block sonata_mosaic_description %}
-                                {% if admin.isGranted('EDIT', object) and admin.hasRoute('edit') %}
+                                {% if admin.hasAccess('edit', object) and admin.hasRoute('edit') %}
                                     <a class="mosaic-inner-link" href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|truncate(40) }}</a>
-                                {% elseif admin.isGranted('VIEW', object) and admin.hasRoute('show') %}
+                                {% elseif admin.hasAccess('show', object) and admin.hasRoute('show') %}
                                     <a class="mosaic-inner-link" href="{{ admin.generateUrl('show', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|truncate(40) }}</a>
                                 {% else %}
                                     {{ meta.title|truncate(40) }}

--- a/Resources/views/Core/add_block.html.twig
+++ b/Resources/views/Core/add_block.html.twig
@@ -6,7 +6,7 @@
         {% set display_group = false %}
 
         {% for admin in group.items if display_group == false %}
-            {% if admin.hasRoute('create') and admin.isGranted('CREATE') %}
+            {% if admin.hasRoute('create') and admin.hasAccess('create') %}
                 {% set display_group = true %}
                 {% set groups = [group]|merge(groups) %}
             {% endif %}
@@ -46,7 +46,7 @@
                 </li>
 
                 {% for admin in group.items %}
-                    {% if admin.hasRoute('create') and admin.isGranted('CREATE') %}
+                    {% if admin.hasRoute('create') and admin.hasAccess('create') %}
                         {% if admin.subClasses is empty %}
                             <li role="presentation">
                                 <a role="menuitem" tabindex="-1" href="{{ admin.generateUrl('create')}}">{{ admin.label|trans({}, admin.translationdomain) }}</a>

--- a/Resources/views/Core/search.html.twig
+++ b/Resources/views/Core/search.html.twig
@@ -29,7 +29,7 @@ file that was distributed with this source code.
             {% if display %}
                 {% for admin in group.items %}
                     {% set count = count + 1 %}
-                    {% if admin.hasRoute('create') and admin.isGranted('CREATE') or admin.hasRoute('list') and admin.isGranted('LIST') %}
+                    {% if admin.hasRoute('create') and admin.hasAccess('create') or admin.hasRoute('list') and admin.hasAccess('list') %}
                         {{ sonata_block_render({
                             'type': 'sonata.admin.block.search_result'
                         }, {

--- a/Resources/views/Helper/short-object-description.html.twig
+++ b/Resources/views/Helper/short-object-description.html.twig
@@ -1,5 +1,5 @@
 <span class="inner-field-short-description">
-    {% if object and admin.hasRoute('edit') and admin.isGranted('EDIT') %}
+    {% if object and admin.hasRoute('edit') and admin.hasAccess('edit') %}
         <a href="{{ admin.generateObjectUrl('edit', object, link_parameters) }}" target="new">{{ description }}</a>
     {% else %}
         {{ description }}

--- a/Tests/Admin/BreadcrumbsBuilderTest.php
+++ b/Tests/Admin/BreadcrumbsBuilderTest.php
@@ -345,7 +345,7 @@ class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
             ->willReturn($labelTranslatorStrategy->reveal());
         $childAdmin->getClassnameLabel()->willReturn('my_child_class_name');
         $childAdmin->hasRoute('list')->willReturn(true);
-        $childAdmin->isGranted('LIST')->willReturn(true);
+        $childAdmin->hasAccess('list')->willReturn(true);
         $childAdmin->generateUrl('list')->willReturn('/myadmin/my-object/mychildadmin/list');
         $childAdmin->getCurrentChildAdmin()->willReturn(null);
         $childAdmin->hasSubject()->willReturn(true);
@@ -358,7 +358,7 @@ class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
 
         $admin->trans('My class', array(), null)->willReturn('Ma classe');
         $admin->hasRoute('list')->willReturn(true);
-        $admin->isGranted('LIST')->willReturn(true);
+        $admin->hasAccess('list')->willReturn(true);
         $admin->generateUrl('list')->willReturn('/myadmin/list');
         $admin->getCurrentChildAdmin()->willReturn($childAdmin->reveal());
         $request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
@@ -366,7 +366,7 @@ class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
 
         $admin->getIdParameter()->willReturn('slug');
         $admin->hasRoute('edit')->willReturn(true);
-        $admin->isGranted('EDIT')->willReturn(true);
+        $admin->hasAccess('edit')->willReturn(true);
         $admin->generateUrl('edit', array('id' => 'my-object'))->willReturn('/myadmin/my-object');
         $admin->getRequest()->willReturn($request->reveal());
         $admin->hasSubject()->willReturn(true);
@@ -483,7 +483,7 @@ class BreadcrumbsBuilderTest extends PHPUnit_Framework_TestCase
         $childAdmin->hasSubject()->willReturn(false);
 
         $admin->hasRoute('list')->willReturn(true);
-        $admin->isGranted('LIST')->willReturn(true);
+        $admin->hasAccess('list')->willReturn(true);
         $admin->generateUrl('list')->willReturn('/myadmin/list');
         $admin->getCurrentChildAdmin()->willReturn(
             $action == 'my_action' ? $childAdmin->reveal() : false

--- a/Tests/Bridge/Exporter/AdminExporterTest.php
+++ b/Tests/Bridge/Exporter/AdminExporterTest.php
@@ -13,8 +13,9 @@ namespace Sonata\AdminBundle\Tests\Bridge\Exporter;
 
 use Exporter\Exporter;
 use Sonata\AdminBundle\Bridge\Exporter\AdminExporter;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class AdminExporterTest extends \PHPUnit_Framework_TestCase
+class AdminExporterTest extends PHPUnit_Framework_TestCase
 {
     public function provideExportFormats()
     {
@@ -31,7 +32,7 @@ class AdminExporterTest extends \PHPUnit_Framework_TestCase
     {
         $writers = array();
         foreach ($globalFormats as $exportFormat) {
-            $writer = $this->getMock('Exporter\Writer\TypedWriterInterface');
+            $writer = $this->createMock('Exporter\Writer\TypedWriterInterface');
             $writer->expects($this->once())
                 ->method('getFormat')
                 ->will($this->returnValue($exportFormat));
@@ -39,7 +40,7 @@ class AdminExporterTest extends \PHPUnit_Framework_TestCase
         }
 
         $exporter = new Exporter($writers);
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())
             ->method('getExportFormats')
             ->will($this->returnValue($adminFormats));
@@ -49,7 +50,7 @@ class AdminExporterTest extends \PHPUnit_Framework_TestCase
 
     public function testGetExportFilename()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())
             ->method('getClass')
             ->will($this->returnValue('MyProject\AppBundle\Model\MyClass'));

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -85,7 +85,7 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
         $pool = new Pool($container, 'title', 'logo.png');
         $pool->setAdminServiceIds(array('foo.admin'));
 
-        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
 
         $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
         $helper = new AdminHelper($pool);
@@ -254,9 +254,9 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
         $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getOption')->will($this->returnValue(true));
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
         $admin->expects($this->once())->method('getObject')->will($this->returnValue($object));
-        $admin->expects($this->once())->method('isGranted')->will($this->returnValue(true));
+        $admin->expects($this->once())->method('hasAccess')->will($this->returnValue(true));
         $admin->expects($this->once())->method('getListFieldDescription')->will($this->returnValue($fieldDescription));
         $fieldDescription->expects($this->exactly(2))->method('getAdmin')->will($this->returnValue($admin));
 
@@ -273,7 +273,12 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
         );
 
         $loader = $this->createMock('\Twig_LoaderInterface');
-        $loader->method('getSource')->will($this->returnValue('<foo />'));
+
+        if (method_exists('\Twig_LoaderInterface', 'getSourceContext')) {
+            $loader->method('getSourceContext')->will($this->returnValue(new \Twig_Source('<foo />', 'foo')));
+        } else {
+            $loader->method('getSource')->will($this->returnValue('<foo />'));
+        }
 
         $twig = new \Twig_Environment($loader);
         $twig->addExtension($adminExtension);
@@ -486,9 +491,9 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
         $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getOption')->will($this->returnValue(true));
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
         $admin->expects($this->once())->method('getObject')->will($this->returnValue($object));
-        $admin->expects($this->once())->method('isGranted')->will($this->returnValue(true));
+        $admin->expects($this->once())->method('hasAccess')->will($this->returnValue(true));
         $admin->expects($this->once())->method('getListFieldDescription')->will($this->returnValue($fieldDescription));
 
         $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
@@ -536,32 +541,9 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
     public function testRetrieveAutocompleteItemsActionNotGranted()
     {
         $this->admin->expects($this->exactly(2))
-            ->method('isGranted')
-             ->will($this->returnCallback(function ($operation) {
-                 if ($operation == 'CREATE' || $operation == 'EDIT') {
-                     return false;
-                 }
-
-                 return;
-             }));
-
-        $request = new Request(array(
-            'admin_code' => 'foo.admin',
-        ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'));
-
-        $this->controller->retrieveAutocompleteItemsAction($request);
-    }
-
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
-     * @exceptionMessage Invalid format
-     */
-    public function testRetrieveFilterAutocompleteItemsActionNotGranted()
-    {
-        $this->admin->expects($this->exactly(1))
-            ->method('isGranted')
+            ->method('hasAccess')
             ->will($this->returnCallback(function ($operation) {
-                if ($operation == 'LIST') {
+                if ($operation == 'create' || $operation == 'edit') {
                     return false;
                 }
 
@@ -570,7 +552,6 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
 
         $request = new Request(array(
             'admin_code' => 'foo.admin',
-            '_context' => 'filter',
         ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'));
 
         $this->controller->retrieveAutocompleteItemsAction($request);
@@ -583,8 +564,8 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
     public function testRetrieveAutocompleteItemsActionDisabledFormelememt()
     {
         $this->admin->expects($this->once())
-            ->method('isGranted')
-            ->with('CREATE')
+            ->method('hasAccess')
+            ->with('create')
             ->will($this->returnValue(true));
 
         $entity = new Foo();
@@ -637,100 +618,6 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
             ->method('getAttribute')
             ->with('disabled')
             ->will($this->returnValue(true));
-
-        $request = new Request(array(
-            'admin_code' => 'foo.admin',
-            'field' => 'barField',
-        ), array(), array(), array(), array(), array('REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'));
-
-        $this->controller->retrieveAutocompleteItemsAction($request);
-    }
-
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
-     */
-    public function testRetrieveAutocompleteItemsActionNotGrantedTarget()
-    {
-        $this->admin->expects($this->once())
-            ->method('isGranted')
-            ->with('CREATE')
-            ->will($this->returnValue(true));
-
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
-
-        $fieldDescription->expects($this->once())
-            ->method('getTargetEntity')
-            ->will($this->returnValue('Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo'));
-
-        $fieldDescription->expects($this->once())
-            ->method('getName')
-            ->will($this->returnValue('barField'));
-
-        $targetAdmin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
-
-        $fieldDescription->expects($this->once())
-            ->method('getAssociationAdmin')
-            ->will($this->returnValue($targetAdmin));
-
-        $targetAdmin->expects($this->once())
-            ->method('isGranted')
-            ->with('LIST')
-            ->will($this->returnValue(false));
-
-        $this->admin->expects($this->once())
-            ->method('getFormFieldDescriptions')
-            ->will($this->returnValue(null));
-
-        $this->admin->expects($this->once())
-            ->method('getFormFieldDescription')
-            ->with('barField')
-            ->will($this->returnValue($fieldDescription));
-
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->admin->expects($this->once())
-            ->method('getForm')
-            ->will($this->returnValue($form));
-
-        $formType = $this->getMockBuilder('Symfony\Component\Form\Form')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $form->expects($this->once())
-            ->method('get')
-            ->with('barField')
-            ->will($this->returnValue($formType));
-
-        $formConfig = $this->getMockBuilder('Symfony\Component\Form\FormConfigInterface')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $formType->expects($this->any())
-            ->method('getConfig')
-            ->will($this->returnValue($formConfig));
-
-        $formConfig->expects($this->any())
-            ->method('getAttribute')
-            ->will($this->returnCallback(function ($name) {
-                switch ($name) {
-                    case 'disabled':
-                        return false;
-                    case 'property':
-                        return 'fooProperty';
-                    case 'callback':
-                        return;
-                    case 'minimum_input_length':
-                        return 3;
-                    case 'items_per_page':
-                        return 10;
-                    case 'req_param_name_page_number':
-                        return '_page';
-                    case 'to_string_callback':
-                        return;
-                }
-            }));
 
         $request = new Request(array(
             'admin_code' => 'foo.admin',

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -89,7 +89,13 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
 
         $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
         $helper = new AdminHelper($pool);
-        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+
+        // NEXT_MAJOR: Remove this when dropping support for SF < 2.8
+        if (interface_exists('Symfony\Component\Validator\ValidatorInterface')) {
+            $validator = $this->createMock('Symfony\Component\Validator\ValidatorInterface');
+        } else {
+            $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        }
         $this->controller = new HelperController($twig, $pool, $helper, $validator);
 
         // php 5.3 BC
@@ -274,6 +280,7 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
 
         $loader = $this->createMock('\Twig_LoaderInterface');
 
+        // NEXT_MAJOR: Remove this check when dropping support for twig < 2
         if (method_exists('\Twig_LoaderInterface', 'getSourceContext')) {
             $loader->method('getSourceContext')->will($this->returnValue(new \Twig_Source('<foo />', 'foo')));
         } else {

--- a/Tests/Datagrid/ListMapperTest.php
+++ b/Tests/Datagrid/ListMapperTest.php
@@ -42,7 +42,7 @@ class ListMapperTest extends PHPUnit_Framework_TestCase
     {
         $listBuilder = $this->createMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
         $this->fieldDescriptionCollection = new FieldDescriptionCollection();
-        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
 
         $listBuilder->expects($this->any())
             ->method('addField')

--- a/Tests/Form/Type/AdminTypeTest.php
+++ b/Tests/Form/Type/AdminTypeTest.php
@@ -62,7 +62,7 @@ class AdminTypeTest extends TypeTestCase
         $admin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
         $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(false);
         $admin->getParentFieldDescription()->shouldBeCalled()->willReturn($parentField->reveal());
-        $admin->isGranted('DELETE')->shouldBeCalled()->willReturn(false);
+        $admin->hasAccess('delete')->shouldBeCalled()->willReturn(false);
         $admin->setSubject(null)->shouldBeCalled();
         $admin->defineFormBuilder(new AnyValueToken())->shouldBeCalled();
         $admin->getModelManager()->shouldBeCalled()->willReturn($modelManager);

--- a/Tests/Helpers/PHPUnit_Framework_TestCase.php
+++ b/Tests/Helpers/PHPUnit_Framework_TestCase.php
@@ -49,6 +49,10 @@ class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
             return parent::createMock($originalClassName);
         }
 
-        return parent::getMock($originalClassName);
+        return parent::getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->getMock();
     }
 }

--- a/Tests/Menu/Matcher/Voter/AbstractVoterTest.php
+++ b/Tests/Menu/Matcher/Voter/AbstractVoterTest.php
@@ -13,8 +13,9 @@ namespace Sonata\AdminBundle\Tests\Menu\Matcher\Voter;
 
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\VoterInterface;
+use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-abstract class AbstractVoterTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractVoterTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @return array

--- a/Tests/Menu/Matcher/Voter/AdminVoterTest.php
+++ b/Tests/Menu/Matcher/Voter/AdminVoterTest.php
@@ -71,7 +71,7 @@ class AdminVoterTest extends AbstractVoterTest
      */
     private function getAdmin($code, $list = false, $granted = false)
     {
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
         $admin
             ->expects($this->any())
             ->method('hasRoute')
@@ -80,8 +80,8 @@ class AdminVoterTest extends AbstractVoterTest
         ;
         $admin
             ->expects($this->any())
-            ->method('isGranted')
-            ->with('LIST')
+            ->method('hasAccess')
+            ->with('list')
             ->will($this->returnValue($granted))
         ;
         $admin

--- a/Tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/Tests/Menu/Provider/GroupMenuProviderTest.php
@@ -331,15 +331,15 @@ class GroupMenuProviderTest extends PHPUnit_Framework_TestCase
      */
     private function getAdminMock($hasRoute = true, $isGranted = true)
     {
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
         $admin->expects($this->once())
             ->method('hasRoute')
             ->with($this->equalTo('list'))
             ->will($this->returnValue($hasRoute));
 
         $admin->expects($this->any())
-            ->method('isGranted')
-            ->with($this->equalTo('LIST'))
+            ->method('hasAccess')
+            ->with($this->equalTo('list'))
             ->will($this->returnValue($isGranted));
 
         $admin->expects($this->any())

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -165,7 +165,7 @@ class SonataAdminExtensionTest extends PHPUnit_Framework_TestCase
         $this->object = new \stdClass();
 
         // initialize admin
-        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
 
         $this->admin->expects($this->any())
             ->method('getCode')
@@ -187,9 +187,9 @@ class SonataAdminExtensionTest extends PHPUnit_Framework_TestCase
                 return $translator->trans($id, $parameters, $domain);
             }));
 
-        $this->adminBar = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->adminBar = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
         $this->adminBar->expects($this->any())
-            ->method('isGranted')
+            ->method('hasAccess')
             ->will($this->returnValue(true));
         $this->adminBar->expects($this->any())
             ->method('getNormalizedIdentifier')
@@ -238,7 +238,7 @@ class SonataAdminExtensionTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue(array('context' => 'foo')));
 
         $this->admin->expects($this->any())
-            ->method('isGranted')
+            ->method('hasAccess')
             ->will($this->returnValue(true));
 
         $this->admin->expects($this->any())
@@ -319,7 +319,7 @@ class SonataAdminExtensionTest extends PHPUnit_Framework_TestCase
     public function testDeprecatedRenderListElement($expected, $value, array $options)
     {
         $this->admin->expects($this->any())
-            ->method('isGranted')
+            ->method('hasAccess')
             ->will($this->returnValue(true));
 
         $this->admin->expects($this->any())


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Replaced `isGranted()` by `hasAccess()` or `checkAccess()`
```

## Subject

<!-- Describe your Pull Request content here -->
Replacing all calls to isGranted by hasAccess or checkAccess depending on the situation. This allows clearer code because you don't have to think which role belongs to each route, hasAccess does the trick.