### PR TITLE
fix bug with nested array in list view

### DIFF
--- a/Resources/views/CRUD/list_array.html.twig
+++ b/Resources/views/CRUD/list_array.html.twig
@@ -9,10 +9,10 @@ file that was distributed with this source code.
 
 #}
 {% import _self as list %}
-{%  macro render_array(value) %}
+{%  macro render_array(value,list) %}
     {% for key, val in value %}
         {% if val is iterable %}
-            [{{ key }} => {{ list.render_array(val) }}}]
+            [{{ key }} => {{ list.render_array(val) }}]
         {%  else %}
             [{{ key }} => {{ val }}]
         {%  endif %}
@@ -22,5 +22,5 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    {{ list.render_array(value) }}
+    {{ list.render_array(value,list) }}
 {% endblock %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because bug in current stable.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
Bug with multidimensional arrays in list view

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests

## Subject

<!-- Describe your Pull Request content here -->
When you have a multidimensional array it will have an error, when array is multidimensional: Notice: Undefined index: list
