### PR TITLE
remove select required attribute

### DIFF
--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -19,7 +19,6 @@ file that was distributed with this source code.
     <select id="{{ id }}_autocomplete_input_v4" data-sonata-select2="false"
         {%- if read_only is defined and read_only %} readonly="readonly"{% endif -%}
         {%- if disabled %} disabled="disabled"{% endif -%}
-        {%- if required %} required="required"{% endif %}
     >
         {%- for idx, val  in value if idx~'' != '_labels' -%}
             <option value="{{ val }}" selected>{{ value['_labels'][idx] }}</option>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4022, #4486

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Removed
Attribute 'required' from HTML element select in Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig

### Fixed
Error on save form with autocomplete form field ('sonata_type_model_autocomplete') where required is set to 'true'

### Security
Input field in 'sonata_type_model_autocomplete' already  have attribute 'required'
```


## Subject

<!-- Describe your Pull Request content here -->

Fix problem with required autocomplete field on save from.