### PR TITLE
Translate main header title

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -132,10 +132,10 @@ file that was distributed with this source code.
                     {% spaceless %}
                         <a class="logo" href="{{ path('sonata_admin_dashboard') }}">
                             {% if 'single_image' == sonata_admin.adminPool.getOption('title_mode') or 'both' == sonata_admin.adminPool.getOption('title_mode') %}
-                                <img src="{{ asset(sonata_admin.adminPool.titlelogo) }}" alt="{{ sonata_admin.adminPool.title }}">
+                                <img src="{{ asset(sonata_admin.adminPool.titlelogo) }}" alt="{{ sonata_admin.adminPool.title|trans }}">
                             {% endif %}
                             {% if 'single_text' == sonata_admin.adminPool.getOption('title_mode') or 'both' == sonata_admin.adminPool.getOption('title_mode') %}
-                                <span>{{ sonata_admin.adminPool.title }}</span>
+                                <span>{{ sonata_admin.adminPool.title|trans }}</span>
                             {% endif %}
                         </a>
                     {% endspaceless %}


### PR DESCRIPTION
I am targeting this branch, because this a backward-compatible patch.

## Changelog

```markdown
### Changed
- Main header title and logo's alternative text are now translatable.
```

## To do
- [x] Make sure the translation domain is correct.

## Subject
Main header title and logo's alternative text are now translatable.