### PR TITLE
In menu, allow route_absolute and route_params use for on_top items

### DIFF
--- a/Menu/Provider/GroupMenuProvider.php
+++ b/Menu/Provider/GroupMenuProvider.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Menu\Provider;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Menu provider based on group options.
@@ -159,7 +160,7 @@ class GroupMenuProvider implements MenuProviderInterface
                     $menuItem->setUri($options);
                 } else {
                     $router = $this->pool->getContainer()->get('router');
-                    $menuItem->setUri($router->generate($item['route']));
+                    $menuItem->setUri($router->generate($item['route'], $item['route_params'], $item['route_absolute'] ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH));
                 }
             }
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

I am targeting this branch, because this is a simple and backwards compatible fix/feature.

Resolves #4413

## Changelog

```markdown
### Fixed
- Allow the use of the `route_params` and `route_absolute` options for `on_top` menu items.
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests

## Subject
`on_top` menu items didn't use the knp_menu's options, but instead simply generated the URI via symfony's router. The generate call wasn't using all the options we have(`route_params` and `route_absolute`). It does now.
