### PR TITLE
replace title_show placeholder with transleted value (only for IT)

### DIFF
--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -88,7 +88,7 @@
             </trans-unit>
             <trans-unit id="title_show">
                 <source>title_show</source>
-                <target>title_show</target>
+                <target>Mostra "%name%"</target>
             </trans-unit>
             <trans-unit id="title_dashboard">
                 <source>title_dashboard</source>


### PR DESCRIPTION
Closes #4465.

```markdown
### Fixed
- added missing italian translations
```