### PR TITLE
Fix non-existent variable "action" in base_list_field.html.twig

### DIFF
--- a/Resources/views/CRUD/base_list_field.html.twig
+++ b/Resources/views/CRUD/base_list_field.html.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
         field_description.options.identifier is defined
         and route
         and admin.hasRoute(route)
-        and admin.hasAccess(route, action in ['show', 'edit'] ? object : null)
+        and admin.hasAccess(route, route in ['show', 'edit'] ? object : null)
     %}
         <a class="sonata-link-identifier" href="{{ admin.generateObjectUrl(route, object, field_description.options.route.parameters) }}">
             {%- block field %}


### PR DESCRIPTION
I am targeting this branch, because it's a hotfix

## Changelog

```markdown
### Fixed
- Fixed non-existent variable `action` in `base_list_field.html.twig`
```
