### PR TITLE
Only add classes to compile on PHP < 7.0

### DIFF
--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -212,7 +212,9 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
 
         $container->setParameter('sonata.admin.configuration.show.mosaic.button', $config['show_mosaic_button']);
 
-        $this->configureClassesToCompile();
+        if (\PHP_VERSION_ID < 70000) {
+            $this->configureClassesToCompile();
+        }
 
         $this->replacePropertyAccessor($container);
     }


### PR DESCRIPTION
I am targeting this branch, because this fix a deprecation warning and is BC.

## Changelog

```markdown
### Fixed
- deprecation notices related to `addClassesToCompile`
```

## Subject

Only call addClassesToCompile on PHP < 7.0 since it is deprecated and doesn't improve performances with PHP >= 7.0