### PR TITLE
use generated route instead of plain route in nav items

### DIFF
--- a/Menu/Provider/GroupMenuProvider.php
+++ b/Menu/Provider/GroupMenuProvider.php
@@ -158,7 +158,8 @@ class GroupMenuProvider implements MenuProviderInterface
                     $menuItem->setExtra('on_top', $group['on_top']);
                     $menuItem->setUri($options);
                 } else {
-                    $menuItem->setUri($item['route']);
+                    $router = $this->pool->getContainer()->get('router');
+                    $menuItem->setUri($router->generate($item['route']));
                 }
             }
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs #4023

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- use generated route instead of plain route in nav items
```

## Subject

As mentioned here https://github.com/sonata-project/SonataAdminBundle/issues/4023#issuecomment-302629065, I can confirm this fixes the problem