### PR TITLE
Update `AbstractAdmin::hasSubject()` in order to call `AbstractAdmin::getSubject()` to trigger the subject detection

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1701,7 +1701,7 @@ EOT;
      */
     public function hasSubject()
     {
-        return $this->subject != null;
+        return $this->getSubject() != null;
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because `AbstractAdmin::hasSubject()` returns `false` since `AbstractAdmin::$subject` is not hydrated until `AbstractAdmin::getSubject()` is called.

Closes #4569 

## Changelog
```Markdown
### Fixed
- `AbstractAdmin::hasSubject()` returning `false` when `AbstractAdmin::$subject` isn't populated yet.
```
## To do
- [ ] Add tests in order to avoid regressions