### PR TITLE
Deprecate translator code

### DIFF
--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -72,12 +72,16 @@ interface AdminInterface
     /**
      * Set translator.
      *
+     * NEXT_MAJOR: remove this method
+     *
      * @param TranslatorInterface $translator
      */
     public function setTranslator(TranslatorInterface $translator);
 
     /**
      * Get translator.
+     *
+     * NEXT_MAJOR: remove this method
      *
      * @return TranslatorInterface
      */

--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -145,7 +145,11 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
             );
 
             if ($this->logger) {
-                $this->logger->info(sprintf('Retrieving message from admin:%s - class: %s', $admin->getCode(), get_class($admin)));
+                $this->logger->info(sprintf(
+                    'Retrieving message from admin:%s - class: %s',
+                        $admin->getCode(),
+                        get_class($admin)
+                ));
             }
 
             foreach ($methods as $method) {
@@ -153,7 +157,11 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
                     $admin->$method();
                 } catch (\Exception $e) {
                     if ($this->logger) {
-                        $this->logger->error(sprintf('ERROR : admin:%s - Raise an exception : %s', $admin->getCode(), $e->getMessage()));
+                        $this->logger->error(sprintf(
+                            'ERROR : admin:%s - Raise an exception : %s',
+                                $admin->getCode(),
+                                $e->getMessage()
+                        ));
                     }
 
                     throw $e;

--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -123,13 +123,9 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
             $this->labelStrategy = $admin->getLabelTranslatorStrategy();
             $this->domain = $admin->getTranslationDomain();
 
-            $admin->setTranslator($this);
+            $admin->setTranslator($this); // NEXT_MAJOR: remove this line
             $admin->setSecurityHandler($this);
             $admin->setLabelTranslatorStrategy($this);
-
-//            foreach ($admin->getChildren() as $child) {
-//                $child->setTranslator($this);
-//            }
 
             // call the different public method
             $methods = array(
@@ -291,8 +287,6 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
     private function addMessage($id, $domain)
     {
         $message = new Message($id, $domain);
-
-        //        $this->logger->debug(sprintf('extract: %s - domain:%s', $id, $domain));
 
         $trace = debug_backtrace(false);
         if (isset($trace[1]['file'])) {

--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -23,6 +23,9 @@ use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
+/**
+ * NEXT_MAJOR: do not implement TranslatorInterface anymore.
+ */
 class AdminExtractor implements ExtractorInterface, TranslatorInterface, SecurityHandlerInterface, LabelTranslatorStrategyInterface
 {
     /**
@@ -41,6 +44,8 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
     private $catalogue;
 
     /**
+     * NEXT_MAJOR: remove this property.
+     *
      * @var string|bool
      */
     private $translator;
@@ -66,12 +71,18 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
      */
     public function __construct(Pool $adminPool, LoggerInterface $logger = null)
     {
+        @trigger_error(
+            'Implementing the Symfony\Component\Translation\TranslatorInterface for '.__CLASS__
+            .' is deprecated since version 3.x and will be removed in 4.0.',
+            E_USER_DEPRECATED
+        );
+
         $this->logger = $logger;
         $this->adminPool = $adminPool;
 
         // state variable
         $this->catalogue = false;
-        $this->translator = false;
+        $this->translator = false; // NEXT_MAJOR: remove this line
         $this->labelStrategy = false;
         $this->domain = false;
     }
@@ -195,38 +206,66 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * {@inheritdoc}
      */
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.',
+            E_USER_DEPRECATED
+        );
+
         $this->addMessage($id, $domain);
 
         return $id;
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * {@inheritdoc}
      */
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.',
+            E_USER_DEPRECATED
+        );
+
         $this->addMessage($id, $domain);
 
         return $id;
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * {@inheritdoc}
      */
     public function setLocale($locale)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.',
+            E_USER_DEPRECATED
+        );
+
         $this->translator->setLocale($locale);
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * {@inheritdoc}
      */
     public function getLocale()
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 3.x and will be removed in 4.0.',
+            E_USER_DEPRECATED
+        );
+
         return $this->translator->getLocale();
     }
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,20 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated translator for ``AdminExtractor``
+
+The `$translator` property and the corresponding methods:
+* `setTranslator`,
+* `getTranslator`,
+* `trans`,
+* `transChoice`,
+* `setLocale`
+* `getLocale`)
+
+in `AdminExtractor` are deprecated.
+
+Please use `CRUDController::trans` or twig templates instead.
+
 UPGRADE FROM 3.13 to 3.14
 =========================
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs #4366

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `$translator` property and the corresponding methods in `AdminExtractor`
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Mark related tests with `@group legacy`

## Subject

#4366 points out, that there is some related translator code which is not deprecated yet.
We decided to deprecate it first