### PR TITLE
Deprecate ModelChoiceList

### DIFF
--- a/Form/ChoiceList/ModelChoiceList.php
+++ b/Form/ChoiceList/ModelChoiceList.php
@@ -20,7 +20,17 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPath;
 
+@trigger_error(
+    'The '.__CLASS__.' class is deprecated since 3.x and will be removed in 4.0.'
+    .' Use '.__NAMESPACE__.'\ModelChoiceLoader instead.',
+    E_USER_DEPRECATED
+);
+
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated Since 3.x, to be removed in 4.0. Use Sonata\AdminBundle\ModelChoiceLoader instead
+ *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ModelChoiceList extends SimpleChoiceList

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -75,7 +75,11 @@ preferred_choices
   defaults to array() - see the `Symfony choice Field Type docs`_ for more info
 
 choice_list
+  **(deprecated in favor of choice_loader since Symfony 2.7)**
   defaults to a ``ModelChoiceList`` built from the other options
+
+choice_loader
+  defaults to a ``ModelChoiceLoader`` built from the other options
 
 model_manager
   defaults to null, but is actually calculated from the linked Admin class.

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,14 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated ModelChoiceList class in favor of ModelChoiceLoader
+
+The `ModelChoiceList` class is no longer supported. Please use the `ModelChoiceLoader` class instead.
+
+The `ModelChoiceList` is usually used on the [`choice_list`](http://symfony.com/doc/2.8/reference/forms/types/choice.html#choice-list)
+option of a `FormBuilder`. The `ModelChoiceLoader` class must be replaced on the
+[`choice_loader`](http://symfony.com/doc/3.3/reference/forms/types/choice.html#choice-loader) option.
+
 UPGRADE FROM 3.13 to 3.14
 =========================
 


### PR DESCRIPTION
I am targeting this branch, because this is a deprecation PR.

Closes #4484

## Changelog

```markdown
### Deprecated
- `ModelChoiceList` in favor of `ModelChoiceLoader`
```
