### PR TITLE
Get data from the form in create/update actions.

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -265,6 +265,9 @@ class CRUDController extends Controller
 
             // persist if the form was valid and if in preview mode the preview was approved
             if ($isFormValid && (!$this->isInPreviewMode() || $this->isPreviewApproved())) {
+                $object = $form->getData();
+                $this->admin->setSubject($object);
+                
                 try {
                     $object = $this->admin->update($object);
 
@@ -509,6 +512,8 @@ class CRUDController extends Controller
 
             // persist if the form was valid and if in preview mode the preview was approved
             if ($isFormValid && (!$this->isInPreviewMode() || $this->isPreviewApproved())) {
+                $object = $form->getData();
+                $this->admin->setSubject($object);
                 $this->admin->checkAccess('create', $object);
 
                 try {

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -267,7 +267,7 @@ class CRUDController extends Controller
             if ($isFormValid && (!$this->isInPreviewMode() || $this->isPreviewApproved())) {
                 $object = $form->getData();
                 $this->admin->setSubject($object);
-                
+
                 try {
                     $object = $this->admin->update($object);
 

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -236,46 +236,46 @@ class CRUDController extends Controller
         $templateKey = 'edit';
 
         $id = $request->get($this->admin->getIdParameter());
-        $object = $this->admin->getObject($id);
+        $existingObject = $this->admin->getObject($id);
 
-        if (!$object) {
+        if (!$existingObject) {
             throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
         }
 
-        $this->admin->checkAccess('edit', $object);
+        $this->admin->checkAccess('edit', $existingObject);
 
-        $preResponse = $this->preEdit($request, $object);
+        $preResponse = $this->preEdit($request, $existingObject);
         if ($preResponse !== null) {
             return $preResponse;
         }
 
-        $this->admin->setSubject($object);
+        $this->admin->setSubject($existingObject);
 
         /** @var $form Form */
         $form = $this->admin->getForm();
-        $form->setData($object);
+        $form->setData($existingObject);
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
             //TODO: remove this check for 4.0
             if (method_exists($this->admin, 'preValidate')) {
-                $this->admin->preValidate($object);
+                $this->admin->preValidate($existingObject);
             }
             $isFormValid = $form->isValid();
 
             // persist if the form was valid and if in preview mode the preview was approved
             if ($isFormValid && (!$this->isInPreviewMode() || $this->isPreviewApproved())) {
-                $object = $form->getData();
-                $this->admin->setSubject($object);
+                $submittedObject = $form->getData();
+                $this->admin->setSubject($submittedObject);
 
                 try {
-                    $object = $this->admin->update($object);
+                    $existingObject = $this->admin->update($submittedObject);
 
                     if ($this->isXmlHttpRequest()) {
                         return $this->renderJson(array(
                             'result' => 'ok',
-                            'objectId' => $this->admin->getNormalizedIdentifier($object),
-                            'objectName' => $this->escapeHtml($this->admin->toString($object)),
+                            'objectId' => $this->admin->getNormalizedIdentifier($existingObject),
+                            'objectName' => $this->escapeHtml($this->admin->toString($existingObject)),
                         ), 200, array());
                     }
 
@@ -283,21 +283,21 @@ class CRUDController extends Controller
                         'sonata_flash_success',
                         $this->trans(
                             'flash_edit_success',
-                            array('%name%' => $this->escapeHtml($this->admin->toString($object))),
+                            array('%name%' => $this->escapeHtml($this->admin->toString($existingObject))),
                             'SonataAdminBundle'
                         )
                     );
 
                     // redirect to edit mode
-                    return $this->redirectTo($object);
+                    return $this->redirectTo($existingObject);
                 } catch (ModelManagerException $e) {
                     $this->handleModelManagerException($e);
 
                     $isFormValid = false;
                 } catch (LockException $e) {
                     $this->addFlash('sonata_flash_error', $this->trans('flash_lock_error', array(
-                        '%name%' => $this->escapeHtml($this->admin->toString($object)),
-                        '%link_start%' => '<a href="'.$this->admin->generateObjectUrl('edit', $object).'">',
+                        '%name%' => $this->escapeHtml($this->admin->toString($existingObject)),
+                        '%link_start%' => '<a href="'.$this->admin->generateObjectUrl('edit', $existingObject).'">',
                         '%link_end%' => '</a>',
                     ), 'SonataAdminBundle'));
                 }
@@ -310,7 +310,7 @@ class CRUDController extends Controller
                         'sonata_flash_error',
                         $this->trans(
                             'flash_edit_error',
-                            array('%name%' => $this->escapeHtml($this->admin->toString($object))),
+                            array('%name%' => $this->escapeHtml($this->admin->toString($existingObject))),
                             'SonataAdminBundle'
                         )
                     );
@@ -329,7 +329,7 @@ class CRUDController extends Controller
         return $this->render($this->admin->getTemplate($templateKey), array(
             'action' => 'edit',
             'form' => $formView,
-            'object' => $object,
+            'object' => $existingObject,
         ), null);
     }
 
@@ -489,40 +489,40 @@ class CRUDController extends Controller
             );
         }
 
-        $object = $this->admin->getNewInstance();
+        $newObject = $this->admin->getNewInstance();
 
-        $preResponse = $this->preCreate($request, $object);
+        $preResponse = $this->preCreate($request, $newObject);
         if ($preResponse !== null) {
             return $preResponse;
         }
 
-        $this->admin->setSubject($object);
+        $this->admin->setSubject($newObject);
 
         /** @var $form \Symfony\Component\Form\Form */
         $form = $this->admin->getForm();
-        $form->setData($object);
+        $form->setData($newObject);
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
             //TODO: remove this check for 4.0
             if (method_exists($this->admin, 'preValidate')) {
-                $this->admin->preValidate($object);
+                $this->admin->preValidate($newObject);
             }
             $isFormValid = $form->isValid();
 
             // persist if the form was valid and if in preview mode the preview was approved
             if ($isFormValid && (!$this->isInPreviewMode() || $this->isPreviewApproved())) {
-                $object = $form->getData();
-                $this->admin->setSubject($object);
-                $this->admin->checkAccess('create', $object);
+                $submittedObject = $form->getData();
+                $this->admin->setSubject($submittedObject);
+                $this->admin->checkAccess('create', $submittedObject);
 
                 try {
-                    $object = $this->admin->create($object);
+                    $newObject = $this->admin->create($submittedObject);
 
                     if ($this->isXmlHttpRequest()) {
                         return $this->renderJson(array(
                             'result' => 'ok',
-                            'objectId' => $this->admin->getNormalizedIdentifier($object),
+                            'objectId' => $this->admin->getNormalizedIdentifier($newObject),
                         ), 200, array());
                     }
 
@@ -530,13 +530,13 @@ class CRUDController extends Controller
                         'sonata_flash_success',
                         $this->trans(
                             'flash_create_success',
-                            array('%name%' => $this->escapeHtml($this->admin->toString($object))),
+                            array('%name%' => $this->escapeHtml($this->admin->toString($newObject))),
                             'SonataAdminBundle'
                         )
                     );
 
                     // redirect to edit mode
-                    return $this->redirectTo($object);
+                    return $this->redirectTo($newObject);
                 } catch (ModelManagerException $e) {
                     $this->handleModelManagerException($e);
 
@@ -551,7 +551,7 @@ class CRUDController extends Controller
                         'sonata_flash_error',
                         $this->trans(
                             'flash_create_error',
-                            array('%name%' => $this->escapeHtml($this->admin->toString($object))),
+                            array('%name%' => $this->escapeHtml($this->admin->toString($newObject))),
                             'SonataAdminBundle'
                         )
                     );
@@ -570,7 +570,7 @@ class CRUDController extends Controller
         return $this->render($this->admin->getTemplate($templateKey), array(
             'action' => 'create',
             'form' => $formView,
-            'object' => $object,
+            'object' => $newObject,
         ), null);
     }
 

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -1512,6 +1512,10 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
+
         $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
@@ -1634,6 +1638,10 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->method('isValid')
             ->will($this->returnValue(true));
 
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
+
         $this->admin->expects($this->once())
             ->method('getNormalizedIdentifier')
             ->with($this->equalTo($object))
@@ -1736,6 +1744,10 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
         $form->expects($this->once())
             ->method('isValid')
             ->will($this->returnValue(true));
+
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
 
         $this->admin->expects($this->once())
             ->method('toString')
@@ -1851,6 +1863,10 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
         $form->expects($this->any())
             ->method('isValid')
             ->will($this->returnValue(true));
+
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
 
         $this->admin->expects($this->any())
             ->method('getForm')
@@ -2031,6 +2047,10 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->method('isValid')
             ->will($this->returnValue(true));
 
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
+
         $this->admin->expects($this->once())
             ->method('toString')
             ->with($this->equalTo($object))
@@ -2085,6 +2105,10 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
         $form->expects($this->once())
             ->method('isSubmitted')
             ->will($this->returnValue(true));
+
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
 
         $form->expects($this->once())
             ->method('isValid')
@@ -2203,6 +2227,10 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->method('isSubmitted')
             ->will($this->returnValue(true));
 
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
+
         $this->request->setMethod('POST');
 
         $formView = $this->createMock('Symfony\Component\Form\FormView');
@@ -2268,6 +2296,10 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
         $form->expects($this->once())
             ->method('isValid')
             ->will($this->returnValue(true));
+
+        $form->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue($object));
 
         $this->admin->expects($this->any())
             ->method('getClass')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because 3.x branch is used on a project I'm working on. On the other hand it should be applicable to master according to CRUDController code.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4494

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- compatibility with immutable entities was improved
```

## Subject

On the project I'm working on immutable entities are used. DataMapper solves the problem with creating new Entity instance based on Form data. But $object is never got from the form in CRUDController::createAction() and CRUDController::editAction(). If new object is not created then nothing will change as the same instance will be returned. But this patch can be easily adopted and provides others working with DDD entities with a solution.