### PR TITLE
Pumped 'code' option functionality

### DIFF
--- a/Admin/BaseFieldDescription.php
+++ b/Admin/BaseFieldDescription.php
@@ -358,7 +358,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
                 return call_user_func_array(array($providedObject, $providedMethod), $parameters);
             } elseif (is_callable($code)) {
                 return $code(...$parameters);
-            } elseif (is_string($code))  {
+            } elseif (is_string($code)) {
                 $getters[] = $code;
             } else {
                 throw new \RuntimeException(

--- a/Admin/BaseFieldDescription.php
+++ b/Admin/BaseFieldDescription.php
@@ -327,17 +327,47 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
 
         $camelizedFieldName = Inflector::classify($fieldName);
 
+        // Getters will be populated with all possible getters variations, if string provided was not
+        // method name, but property name
         $getters = array();
-        $parameters = array();
+        // Parameters given
+        $parameters = $this->getOption('parameters') ? $this->getOption('parameters') : array();
+
+        $code = $this->getOption('code');
 
         // prefer method name given in the code option
-        if ($this->getOption('code')) {
-            $getters[] = $this->getOption('code');
+        if ($code) {
+            // Checking if getter is array with 1 argument as object and second method name
+            if (is_array($code)) {
+                if (count($code) < 2 || !is_object($code[0]) || !is_string($code[1])) {
+                    throw new \RuntimeException(
+                        'If you use array in `code`, you need to specify object and string methodName of specified object.
+                         Like this: [$someObject, \'someMethod\']'
+                    );
+                }
+
+                $providedObject = $code[0];
+                $providedMethod = $code[1];
+
+                if (!method_exists($providedObject, $providedMethod)) {
+                    throw new \RuntimeException(
+                        sprintf('Method %s does not exist in provided instance of class %s', get_class($providedObject), $providedMethod)
+                    );
+                }
+
+                return call_user_func_array(array($providedObject, $providedMethod), $parameters);
+            } elseif (is_callable($code)) {
+                return $code(...$parameters);
+            } elseif (is_string($code))  {
+                $getters[] = $code;
+            } else {
+                throw new \RuntimeException(
+                    'Provided incorrect value for `code` option. It can be string for method name of admin object,
+                    can be array with object and string method name for provided object and it can be function'
+                );
+            }
         }
-        // parameters for the method given in the code option
-        if ($this->getOption('parameters')) {
-            $parameters = $this->getOption('parameters');
-        }
+
         $getters[] = 'get'.$camelizedFieldName;
         $getters[] = 'is'.$camelizedFieldName;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is feature actually needed often for building rich show pages without need to bloat admin templates folder.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #3171

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Modified method `BaseFieldDescription::getFieldValue`, so code option could be used
with variety of values.
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
Code option is kinda poor on different values. Often developers need to use different object or
admin class itself for getting some value with 'code' option. Also it will be very convenient to use it with simple function. Parameters still apply to new values.
Not it can be used like this:

```php
    $showMapper
         ->add('previewAndDownload', 'html', [
             'label' => 'Preview and download',
              'mapped' => false,
              'code' => [$this, 'getPreviewAndDownloadHtml']
         ])
    ;

    $showMapper
         ->add('previewAndDownload', 'html', [
             'label' => 'Preview and download',
              'mapped' => false,
              'code' => [$this, 'getPreviewAndDownloadHtml'],
              'parameters' => [true]
         ])
    ;

    $showMapper
         ->add('previewAndDownload', 'html', [
             'label' => 'Preview and download',
              'mapped' => false,
              'code' => function() { return '<b>hello thar</b>'; }
         ])
    ;

    $showMapper
         ->add('previewAndDownload', 'html', [
             'label' => 'Preview and download',
              'mapped' => false,
              'code' => function($val) { return "<b>hello thar, $val</b>"; },
              'parameters' => ['your_name']
         ])
    ;
```