### PR TITLE
Fix missing selected value on Select2 v4 autocomplete

### DIFF
--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -21,6 +21,9 @@ file that was distributed with this source code.
         {%- if disabled %} disabled="disabled"{% endif -%}
         {%- if required %} required="required"{% endif %}
     >
+        {%- for idx, val  in value if idx~'' != '_labels' -%}
+            <option value="{{ val }}" selected>{{ value['_labels'][idx] }}</option>
+        {%- endfor -%}
     </select>
 
     <div id="{{ id }}_hidden_inputs_wrap">


### PR DESCRIPTION
I am targeting this branch, because this is a fix.

## Changelog

```markdown
### Fixed
- Selected values issue with Select2 v4 on model autocomplete type
```

## Subject

This is a missing part of #4480 for already selected values.