### PR TITLE
Added support for editable association fields from type choice in Lis…

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -235,11 +235,11 @@ class HelperController
 
         // alter should be done by using a post method
         if (!$request->isXmlHttpRequest()) {
-            return new JsonResponse('Expected a XmlHttpRequest request header', 405);
+            return new JsonResponse('Expected an XmlHttpRequest request header', 405);
         }
 
         if ($request->getMethod() != 'POST') {
-            return new JsonResponse('Expected a POST Request', 405);
+            return new JsonResponse('Expected an POST Request', 405);
         }
 
         $rootObject = $object = $admin->getObject($objectId);
@@ -264,7 +264,7 @@ class HelperController
         }
 
         if (!$fieldDescription->getOption('editable')) {
-            return new JsonResponse('The field cannot be edit, editable option must be set to true', 400);
+            return new JsonResponse('The field cannot be edited, editable option must be set to true', 400);
         }
 
         $propertyPath = new PropertyPath($field);

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -235,39 +235,36 @@ class HelperController
 
         // alter should be done by using a post method
         if (!$request->isXmlHttpRequest()) {
-            return new JsonResponse(array('status' => 'KO', 'message' => 'Expected a XmlHttpRequest request header'));
+            return new JsonResponse('Expected a XmlHttpRequest request header', 405);
         }
 
         if ($request->getMethod() != 'POST') {
-            return new JsonResponse(array('status' => 'KO', 'message' => 'Expected a POST Request'));
+            return new JsonResponse('Expected a POST Request', 405);
         }
 
         $rootObject = $object = $admin->getObject($objectId);
 
         if (!$object) {
-            return new JsonResponse(array('status' => 'KO', 'message' => 'Object does not exist'));
+            return new JsonResponse('Object does not exist', 404);
         }
 
         // check user permission
         if (false === $admin->hasAccess('edit', $object)) {
-            return new JsonResponse(array('status' => 'KO', 'message' => 'Invalid permissions'));
+            return new JsonResponse('Invalid permissions', 403);
         }
 
         if ($context == 'list') {
             $fieldDescription = $admin->getListFieldDescription($field);
         } else {
-            return new JsonResponse(array('status' => 'KO', 'message' => 'Invalid context'));
+            return new JsonResponse('Invalid context', 400);
         }
 
         if (!$fieldDescription) {
-            return new JsonResponse(array('status' => 'KO', 'message' => 'The field does not exist'));
+            return new JsonResponse('The field does not exist', 400);
         }
 
         if (!$fieldDescription->getOption('editable')) {
-            return new JsonResponse(array(
-                'status' => 'KO',
-                'message' => 'The field cannot be edit, editable option must be set to true',
-            ));
+            return new JsonResponse('The field cannot be edit, editable option must be set to true', 400);
         }
 
         $propertyPath = new PropertyPath($field);
@@ -293,18 +290,14 @@ class HelperController
 
         // Handle entity choice association type, transforming the value into entity
         if ('' !== $value && $fieldDescription->getType() == 'choice' && $fieldDescription->getOption('class')) {
-
             // Get existing associations for current object
             $associations = $admin->getModelManager()
                 ->getEntityManager($admin->getClass())->getClassMetadata($admin->getClass())
                 ->getAssociationNames();
 
             if (!in_array($field, $associations)) {
-                return new JsonResponse(array(
-                    'status' => 'KO',
-                    'message' => sprintf('Unknown association "%s", association does not exist in entity "%s", available associations are "%s".',
-                        $field, $this->admin->getClass(), implode(', ', $associations)),
-                ));
+                return new JsonResponse(sprintf('Unknown association "%s", association does not exist in entity "%s", available associations are "%s".',
+                        $field, $this->admin->getClass(), implode(', ', $associations)), 404);
             }
 
             $value = $admin->getConfigurationPool()->getContainer()->get('doctrine')->getManager()
@@ -312,11 +305,8 @@ class HelperController
                 ->find($value);
 
             if (!$value) {
-                return new JsonResponse(array(
-                    'status' => 'KO',
-                    'message' => sprintf('Edit failed, object with id %s not found in association %s.',
-                        $originalValue, $field),
-                ));
+                return new JsonResponse(sprintf('Edit failed, object with id "%s" not found in association "%s".',
+                        $originalValue, $field), 404);
             }
         }
 
@@ -331,7 +321,7 @@ class HelperController
                 $messages[] = $violation->getMessage();
             }
 
-            return new JsonResponse(array('status' => 'KO', 'message' => implode("\n", $messages)));
+            return new JsonResponse(implode("\n", $messages), 400);
         }
 
         $admin->update($object);
@@ -342,7 +332,7 @@ class HelperController
 
         $content = $extension->renderListElement($this->twig, $rootObject, $fieldDescription);
 
-        return new JsonResponse(array('status' => 'OK', 'content' => $content));
+        return new JsonResponse($content, 200);
     }
 
     /**

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -227,7 +227,7 @@ class HelperController
         $field = $request->get('field');
         $code = $request->get('code');
         $objectId = $request->get('objectId');
-        $value = $request->get('value');
+        $value = $originalValue = $request->get('value');
         $context = $request->get('context');
 
         $admin = $this->pool->getInstance($code);
@@ -315,7 +315,7 @@ class HelperController
                 return new JsonResponse(array(
                     'status' => 'KO',
                     'message' => sprintf('Edit failed, object with id %s not found in association %s.',
-                        $objectId, $field),
+                        $originalValue, $field),
                 ));
             }
         }

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -239,7 +239,7 @@ class HelperController
         }
 
         if ($request->getMethod() != 'POST') {
-            return new JsonResponse('Expected an POST Request', 405);
+            return new JsonResponse('Expected a POST Request', 405);
         }
 
         $rootObject = $object = $admin->getObject($objectId);

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -296,8 +296,13 @@ class HelperController
                 ->getAssociationNames();
 
             if (!in_array($field, $associations)) {
-                return new JsonResponse(sprintf('Unknown association "%s", association does not exist in entity "%s", available associations are "%s".',
-                        $field, $this->admin->getClass(), implode(', ', $associations)), 404);
+                return new JsonResponse(
+                    sprintf(
+                        'Unknown association "%s", association does not exist in entity "%s", available associations are "%s".',
+                        $field,
+                        $this->admin->getClass(),
+                        implode(', ', $associations)),
+                    404);
             }
 
             $value = $admin->getConfigurationPool()->getContainer()->get('doctrine')->getManager()
@@ -305,8 +310,12 @@ class HelperController
                 ->find($value);
 
             if (!$value) {
-                return new JsonResponse(sprintf('Edit failed, object with id "%s" not found in association "%s".',
-                        $originalValue, $field), 404);
+                return new JsonResponse(
+                    sprintf(
+                        'Edit failed, object with id "%s" not found in association "%s".',
+                        $originalValue,
+                        $field),
+                    404);
             }
         }
 

--- a/Resources/doc/reference/action_list.rst
+++ b/Resources/doc/reference/action_list.rst
@@ -67,6 +67,17 @@ Here is an example:
                 'editable' => true
             ))
 
+            // editable association field
+            ->add('status', 'choice', array(
+                'editable' => true,
+                'class' => 'Vendor\ExampleBundle\Entity\ExampleStatus',
+                'choices' => array(
+                    1 => 'Active',
+                    2 => 'Inactive',
+                    3 => 'Draft',
+                ),
+            ))
+
             // we can add options to the field depending on the type
             ->add('price', 'currency', array(
                 'currency' => $this->currencyDetector->getCurrency()->getLabel()
@@ -141,6 +152,8 @@ Available types and associated options
 |           | delimiter      | Separator of values if multiple.                                      |
 +           +----------------+-----------------------------------------------------------------------+
 |           | catalogue      | Translation catalogue.                                                |
++           +----------------+-----------------------------------------------------------------------+
+|           | class          | Class path for editable association field.                            |
 +-----------+----------------+-----------------------------------------------------------------------+
 | currency  | currency (m)   | A currency string (EUR or USD for instance).                          |
 +-----------+----------------+-----------------------------------------------------------------------+

--- a/Resources/doc/reference/field_types.rst
+++ b/Resources/doc/reference/field_types.rst
@@ -26,7 +26,7 @@ html            display (and optionally truncate or strip tags from) raw html
 ============    =============================================
 
 Theses types accept an ``editable`` parameter to edit the value from within the list action.
-This is currently limited to scalar types (text, integer, url...).
+This is currently limited to scalar types (text, integer, url...) and choice types with association field.
 
 .. note::
 

--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -55,7 +55,7 @@ var Admin = {
             padding: 15,
             overflow: 'auto'
         });
-      
+
         jQuery(modal).trigger('sonata-admin-setup-list-modal');
     },
     setup_select2: function(subject) {
@@ -114,17 +114,14 @@ var Admin = {
             container: 'body',
             placement: 'auto',
             success: function(response) {
-                if('KO' === response.status) {
-                    return response.message;
-                }
-
-                var html = jQuery(response.content);
+                var html = jQuery(response);
                 Admin.setup_xeditable(html);
-
                 jQuery(this)
                     .closest('td')
-                    .replaceWith(html)
-                ;
+                    .replaceWith(html);
+            },
+            error: function(xhr, statusText, errorThrown) {
+                return xhr.responseText;
             }
         });
     },
@@ -241,22 +238,20 @@ var Admin = {
         this.log(jQuery('a.sonata-ba-edit-inline', subject));
         jQuery('a.sonata-ba-edit-inline', subject).click(function(event) {
             Admin.stopEvent(event);
-
             var subject = jQuery(this);
             jQuery.ajax({
                 url: subject.attr('href'),
                 type: 'POST',
-                success: function(json) {
-                    if(json.status === "OK") {
-                        var elm = jQuery(subject).parent();
-                        elm.children().remove();
-                        // fix issue with html comment ...
-                        elm.html(jQuery(json.content.replace(/<!--[\s\S]*?-->/g, "")).html());
-                        elm.effect("highlight", {'color' : '#57A957'}, 2000);
-                        Admin.set_object_field_value(elm);
-                    } else {
-                        jQuery(subject).parent().effect("highlight", {'color' : '#C43C35'}, 2000);
-                    }
+                success: function(response) {
+                    var elm = jQuery(subject).parent();
+                    elm.children().remove();
+                    // fix issue with html comment ...
+                    elm.html(jQuery(response.replace(/<!--[\s\S]*?-->/g, "")).html());
+                    elm.effect("highlight", {'color' : '#57A957'}, 2000);
+                    Admin.set_object_field_value(elm);
+                },
+                error: function(xhr, statusText, errorThrown) {
+                    jQuery(subject).parent().effect("highlight", {'color' : '#C43C35'}, 2000);
                 }
             });
         });

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -305,7 +305,7 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
 
         $response = $controller->setObjectFieldValueAction($request);
 
-        $this->assertSame('{"status":"OK","content":"\u003Cfoo \/\u003E"}', $response->getContent());
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     /**
@@ -538,7 +538,8 @@ class HelperControllerTest extends PHPUnit_Framework_TestCase
 
         $response = $controller->setObjectFieldValueAction($request);
 
-        $this->assertSame('{"status":"KO","message":"error1\nerror2"}', $response->getContent());
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame(json_encode("error1\nerror2"), $response->getContent());
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is new feature with BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added editable support for association fields from type choice in `ListMapper`
- Added also new `class` option for field description
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [x] Update the documentation

## Subject

<!-- Describe your Pull Request content here -->

Added support for **editable association fields** from type choice in ListMapper, also **added new field description option class**. As example:

```php
    protected function configureListFields(ListMapper $listMapper)
    {
        $listMapper
            ->add('status', 'choice', array(
                'editable' => true,
                'class' => 'Vendor\ExampleBundle\Entity\PageStatus',
                'choices' => array(
                    1 => 'Active',
                    2 => 'Inactive',
                    3 => 'Draft',
                ),
            ));
    }
```