### PR TITLE
fixed choice field mask form type using immutable array form type

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -463,37 +463,41 @@ file that was distributed with this source code.
 
 {% block sonata_type_choice_field_mask_widget %}
     {{ block('choice_widget') }}
-    {% set main_form_name = id|slice(0, id|length - name|length) %}
+    {# Taking the form name excluding ending field glue character #}
+    {% set main_form_name = id|slice(0, (id|length - name|length)-1) %}
     <script>
         jQuery(document).ready(function() {
             var allFields = {{ all_fields|json_encode|raw }};
             var map = {{ map|json_encode|raw }};
 
-            var showMaskChoiceEl = jQuery('#{{ main_form_name }}{{ name }}');
+            var showMaskChoiceEl = jQuery('#{{ main_form_name }}_{{ name }}');
 
             showMaskChoiceEl.on('change', function () {
                 choice_field_mask_show(jQuery(this).val());
             });
 
-            function choice_field_mask_show(val)
-            {
+            function choice_field_mask_show(val) {
                 var controlGroupIdFunc = function (field) {
-                    return '#sonata-ba-field-container-{{ main_form_name }}' + field;
+                    // Most of fields are named with an underscore
+                    var defaultFieldId = '#sonata-ba-field-container-{{ main_form_name }}_' + field;
 
+                    // Some fields may be named with a dash (like keys of immutable array form type)
+                    if (jQuery(defaultFieldId).length === 0) {
+                        return '#sonata-ba-field-container-{{ main_form_name }}-' + field;
+                    }
+
+                    return defaultFieldId;
                 };
-                if (map[val] == undefined) {
-                    jQuery.each(allFields, function (i, field) {
-                        jQuery(controlGroupIdFunc(field)).hide();
-                    });
-                    return;
-                }
 
                 jQuery.each(allFields, function (i, field) {
                     jQuery(controlGroupIdFunc(field)).hide();
                 });
-                jQuery.each(map[val], function (i, field) {
-                    jQuery(controlGroupIdFunc(field)).show();
-                });
+
+                if (map[val]) {
+                    jQuery.each(map[val], function (i, field) {
+                        jQuery(controlGroupIdFunc(field)).show();
+                    });
+                }
             }
             choice_field_mask_show(showMaskChoiceEl.val());
         });


### PR DESCRIPTION
I am targeting this branch, because this fix is backwards compatible.

## Changelog
```markdown
### Fixed
- Fixed choice field mask type javascript in the twig templates to works with immutable array form types
```

## Subject

The javascript code showing/hiding fields on the ChoiceFieldMaskType widget did not work when the ChoiceFieldMaskType was used inside an ImmutableArrayType. This is due to the use of a different glue character, the dash, in ImmutableArrayType to append keys in the widget name. This fix consists in adding a fallback on this dash-naming if the default naming with underscore does not match any javascript element.

## Code sample

```php
    protected function configureFormFields(FormMapper $formMapper)
    {
        parent::configureFormFields($formMapper);

        $formMapper
            // Was working before
            ->with('Test Without Immutable')
                ->add('test2', ChoiceFieldMaskType::class, [
                    'choices'  => [
                        ''     => 'Nothing',
                        'show' => 'Show fields'
                    ],
                    'required' => true,
                    'mapped'   => false,
                    'label'    => false,
                    'map'      => [
                        ''     => [],
                        'show' => ['test_field_2'],
                    ],
                ])
                ->add('test_field_2', TextType::class, [
                    'label'    => false,
                    'required' => false,
                    'mapped'   => false,
                ])
            ->end()

            // Did not work before
            ->with('Test Immutable')
                ->add('test', ImmutableArrayType::class, [
                    'required' => false,
                    'mapped'   => false,
                    'label'    => false,
                    'keys'     => [
                        [
                            'visibility', ChoiceFieldMaskType::class, [
                                'choices'  => [
                                    ''    => 'Nothing',
                                    'show' => 'Show fields'
                                ],
                                'required' => true,
                                'map'      => [
                                    ''     => [],
                                    'show' => ['test_field_1'],
                                ],
                            ]
                        ],
                        [
                            'test_field_1', TextType::class, [
                                'label'    => false,
                                'required' => false,
                            ]
                        ]
                    ]
                ])
            ->end()
        ;
    }
```


