### PR TITLE
Add a condition to check if there is a field

### DIFF
--- a/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -17,7 +17,7 @@
                             <p>{{ form_group.description|raw }}</p>
                         {% endif %}
 
-                        {% for field_name in form_group.fields if admin.formfielddescriptions[field_name] is defined %}
+                        {% for field_name in form_group.fields if form[field_name] is defined %}
                             {{ form_row(form[field_name])}}
                         {% else %}
                             <em>{{ 'message_form_group_empty'|trans({}, 'SonataAdminBundle') }}</em>


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Changed
- Add a condition to check if there is a field in the form
```

## Subject
In some situations I get an error:
`
Key "isSuperior" in object with ArrayAccess of class "Symfony\Component\Form\FormView" does not exist.
`

I think that this condition is missing.
Actually, there could be only one condition `form[field_name] is defined`.