### PR TITLE
AdminType doubles $fieldDescription and property_path

### DIFF
--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -79,8 +79,9 @@ class AdminType extends AbstractType
                         // for PropertyAccessor >= 2.5
                         $subject = $p->getValue(
                             $parentSubject,
-                            $this->getFieldDescription($options)->getFieldName().$options['property_path']
+                            $options['property_path']
                         );
+
                     }
                     $builder->setData($subject);
                 }

--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -81,7 +81,6 @@ class AdminType extends AbstractType
                             $parentSubject,
                             $options['property_path']
                         );
-
                     }
                     $builder->setData($subject);
                 }

--- a/Tests/Form/Type/AdminTypeTest.php
+++ b/Tests/Form/Type/AdminTypeTest.php
@@ -88,6 +88,44 @@ class AdminTypeTest extends TypeTestCase
         $this->assertTrue($form->isSynchronized());
     }
 
+    public function testDotFields()
+    {
+        $parentSubject = new \stdClass();
+        $parentSubject->foo = 1;
+
+        $parentAdmin = $this->prophesize('Sonata\AdminBundle\Admin\AdminInterface');
+        $parentAdmin->getSubject()->shouldBeCalled()->willReturn($parentSubject);
+        $parentField = $this->prophesize('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
+
+        $modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
+
+        $admin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(false);
+        $admin->getParentFieldDescription()->shouldBeCalled()->willReturn($parentField->reveal());
+        $admin->setSubject(1)->shouldBeCalled();
+        $admin->defineFormBuilder(new AnyValueToken())->shouldBeCalled();
+        $admin->getModelManager()->shouldBeCalled()->willReturn($modelManager);
+        $admin->getClass()->shouldBeCalled()->willReturn('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo');
+
+        $field = $this->prophesize('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $field->getAssociationAdmin()->shouldBeCalled()->willReturn($admin->reveal());
+
+        $this->builder->add('foo.bar');
+
+        try {
+            $type = new AdminType();
+            $type->buildForm($this->builder, array(
+                'sonata_field_description' => $field->reveal(),
+                'delete' => false, // not needed
+                'property_path' => 'foo', // actual test case
+            ));
+
+        } catch (\Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException $exception) {
+            $this->fail($exception->getMessage());
+        }
+    }
+
     protected function getExtensions()
     {
         $extensions = parent::getExtensions();

--- a/Tests/Form/Type/AdminTypeTest.php
+++ b/Tests/Form/Type/AdminTypeTest.php
@@ -120,7 +120,6 @@ class AdminTypeTest extends TypeTestCase
                 'delete' => false, // not needed
                 'property_path' => 'foo', // actual test case
             ));
-
         } catch (\Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException $exception) {
             $this->fail($exception->getMessage());
         }

--- a/Tests/Form/Type/AdminTypeTest.php
+++ b/Tests/Form/Type/AdminTypeTest.php
@@ -90,6 +90,10 @@ class AdminTypeTest extends TypeTestCase
 
     public function testDotFields()
     {
+        if (!method_exists('Symfony\Component\PropertyAccess\PropertyAccessor', 'isReadable')) {
+            return $this->markTestSkipped('Testing ancient versions would be more complicated.');
+        }
+
         $parentSubject = new \stdClass();
         $parentSubject->foo = 1;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a bugfix for #4425.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #4425 
Closes #4428 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- do not double `FieldDescription::Name` and `property_path` in ``AdminType``
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

This removes the doubled FieldDescription::Name and property_path as described in #4425 