### PR TITLE
add a tip to handle subfield in sonata_type_choice_field_mask

### DIFF
--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -370,6 +370,9 @@ According the choice made only associated fields are displayed. The others field
 map
   Associative array. Describes the fields that are displayed for each choice.
 
+**TIP**: To mask a subfield replace `.` by `__`.
+
+
 
 sonata_type_admin
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's the one linked on the documentation page.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added documentation on how to handle subfield with `sonata_type_choice_field_mask`

```
