### PR TITLE
Remove <th> if label is false in show field

### DIFF
--- a/Resources/views/CRUD/base_show_field.html.twig
+++ b/Resources/views/CRUD/base_show_field.html.twig
@@ -9,7 +9,9 @@ file that was distributed with this source code.
 
 #}
 
-<th{% if(is_diff|default(false)) %} class="diff"{% endif %}>{% block name %}{{ field_description.label|trans({}, field_description.translationDomain ?: admin.translationDomain) }}{% endblock %}</th>
+{% if field_description.label != false %}
+    <th{% if(is_diff|default(false)) %} class="diff"{% endif %}>{% block name %}{{ field_description.label|trans({}, field_description.translationDomain ?: admin.translationDomain) }}{% endblock %}</th>
+{% endif %}
 <td>
     {%- block field -%}
         {% spaceless %}


### PR DESCRIPTION
This is BC.

After this PR #4398 is possible to hide the label for a field in the show view. But the _th_ tag is still printed and a white space is visible for the user.

## Changelog

```markdown
### Changed
- Remove `<th>` if label is false in show field
```

## Subject

Allow to hide the th tag if the label is set to false.