### PR TITLE
Revert "sanitize choice mask fields (#4405)"

### DIFF
--- a/Form/FormMapper.php
+++ b/Form/FormMapper.php
@@ -70,11 +70,11 @@ class FormMapper extends BaseGroupedMapper
         }
 
         // "Dot" notation is not allowed as form name, but can be used as property path to access nested data.
-        if (!$name instanceof FormBuilderInterface && !isset($options['property_path'])) {
+        if (!$name instanceof FormBuilderInterface && strpos($fieldName, '.') !== false && !isset($options['property_path'])) {
             $options['property_path'] = $fieldName;
 
-            // fix the form name
-            $fieldName = $this->sanitizeFieldName($fieldName);
+             // fix the form name
+             $fieldName = str_replace('.', '__', $fieldName);
         }
 
         // change `collection` to `sonata_type_native_collection` form type to
@@ -153,8 +153,6 @@ class FormMapper extends BaseGroupedMapper
      */
     public function get($name)
     {
-        $name = $this->sanitizeFieldName($name);
-
         return $this->formBuilder->get($name);
     }
 
@@ -163,8 +161,6 @@ class FormMapper extends BaseGroupedMapper
      */
     public function has($key)
     {
-        $key = $this->sanitizeFieldName($key);
-
         return $this->formBuilder->has($key);
     }
 
@@ -181,7 +177,6 @@ class FormMapper extends BaseGroupedMapper
      */
     public function remove($key)
     {
-        $key = $this->sanitizeFieldName($key);
         $this->admin->removeFormFieldDescription($key);
         $this->admin->removeFieldFromFormGroup($key);
         $this->formBuilder->remove($key);
@@ -277,21 +272,6 @@ class FormMapper extends BaseGroupedMapper
         }
 
         return $this;
-    }
-
-    /**
-     * Symfony default form class sadly can't handle
-     * form element with dots in its name (when data
-     * get bound, the default dataMapper is a PropertyPathMapper).
-     * So use this trick to avoid any issue.
-     *
-     * @param string $fieldName
-     *
-     * @return string
-     */
-    protected function sanitizeFieldName($fieldName)
-    {
-        return str_replace(array('__', '.'), array('____', '__'), $fieldName);
     }
 
     /**

--- a/Form/Type/ChoiceFieldMaskType.php
+++ b/Form/Type/ChoiceFieldMaskType.php
@@ -27,19 +27,16 @@ class ChoiceFieldMaskType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $sanitizedMap = array();
+        $allFieldNames = array();
         foreach ($options['map'] as $value => $fieldNames) {
             foreach ($fieldNames as $fieldName) {
-                $sanitizedMap[$value][] =
-                    str_replace(array('__', '.'), array('____', '__'), $fieldName);
+                $allFieldNames[$fieldName] = $fieldName;
             }
         }
-
-        $allFieldNames = call_user_func_array('array_merge', $sanitizedMap);
-        $allFieldNames = array_unique($allFieldNames);
+        $allFieldNames = array_values($allFieldNames);
 
         $view->vars['all_fields'] = $allFieldNames;
-        $view->vars['map'] = $sanitizedMap;
+        $view->vars['map'] = $options['map'];
 
         $options['expanded'] = false;
 

--- a/Tests/Form/FormMapperTest.php
+++ b/Tests/Form/FormMapperTest.php
@@ -429,20 +429,6 @@ class FormMapperTest extends PHPUnit_Framework_TestCase
         $this->assertSame(array('foo', 'baz'), $this->formMapper->keys());
     }
 
-    public function testFieldNameIsSanitized()
-    {
-        $this->contractor->expects($this->any())
-            ->method('getDefaultOptions')
-            ->will($this->returnValue(array()));
-
-        $this->formMapper
-            ->add('fo.o', 'bar')
-            ->add('ba__z', 'foobaz')
-        ;
-
-        $this->assertSame(array('fo__o', 'ba____z'), $this->formMapper->keys());
-    }
-
     private function getFieldDescriptionMock($name = null, $label = null, $translationDomain = null)
     {
         $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\BaseFieldDescription');


### PR DESCRIPTION

I am targeting this branch, because this is a bugfix.

 Closes #4425

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- a critical bug with `sonata_type_admin` was fixed
```

## Subject

This reverts commit 3a75cad5e1d6e6e6dfcd8d639c5c4f8fb6678152, that
proved to be faulty.
