### PR TITLE
Add checkbox range selection

### DIFF
--- a/Resources/doc/reference/action_list.rst
+++ b/Resources/doc/reference/action_list.rst
@@ -627,3 +627,11 @@ in your admin services:
         arguments: [~, Sonata\AdminBundle\Entity\News, ~]
         tags:
             - { name: sonata.admin, manager_type: orm, group: admin, label: News, show_mosaic_button: false }
+
+Checkbox range selection
+------------------------
+
+.. tip::
+
+    You can check / uncheck a range of checkboxes by clicking a first one,
+    then a second one with shift + click.

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -565,6 +565,11 @@ You can listen to this event to trigger custom JavaScript (eg: add a calendar wi
 **TIP**: Setting the 'required' option to true does not cause a requirement of 'at least one' child entity.
 Setting the 'required' option to false causes all nested form fields to become not required as well.
 
+.. tip::
+
+    You can check / uncheck a range of checkboxes by clicking a first one,
+    then a second one with shift + click.
+
 sonata_type_native_collection (previously collection)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -25,6 +25,7 @@ var Admin = {
         Admin.add_filters(subject);
         Admin.setup_select2(subject);
         Admin.setup_icheck(subject);
+        Admin.setup_checkbox_range_selection(subject);
         Admin.setup_xeditable(subject);
         Admin.setup_form_tabs_for_errors(subject);
         Admin.setup_inline_form_errors(subject);
@@ -104,6 +105,55 @@ var Admin = {
                 radioClass: 'iradio_square-blue'
             });
         }
+    },
+    /**
+     * Setup checkbox range selection
+     *
+     * Clicking on a first checkbox then another with shift + click
+     * will check / uncheck all checkboxes between them
+     *
+     * @param {string|Object} subject The html selector or object on which function should be applied
+     */
+    setup_checkbox_range_selection: function(subject) {
+        Admin.log('[core|setup_checkbox_range_selection] configure checkbox range selection on', subject);
+
+        var previousIndex,
+            useICheck = window.SONATA_CONFIG && window.SONATA_CONFIG.USE_ICHECK
+        ;
+
+        // When a checkbox or an iCheck helper is clicked
+        jQuery('tbody input[type="checkbox"], tbody .iCheck-helper', subject).click(function (event) {
+            var input;
+
+            if (useICheck) {
+                input = jQuery(this).prev('input[type="checkbox"]');
+            } else {
+                input = jQuery(this);
+            }
+
+            if (input.length) {
+                var currentIndex = input.closest('tr').index();
+
+                if (event.shiftKey && previousIndex >= 0) {
+                    var isChecked = jQuery('tbody input[type="checkbox"]:nth(' + currentIndex + ')', subject).prop('checked');
+
+                    // Check all checkbox between previous and current one clicked
+                    jQuery('tbody input[type="checkbox"]', subject).each(function (i, e) {
+                        if (i > previousIndex && i < currentIndex || i > currentIndex && i < previousIndex) {
+                            if (useICheck) {
+                                jQuery(e).iCheck(isChecked ? 'check' : 'uncheck');
+
+                                return;
+                            }
+
+                            jQuery(e).prop('checked', isChecked);
+                        }
+                    });
+                }
+
+                previousIndex  = currentIndex;
+            }
+        });
     },
 
     setup_xeditable: function(subject) {


### PR DESCRIPTION
## Changelog

```markdown
### Added
- Added checkbox range selection with shift + click
```
## Subject

This PR adds checkbox range selection by clicking a first then a second checkbox with shift + click. All the checkboxes between them will be checked / unchecked. It's working from top to bottom and vice versa.

I tried to use an existing JS library (checkboxes.js), but it's not working with iCheck. So I ended up adding some custom JS (inspired by https://www.hieule.info/web/html-checkbox-enhancement-icheck-shift-click). It's working when iCheck is enabled or disabled.

![checkbox-range](https://user-images.githubusercontent.com/663607/28668639-228bc780-72d1-11e7-811b-5d404d97a31b.gif)

