### PR TITLE
Fixed getExtendedType compatibility for symfony >= 2.8

### DIFF
--- a/Form/Extension/ChoiceTypeExtension.php
+++ b/Form/Extension/ChoiceTypeExtension.php
@@ -56,12 +56,12 @@ class ChoiceTypeExtension extends AbstractTypeExtension
     }
 
     /**
-     * Returns the name of the type being extended.
-     *
-     * @return string The name of the type being extended
+     * {@inheritdoc}
      */
     public function getExtendedType()
     {
-        return 'choice';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+            : 'choice';
     }
 }

--- a/Form/Extension/ChoiceTypeExtension.php
+++ b/Form/Extension/ChoiceTypeExtension.php
@@ -60,7 +60,7 @@ class ChoiceTypeExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        /**
+        /*
          * NEXT_MAJOR: Remove when dropping Symfony <2.8 support. It should
          * simply be return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
          */

--- a/Form/Extension/ChoiceTypeExtension.php
+++ b/Form/Extension/ChoiceTypeExtension.php
@@ -60,6 +60,10 @@ class ChoiceTypeExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
+        /**
+         * NEXT_MAJOR: Remove when dropping Symfony <2.8 support. It should
+         * simply be return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
+         */
         return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
             ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
             : 'choice';

--- a/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
@@ -62,7 +62,7 @@ class MopaCompatibilityTypeFieldExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        /**
+        /*
          * NEXT_MAJOR: Remove when dropping Symfony <2.8 support. It should
          * simply be return 'Symfony\Component\Form\Extension\Core\Type\FormType';
          */

--- a/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
@@ -58,12 +58,12 @@ class MopaCompatibilityTypeFieldExtension extends AbstractTypeExtension
     }
 
     /**
-     * Returns the name of the type being extended.
-     *
-     * @return string The name of the type being extended
+     * {@inheritdoc}
      */
     public function getExtendedType()
     {
-        return 'form';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\FormType'
+            : 'form';
     }
 }

--- a/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
@@ -62,6 +62,10 @@ class MopaCompatibilityTypeFieldExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
+        /**
+         * NEXT_MAJOR: Remove when dropping Symfony <2.8 support. It should
+         * simply be return 'Symfony\Component\Form\Extension\Core\Type\FormType';
+         */
         return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
             ? 'Symfony\Component\Form\Extension\Core\Type\FormType'
             : 'form';

--- a/Tests/Form/Extension/ChoiceTypeExtensionTest.php
+++ b/Tests/Form/Extension/ChoiceTypeExtensionTest.php
@@ -62,7 +62,7 @@ class ChoiceTypeExtensionTest extends PHPUnit_Framework_TestCase
     {
         $extension = new ChoiceTypeExtension();
 
-        /**
+        /*
          * NEXT_MAJOR: Remove when dropping Symfony <2.8 support. It should
          * simply be:
          *

--- a/Tests/Form/Extension/ChoiceTypeExtensionTest.php
+++ b/Tests/Form/Extension/ChoiceTypeExtensionTest.php
@@ -62,7 +62,14 @@ class ChoiceTypeExtensionTest extends PHPUnit_Framework_TestCase
     {
         $extension = new ChoiceTypeExtension();
 
-        $this->assertSame('choice', $extension->getExtendedType());
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $this->assertSame(
+                'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+                $extension->getExtendedType()
+            );
+        } else {
+            $this->assertSame('choice', $extension->getExtendedType());
+        }
     }
 
     public function testDefaultOptionsWithSortable()

--- a/Tests/Form/Extension/ChoiceTypeExtensionTest.php
+++ b/Tests/Form/Extension/ChoiceTypeExtensionTest.php
@@ -62,6 +62,15 @@ class ChoiceTypeExtensionTest extends PHPUnit_Framework_TestCase
     {
         $extension = new ChoiceTypeExtension();
 
+        /**
+         * NEXT_MAJOR: Remove when dropping Symfony <2.8 support. It should
+         * simply be:
+         *
+         * $this->assertSame(
+         *     'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+         *     $extension->getExtendedType()
+         * );
+         */
         if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
             $this->assertSame(
                 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because i want to fix the issue #3474 in the 3.x branch (which is the one that the issue happens).

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #3474

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
Fixed issue on getExtendedType of MopaCompatibilityTypeFieldExtension and ChoiceTypeExtension because the method requires to return the fully-qualified class name (FQCN) since symfony version 2.8
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests?

## Subject

<!-- Describe your Pull Request content here -->
Fixed issue on getExtendedType of MopaCompatibilityTypeFieldExtension and ChoiceTypeExtension because the method requires to return the fully-qualified class name (FQCN) since symfony version 2.8

The commit that adds the code that cause the issue is: https://github.com/symfony/form/commit/4416ae7c67f511e92f19f962f8a73723f5df35bc