### PR TITLE
Remove protected method

### DIFF
--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -1072,12 +1072,4 @@ interface AdminInterface
      */
 //    NEXT_MAJOR: uncomment this method in 4.0
     // public function isDefaultFilter($name);
-
-    /*
-     * Returns a list of default filters.
-     *
-     * @return array
-     */
-//    NEXT_MAJOR: uncomment this method in 4.0
-    // public function getDefaultFilterValues();
 }

--- a/Controller/CoreController.php
+++ b/Controller/CoreController.php
@@ -119,7 +119,7 @@ class CoreController extends Controller
      * NEXT_MAJOR: remove this method.
      *
      * @deprecated since 3.0, to be removed in 4.0 and action methods will be adjusted.
-     *             Use Symfony\Component\HttpFoundation\Request as an action argument.
+     *             Use Symfony\Component\HttpFoundation\Request as an action argument
      *
      * @return Request
      */

--- a/Tests/Helpers/PHPUnit_Framework_TestCase.php
+++ b/Tests/Helpers/PHPUnit_Framework_TestCase.php
@@ -14,7 +14,7 @@ namespace Sonata\AdminBundle\Tests\Helpers;
 /**
  * This is helpers class for supporting old and new PHPUnit versions.
  *
- * @todo NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ * @todo NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4
  *
  * @author Oleksandr Savchenko <savchenko.oleksandr.ua@gmail.com>
  */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is pedantic.

The implementation of the method in the interface is protected, so there is no reason to make it
public, is there?