### PR TITLE
Remove unused field

### DIFF
--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -43,7 +43,7 @@ file that was distributed with this source code.
             var usedInputRef = window.Select2 ? '#{{ id }}_autocomplete_input' : '#{{ id }}_autocomplete_input_v4';
             var unusedInputRef = window.Select2 ? '#{{ id }}_autocomplete_input_v4' : '#{{ id }}_autocomplete_input';
 
-            $(unusedInputRef).hide();
+            $(unusedInputRef).remove();
             var autocompleteInput = $(usedInputRef);
 
             var select2Options = {


### PR DESCRIPTION
Hiding is not enough. If you are using AJAX, and your field is required,
you may end up with an empty select tag, with a required attribute that
is never filled with options, because there are currently 2 tags, one
for each version of Select2, and only one of them is filled.
This commit removes the other one instead of just hiding it,
that way it can't interfere with the other.
Fixes #4486, #4261

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- forms with a required autocomplete ajax field can be submitted again
```

