### PR TITLE
Documentation update getting_started.rst missing namespaces

### DIFF
--- a/Resources/doc/reference/getting_started.rst
+++ b/Resources/doc/reference/getting_started.rst
@@ -232,6 +232,8 @@ and for ``admin.yml``:
 
     namespace AppBundle\DependencyInjection;
 
+    use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+    use Symfony\Component\DependencyInjection\ContainerBuilder;
     use Symfony\Component\DependencyInjection\Loader;
     use Symfony\Component\Config\FileLocator;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this was missing in this branch

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
### Added
Missing namespaces into example in documentation

## Subject
<!-- Describe your Pull Request content here -->
Documentation Missing namespaces in yaml loader example