### PR TITLE
Allow disabling translation on form fields

### DIFF
--- a/Resources/doc/reference/translation.rst
+++ b/Resources/doc/reference/translation.rst
@@ -102,6 +102,9 @@ over-rides that setting for one of the fields:
         ->end()
     ;
 
+Translation can also be disabled on a specific field by setting
+``translation_domain`` to ``false``.
+
 Setting the label name
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -131,7 +131,9 @@ file that was distributed with this source code.
         {% endif %}
 
         <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-            {% if not sonata_admin.admin %}
+            {% if translation_domain is same as(false) %}
+                {{- label -}}
+            {% elseif not sonata_admin.admin %}
                 {{- label|trans({}, translation_domain) -}}
             {% else %}
                 {{ label|trans({}, sonata_admin.field_description.translationDomain ?: admin.translationDomain) }}


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC (people cannot use `false` as a translation domain).

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Translation can now be disabled on specific form fields
```


## Subject

<!-- Describe your Pull Request content here -->
This is what Symfony does in its Twig integration bundle, we should do
the same.
