### PR TITLE
fix subject assignment in embedded admins

### DIFF
--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -69,11 +69,16 @@ class AdminType extends AbstractType
                             $subject = $subjectCollection->get(trim($options['property_path'], '[]'));
                         }
                     } else {
+                        // this check is to work around duplication issue in property path
+                        // https://github.com/sonata-project/SonataAdminBundle/issues/4425
+                        if ($this->getFieldDescription($options)->getFieldName() === $options['property_path']) {
+                            $path = $options['property_path'];
+                        } else {
+                            $path = $this->getFieldDescription($options)->getFieldName().$options['property_path'];
+                        }
+
                         // for PropertyAccessor >= 2.5
-                        $subject = $p->getValue(
-                            $parentSubject,
-                            $options['property_path']
-                        );
+                        $subject = $p->getValue($parentSubject, $path);
                     }
                     $builder->setData($subject);
                 }

--- a/tests/Form/Type/AdminTypeTest.php
+++ b/tests/Form/Type/AdminTypeTest.php
@@ -114,6 +114,7 @@ class AdminTypeTest extends TypeTestCase
 
         $field = $this->prophesize('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $field->getAssociationAdmin()->shouldBeCalled()->willReturn($admin->reveal());
+        $field->getFieldName()->shouldBeCalled()->willReturn('foo');
 
         $this->builder->add('foo.bar');
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the issue was introduced in https://github.com/sonata-project/SonataAdminBundle/pull/4429

also noted in commit: https://github.com/sonata-project/SonataAdminBundle/commit/0761127cfbaf83f2eec3b02e329f2d751a0b6b0f

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4517
Closes #4475

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- subject assignment in embedded admins
```

## Subject

right now embedded admins within a sonata type collect do not populate subject (this was working till version 3.15)

Since the commit that introduced the error was about fixing a path duplication I also added a check for that (this was in issue: #4425)
<!-- Describe your Pull Request content here -->
