### PR TITLE
Update recipe_custom_action.rst

### DIFF
--- a/Resources/doc/cookbook/recipe_custom_action.rst
+++ b/Resources/doc/cookbook/recipe_custom_action.rst
@@ -92,7 +92,10 @@ to implement a ``clone`` action.
 
     class CRUDController extends Controller
     {
-        public function cloneAction()
+        /**
+         * @param $id
+         */
+        public function cloneAction($id)
         {
             $object = $this->admin->getSubject();
 
@@ -117,7 +120,7 @@ to implement a ``clone`` action.
         }
     }
 
-Here we first get the id of the object, see if it exists then clone it and insert the clone
+Here we first get the object, see if it exists then clone it and insert the clone
 as a new object. Finally we set a flash message indicating success and redirect to the list view.
 
 If you want to add the current filter parameters to the redirect url you can add them to the `generateUrl` method:


### PR DESCRIPTION
Fix variable $id not being defined in cloneAction().

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because my change is a tiny backward compatible correction.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->


## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->

Change the code cloneAction() example function to make it not use an undefined variable.