### PR TITLE
fix admin annotation id setting

### DIFF
--- a/Annotation/Admin.php
+++ b/Annotation/Admin.php
@@ -123,6 +123,11 @@ class Admin implements MetadataProcessorInterface
         $tag = array_filter($tag, function ($v) {
             return !is_null($v);
         });
+
+        if (!empty($this->id)) {
+            $metadata->id = $this->id;
+        }
+
         $metadata->tags['sonata.admin'][] = $tag;
         $metadata->arguments = array($this->id, $this->class, $this->baseControllerName);
 

--- a/Resources/doc/reference/annotations.rst
+++ b/Resources/doc/reference/annotations.rst
@@ -38,7 +38,7 @@ If you need to disable this for some reason, you can do this via the configurati
 Define Admins
 ^^^^^^^^^^^^^
 
-All you have to do is include Sonata\AdminBundleAnnotations and define the values you need.
+All you have to do is include ``Sonata\AdminBundle\Annotation`` and define the values you need.
 
 .. code-block:: php
 

--- a/Tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
@@ -53,7 +53,6 @@ class AnnotationCompilerPassTest extends PHPUnit_Framework_TestCase
         $annotation->processMetadata($meta);
 
         $this->assertSame(
-            $meta->tags['sonata.admin'][0],
             array(
                 'manager_type' => 'orm',
                 'group' => 'Admin',
@@ -61,7 +60,8 @@ class AnnotationCompilerPassTest extends PHPUnit_Framework_TestCase
                 'show_in_dashboard' => false,
                 'keep_open' => false,
                 'on_top' => false,
-            )
+            ),
+            $meta->tags['sonata.admin'][0]
         );
     }
 
@@ -78,7 +78,6 @@ class AnnotationCompilerPassTest extends PHPUnit_Framework_TestCase
         $annotation->processMetadata($meta);
 
         $this->assertSame(
-            $meta->tags['sonata.admin'][0],
             array(
                 'manager_type' => 'orm',
                 'group' => 'Admin',
@@ -86,8 +85,25 @@ class AnnotationCompilerPassTest extends PHPUnit_Framework_TestCase
                 'show_in_dashboard' => true,
                 'keep_open' => false,
                 'on_top' => false,
-            )
+            ),
+            $meta->tags['sonata.admin'][0]
         );
+    }
+
+    public function testIdForAdmin()
+    {
+        /*
+         * @Admin(class="Sonata\AdminBundle\Entity\Foo", id="my.id")
+         */
+        $annotation = new Admin();
+        $annotation->class = 'Sonata\AdminBundle\Entity\Foo';
+
+        $meta = new ClassMetadata('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo');
+        $meta->id = 'my.id';
+
+        $annotation->processMetadata($meta);
+
+        $this->assertSame('my.id', $meta->id);
     }
 
     public function testAdmin()
@@ -118,7 +134,6 @@ class AnnotationCompilerPassTest extends PHPUnit_Framework_TestCase
         $annotation->processMetadata($meta);
 
         $this->assertSame(
-            $meta->tags['sonata.admin'][0],
             array(
                 'manager_type' => 'doctrine_mongodb',
                 'group' => 'myGroup',
@@ -126,9 +141,10 @@ class AnnotationCompilerPassTest extends PHPUnit_Framework_TestCase
                 'show_in_dashboard' => false,
                 'keep_open' => true,
                 'on_top' => true,
-            )
+            ),
+            $meta->tags['sonata.admin'][0]
         );
 
-        $this->assertSame($meta->methodCalls[0], array('setTranslationDomain', array('OMG')));
+        $this->assertSame(array('setTranslationDomain', array('OMG')), $meta->methodCalls[0]);
     }
 }


### PR DESCRIPTION
I am targeting this branch, because it is a small fix. 

## Changelog

```markdown
### Fixed
- Take admin annotation id into account
```

## To do
- [x] Update the documentation
- [x] Add an upgrade note

## Subject

service id was not used from annotation and therefor was autogenerated every time. this pull requests corrects this behavior and corrects the namespace of the annotation in the documentation

original in https://github.com/sonata-project/SonataAdminBundle/pull/4555
