### PR TITLE
Fixes missing 'public: true' needed for symfony 3.3+ (#4538)

### DIFF
--- a/Manipulator/ServicesManipulator.php
+++ b/Manipulator/ServicesManipulator.php
@@ -32,6 +32,7 @@ class ServicesManipulator
         arguments: [~, %s, %s]
         tags:
             - { name: sonata.admin, manager_type: %s, group: admin, label: %s }
+        public: true
 ';
 
     /**

--- a/Resources/doc/cookbook/recipe_custom_action.rst
+++ b/Resources/doc/cookbook/recipe_custom_action.rst
@@ -70,6 +70,7 @@ or by adding it to your ``admin.yml``:
                 - null
                 - AppBundle\Entity\Car
                 - AppBundle:CRUD
+            public: true
 
 For more information about service configuration please refer to Step 3 of :doc:`../reference/getting_started`
 

--- a/Resources/doc/cookbook/recipe_improve_performance_large_datasets.rst
+++ b/Resources/doc/cookbook/recipe_improve_performance_large_datasets.rst
@@ -41,6 +41,7 @@ To use `SimplePager` in your admin just define ``pager_type`` inside the service
                     - ~
                     - AppBundle\Entity\Post
                     - ~
+                public: true
 
 .. note::
 

--- a/Resources/doc/cookbook/recipe_knp_menu.rst
+++ b/Resources/doc/cookbook/recipe_knp_menu.rst
@@ -187,6 +187,7 @@ your admin services or simply remove menu items from the ``sonata_admin`` dashbo
         arguments: [~, Sonata\AdminBundle\Entity\Post, SonataAdminBundle:CRUD]
         tags:
             - {name: sonata.admin, manager_type: orm, group: admin, label: Post, show_in_dashboard: false}
+        public: true
 
 .. code-block:: yaml
 
@@ -244,6 +245,7 @@ or in sonata_admin dashboard group configuration:
         arguments: [~, Sonata\AdminBundle\Entity\Post, SonataAdminBundle:CRUD]
         tags:
             - {name: sonata.admin, manager_type: orm, group: admin, label: Post, on_top: true}
+        public: true
 
 .. code-block:: yaml
 

--- a/Resources/doc/cookbook/recipe_sortable_listing.rst
+++ b/Resources/doc/cookbook/recipe_sortable_listing.rst
@@ -116,6 +116,7 @@ Now you can update your ``services.yml`` to use the handler provider by the ``pi
               - ~
               - AppBundle\Entity\Client
               - 'PixSortableBehaviorBundle:SortableAdmin' # define the new controller via the third argument
+            public: true
 
 Now we need to define the sort by field to be ``$position``:
 

--- a/Resources/doc/getting_started/creating_an_admin.rst
+++ b/Resources/doc/getting_started/creating_an_admin.rst
@@ -185,6 +185,7 @@ service and tag it with the ``sonata.admin`` tag:
             arguments: [~, AppBundle\Entity\Category, ~]
             tags:
                 - { name: sonata.admin, manager_type: orm, label: Category }
+            public: true
 
 The constructor of the base Admin class has many arguments. SonataAdminBundle
 provides a compiler pass which takes care of configuring it correctly for you.

--- a/Resources/doc/getting_started/the_form_view.rst
+++ b/Resources/doc/getting_started/the_form_view.rst
@@ -47,6 +47,7 @@ The same applies to the service definition:
             arguments: [~, AppBundle\Entity\BlogPost, ~]
             tags:
                 - { name: sonata.admin, manager_type: orm, label: Blog post }
+            public: true
 
 Configuring the Form Mapper
 ---------------------------

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -63,6 +63,7 @@ You have 2 ways of defining the dependencies inside ``services.xml``:
                 - ~
                 - AppBundle\Entity\Project
                 - ~
+            public: true
 
 * With a method call, more verbose
 
@@ -105,6 +106,7 @@ You have 2 ways of defining the dependencies inside ``services.xml``:
             calls:
                 - [ setLabelTranslatorStrategy, [ "@sonata.admin.label.strategy.native" ]]
                 - [ setRouteBuilder, [ "@sonata.admin.route.path_info" ]]
+            public: true
 
 If you want to modify the service that is going to be injected, add the following code to your
 application's config file:

--- a/Resources/doc/reference/architecture.rst
+++ b/Resources/doc/reference/architecture.rst
@@ -92,6 +92,7 @@ your ``Admin`` services. This is done using a ``call`` to the matching ``setter`
                     - ~
                 calls:
                     - [ setLabelTranslatorStrategy, ["@sonata.admin.label.strategy.underscore"]]
+                public: true
 
 Here, we declare the same ``Admin`` service as in the :doc:`getting_started` chapter, but using a
 different label translator strategy, replacing the default one. Notice that
@@ -147,6 +148,7 @@ to set the controller to ``AppBundle:PostAdmin``:
                     - AppBundle:PostAdmin
                 calls:
                     - [ setTranslationDomain, [AppBundle]]
+                public: true
 
 When extending ``CRUDController``, remember that the ``Admin`` class already has
 a set of automatically injected dependencies that are useful when implementing several

--- a/Resources/doc/reference/dashboard.rst
+++ b/Resources/doc/reference/dashboard.rst
@@ -88,6 +88,7 @@ services:
                     - ~
                     - AppBundle\Entity\Post
                     - ~
+                public: true
 
 In these examples, notice the ``group`` tag, stating that this particular ``Admin``
 service belongs to the ``Content`` group.

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -461,6 +461,7 @@ that looks like this:
                     - 'SonataAdminBundle:CRUD'
                 calls:
                     - [ setTranslationDomain, [AppBundle]]
+                public: true
 
 .. note::
 

--- a/Resources/doc/reference/getting_started.rst
+++ b/Resources/doc/reference/getting_started.rst
@@ -173,6 +173,7 @@ Create either a new ``admin.xml`` or ``admin.yml`` file inside the ``src/AppBund
                     - ~
                 calls:
                     - [ setTranslationDomain, [AppBundle]]
+                public: true
 
 The example above assumes that you're using ``SonataDoctrineORMAdminBundle``.
 If you're using ``SonataDoctrineMongoDBAdminBundle``, ``SonataPropelAdminBundle`` or ``SonataDoctrinePhpcrAdminBundle`` instead, set ``manager_type`` option to ``doctrine_mongodb``, ``propel`` or ``doctrine_phpcr`` respectively.

--- a/Resources/doc/reference/routing.rst
+++ b/Resources/doc/reference/routing.rst
@@ -209,6 +209,7 @@ For example, lets change the Controller for our MediaAdmin class to AppBundle:Me
                 - ~
                 - AppBundle\Entity\Page
                 - 'AppBundle:MediaCRUD' # define the new controller via the third argument
+            public: true
 
 We now need to create our Controller, the easiest way is to extend the basic Sonata CRUD controller:
 

--- a/Resources/doc/reference/templates.rst
+++ b/Resources/doc/reference/templates.rst
@@ -183,6 +183,7 @@ specify the templates to use in the ``Admin`` service definition:
                     - ~
                 calls:
                     - [ setTemplate, [edit, AppBundle:PostAdmin:edit.html.twig]]
+                public: true
 
 .. note::
 

--- a/Tests/Manipulator/ServicesManipulatorTest.php
+++ b/Tests/Manipulator/ServicesManipulatorTest.php
@@ -56,7 +56,8 @@ class ServicesManipulatorTest extends \PHPUnit_Framework_TestCase
         class: admin_class
         arguments: [~, class, controller_name]
         tags:
-            - { name: sonata.admin, manager_type: manager_type, group: admin, label: class }\n",
+            - { name: sonata.admin, manager_type: manager_type, group: admin, label: class }
+        public: true\n",
             file_get_contents($this->file)
         );
         $this->servicesManipulator->addResource(
@@ -73,12 +74,14 @@ class ServicesManipulatorTest extends \PHPUnit_Framework_TestCase
         arguments: [~, class, controller_name]
         tags:
             - { name: sonata.admin, manager_type: manager_type, group: admin, label: class }
+        public: true
 
     another_service_id:
         class: another_admin_class
         arguments: [~, another_class, another_controller_name]
         tags:
-            - { name: sonata.admin, manager_type: another_manager_type, group: admin, label: another_class }\n",
+            - { name: sonata.admin, manager_type: another_manager_type, group: admin, label: another_class }
+        public: true\n",
             file_get_contents($this->file)
         );
     }
@@ -121,7 +124,8 @@ class ServicesManipulatorTest extends \PHPUnit_Framework_TestCase
         class: admin_class
         arguments: [~, class, controller_name]
         tags:
-            - { name: sonata.admin, manager_type: manager_type, group: admin, label: class }\n",
+            - { name: sonata.admin, manager_type: manager_type, group: admin, label: class }
+        public: true\n",
             file_get_contents($this->file)
         );
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because symfony 3.3 out-of-box compatibility is broken.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4538 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `ServiceManipulator` now adds `public: true` to service declaration by default
```
## Subject

Fixes missing `public: true` needed for symfony 3.3+ (#4538)