### PR TITLE
skeletons are now valid for @Symfony ruleset by PHP-CS-Fixer

### DIFF
--- a/Resources/skeleton/Admin.php.twig
+++ b/Resources/skeleton/Admin.php.twig
@@ -38,7 +38,7 @@ class {{ classBasename }} extends AbstractAdmin
                     'show' => array(),
                     'edit' => array(),
                     'delete' => array(),
-                )
+                ),
             ))
         ;
     }

--- a/Resources/skeleton/AdminController.php.twig
+++ b/Resources/skeleton/AdminController.php.twig
@@ -6,5 +6,4 @@ use Sonata\AdminBundle\Controller\CRUDController;
 
 class {{ classBasename }} extends CRUDController
 {
-
 }

--- a/Tests/Fixtures/Admin/ModelAdmin.php
+++ b/Tests/Fixtures/Admin/ModelAdmin.php
@@ -36,7 +36,7 @@ class ModelAdmin extends AbstractAdmin
                     'show' => array(),
                     'edit' => array(),
                     'delete' => array(),
-                )
+                ),
             ))
         ;
     }

--- a/Tests/Fixtures/Controller/ModelAdminController.php
+++ b/Tests/Fixtures/Controller/ModelAdminController.php
@@ -6,5 +6,4 @@ use Sonata\AdminBundle\Controller\CRUDController;
 
 class ModelAdminController extends CRUDController
 {
-
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->

Otherwise this would be fixed by PHP-CS-Fixer all the time afterwards