### PR TITLE
Fixed menu group being displayed for user without permissions when on_top is specified

### DIFF
--- a/Menu/Provider/GroupMenuProvider.php
+++ b/Menu/Provider/GroupMenuProvider.php
@@ -147,8 +147,9 @@ class GroupMenuProvider implements MenuProviderInterface
                 if (isset($item['admin']) && !empty($item['admin'])) {
                     $admin = $this->pool->getInstance($item['admin']);
 
-                    // skip menu item if no `list` url is available or user doesn't have the LIST access rights
+                    // Do not display group if no `list` url is available or user doesn't have the LIST access rights
                     if (!$admin->hasRoute('list') || !$admin->hasAccess('list')) {
+                        $menuItem->setDisplay(false);
                         continue;
                     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's currently developed for Symfony 3.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- Changed GroupMenuProvider::get to setDisplay(false) on menuItem if on_top used and no items could be displayed
```

## Subject
Hiding menu group if it has only one item with on_top and user has no permissions to access 'list' action or no 'list' action exists.
