### PR TITLE
Add a second argument to batchActionDelete()

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -120,12 +120,13 @@ class CRUDController extends Controller
      * Execute a batch delete.
      *
      * @param ProxyQueryInterface $query
+     * @param Request $request
      *
      * @return RedirectResponse
      *
      * @throws AccessDeniedException If access is not granted
      */
-    public function batchActionDelete(ProxyQueryInterface $query)
+    public function batchActionDelete(ProxyQueryInterface $query, Request $request)
     {
         $this->admin->checkAccess('batchDelete');
 


### PR DESCRIPTION
In order to perform some additional actions before you delete some element in the list view, the **preDelete** method is provided by **CRUDController.php**. By overriding this method you can for example check some conditions and prevent deletion by returning a Response object. However if you delete multiple elements in list view the **batchActionDelete** will be called and there is no **preBatchActionDelete** method available.
 
Of course there is the **preBatchAction** method, but it has some limitations: 
1) it's declared in admin class and not in CRUDController
2) it can't prevent deletion, bacuse the returning value will not be taken into account
3) It is general and will be called regardless of actual batch action (delete or some other custom action)

We can override the **batchActionDelete** method which is located in CRUDController, but this method takes only one parameter: **$query**, so we have no array with all IDs (like in **preBatchAction**)
It is strange, because if we create some custom batch action it will receive two arguments: **$query** and **$request**. We can than get from the **$request** all necessary information (e.g. list of chosen IDs) and depending on it change the query or prevent deletion by returning new Response object.

Actually both of them, the **batchActionDelete** and the mentioned above custom batchAction<MyAction> will be called by the same function (line **457**), so both of them actually receive the second parameter: **$request**.

My suggestion is just to declare the second argument in **batchActionDelete**, because it will already be passed to it.

Thanks

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added

### Changed
- Changed `CRUDController::batchActionDelete` to get the second argument

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
