### PR TITLE
[WIP] Fix issue when Global search return wrong result with custom query

### DIFF
--- a/Datagrid/Datagrid.php
+++ b/Datagrid/Datagrid.php
@@ -148,10 +148,21 @@ class Datagrid implements DatagridInterface
 
         $data = $this->form->getData();
 
+        $originalWhereConditions = $this->query->getDQLPart('where');
+        $this->query->resetDQLPart('where');
+
         foreach ($this->getFilters() as $name => $filter) {
             $this->values[$name] = isset($this->values[$name]) ? $this->values[$name] : null;
             $filter->apply($this->query, $data[$filter->getFormName()]);
         }
+
+        $filterWhereConditions = $this->query->getDQLPart('where');
+        $this->query->resetDQLPart('where');
+
+        $and = $this->query->expr()->andX();
+        $and->add($originalWhereConditions);
+        $and->add($filterWhereConditions);
+        $this->query->where($and);
 
         if (isset($this->values['_sort_by'])) {
             if (!$this->values['_sort_by'] instanceof FieldDescriptionInterface) {


### PR DESCRIPTION
I am targeting this branch, because bug in current stable.

Closes #3368

## Changelog

```markdown
### Fixed
- Fixed issue when Global Search return wrong result with createQuery inside Admin class
```
## Subject
My ```AcmeAdmin``` uses ```createQuery``` method.

```php
public function createQuery($context = 'list')
    {
        $query = parent::createQuery($context);
        $query->where(
            $query->expr()->notIn($query->getRootAliases()[0] . '.id', ':ids')
        );

        $query->setParameter('ids', [1,2,3]);
        return $query;
    }
```
The where condition is not added with an ```AND``` operator but an ```OR```:

```sql
SELECT
  d0_.id         AS id0,
  d0_.field      AS field1,
  d0_.field_info AS field_info2,
  d0_.text       AS text3
FROM acme_table d0_
WHERE 
  d0_.id NOT IN (1, 2, 3) 
  OR d0_.field LIKE '%test%' 
  OR d0_.field_info LIKE '%test%' 
  OR d0_.text LIKE '%test%'
```

This only happens when using the ```createQuery``` method and seems to be a problem of the global search adding it.

With that fix it is generated correctly:

```sql
SELECT
  d0_.id         AS id0,
  d0_.field      AS field1,
  d0_.field_info AS field_info2,
  d0_.text       AS text3
FROM acme_table d0_
WHERE
  d0_.id NOT IN (1, 2, 3)
  AND
  (
    d0_.field LIKE '%test%'
    OR d0_.field_info LIKE '%test%'
    OR d0_.text LIKE '%test%'
  )
```

If we remove ```createQuery``` from admin class, SQL code still unchanged.

```sql
SELECT
  d0_.id         AS id0,
  d0_.field      AS field1,
  d0_.field_info AS field_info2,
  d0_.text       AS text3
FROM acme_table d0_
WHERE 
  d0_.field LIKE '%test%' 
  OR d0_.field_info LIKE '%test%' 
  OR d0_.text LIKE '%test%'
```
This fix seems backwards-compatible with older versions.
This solution provided by @lopsided, thank you.