### PR TITLE
Bump SonataCoreBundle version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/inflector": "^1.0",
         "knplabs/knp-menu-bundle": "^2.1.1",
         "sonata-project/block-bundle": "^3.2",
-        "sonata-project/core-bundle": "^3.1",
+        "sonata-project/core-bundle": "^3.4",
         "sonata-project/exporter": "^1.7",
         "symfony/class-loader": "^2.3 || ^3.0",
         "symfony/config": "^2.3.9 || ^3.0",


### PR DESCRIPTION
People that upgrade the admin bundle in order to get Symfony 3.3
compatibility might not be aware that the core bundle is compatible with
it only since 3.4.0, and not think of updating it too. This change is
not pure in the sense that this incompatibility should be expressed in
the core bundle itself, but it should spare us some support issues.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- it is no longer possible to get core bundle versions incompatible with sf3

```

