### PR TITLE
Added the ability to remove the label of a show field

### DIFF
--- a/Resources/doc/reference/action_show.rst
+++ b/Resources/doc/reference/action_show.rst
@@ -135,6 +135,15 @@ The following is a working example of a ShowAction
         }
     }
 
+.. tip::
+    To customize the displayed label of a show field you can use the ``label`` option:
+
+    .. code-block:: php
+    
+        $showMapper->add('name', null, array('label' => 'UserName'));
+
+    Setting this option to ``false`` will make the label empty.
+
 Setting up a custom show template (very useful)
 ===============================================
 

--- a/Show/ShowMapper.php
+++ b/Show/ShowMapper.php
@@ -73,7 +73,7 @@ class ShowMapper extends BaseGroupedMapper
             throw new \RuntimeException('invalid state');
         }
 
-        if (!$fieldDescription->getLabel()) {
+        if (!$fieldDescription->getLabel() && false !== $fieldDescription->getOption('label')) {
             $fieldDescription->setOption('label', $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'show', 'label'));
         }
 

--- a/Tests/Show/ShowMapperTest.php
+++ b/Tests/Show/ShowMapperTest.php
@@ -435,6 +435,13 @@ class ShowMapperTest extends PHPUnit_Framework_TestCase
         $this->assertSame(array(), $this->admin->getShowTabs());
     }
 
+    public function testEmptyFieldLabel()
+    {
+        $this->showMapper->add('foo', null, array('label' => false));
+
+        $this->assertFalse($this->showMapper->get('foo')->getOption('label'));
+    }
+
     private function cleanShowMapper()
     {
         $this->showBuilder = $this->getMockForAbstractClass('Sonata\AdminBundle\Builder\ShowBuilderInterface');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added the ability to leave the label of a show field empty by passing `label => false` to `ShowMapper::add()`
```


