### PR TITLE
Use ModelListType instead of deprecated ModelTypeList

### DIFF
--- a/Resources/config/form_types.xml
+++ b/Resources/config/form_types.xml
@@ -9,7 +9,7 @@
             <argument type="service" id="property_accessor"/>
             <tag name="form.type" alias="sonata_type_model"/>
         </service>
-        <service id="sonata.admin.form.type.model_list" class="Sonata\AdminBundle\Form\Type\ModelTypeList">
+        <service id="sonata.admin.form.type.model_list" class="Sonata\AdminBundle\Form\Type\ModelListType">
             <tag name="form.type" alias="sonata_type_model_list"/>
         </service>
         <service id="sonata.admin.form.type.model_reference" class="Sonata\AdminBundle\Form\Type\ModelReferenceType">

--- a/SonataAdminBundle.php
+++ b/SonataAdminBundle.php
@@ -50,7 +50,7 @@ class SonataAdminBundle extends Bundle
         FormHelper::registerFormTypeMapping(array(
             'sonata_type_admin' => 'Sonata\AdminBundle\Form\Type\AdminType',
             'sonata_type_model' => 'Sonata\AdminBundle\Form\Type\ModelType',
-            'sonata_type_model_list' => 'Sonata\AdminBundle\Form\Type\ModelTypeList',
+            'sonata_type_model_list' => 'Sonata\AdminBundle\Form\Type\ModelListType',
             'sonata_type_model_reference' => 'Sonata\AdminBundle\Form\Type\ModelReferenceType',
             'sonata_type_model_hidden' => 'Sonata\AdminBundle\Form\Type\ModelHiddenType',
             'sonata_type_model_autocomplete' => 'Sonata\AdminBundle\Form\Type\ModelAutocompleteType',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I got deprecation notification when using autowire for my services.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- deprecations when using `sonata.admin.form.type.model_list`
```

## Subject

<!-- Describe your Pull Request content here -->
Deprecated classes should not be used in not deprecated services.
So we need to use not deprecated classes in services or mark service as deprecated.