### PR TITLE
Fixed 'hidden' form type deprecation warning

### DIFF
--- a/Admin/Extension/LockExtension.php
+++ b/Admin/Extension/LockExtension.php
@@ -60,9 +60,9 @@ class LockExtension extends AbstractAdminExtension
             $form->add(
                 $fieldName,
                 // NEXT_MAJOR: remove the check and add the FQCN
-                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                    'Symfony\Component\Form\Extension\Core\Type\HiddenType' :
-                    'hidden',
+                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+                    : 'hidden',
                 array(
                     'mapped' => false,
                     'data' => $lockVersion,

--- a/Admin/Extension/LockExtension.php
+++ b/Admin/Extension/LockExtension.php
@@ -15,7 +15,6 @@ use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Model\LockInterface;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
@@ -58,10 +57,17 @@ class LockExtension extends AbstractAdminExtension
                 return;
             }
 
-            $form->add($fieldName, HiddenType::class, array(
-                'mapped' => false,
-                'data' => $lockVersion,
-            ));
+            $form->add(
+                $fieldName,
+                // NEXT_MAJOR: remove these three lines and uncomment the one following
+                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                    'Symfony\Component\Form\Extension\Core\Type\HiddenType' :
+                    'hidden',
+                array(
+                    'mapped' => false,
+                    'data' => $lockVersion,
+                )
+            );
         });
     }
 

--- a/Admin/Extension/LockExtension.php
+++ b/Admin/Extension/LockExtension.php
@@ -59,7 +59,7 @@ class LockExtension extends AbstractAdminExtension
 
             $form->add(
                 $fieldName,
-                // NEXT_MAJOR: remove these three lines and uncomment the one following
+                // NEXT_MAJOR: remove the check and add the FQCN
                 method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
                     'Symfony\Component\Form\Extension\Core\Type\HiddenType' :
                     'hidden',

--- a/Admin/Extension/LockExtension.php
+++ b/Admin/Extension/LockExtension.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Model\LockInterface;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
@@ -57,7 +58,7 @@ class LockExtension extends AbstractAdminExtension
                 return;
             }
 
-            $form->add($fieldName, 'hidden', array(
+            $form->add($fieldName, HiddenType::class, array(
                 'mapped' => false,
                 'data' => $lockVersion,
             ));

--- a/Tests/Admin/Extension/LockExtensionTest.php
+++ b/Tests/Admin/Extension/LockExtensionTest.php
@@ -71,12 +71,14 @@ class LockExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->modelManager->getLockVersion(array())->willReturn(1);
 
-        // NEXT_MAJOR: remove the check and add the FQCN
-        $hiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\HiddenType' :
-            'hidden';
-
-        $form->add('_lock_version', $hiddenType, array('mapped' => false, 'data' => 1))->shouldBeCalled();
+        $form->add(
+            '_lock_version',
+            // NEXT_MAJOR: remove the check and add the FQCN
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+                : 'hidden',
+            array('mapped' => false, 'data' => 1)
+        )->shouldBeCalled();
 
         $this->lockExtension->configureFormFields($formMapper);
         $this->eventDispatcher->dispatch(FormEvents::PRE_SET_DATA, $event);

--- a/Tests/Admin/Extension/LockExtensionTest.php
+++ b/Tests/Admin/Extension/LockExtensionTest.php
@@ -70,7 +70,13 @@ class LockExtensionTest extends \PHPUnit_Framework_TestCase
         $event = new FormEvent($form->reveal(), array());
 
         $this->modelManager->getLockVersion(array())->willReturn(1);
-        $form->add('_lock_version', 'hidden', array('mapped' => false, 'data' => 1))->shouldBeCalled();
+
+        // NEXT_MAJOR: remove the check and add the FQCN
+        $hiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+            'Symfony\Component\Form\Extension\Core\Type\HiddenType' :
+            'hidden';
+
+        $form->add('_lock_version', $hiddenType, array('mapped' => false, 'data' => 1))->shouldBeCalled();
 
         $this->lockExtension->configureFormFields($formMapper);
         $this->eventDispatcher->dispatch(FormEvents::PRE_SET_DATA, $event);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is just a fix for a deprecation warning. Change is BC.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Fixed deprecation for Sf 3. support
```

## Subject

Fixed a Symfony 3 form type as string deprecation warning.