### PR TITLE
Make urls in sidebar relative by default.

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -101,7 +101,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     'label' => !empty($attributes['label']) ? $attributes['label'] : '',
                     'route' => '',
                     'route_params' => array(),
-                    'route_absolute' => true,
+                    'route_absolute' => false,
                 );
 
                 if (isset($groupDefaults[$resolvedGroupName]['on_top']) && $groupDefaults[$resolvedGroupName]['on_top']

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -180,7 +180,7 @@ class Configuration implements ConfigurationInterface
                                                             'label' => '',
                                                             'route' => '',
                                                             'route_params' => array(),
-                                                            'route_absolute' => true,
+                                                            'route_absolute' => false,
                                                         );
                                                     }
                                                 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -204,7 +204,7 @@ class Configuration implements ConfigurationInterface
                                                 ->end()
                                                 ->booleanNode('route_absolute')
                                                     ->info('Whether the generated url should be absolute')
-                                                    ->defaultTrue()
+                                                    ->defaultFalse()
                                                 ->end()
                                             ->end()
                                         ->end()

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -148,7 +148,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
                 'label' => '',
                 'route' => '',
                 'route_params' => array(),
-                'route_absolute' => true,
+                'route_absolute' => false,
                 'roles' => array(),
             )
         );
@@ -159,7 +159,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
                 'label' => '',
                 'route' => '',
                 'route_params' => array(),
-                'route_absolute' => true,
+                'route_absolute' => false,
                 'roles' => array(),
             )
         );
@@ -182,7 +182,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
                 'route_params' => array(),
                 'admin' => '',
                 'roles' => array(),
-                'route_absolute' => true,
+                'route_absolute' => false,
             )
         );
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I just change urls building in sidebar. For now it creates relative urls by default instead of absolute.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Fixes potentially wrong scheme in the sidebar urls by using relative urls
```

## Subject

<!-- Describe your Pull Request content here -->
It can be useful for example when you are using https provided by cloudflare. So the urls will always navigate to current schema. Almost all another generated urls in sonata admin are relative by default.