### PR TITLE
Remove duplicate dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "knplabs/knp-menu-bundle": "^2.1.1",
         "sonata-project/block-bundle": "^3.2",
         "sonata-project/core-bundle": "^3.1",
-        "sonata-project/exporter": "^1.0",
+        "sonata-project/exporter": "^1.7",
         "symfony/class-loader": "^2.3 || ^3.0",
         "symfony/config": "^2.3.9 || ^3.0",
         "symfony/console": "^2.3 || ^3.0",
@@ -48,7 +48,6 @@
         "matthiasnoback/symfony-dependency-injection-test": "^0.1 || ^1.0",
         "sensio/generator-bundle": "^2.3 || ^3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "sonata-project/exporter": "^1.7",
         "sonata-project/intl-bundle": "^2.2.4",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "symfony/yaml": "^2.3 || ^3.0"


### PR DESCRIPTION
This dependency is required in both require and require-dev section,
which can lead to unexpected behavior.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

# Changelog

```markdown
# Changed
- The sonata/exporter constraint has been bumped to `^1.7`
```