### PR TITLE
Editable date - base_list_field.html.twig

### DIFF
--- a/Resources/views/CRUD/base_list_field.html.twig
+++ b/Resources/views/CRUD/base_list_field.html.twig
@@ -48,7 +48,7 @@ file that was distributed with this source code.
                 })
             ) %}
 
-            {% if field_description == 'date' and value is not empty %}
+            {% if field_description.type == 'date' and value is not empty %}
                 {% set data_value = value.format('Y-m-d') %}
             {% elseif field_description.type == 'boolean' and value is empty %}
                 {% set data_value = 0 %}


### PR DESCRIPTION
I am targeting this branch, because it is a bugfix.

Closes #4433

## Changelog

### Fixed
[`base_list_field.html.twig`](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/Resources/views/CRUD/base_list_field.html.twig#L51) `field_description` comparison

## Subject

#4415 introduced a bug for editable list field for `date` type.
