### PR TITLE
update form types documentation - fix #4397

### DIFF
--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -357,7 +357,7 @@ According the choice made only associated fields are displayed. The others field
                         'route' => array('route', 'parameters'),
                         'uri' => array('uri'),
                     ),
-                    'empty_value' => 'Choose an option',
+                    'placeholder' => 'Choose an option',
                     'required' => false
                 ))
                 ->add('route', 'text')


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, to enhance documentation.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4397 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
replace empty_value by placeholder in form definition documentation
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] should upgrade views to reflect this change in symfony's form

## Subject

<!-- Describe your Pull Request content here -->
The current documentation lead to an exception since `empty_value` doesn't exist anymore and has been replaced by `placeholder`, this PR fix the example in documentation