### PR TITLE
Fixed undefined variable in base_show.html.twig

### DIFF
--- a/Resources/views/CRUD/base_show.html.twig
+++ b/Resources/views/CRUD/base_show.html.twig
@@ -44,7 +44,7 @@ file that was distributed with this source code.
                         <li{% if loop.first %} class="active"{% endif %}>
                             <a href="#tab_{{ admin.uniqid }}_{{ loop.index }}" data-toggle="tab">
                                 <i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i>
-                                {{ view_group.label|trans({}, show_tab.translation_domain ?: admin.translationDomain) }}
+                                {{ show_tab.label|trans({}, show_tab.translation_domain ?: admin.translationDomain) }}
                             </a>
                         </li>
                     {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this bug was introduced there.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4525

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed undefined `view_group` variable in show template
```

## Subject

<!-- Describe your Pull Request content here -->
#4028 introduced bug in base_show.html.twig. This Pull Request will fix that bug.
In the CRUD/base_show.html.twig view on line 47, the variable ``name`` was replaced with ``view_group``. However, this should have been ``show_tab`` (see start of loop on line 43).