### PR TITLE
Allow html labels on list

### DIFF
--- a/Datagrid/ListMapper.php
+++ b/Datagrid/ListMapper.php
@@ -117,7 +117,7 @@ class ListMapper extends BaseMapper
             );
         }
 
-        if (!$fieldDescription->getLabel()) {
+        if ($fieldDescription->getLabel() !== false) {
             $fieldDescription->setOption(
                 'label',
                 $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'list', 'label')

--- a/Resources/doc/reference/action_list.rst
+++ b/Resources/doc/reference/action_list.rst
@@ -539,7 +539,8 @@ You can :
 - `header_style`: Customize the style of header (width, color, background, align...)
 - `header_class`: Customize the class of the header
 - `collapse`: Allow to collapse long text fields with a "read more" link
-- `row_align`:    Customize the alignment of the rendered inner cells
+- `row_align`: Customize the alignment of the rendered inner cells
+- `label_icon`: Add an icon before label
 
 .. code-block:: php
 
@@ -558,6 +559,9 @@ You can :
             ->add('description', 'text', array(
                 'header_style' => 'width: 35%',
                 'collapse' => true
+            )
+            ->add('upvotes', null, array(
+                'label_icon' => 'fa fa-thumbs-o-up'
             )
             ->add('actions', null, array(
                 'header_class' => 'customActions',
@@ -583,7 +587,16 @@ If you want to customise the `collapse` option, you can also give an array to ov
             )
             // ...
 
+If you want to show only the `label_icon`:
 
+.. code-block:: php
+
+            // ...
+            ->add('upvotes', null, array(
+                'label' => false,
+                'label_icon' => 'fa fa-thumbs-o-up'
+            )
+            // ...
 
 .. _`issues on GitHub`: https://github.com/sonata-project/SonataAdminBundle/issues/1519
 

--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -175,6 +175,10 @@ th.sonata-ba-list-field-header-order-asc.sonata-ba-list-field-order-active a:hov
     margin-top: -5px;
 }
 
+.sonata-ba-list-field-header-label-icon {
+  margin-right: 2px;
+}
+
 em.sonata-ba-field-help {
     display: block;
     color: #999;

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -76,7 +76,10 @@ file that was distributed with this source code.
                                             {% spaceless %}
                                                 <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.options.header_class is defined %} {{ field_description.options.header_class }}{% endif %}"{% if field_description.options.header_style is defined %} style="{{ field_description.options.header_style }}"{% endif %}>
                                                     {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters) }}">{% endif %}
-                                                    {{ field_description.label|trans({}, field_description.translationDomain) }}
+                                                    {% if field_description.getOption('label_icon') %}
+                                                        <i class="sonata-ba-list-field-header-label-icon {{ field_description.getOption('label_icon') }}" aria-hidden="true"></i>
+                                                    {% endif %}
+                                                    {{ field_description.label|trans({}, field_description.translationDomain)|raw }}
                                                     {% if sortable %}</a>{% endif %}
                                                 </th>
                                             {% endspaceless %}


### PR DESCRIPTION
I am targeting 3.x, because this is BC, it will not break any current working applications.

## Changelog

```markdown
### Added
- Allow label icon on CRUD list table headers.
- Allow to disable label on CRUD list table heades.
```

## Subject

I want to use Font Awesome icons on table headers:

```php
->add('upvotes', null, [
    'label' => '<i class="fa fa-thumbs-o-up" aria-hidden="true"></i>',
])
->add('downvotes', null, [
    'label' => '<i class="fa fa-thumbs-o-down" aria-hidden="true"></i>',
])
```

But currently it displays the escaped html:

![before](https://user-images.githubusercontent.com/1219000/28057364-163200fc-6620-11e7-9c53-c6b4f1b2bc0a.png)

After adding the raw filter it will look like this:

![after](https://user-images.githubusercontent.com/1219000/28057375-1dafc710-6620-11e7-8bf5-795c40a422a3.png)
