### PR TITLE
Use same show picto in list view

### DIFF
--- a/Resources/views/CRUD/list__action_show.html.twig
+++ b/Resources/views/CRUD/list__action_show.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% if admin.hasAccess('show', object) and admin.hasRoute('show') %}
     <a href="{{ admin.generateObjectUrl('show', object) }}" class="btn btn-sm btn-default view_link" title="{{ 'action_show'|trans({}, 'SonataAdminBundle') }}">
-        <i class="fa fa-search-plus" aria-hidden="true"></i>
+        <i class="fa fa-eye" aria-hidden="true"></i>
         {{ 'action_show'|trans({}, 'SonataAdminBundle') }}
     </a>
 {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this affect the current release.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- change show picto on list view to use the same than in edit view

```


