### PR TITLE
fix icon for nav items with on_top: true

### DIFF
--- a/Resources/views/Menu/sonata_menu.html.twig
+++ b/Resources/views/Menu/sonata_menu.html.twig
@@ -27,7 +27,7 @@
     {% spaceless %}
         {% if item.extra('on_top') is defined and not item.extra('on_top') %}
             {% set translation_domain = item.extra('translation_domain', 'messages') %}
-            {% set icon = item.attribute('icon')|default(item.level > 1 ? '<i class="fa fa-angle-double-right" aria-hidden="true"></i>' : '') %}
+            {% set icon = item.extra('icon')|default(item.level > 1 ? '<i class="fa fa-angle-double-right" aria-hidden="true"></i>' : '') %}
         {% else %}
             {% set icon = item.extra('icon') %}
         {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs #4023

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Show icon for nav items when using `on_top`-option 
```

## Subject

As mentioned here https://github.com/sonata-project/SonataAdminBundle/issues/4023#issuecomment-302629065, I can confirm this fixes the problem