### PR TITLE
Removing deprecated « read_only » usage, added attribute twig loop in…

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -468,7 +468,16 @@ class CRUDController extends Controller
         if (count($idx) > 0) {
             $this->admin->getModelManager()->addIdentifiersToQuery($this->admin->getClass(), $query, $idx);
         } elseif (!$allElements) {
-            $query = null;
+            $this->addFlash(
+                'sonata_flash_info',
+                $this->trans('flash_batch_no_elements_processed', [], 'SonataAdminBundle')
+            );
+
+            return new RedirectResponse(
+                $this->admin->generateUrl('list', [
+                    'filter' => $this->admin->getFilterParameters(),
+                ])
+            );
         }
 
         return call_user_func([$this, $finalAction], $query, $request);

--- a/src/Resources/translations/SonataAdminBundle.en.xliff
+++ b/src/Resources/translations/SonataAdminBundle.en.xliff
@@ -174,6 +174,10 @@
                 <source>flash_batch_delete_success</source>
                 <target>Selected items have been successfully deleted.</target>
             </trans-unit>
+            <trans-unit id="flash_batch_no_elements_processed">
+                <source>flash_batch_no_elements_processed</source>
+                <target>No elements processed.</target>
+            </trans-unit>
             <trans-unit id="flash_batch_delete_error">
                 <source>flash_batch_delete_error</source>
                 <target>An Error has occurred during selected items deletion.</target>

--- a/src/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.fr.xliff
@@ -174,6 +174,10 @@
                 <source>flash_batch_delete_success</source>
                 <target>Les éléments séléctionnés ont été supprimés avec succès.</target>
             </trans-unit>
+            <trans-unit id="flash_batch_no_elements_processed">
+                <source>flash_batch_no_elements_processed</source>
+                <target>Aucun élément traité.</target>
+            </trans-unit>
             <trans-unit id="flash_batch_delete_error">
                 <source>flash_batch_delete_error</source>
                 <target>Une erreur est intervenue lors de la suppression des éléments séléctionnés.</target>

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -11,7 +11,8 @@ file that was distributed with this source code.
 {% spaceless %}
 
     <input type="text" id="{{ id }}_autocomplete_input" value=""
-        {%- if read_only is defined and read_only %} readonly="readonly"{% endif -%}
+        {%- for attribute,value in attr %} {{attribute}}="{{value}}" {% endfor -%}
+        {%- if read_only is defined and read_only %} readonly="readonly"{% endif -%}    {# NEXT_MAJOR: remove #}
         {%- if disabled %} disabled="disabled"{% endif -%}
         {%- if required %} required="required"{% endif %}
     />
@@ -71,7 +72,8 @@ file that was distributed with this source code.
                 placeholder: '{{ placeholder ?: allowClearPlaceholder }}', // allowClear needs placeholder to work properly
                 allowClear: {{ required ? 'false' : 'true' }},
                 enable: {{ disabled ? 'false' : 'true' }},
-                readonly: {{ read_only is defined and read_only or attr.readonly is defined and attr.readonly ? 'true' : 'false' }},
+                readonly: {{ read_only is defined and read_only or attr.readonly is defined and attr.readonly ? 'true' : 'false' }}, {# NEXT_MAJOR: remove #}
+                {# readonly: {{ attr.readonly is defined and attr.readonly ? 'true' : 'false' }}, #}    {# NEXT_MAJOR: uncomment #}
                 minimumInputLength: {{ minimum_input_length }},
                 multiple: {{ multiple ? 'true' : 'false' }},
                 width: function() {

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3647,7 +3647,7 @@ class CRUDControllerTest extends TestCase
         $result = $controller->batchAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $result);
-        $this->assertSame('batchActionBar executed', $result->getContent());
+        $this->assertRegExp('/Redirecting to list/', $result->getContent());
     }
 
     /**


### PR DESCRIPTION
… order to make « readonly » usable when setting attr: readonly in FormField configuration

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the read_only management for sonata_type_model_autocomplete is partially done.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs #3996 (Already closed)
Replace PullRequest #4466

## Changelog

```markdown
### Added
- Add html tag attributes support for sonata_type_model_autocomplete form type

### Removed
- Old usage of read_only var
```

## Subject

Removed unusable read_only var in sonata_type_model_autocomplete view.
Added default attr loop in order to allow using readonly html attribute on hidden input used by select2 widget.