### PR TITLE
fixed xeditable boolean handling

### DIFF
--- a/Resources/views/CRUD/base_list_field.html.twig
+++ b/Resources/views/CRUD/base_list_field.html.twig
@@ -47,7 +47,21 @@ file that was distributed with this source code.
                     'code': admin.code(object)
                 })
             ) %}
-            <span {% block field_span_attributes %}class="x-editable" data-type="{{ xEditableType }}" data-value="{{ field_description.type == 'date' and value is not empty ? value.format('Y-m-d') : value }}" data-title="{{ field_description.label|trans({}, field_description.translationDomain) }}" data-pk="{{ admin.id(object) }}" data-url="{{ url }}" {% endblock %}>
+
+            {% if field_description == 'date' and value is not empty %}
+                {% set data_value = value.format('Y-m-d') %}
+            {% elseif field_description.type == 'boolean' and value is empty %}
+                {% set data_value = 0 %}
+            {% else %}
+                {% set data_value = value %}
+            {% endif %}
+
+            <span {% block field_span_attributes %}class="x-editable"
+                  data-type="{{ xEditableType }}"
+                  data-value="{{ data_value }}"
+                  data-title="{{ field_description.label|trans({}, field_description.translationDomain) }}"
+                  data-pk="{{ admin.id(object) }}"
+                  data-url="{{ url }}" {% endblock %}>
                 {{ block('field') }}
             </span>
         {% else %}

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -688,7 +688,7 @@ EOT
     <span
         class="x-editable"
         data-type="select"
-        data-value=""
+        data-value="0"
         data-title="Data"
         data-pk="12345"
         data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=xyz"
@@ -708,7 +708,7 @@ EOT
     <span
         class="x-editable"
         data-type="select"
-        data-value=""
+        data-value="0"
         data-title="Data"
         data-pk="12345"
         data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=xyz"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is bc.


Closes  #1968

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- fixed boolean handling for `xEditableType`
```

## Subject

### Before
![image_sonata_bug](https://cloud.githubusercontent.com/assets/10114981/24292305/0e233f9a-108d-11e7-9aa4-8077bdad1df8.png)

```html
<span class="x-editable editable editable-click editable-open" data-type="select" data-value="" data-title="Aktiviert" data-pk="2" data-url="/app_dev.php/admin/core/set-object-field-value?context=list&amp;field=enabled&amp;objectId=2&amp;code=topic.admin.archive_topic" data-source="[{value: 0, text: 'nein'},{value: 1, text: 'ja'}]" data-original-title="" title="" aria-describedby="popover210070">
    <span class="label label-danger">nein</span>
</span>
```
The ` data-value ` is always ` null `, and results in `data-value=""`, which could not be handled by the javascript part.

### After
![sonata_xeditable_fix](https://cloud.githubusercontent.com/assets/10114981/24292462/bea56a00-108d-11e7-9c29-aa2a377e2362.png)

```html
<span class="x-editable editable editable-click editable-open" data-type="select" data-value="0" data-title="Aktiviert" data-pk="2" data-url="/app_dev.php/admin/core/set-object-field-value?context=list&amp;field=enabled&amp;objectId=2&amp;code=topic.admin.archive_topic" data-source="[{value: 0, text: 'nein'},{value: 1, text: 'ja'}]" data-original-title="" title="" aria-describedby="popover519242">
    <span class="label label-danger">nein</span>
</span>
```

The ` data-value ` is ` 0 `, and results in `data-value="0"`, which is expected.
