### PR TITLE
Update services 'admin.category' parameter

### DIFF
--- a/Resources/doc/getting_started/creating_an_admin.rst
+++ b/Resources/doc/getting_started/creating_an_admin.rst
@@ -185,6 +185,7 @@ service and tag it with the ``sonata.admin`` tag:
             arguments: [~, AppBundle\Entity\Category, ~]
             tags:
                 - { name: sonata.admin, manager_type: orm, label: Category }
+            public: true
 
 The constructor of the base Admin class has many arguments. SonataAdminBundle
 provides a compiler pass which takes care of configuring it correctly for you.


### PR DESCRIPTION
For symfony default install setting, if no 'public : true' it will raise following error :

```
[Symfony\Component\Config\Exception\FileLoaderLoadException]                                                                                                                                  
  You have requested a non-existent service "admin.category" in . (which is being imported from "/Users/huhe/project/php/blog/app/config/routing.yml"). Make sure there is a loader supporting  
   the "sonata_admin" type.                                                                                                                                                                     
                                                                                                                                                                                                

                                                                              
  [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]  
  You have requested a non-existent service "admin.category".  
```

because the '_defaults' services set the public to false.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

In case of bug fix, `3.x` **MUST** be targeted.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}


## Subject

<!-- Describe your Pull Request content here -->
