### PR TITLE
Avoid whitespaces on blocks

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -8,18 +8,19 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% set _preview              = block('preview') is defined ? block('preview') : null %}
-{% set _form                 = block('form') is defined ? block('form') : null %}
-{% set _show                 = block('show') is defined ? block('show') : null %}
-{% set _list_table           = block('list_table') is defined ? block('list_table') : null %}
-{% set _list_filters         = block('list_filters') is defined ? block('list_filters') : null %}
-{% set _tab_menu             = block('tab_menu') is defined ? block('tab_menu') : null %}
-{% set _content              = block('content') is defined ? block('content') : null %}
-{% set _title                = block('title') is defined ? block('title') : null %}
-{% set _breadcrumb           = block('breadcrumb') is defined ? block('breadcrumb') : null %}
-{% set _actions              = block('actions') is defined ? block('actions') : null %}
-{% set _navbar_title         = block('navbar_title') is defined ? block('navbar_title') : null %}
-{% set _list_filters_actions = block('list_filters_actions') is defined ? block('list_filters_actions') : null %}
+
+{% set _preview = block('preview') is defined ? block('preview')|trim : null %}
+{% set _form = block('form') is defined ? block('form')|trim : null %}
+{% set _show = block('show') is defined ? block('show')|trim : null %}
+{% set _list_table = block('list_table') is defined ? block('list_table')|trim : null %}
+{% set _list_filters = block('list_filters') is defined ? block('list_filters')|trim : null %}
+{% set _tab_menu = block('tab_menu') is defined ? block('tab_menu')|trim : null %}
+{% set _content = block('content') is defined ? block('content')|trim : null %}
+{% set _title = block('title') is defined ? block('title')|trim : null %}
+{% set _breadcrumb = block('breadcrumb') is defined ? block('breadcrumb')|trim : null %}
+{% set _actions = block('actions') is defined ? block('actions')|trim : null %}
+{% set _navbar_title = block('navbar_title') is defined ? block('navbar_title')|trim : null %}
+{% set _list_filters_actions = block('list_filters_actions') is defined ? block('list_filters_actions')|trim : null %}
 
 <!DOCTYPE html>
 <html {% block html_attributes %}class="no-js"{% endblock %}>
@@ -266,11 +267,11 @@ file that was distributed with this source code.
                                             {% endblock %}
 
                                             <div class="navbar-collapse">
-                                                <div class="navbar-left">
-                                                    {% if _tab_menu is not empty %}
-                                                        {{ _tab_menu|raw }}
-                                                    {% endif %}
-                                                </div>
+                                                {% if _tab_menu is not empty %}
+                                                    <div class="navbar-left">
+                                                            {{ _tab_menu|raw }}
+                                                    </div>
+                                                {% endif %}
 
                                                 {% if admin is defined and action is defined and action == 'list' and admin.listModes|length > 1 %}
                                                     <div class="nav navbar-right btn-group">
@@ -331,17 +332,16 @@ file that was distributed with this source code.
                                 <div class="sonata-ba-form">{{ _form|raw }}</div>
                             {% endif %}
 
-                            {% if _list_table is not empty or _list_filters is not empty %}
-                                {% if _list_filters|trim %}
-                                    <div class="row">
-                                        {{ _list_filters|raw }}
-                                    </div>
-                                {% endif %}
+                            {% if _list_filters is not empty %}
+                                <div class="row">
+                                    {{ _list_filters|raw }}
+                                </div>
+                            {% endif %}
 
+                            {% if _list_table is not empty %}
                                 <div class="row">
                                     {{ _list_table|raw }}
                                 </div>
-
                             {% endif %}
                         {% endblock sonata_admin_content %}
                     </section>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Whitespaces are not taken into account when rendering blocks on `standard_layout`
```

## Subject

<!-- Describe your Pull Request content here -->
There was a lot of empty html because the comparisons between `blocks` and `is not empty` is not working if the block has whitespaces.

Can I remove the equal sign alignment?

Example.

BEFORE:
![captura de pantalla 2017-03-20 a las 15 13 12](https://cloud.githubusercontent.com/assets/1137485/24103533/dfece104-0d7f-11e7-9476-5bb1d69395a4.png)

AFTER:
![captura de pantalla 2017-03-20 a las 15 13 46](https://cloud.githubusercontent.com/assets/1137485/24103547/e6833996-0d7f-11e7-9fe6-c3e929dd6ca6.png)