### PR TITLE
Fix isp violations

### DIFF
--- a/Admin/AccessRegistryInterface.php
+++ b/Admin/AccessRegistryInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+/**
+ * Tells if the current user has access to a given action.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+interface AccessRegistryInterface
+{
+    /**
+     * Return the controller access mapping.
+     *
+     * @return array
+     */
+    public function getAccessMapping();
+
+    /**
+     * Hook to handle access authorization.
+     *
+     * @param string $action
+     * @param object $object
+     */
+    public function checkAccess($action, $object = null);
+
+    /*
+     * Hook to handle access authorization, without throwing an exception.
+     *
+     * @param string $action
+     * @param object $object
+     *
+     * @return bool
+     * TODO: uncomment this method for next major release
+     */
+     // public function hasAccess($action, $object = null);
+}

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -30,7 +30,7 @@ use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface
+interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface
 {
     /**
      * @param FormContractorInterface $formContractor
@@ -724,21 +724,6 @@ interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHoo
      */
     public function getListMode();
 
-    /**
-     * Return the controller access mapping.
-     *
-     * @return array
-     */
-    public function getAccessMapping();
-
-    /**
-     * Hook to handle access authorization.
-     *
-     * @param string $action
-     * @param object $object
-     */
-    public function checkAccess($action, $object = null);
-
     /*
      * Configure buttons for an action
      *
@@ -747,17 +732,6 @@ interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHoo
      *
      */
     // public function configureActionButtons($action, $object = null);
-
-//    TODO: uncomment this method for next major release
-//    /**
-//     * Hook to handle access authorization, without throw Exception
-//     *
-//     * @param string $action
-//     * @param object $object
-//     *
-//     * @return bool
-//     */
-//    public function hasAccess($action, $object = null);
 
     //TODO: uncomment this method for 4.0
     /*

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Admin;
 
+use Knp\Menu\FactoryInterface as MenuFactoryInterface;
 use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
@@ -32,6 +33,16 @@ use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
  */
 interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface
 {
+    /**
+     * @param MenuFactoryInterface $menuFactory
+     */
+    public function setMenuFactory(MenuFactoryInterface $menuFactory);
+
+    /**
+     * @return MenuFactoryInterface
+     */
+    public function getMenuFactory();
+
     /**
      * @param FormContractorInterface $formContractor
      */

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -16,8 +16,6 @@ use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
 use Sonata\AdminBundle\Builder\RouteBuilderInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-use Sonata\AdminBundle\Route\RouteCollection;
-use Sonata\AdminBundle\Route\RouteGeneratorInterface;
 use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Sonata\CoreBundle\Model\Metadata;
@@ -32,7 +30,7 @@ use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface
+interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface
 {
     /**
      * @param FormContractorInterface $formContractor
@@ -92,11 +90,6 @@ interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHoo
     public function setConfigurationPool(Pool $pool);
 
     /**
-     * @param RouteGeneratorInterface $routeGenerator
-     */
-    public function setRouteGenerator(RouteGeneratorInterface $routeGenerator);
-
-    /**
      * Returns subjectClass/class/subclass name managed
      * - subclass name if subclass parameter is defined
      * - subject class name if subject is defined
@@ -129,40 +122,6 @@ interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHoo
      * @return string
      */
     public function getBaseControllerName();
-
-    /**
-     * Generates the object url with the given $name.
-     *
-     * @param string $name
-     * @param mixed  $object
-     * @param array  $parameters
-     * @param bool   $absolute
-     *
-     * @return string return a complete url
-     */
-    public function generateObjectUrl($name, $object, array $parameters = array(), $absolute = false);
-
-    /**
-     * Generates a url for the given parameters.
-     *
-     * @param string $name
-     * @param array  $parameters
-     * @param bool   $absolute
-     *
-     * @return string return a complete url
-     */
-    public function generateUrl($name, array $parameters = array(), $absolute = false);
-
-    /**
-     * Generates a url for the given parameters.
-     *
-     * @param string $name
-     * @param array  $parameters
-     * @param bool   $absolute
-     *
-     * @return array return url parts: 'route', 'routeParameters', 'routeAbsolute'
-     */
-    public function generateMenuUrl($name, array $parameters = array(), $absolute = false);
 
     /**
      * @return \Sonata\AdminBundle\Model\ModelManagerInterface
@@ -262,20 +221,6 @@ interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHoo
     public function trans($id, array $parameters = array(), $domain = null, $locale = null);
 
     /**
-     * Returns the list of available urls.
-     *
-     * @return RouteCollection the list of available urls
-     */
-    public function getRoutes();
-
-    /**
-     * Return the parameter name used to represent the id in the url.
-     *
-     * @return string
-     */
-    public function getRouterIdParameter();
-
-    /**
      * Returns the parameter representing request id, ie: id or childId.
      *
      * @return string
@@ -325,13 +270,6 @@ interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHoo
      * @return bool
      */
     public function isGranted($name, $object = null);
-
-    /**
-     * @param mixed $entity
-     *
-     * @return string a string representation of the id that is safe to use in a url
-     */
-    public function getUrlsafeIdentifier($entity);
 
     /**
      * @param mixed $entity

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -34,7 +34,7 @@ use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-interface AdminInterface
+interface AdminInterface extends FieldDescriptionRegistryInterface
 {
     /**
      * @param FormContractorInterface $formContractor
@@ -189,22 +189,6 @@ interface AdminInterface
     public function getFormBuilder();
 
     /**
-     * Return FormFieldDescription.
-     *
-     * @param string $name
-     *
-     * @return FieldDescriptionInterface
-     */
-    public function getFormFieldDescription($name);
-
-    /**
-     * Build and return the collection of form FieldDescription.
-     *
-     * @return array collection of form FieldDescription
-     */
-    public function getFormFieldDescriptions();
-
-    /**
      * Returns a form depend on the given $object.
      *
      * @return Form
@@ -325,92 +309,6 @@ interface AdminInterface
      * @return bool
      */
     // public function isCurrentRoute($name, $adminCode = null);
-
-    /**
-     * Returns true if the admin has a FieldDescription with the given $name.
-     *
-     * @param string $name
-     *
-     * @return bool
-     */
-    public function hasShowFieldDescription($name);
-
-    /**
-     * add a FieldDescription.
-     *
-     * @param string                    $name
-     * @param FieldDescriptionInterface $fieldDescription
-     */
-    public function addShowFieldDescription($name, FieldDescriptionInterface $fieldDescription);
-
-    /**
-     * Remove a ShowFieldDescription.
-     *
-     * @param string $name
-     */
-    public function removeShowFieldDescription($name);
-
-    /**
-     * add a list FieldDescription.
-     *
-     * @param string                    $name
-     * @param FieldDescriptionInterface $fieldDescription
-     */
-    public function addListFieldDescription($name, FieldDescriptionInterface $fieldDescription);
-
-    /**
-     * Remove a list FieldDescription.
-     *
-     * @param string $name
-     */
-    public function removeListFieldDescription($name);
-
-    /**
-     * Returns true if the filter FieldDescription exists.
-     *
-     * @param string $name
-     *
-     * @return bool
-     */
-    public function hasFilterFieldDescription($name);
-
-    /**
-     * add a filter FieldDescription.
-     *
-     * @param string                    $name
-     * @param FieldDescriptionInterface $fieldDescription
-     */
-    public function addFilterFieldDescription($name, FieldDescriptionInterface $fieldDescription);
-
-    /**
-     * Remove a filter FieldDescription.
-     *
-     * @param string $name
-     */
-    public function removeFilterFieldDescription($name);
-
-    /**
-     * Returns the filter FieldDescription collection.
-     *
-     * @return FieldDescriptionInterface[]
-     */
-    public function getFilterFieldDescriptions();
-
-    /**
-     * Returns a filter FieldDescription.
-     *
-     * @param string $name
-     *
-     * @return FieldDescriptionInterface|null
-     */
-    public function getFilterFieldDescription($name);
-
-    /**
-     * Returns a list depend on the given $object.
-     *
-     * @return FieldDescriptionCollection
-     */
-    public function getList();
 
     /**
      * @param SecurityHandlerInterface $securityHandler

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -34,7 +34,7 @@ use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-interface AdminInterface extends FieldDescriptionRegistryInterface
+interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHookProviderInterface
 {
     /**
      * @param FormContractorInterface $formContractor
@@ -550,61 +550,6 @@ interface AdminInterface extends FieldDescriptionRegistryInterface
     public function getDataSourceIterator();
 
     public function configure();
-
-    /**
-     * @param mixed $object
-     *
-     * @return mixed
-     */
-    public function update($object);
-
-    /**
-     * @param mixed $object
-     *
-     * @return mixed
-     */
-    public function create($object);
-
-    /**
-     * @param mixed $object
-     */
-    public function delete($object);
-
-    //TODO: uncomment this method for 4.0
-    //    /**
-    //     * @param mixed $object
-    //     */
-    //    public function preValidate($object);
-
-    /**
-     * @param mixed $object
-     */
-    public function preUpdate($object);
-
-    /**
-     * @param mixed $object
-     */
-    public function postUpdate($object);
-
-    /**
-     * @param mixed $object
-     */
-    public function prePersist($object);
-
-    /**
-     * @param mixed $object
-     */
-    public function postPersist($object);
-
-    /**
-     * @param mixed $object
-     */
-    public function preRemove($object);
-
-    /**
-     * @param mixed $object
-     */
-    public function postRemove($object);
 
     /**
      * Call before the batch action, allow you to alter the query and the idx.

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -32,7 +32,7 @@ use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface
+interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface
 {
     /**
      * @param FormContractorInterface $formContractor
@@ -431,38 +431,6 @@ interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHoo
      * @return bool
      */
     public function supportsPreviewMode();
-
-    /**
-     * add an Admin child to the current one.
-     *
-     * @param AdminInterface $child
-     */
-    public function addChild(AdminInterface $child);
-
-    /**
-     * Returns true or false if an Admin child exists for the given $code.
-     *
-     * @param string $code Admin code
-     *
-     * @return bool True if child exist, false otherwise
-     */
-    public function hasChild($code);
-
-    /**
-     * Returns an collection of admin children.
-     *
-     * @return array list of Admin children
-     */
-    public function getChildren();
-
-    /**
-     * Returns an admin child with the given $code.
-     *
-     * @param string $code
-     *
-     * @return AdminInterface|null
-     */
-    public function getChild($code);
 
     /**
      * @return mixed a new object instance

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -11,8 +11,6 @@
 
 namespace Sonata\AdminBundle\Admin;
 
-use Knp\Menu\FactoryInterface as MenuFactoryInterface;
-use Knp\Menu\ItemInterface;
 use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
@@ -34,7 +32,7 @@ use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHookProviderInterface
+interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface
 {
     /**
      * @param FormContractorInterface $formContractor
@@ -397,16 +395,6 @@ interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHoo
      * @return AdminExtensionInterface[]
      */
     public function getExtensions();
-
-    /**
-     * @param \Knp\Menu\FactoryInterface $menuFactory
-     */
-    public function setMenuFactory(MenuFactoryInterface $menuFactory);
-
-    /**
-     * @return \Knp\Menu\FactoryInterface
-     */
-    public function getMenuFactory();
 
     /**
      * @param RouteBuilderInterface $routeBuilder
@@ -805,28 +793,6 @@ interface AdminInterface extends FieldDescriptionRegistryInterface, LifecycleHoo
      * @return string
      */
     public function getTranslationLabel($label, $context = '', $type = '');
-
-    /**
-     * NEXT_MAJOR: remove this method.
-     *
-     * @param string         $action
-     * @param AdminInterface $childAdmin
-     *
-     * @return ItemInterface|bool
-     *
-     * @deprecated Use buildTabMenu instead
-     */
-    public function buildSideMenu($action, AdminInterface $childAdmin = null);
-
-    /**
-     * Build the tab menu related to the current action.
-     *
-     * @param string         $action
-     * @param AdminInterface $childAdmin
-     *
-     * @return ItemInterface|bool
-     */
-    public function buildTabMenu($action, AdminInterface $childAdmin = null);
 
     /**
      * @param $object

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -145,7 +145,7 @@ interface AdminInterface extends FieldDescriptionRegistryInterface
     public function generateObjectUrl($name, $object, array $parameters = array(), $absolute = false);
 
     /**
-     * Generates an url for the given parameters.
+     * Generates a url for the given parameters.
      *
      * @param string $name
      * @param array  $parameters
@@ -156,7 +156,7 @@ interface AdminInterface extends FieldDescriptionRegistryInterface
     public function generateUrl($name, array $parameters = array(), $absolute = false);
 
     /**
-     * Generates an url for the given parameters.
+     * Generates a url for the given parameters.
      *
      * @param string $name
      * @param array  $parameters
@@ -331,7 +331,7 @@ interface AdminInterface extends FieldDescriptionRegistryInterface
     /**
      * @param mixed $entity
      *
-     * @return string a string representation of the id that is save to use in an url
+     * @return string a string representation of the id that is safe to use in a url
      */
     public function getUrlsafeIdentifier($entity);
 

--- a/Admin/FieldDescriptionRegistryInterface.php
+++ b/Admin/FieldDescriptionRegistryInterface.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+/**
+ * Implementations should provide arrays of FieldDescriptionInterface instances.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+interface FieldDescriptionRegistryInterface
+{
+    /**
+     * Return FormFieldDescription.
+     *
+     * @param string $name
+     *
+     * @return FieldDescriptionInterface
+     */
+    public function getFormFieldDescription($name);
+
+    /**
+     * Build and return the collection of form FieldDescription.
+     *
+     * @return FieldDescriptionInterface[] collection of form FieldDescription
+     */
+    public function getFormFieldDescriptions();
+
+    /**
+     * Returns true if the admin has a FieldDescription with the given $name.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasShowFieldDescription($name);
+
+    /**
+     * Adds a FieldDescription.
+     *
+     * @param string                    $name
+     * @param FieldDescriptionInterface $fieldDescription
+     */
+    public function addShowFieldDescription($name, FieldDescriptionInterface $fieldDescription);
+
+    /**
+     * Removes a ShowFieldDescription.
+     *
+     * @param string $name
+     */
+    public function removeShowFieldDescription($name);
+
+    /**
+     * Adds a list FieldDescription.
+     *
+     * @param string                    $name
+     * @param FieldDescriptionInterface $fieldDescription
+     */
+    public function addListFieldDescription($name, FieldDescriptionInterface $fieldDescription);
+
+    /**
+     * Removes a list FieldDescription.
+     *
+     * @param string $name
+     */
+    public function removeListFieldDescription($name);
+
+    /**
+     * Returns a list depend on the given $object.
+     *
+     * @return FieldDescriptionCollection
+     */
+    public function getList();
+
+    /**
+     * Returns true if the filter FieldDescription exists.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasFilterFieldDescription($name);
+
+    /**
+     * Adds a filter FieldDescription.
+     *
+     * @param string                    $name
+     * @param FieldDescriptionInterface $fieldDescription
+     */
+    public function addFilterFieldDescription($name, FieldDescriptionInterface $fieldDescription);
+
+    /**
+     * Removes a filter FieldDescription.
+     *
+     * @param string $name
+     */
+    public function removeFilterFieldDescription($name);
+
+    /**
+     * Returns the filter FieldDescription collection.
+     *
+     * @return FieldDescriptionInterface[]
+     */
+    public function getFilterFieldDescriptions();
+
+    /**
+     * Returns a filter FieldDescription.
+     *
+     * @param string $name
+     *
+     * @return FieldDescriptionInterface|null
+     */
+    public function getFilterFieldDescription($name);
+}

--- a/Admin/LifecycleHookProviderInterface.php
+++ b/Admin/LifecycleHookProviderInterface.php
@@ -20,6 +20,8 @@ namespace Sonata\AdminBundle\Admin;
 interface LifecycleHookProviderInterface
 {
     /**
+     * This method should call preUpdate, do the update, and call postUpdate.
+     *
      * @param object $object
      *
      * @return object
@@ -27,6 +29,8 @@ interface LifecycleHookProviderInterface
     public function update($object);
 
     /**
+     * This method should call prePersist, do the creation, and call postPersist.
+     *
      * @param object $object
      *
      * @return object
@@ -34,6 +38,8 @@ interface LifecycleHookProviderInterface
     public function create($object);
 
     /**
+     * This method should call preRemove, do the removal, and call postRemove.
+     *
      * @param object $object
      */
     public function delete($object);

--- a/Admin/LifecycleHookProviderInterface.php
+++ b/Admin/LifecycleHookProviderInterface.php
@@ -44,11 +44,11 @@ interface LifecycleHookProviderInterface
      */
     public function delete($object);
 
-//NEXT_MAJOR: uncomment this method for 4.0
-//    /**
-//     * @param object $object
-//     */
-//    public function preValidate($object);
+    //NEXT_MAJOR: uncomment this method for 4.0
+    //    /**
+    //     * @param object $object
+    //     */
+    //    public function preValidate($object);
 
     /**
      * @param object $object

--- a/Admin/LifecycleHookProviderInterface.php
+++ b/Admin/LifecycleHookProviderInterface.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+/**
+ * This interface can be implemented to provide hooks that will be called
+ * during the lifecycle of the object.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+interface LifecycleHookProviderInterface
+{
+    /**
+     * @param object $object
+     *
+     * @return object
+     */
+    public function update($object);
+
+    /**
+     * @param object $object
+     *
+     * @return object
+     */
+    public function create($object);
+
+    /**
+     * @param object $object
+     */
+    public function delete($object);
+
+//NEXT_MAJOR: uncomment this method for 4.0
+//    /**
+//     * @param object $object
+//     */
+//    public function preValidate($object);
+
+    /**
+     * @param object $object
+     */
+    public function preUpdate($object);
+
+    /**
+     * @param object $object
+     */
+    public function postUpdate($object);
+
+    /**
+     * @param object $object
+     */
+    public function prePersist($object);
+
+    /**
+     * @param object $object
+     */
+    public function postPersist($object);
+
+    /**
+     * @param object $object
+     */
+    public function preRemove($object);
+
+    /**
+     * @param object $object
+     */
+    public function postRemove($object);
+}

--- a/Admin/MenuBuilderInterface.php
+++ b/Admin/MenuBuilderInterface.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\AdminBundle\Admin;
 
-use Knp\Menu\FactoryInterface as MenuFactoryInterface;
 use Knp\Menu\ItemInterface;
 
 /**
@@ -21,16 +20,6 @@ use Knp\Menu\ItemInterface;
  */
 interface MenuBuilderInterface
 {
-    /**
-     * @param MenuFactoryInterface $menuFactory
-     */
-    public function setMenuFactory(MenuFactoryInterface $menuFactory);
-
-    /**
-     * @return MenuFactoryInterface
-     */
-    public function getMenuFactory();
-
     /**
      * NEXT_MAJOR: remove this method.
      *

--- a/Admin/MenuBuilderInterface.php
+++ b/Admin/MenuBuilderInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+use Knp\Menu\FactoryInterface as MenuFactoryInterface;
+use Knp\Menu\ItemInterface;
+
+/**
+ * This interface can be implemented by admins that need to build menus.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+interface MenuBuilderInterface
+{
+    /**
+     * @param MenuFactoryInterface $menuFactory
+     */
+    public function setMenuFactory(MenuFactoryInterface $menuFactory);
+
+    /**
+     * @return MenuFactoryInterface
+     */
+    public function getMenuFactory();
+
+    /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @param string         $action
+     * @param AdminInterface $childAdmin
+     *
+     * @return ItemInterface|bool
+     *
+     * @deprecated Use buildTabMenu instead
+     */
+    public function buildSideMenu($action, AdminInterface $childAdmin = null);
+
+    /**
+     * Build the tab menu related to the current action.
+     *
+     * @param string         $action
+     * @param AdminInterface $childAdmin
+     *
+     * @return ItemInterface|bool
+     */
+    public function buildTabMenu($action, AdminInterface $childAdmin = null);
+}

--- a/Admin/ParentAdminInterface.php
+++ b/Admin/ParentAdminInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+/**
+ * This interface can be used to implement an admin that can have children
+ * admins, meaning admin that correspond to objects with a relationship with
+ * the object managed by this admin.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+interface ParentAdminInterface
+{
+    /**
+     * add an Admin child to the current one.
+     *
+     * @param AdminInterface $child
+     */
+    public function addChild(AdminInterface $child);
+
+    /**
+     * Returns true or false if an Admin child exists for the given $code.
+     *
+     * @param string $code Admin code
+     *
+     * @return bool True if child exist, false otherwise
+     */
+    public function hasChild($code);
+
+    /**
+     * Returns an collection of admin children.
+     *
+     * @return array list of Admin children
+     */
+    public function getChildren();
+
+    /**
+     * Returns an admin child with the given $code.
+     *
+     * @param string $code
+     *
+     * @return AdminInterface|null
+     */
+    public function getChild($code);
+}

--- a/Admin/UrlGeneratorInterface.php
+++ b/Admin/UrlGeneratorInterface.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+use Sonata\AdminBundle\Route\RouteGeneratorInterface;
+
+/**
+ * Contains url generation logic related to an admin.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+interface UrlGeneratorInterface
+{
+    /**
+     * Returns the list of available urls.
+     *
+     * @return RouteCollection the list of available urls
+     */
+    public function getRoutes();
+
+    /**
+     * Return the parameter name used to represent the id in the url.
+     *
+     * @return string
+     */
+    public function getRouterIdParameter();
+
+    /**
+     * @param RouteGeneratorInterface $routeGenerator
+     */
+    public function setRouteGenerator(RouteGeneratorInterface $routeGenerator);
+
+    /**
+     * Generates the object url with the given $name.
+     *
+     * @param string $name
+     * @param mixed  $object
+     * @param array  $parameters
+     * @param bool   $absolute
+     *
+     * @return string return a complete url
+     */
+    public function generateObjectUrl($name, $object, array $parameters = array(), $absolute = false);
+
+    /**
+     * Generates a url for the given parameters.
+     *
+     * @param string $name
+     * @param array  $parameters
+     * @param bool   $absolute
+     *
+     * @return string return a complete url
+     */
+    public function generateUrl($name, array $parameters = array(), $absolute = false);
+
+    /**
+     * Generates a url for the given parameters.
+     *
+     * @param string $name
+     * @param array  $parameters
+     * @param bool   $absolute
+     *
+     * @return array return url parts: 'route', 'routeParameters', 'routeAbsolute'
+     */
+    public function generateMenuUrl($name, array $parameters = array(), $absolute = false);
+
+    /**
+     * @param mixed $entity
+     *
+     * @return string a string representation of the id that is safe to use in a url
+     */
+    public function getUrlsafeIdentifier($entity);
+}

--- a/Model/ModelManagerInterface.php
+++ b/Model/ModelManagerInterface.php
@@ -138,14 +138,14 @@ interface ModelManagerInterface
     public function getNormalizedIdentifier($model);
 
     /**
-     * Get the identifiers as a string that is save to use in an url.
+     * Get the identifiers as a string that is safe to use in a url.
      *
      * This is similar to getNormalizedIdentifier but guarantees an id that can
-     * be used in an URL.
+     * be used in a URL.
      *
      * @param object $model
      *
-     * @return string string representation of the id that is save to use in an url
+     * @return string string representation of the id that is safe to use in a url
      */
     public function getUrlsafeIdentifier($model);
 

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -364,12 +364,12 @@ EOT;
     }
 
     /**
-     * Get the identifiers as a string that is save to use in an url.
+     * Get the identifiers as a string that is safe to use in a url.
      *
      * @param object         $model
      * @param AdminInterface $admin
      *
-     * @return string string representation of the id that is save to use in an url
+     * @return string string representation of the id that is safe to use in a url
      */
     public function getUrlsafeIdentifier($model, AdminInterface $admin = null)
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Subject

The admin interface should be split into smaller interfaces, as per the ISP. This should ease the splitting in of the `AbstractAdmin` class itself.

## Changelog
```markdown
### Added
- `Sonata\AdminBundle\Admin\AdminInterface` was split into smaller interfaces, namely
    - `Sonata\AdminBundle\AdminFieldDescriptionRegistryInterface`
    - `Sonata\AdminBundle\LifecycleHookProviderInterface`
    - `Sonata\AdminBundle\MenuBuilderInterface`
    - `Sonata\AdminBundle\ParentAdminInterface`
```