### PR TITLE
Fix compatibility with Symfony's IdentityTranslator when translator is disabled

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -34,7 +34,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         // check if translator service exist
-        if (!$container->hasAlias('translator')) {
+        if (!$container->has('translator')) {
             throw new \RuntimeException('The "translator" service is not yet enabled.
                 It\'s required by SonataAdmin to display all labels properly.
 

--- a/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -49,6 +49,7 @@ class AddDependencyCallsCompilerPassTest extends PHPUnit_Framework_TestCase
 
         $container = $this->getContainer();
         $container->removeAlias('translator');
+        $container->removeDefinition('translator');
         $this->extension->load(array($this->config), $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because of a bug fix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed compatibility with Symfony's IdentityTranslator when translator is disabled
```

## Subject

When translator is disabled in the FrameworkBundle config (for tests purposes in our case), a IdentityTranslator (that does nothing) is still registered by the FrameworkBundle as a `translator` `service` (and not an `alias`). I think Sonata should not break in this case.
