### PR TITLE
Fix AttachAdminClass handling of not found Admin Classes

### DIFF
--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1886,6 +1886,73 @@ class AdminTest extends PHPUnit_Framework_TestCase
         $admin->getDataSourceIterator();
     }
 
+    public function testAttachAdminClass()
+    {
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $object = new CommentAdmin('sonata.post.admin.comment', 'NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
+
+        $container = new Container();
+        $container->set('sonata.post.admin.comment', $object);
+        $pool = new Pool($container, 'Sonata Admin', '/path/to/pic.png');
+        $pool->setAdminServiceIds(array('sonata.post.admin.post', 'sonata.post.admin.comment'));
+        $pool->setAdminClasses(array('\NewsBundle\Entity\Comment' => array('sonata.post.admin.comment')));
+        $admin->setConfigurationPool($pool);
+
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription
+            ->method('getOption')
+            ->with($this->equalTo('admin_code'))
+            ->will($this->returnValue('sonata.post.admin.comment'));
+        $fieldDescription
+            ->expects($this->once())
+            ->method('setAssociationAdmin')
+            ->with($this->equalTo($object));
+        $admin->attachAdminClass($fieldDescription);
+
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription
+            ->method('getTargetEntity')
+            ->will($this->returnValue('\NewsBundle\Entity\Comment'));
+        $fieldDescription
+            ->expects($this->once())
+            ->method('setAssociationAdmin')
+            ->with($this->equalTo($object));
+        $admin->attachAdminClass($fieldDescription);
+
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription
+            ->method('getOption')
+            ->will($this->returnValue('sonata.post.admin.article'));
+
+        try {
+            $admin->attachAdminClass($fieldDescription);
+        } catch (\Exception $e) {
+            $this->assertTrue($e instanceof \InvalidArgumentException);
+        }
+
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription
+           ->method('getOption')
+           ->will($this->returnValue('sonata.post.admin.post'));
+
+        try {
+            $admin->attachAdminClass($fieldDescription);
+        } catch (\Exception $e) {
+            $this->assertTrue($e instanceof \RuntimeException);
+        }
+
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription
+            ->method('getTargetEntity')
+            ->will($this->returnValue('\NewsBundle\Entity\Post'));
+
+        try {
+            $admin->attachAdminClass($fieldDescription);
+        } catch (\Exception $e) {
+            $this->assertTrue($e instanceof \RuntimeException);
+        }
+    }
+
     private function createTagAdmin(Post $post)
     {
         $postAdmin = $this->getMockBuilder('Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin')


### PR DESCRIPTION
I am targeting this branch, because changing the Exception handling is likely to be a minor BC break. If this is not the case, I'm happy to rebase to 3.x.

Closes https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/222
Closes https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/237
Closes https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/252

## Changelog
```markdown
### Changed
- Changed `AbstractAdmin::attachAdminClass` to throw an exception if there is no Admin class for the specified targetEntity
```
## Subject

When a form field used as ```sonata_type_model_list``` does not have an Admin Class, or the Admin Class has a typo inside the Entity namespace I received a very unhelpfull error: 

```
Impossible to invoke a method ("id") on a NULL variable ("") in SonataDoctrineORMAdminBundle:Form:form_admin_fields.html.twig at line 60
```

This PR fixes the issue by throwing a ```RuntimeException``` if there is a child field that does not have an Admin Class defined (or has bad configuration).
