### PR TITLE
Changes how locale scripts of Moment.js lib are loaded - Branch master

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -67,7 +67,11 @@ file that was distributed with this source code.
             {% set locale = app.request.locale %}
             {# localize moment #}
             {% if locale[:2] != 'en' %}
-                <script src="{{ asset('bundles/sonatacore/vendor/moment/locale/' ~ locale|replace({'_':'-'}) ~ '.js') }}"></script>
+                <script src="{{ asset(
+                    'bundles/sonatacore/vendor/moment/locale/' ~
+                    locale|lower|replace({'_':'-'}) ~
+                    '.js'
+                ) }}"></script>
             {% endif %}
 
             {# localize select2 #}


### PR DESCRIPTION
The scripts will now have it's name all in lowercase. This will make the server stops return 404 when requesting the script for locales like pt_BR

I am targeting this branch because there is already a pull request  #4403 for branch 3.x and this branch has the same issue.

## Changelog

```markdown
### Changed
- Change how moment locale scripts are loaded. Before they were loaded with the raw locale from `app.request`, now the they are being loaded with the locale all in lowercase.
```