### PR TITLE
[WIP] renaming for batch action logic

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -125,9 +125,9 @@ class CRUDController extends Controller
      *
      * @throws AccessDeniedException If access is not granted
      */
-    public function batchActionDelete(ProxyQueryInterface $query)
+    public function deleteBatchAction(ProxyQueryInterface $query)
     {
-        $this->admin->checkAccess('batchDelete');
+        $this->admin->checkAccess('deleteBatch');
 
         $modelManager = $this->admin->getModelManager();
         try {
@@ -387,7 +387,7 @@ class CRUDController extends Controller
         }
 
         $camelizedAction = Inflector::classify($action);
-        $isRelevantAction = sprintf('batchAction%sIsRelevant', $camelizedAction);
+        $isRelevantAction = sprintf('%sBatchActionIsRelevant', $camelizedAction);
 
         if (method_exists($this, $isRelevantAction)) {
             $nonRelevantMessage = call_user_func(array($this, $isRelevantAction), $idx, $allElements, $request);
@@ -437,8 +437,8 @@ class CRUDController extends Controller
             ), null);
         }
 
-        // execute the action, batchActionXxxxx
-        $finalAction = sprintf('batchAction%s', $camelizedAction);
+        // execute the action, xxxxxBatchAction
+        $finalAction = sprintf('%sBatchAction', $camelizedAction);
         if (!is_callable(array($this, $finalAction))) {
             throw new \RuntimeException(sprintf('A `%s::%s` method must be callable', get_class($this), $finalAction));
         }

--- a/Resources/doc/reference/batch_actions.rst
+++ b/Resources/doc/reference/batch_actions.rst
@@ -48,7 +48,7 @@ merges them onto a single target item. It should only be available when two cond
 Define the core action logic
 ----------------------------
 
-The method ``batchAction<MyAction>`` will be executed to process your batch in your ``CRUDController`` class. The selected
+The method ``<MyAction>BatchAction`` will be executed to process your batch in your ``CRUDController`` class. The selected
 objects are passed to this method through a query argument which can be used to retrieve them.
 If for some reason it makes sense to perform your batch action without the default selection
 method (for example you defined another way, at template level, to select model at a lower
@@ -79,7 +79,7 @@ granularity), the passed query is ``null``.
          *
          * @return RedirectResponse
          */
-        public function batchActionMerge(ProxyQueryInterface $selectedModelQuery, Request $request = null)
+        public function mergeBatchAction(ProxyQueryInterface $selectedModelQuery, Request $request = null)
         {
             $this->admin->checkAccess('edit');
             $this->admin->checkAccess('delete');
@@ -169,8 +169,8 @@ for further explanation of overriding bundle templates.
 
 By default, batch actions are not executed if no object was selected, and the user is notified of
 this lack of selection. If your custom batch action needs more complex logic to determine if
-an action can be performed or not, just define a ``batchAction<MyAction>IsRelevant`` method
-(e.g. ``batchActionMergeIsRelevant``) in your ``CRUDController`` class. This check is performed
+an action can be performed or not, just define a ``<MyAction>BatchActionIsRelevant`` method
+(e.g. ``mergeBatchActionIsRelevant``) in your ``CRUDController`` class. This check is performed
 before the user is asked for confirmation, to make sure there is actually something to confirm.
 
 This method may return three different values:
@@ -193,7 +193,7 @@ This method may return three different values:
 
     class CRUDController extends BaseController
     {
-        public function batchActionMergeIsRelevant(array $selectedIds, $allEntitiesSelected, Request $request = null)
+        public function mergeBatchActionIsRelevant(array $selectedIds, $allEntitiesSelected, Request $request = null)
         {
             // here you have access to all POST parameters, if you use some custom ones
             // POST parameters are kept even after the confirmation page.

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -748,25 +748,25 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
         $this->assertSame('SonataAdminBundle:CRUD:list.html.twig', $this->template);
     }
 
-    public function testBatchActionDeleteAccessDenied()
+    public function testDeleteBatchActionAccessDenied()
     {
         $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
-            ->with($this->equalTo('batchDelete'))
+            ->with($this->equalTo('deleteBatch'))
             ->will($this->throwException(new AccessDeniedException()));
 
-        $this->controller->batchActionDelete($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        $this->controller->deleteBatchAction($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
     }
 
-    public function testBatchActionDelete()
+    public function testDeleteBatchAction()
     {
         $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
-            ->with($this->equalTo('batchDelete'))
+            ->with($this->equalTo('deleteBatch'))
             ->will($this->returnValue(true));
 
         $this->admin->expects($this->once())
@@ -777,17 +777,17 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->method('getFilterParameters')
             ->will($this->returnValue(array('foo' => 'bar')));
 
-        $result = $this->controller->batchActionDelete($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        $result = $this->controller->deleteBatchAction($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_delete_success'), $this->session->getFlashBag()->get('sonata_flash_success'));
         $this->assertSame('list?filter%5Bfoo%5D=bar', $result->getTargetUrl());
     }
 
-    public function testBatchActionDeleteWithModelManagerException()
+    public function testDeleteBatchActionWithModelManagerException()
     {
         $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
-        $this->assertLoggerLogsModelManagerException($modelManager, 'batchDelete');
+        $this->assertLoggerLogsModelManagerException($modelManager, 'deleteBatch');
 
         $this->admin->expects($this->once())
             ->method('getModelManager')
@@ -797,20 +797,20 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->method('getFilterParameters')
             ->will($this->returnValue(array('foo' => 'bar')));
 
-        $result = $this->controller->batchActionDelete($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        $result = $this->controller->deleteBatchAction($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
         $this->assertSame(array('flash_batch_delete_error'), $this->session->getFlashBag()->get('sonata_flash_error'));
         $this->assertSame('list?filter%5Bfoo%5D=bar', $result->getTargetUrl());
     }
 
-    public function testBatchActionDeleteWithModelManagerExceptionInDebugMode()
+    public function testDeleteBatchActionWithModelManagerExceptionInDebugMode()
     {
         $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $this->expectException('Sonata\AdminBundle\Exception\ModelManagerException');
 
         $modelManager->expects($this->once())
-            ->method('batchDelete')
+            ->method('deleteBatch')
             ->will($this->returnCallback(function () {
                 throw new ModelManagerException();
             }));
@@ -823,7 +823,7 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->method('isDebug')
             ->will($this->returnValue(true));
 
-        $this->controller->batchActionDelete($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        $this->controller->deleteBatchAction($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
     }
 
     public function testShowActionNotFoundException()
@@ -3330,7 +3330,7 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
      */
     public function testBatchActionMethodNotExist()
     {
-        $this->expectException('RuntimeException', 'A `Sonata\AdminBundle\Controller\CRUDController::batchActionFoo` method must be callable');
+        $this->expectException('RuntimeException', 'A `Sonata\AdminBundle\Controller\CRUDController::fooBatchAction` method must be callable');
 
         $batchActions = array('foo' => array('label' => 'Foo Bar', 'ask_confirmation' => false));
 
@@ -3659,7 +3659,7 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
         $result = $controller->batchAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $result);
-        $this->assertSame('batchActionBar executed', $result->getContent());
+        $this->assertSame('barBatchAction executed', $result->getContent());
     }
 
     /**

--- a/Tests/Fixtures/Controller/BatchAdminController.php
+++ b/Tests/Fixtures/Controller/BatchAdminController.php
@@ -14,7 +14,7 @@ class BatchAdminController extends CRUDController
     /**
      * Returns true if $idx contains 123 and 456
      */
-    public function batchActionFooIsRelevant(array $idx, $allElements)
+    public function fooBatchActionIsRelevant(array $idx, $allElements)
     {
         if (isset($idx[0]) && $idx[0]==123 && isset($idx[1]) && $idx[1]==456) {
             return true;
@@ -27,19 +27,19 @@ class BatchAdminController extends CRUDController
         return false;
     }
 
-    public function batchActionFoo(ProxyQueryInterface $query)
+    public function fooBatchAction(ProxyQueryInterface $query)
     {
     }
 
-    public function batchActionBarIsRelevant(array $idx, $allElements)
+    public function barBatchActionIsRelevant(array $idx, $allElements)
     {
         return true;
     }
 
-    public function batchActionBar(ProxyQueryInterface $query=null)
+    public function barBatchAction(ProxyQueryInterface $query=null)
     {
         if ($query === null) {
-            return new Response('batchActionBar executed');
+            return new Response('barBatchAction executed');
         }
 
         return false;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this should be result, if you all except I will deprecate the usage.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- naming strategy for batch actions
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

I like the wording `mergeBatchAction`, which sounds better, instead of `batchActionMerge`.

WDYT @sonata-project/contributors 
