### PR TITLE
add missing onTop annotation to @admin

### DIFF
--- a/Annotation/Admin.php
+++ b/Annotation/Admin.php
@@ -96,6 +96,11 @@ class Admin implements MetadataProcessorInterface
     public $keepOpen = false;
 
     /**
+     * @var bool
+     */
+    public $onTop = false;
+
+    /**
      * @param ClassMetadata $metadata
      */
     public function processMetadata(ClassMetadata $metadata)
@@ -112,6 +117,7 @@ class Admin implements MetadataProcessorInterface
             'pager_type' => $this->pagerType,
             'persist_filters' => $this->persistFilters,
             'keep_open' => $this->keepOpen,
+            'on_top' => $this->onTop,
         );
 
         $tag = array_filter($tag, function ($v) {

--- a/Resources/doc/reference/annotations.rst
+++ b/Resources/doc/reference/annotations.rst
@@ -51,7 +51,19 @@ All you have to do is include Sonata\AdminBundleAnnotations and define the value
 
     /**
      * @Sonata\Admin(
-     *   class="AcmeBundle\Entity\MyEntity"
+     *   class="AcmeBundle\Entity\MyEntity",
+     *   id="service id (generated per default)",
+     *   managerType="doctrine_mongodb (orm per default)",
+     *   baseControllerName="SonataAdminBundle:CRUD",
+     *   group="myGroup",
+     *   label="myLabel",
+     *   showInDashboard=true,
+     *   translationDomain="OMG",
+     *   pagerType="",
+     *   persistFilters="",
+     *   icon="<i class='fa fa-folder'></i>",
+     *   keepOpen=false,
+     *   onTop=false
      * )
      */
     class MyAdmin extends AbstractAdmin

--- a/Tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
@@ -60,6 +60,7 @@ class AnnotationCompilerPassTest extends PHPUnit_Framework_TestCase
                 'label' => 'Tests\Fixtures\Foo',
                 'show_in_dashboard' => false,
                 'keep_open' => false,
+                'on_top' => false,
             )
         );
     }
@@ -84,6 +85,7 @@ class AnnotationCompilerPassTest extends PHPUnit_Framework_TestCase
                 'label' => 'Foo',
                 'show_in_dashboard' => true,
                 'keep_open' => false,
+                'on_top' => false,
             )
         );
     }
@@ -97,7 +99,8 @@ class AnnotationCompilerPassTest extends PHPUnit_Framework_TestCase
          *      group="myGroup",
          *      label="myLabel",
          *      translationDomain="OMG",
-         *      keepOpen=true
+         *      keepOpen=true,
+         *      onTop=true
          * )
          */
         $annotation = new Admin();
@@ -108,6 +111,7 @@ class AnnotationCompilerPassTest extends PHPUnit_Framework_TestCase
         $annotation->showInDashboard = false;
         $annotation->translationDomain = 'OMG';
         $annotation->keepOpen = true;
+        $annotation->onTop = true;
 
         $meta = new ClassMetadata('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo');
 
@@ -121,6 +125,7 @@ class AnnotationCompilerPassTest extends PHPUnit_Framework_TestCase
                 'label' => 'myLabel',
                 'show_in_dashboard' => false,
                 'keep_open' => true,
+                'on_top' => true,
             )
         );
 


### PR DESCRIPTION
I am targeting this branch, because the change is BC.

## Changelog

```markdown
### Added
- Added `onTop` parameter on `@Admin` annotation
```

## Subject

add on_top tag functionality to annotations as seen here: https://sonata-project.org/bundles/admin/3-x/doc/cookbook/recipe_knp_menu.html
