### PR TITLE
sanitize choice mask fields like in formMapper

### DIFF
--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -289,7 +289,7 @@ class FormMapper extends BaseGroupedMapper
      *
      * @return string
      */
-    public function sanitizeFieldName($fieldName)
+    protected function sanitizeFieldName($fieldName)
     {
         return str_replace(array('__', '.'), array('____', '__'), $fieldName);
     }

--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -154,6 +154,7 @@ class FormMapper extends BaseGroupedMapper
     public function get($name)
     {
         $name = $this->sanitizeFieldName($name);
+
         return $this->formBuilder->get($name);
     }
 
@@ -163,6 +164,7 @@ class FormMapper extends BaseGroupedMapper
     public function has($key)
     {
         $key = $this->sanitizeFieldName($key);
+
         return $this->formBuilder->has($key);
     }
 
@@ -278,6 +280,21 @@ class FormMapper extends BaseGroupedMapper
     }
 
     /**
+     * Symfony default form class sadly can't handle
+     * form element with dots in its name (when data
+     * get bound, the default dataMapper is a PropertyPathMapper).
+     * So use this trick to avoid any issue.
+     *
+     * @param string $fieldName
+     *
+     * @return string
+     */
+    public function sanitizeFieldName($fieldName)
+    {
+        return str_replace(array('__', '.'), array('____', '__'), $fieldName);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getGroups()
@@ -307,21 +324,5 @@ class FormMapper extends BaseGroupedMapper
     protected function setTabs(array $tabs)
     {
         $this->admin->setFormTabs($tabs);
-    }
-
-
-    /**
-     * Symfony default form class sadly can't handle
-     * form element with dots in its name (when data
-     * get bound, the default dataMapper is a PropertyPathMapper).
-     * So use this trick to avoid any issue.
-     *
-     * @param string $fieldName
-     *
-     * @return string
-     */
-    public function sanitizeFieldName($fieldName)
-    {
-        return str_replace(array('__', '.'), array('____', '__'), $fieldName);
     }
 }

--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -322,6 +322,6 @@ class FormMapper extends BaseGroupedMapper
      */
     public function sanitizeFieldName($fieldName)
     {
-        return str_replace(['__', '.'], ['____', '__'], $fieldName);
+        return str_replace(array('__', '.'), array('____', '__'), $fieldName);
     }
 }

--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -70,11 +70,11 @@ class FormMapper extends BaseGroupedMapper
         }
 
         // "Dot" notation is not allowed as form name, but can be used as property path to access nested data.
-        if (!$name instanceof FormBuilderInterface && strpos($fieldName, '.') !== false && !isset($options['property_path'])) {
+        if (!$name instanceof FormBuilderInterface && !isset($options['property_path'])) {
             $options['property_path'] = $fieldName;
 
-             // fix the form name
-             $fieldName = str_replace('.', '__', $fieldName);
+            // fix the form name
+            $fieldName = $this->sanitizeFieldName($fieldName);
         }
 
         // change `collection` to `sonata_type_native_collection` form type to
@@ -153,6 +153,7 @@ class FormMapper extends BaseGroupedMapper
      */
     public function get($name)
     {
+        $name = $this->sanitizeFieldName($name);
         return $this->formBuilder->get($name);
     }
 
@@ -161,6 +162,7 @@ class FormMapper extends BaseGroupedMapper
      */
     public function has($key)
     {
+        $key = $this->sanitizeFieldName($key);
         return $this->formBuilder->has($key);
     }
 
@@ -177,6 +179,7 @@ class FormMapper extends BaseGroupedMapper
      */
     public function remove($key)
     {
+        $key = $this->sanitizeFieldName($key);
         $this->admin->removeFormFieldDescription($key);
         $this->admin->removeFieldFromFormGroup($key);
         $this->formBuilder->remove($key);
@@ -304,5 +307,21 @@ class FormMapper extends BaseGroupedMapper
     protected function setTabs(array $tabs)
     {
         $this->admin->setFormTabs($tabs);
+    }
+
+
+    /**
+     * Symfony default form class sadly can't handle
+     * form element with dots in its name (when data
+     * get bound, the default dataMapper is a PropertyPathMapper).
+     * So use this trick to avoid any issue.
+     *
+     * @param string $fieldName
+     *
+     * @return string
+     */
+    public function sanitizeFieldName($fieldName)
+    {
+        return str_replace(['__', '.'], ['____', '__'], $fieldName);
     }
 }

--- a/Form/Type/ChoiceFieldMaskType.php
+++ b/Form/Type/ChoiceFieldMaskType.php
@@ -27,16 +27,19 @@ class ChoiceFieldMaskType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $allFieldNames = array();
+        $sanitizedMap = array();
         foreach ($options['map'] as $value => $fieldNames) {
             foreach ($fieldNames as $fieldName) {
-                $allFieldNames[$fieldName] = $fieldName;
+                $sanitizedMap[$value][] =
+                    str_replace(['__', '.'], ['____', '__'], $fieldName);
             }
         }
-        $allFieldNames = array_values($allFieldNames);
+
+        $allFieldNames = call_user_func_array('array_merge', $sanitizedMap);
+        $allFieldNames = array_unique($allFieldNames);
 
         $view->vars['all_fields'] = $allFieldNames;
-        $view->vars['map'] = $options['map'];
+        $view->vars['map'] = $sanitizedMap;
 
         $options['expanded'] = false;
 

--- a/Form/Type/ChoiceFieldMaskType.php
+++ b/Form/Type/ChoiceFieldMaskType.php
@@ -31,7 +31,7 @@ class ChoiceFieldMaskType extends AbstractType
         foreach ($options['map'] as $value => $fieldNames) {
             foreach ($fieldNames as $fieldName) {
                 $sanitizedMap[$value][] =
-                    str_replace(['__', '.'], ['____', '__'], $fieldName);
+                    str_replace(array('__', '.'), array('____', '__'), $fieldName);
             }
         }
 

--- a/Tests/Form/FormMapperTest.php
+++ b/Tests/Form/FormMapperTest.php
@@ -429,6 +429,20 @@ class FormMapperTest extends PHPUnit_Framework_TestCase
         $this->assertSame(array('foo', 'baz'), $this->formMapper->keys());
     }
 
+    public function testFieldNameIsSanitized()
+    {
+        $this->contractor->expects($this->any())
+            ->method('getDefaultOptions')
+            ->will($this->returnValue(array()));
+
+        $this->formMapper
+            ->add('fo.o', 'bar')
+            ->add('ba__z', 'foobaz')
+        ;
+
+        $this->assertSame(array('fo__o', 'ba____z'), $this->formMapper->keys());
+    }
+
     private function getFieldDescriptionMock($name = null, $label = null, $translationDomain = null)
     {
         $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\BaseFieldDescription');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4401

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- sanitize masked fields in `ChoiceFieldMaskType`

```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->
This add a new method to sanitize field's name in FormMapper, this method is used in `add`, `get` and `has`.
The same process is used to sanitize fields in the ChoiceFieldMaskType options