### PR TITLE
Removed old autoloader from tests

### DIFF
--- a/Tests/tests/autoload.php.dist
+++ b/Tests/tests/autoload.php.dist
@@ -4,8 +4,6 @@
 
 $files = array(
     __DIR__.'/../../vendor/autoload.php',
-    __DIR__.'/../../../../../app/autoload.php',
-    __DIR__.'/../../../../../apps/autoload.php',
 );
 
 $autoload = false;

--- a/Tests/tests/bootstrap.php
+++ b/Tests/tests/bootstrap.php
@@ -22,8 +22,6 @@ if (file_exists($file = __DIR__.'/autoload.php')) {
 $files = array_filter(array(
     __DIR__.'/../../vendor/symfony/symfony/src/Symfony/Bridge/PhpUnit/bootstrap.php',
     __DIR__.'/../../vendor/symfony/phpunit-bridge/bootstrap.php',
-    __DIR__.'/../../../../../vendor/symfony/symfony/src/Symfony/Bridge/PhpUnit/bootstrap.php',
-    __DIR__.'/../../../../../vendor/symfony/phpunit-bridge/bootstrap.php',
 ), 'file_exists');
 if ($files) {
     require_once current($files);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a pedantic change for tests.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

We excluded the tests directory from the public autoloader, so there's no reason to run this tests out of the project scope.
