### PR TITLE
Reference %sonata.admin.configuration.templates% when possible

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -385,41 +385,13 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         $definition->setMethodCalls($methods);
 
-        // make sure the default templates are defined
-        $definedTemplates = array_merge(array(
-            'user_block' => 'SonataAdminBundle:Core:user_block.html.twig',
-            'add_block' => 'SonataAdminBundle:Core:add_block.html.twig',
-            'layout' => 'SonataAdminBundle::standard_layout.html.twig',
-            'ajax' => 'SonataAdminBundle::ajax_layout.html.twig',
-            'dashboard' => 'SonataAdminBundle:Core:dashboard.html.twig',
-            'list' => 'SonataAdminBundle:CRUD:list.html.twig',
-            'filter' => 'SonataAdminBundle:Form:filter_admin_fields.html.twig',
-            'show' => 'SonataAdminBundle:CRUD:show.html.twig',
-            'show_compare' => 'SonataAdminBundle:CRUD:show_compare.html.twig',
-            'edit' => 'SonataAdminBundle:CRUD:edit.html.twig',
-            'history' => 'SonataAdminBundle:CRUD:history.html.twig',
-            'history_revision_timestamp' => 'SonataAdminBundle:CRUD:history_revision_timestamp.html.twig',
-            'acl' => 'SonataAdminBundle:CRUD:acl.html.twig',
-            'action' => 'SonataAdminBundle:CRUD:action.html.twig',
-            'short_object_description' => 'SonataAdminBundle:Helper:short-object-description.html.twig',
-            'preview' => 'SonataAdminBundle:CRUD:preview.html.twig',
-            'list_block' => 'SonataAdminBundle:Block:block_admin_list.html.twig',
-            'delete' => 'SonataAdminBundle:CRUD:delete.html.twig',
-            'batch' => 'SonataAdminBundle:CRUD:list__batch.html.twig',
-            'select' => 'SonataAdminBundle:CRUD:list__select.html.twig',
-            'batch_confirmation' => 'SonataAdminBundle:CRUD:batch_confirmation.html.twig',
-            'inner_list_row' => 'SonataAdminBundle:CRUD:list_inner_row.html.twig',
-            'base_list_field' => 'SonataAdminBundle:CRUD:base_list_field.html.twig',
-            'pager_links' => 'SonataAdminBundle:Pager:links.html.twig',
-            'pager_results' => 'SonataAdminBundle:Pager:results.html.twig',
-            'tab_menu_template' => 'SonataAdminBundle:Core:tab_menu_template.html.twig',
-            'knp_menu_template' => 'SonataAdminBundle:Menu:sonata_menu.html.twig',
-            'outer_list_rows_mosaic' => 'SonataAdminBundle:CRUD:list_outer_rows_mosaic.html.twig',
-            'outer_list_rows_list' => 'SonataAdminBundle:CRUD:list_outer_rows_list.html.twig',
-            'outer_list_rows_tree' => 'SonataAdminBundle:CRUD:list_outer_rows_tree.html.twig',
-        ), $definedTemplates, $overwrittenTemplates['view']);
+        $definedTemplates = $overwrittenTemplates['view'] + $definedTemplates;
 
-        $definition->addMethodCall('setTemplates', array($definedTemplates));
+        if ($container->getParameter('sonata.admin.configuration.templates') !== $definedTemplates) {
+            $definition->addMethodCall('setTemplates', array($definedTemplates));
+        } else {
+            $definition->addMethodCall('setTemplates', array('%sonata.admin.configuration.templates%'));
+        }
     }
 
     /**

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -96,7 +96,38 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         }
 
         $container->setParameter('sonata.admin.configuration.global_search.empty_boxes', $config['global_search']['empty_boxes']);
-        $container->setParameter('sonata.admin.configuration.templates', $config['templates']);
+        $container->setParameter('sonata.admin.configuration.templates', $config['templates'] + array(
+            'user_block' => 'SonataAdminBundle:Core:user_block.html.twig',
+            'add_block' => 'SonataAdminBundle:Core:add_block.html.twig',
+            'layout' => 'SonataAdminBundle::standard_layout.html.twig',
+            'ajax' => 'SonataAdminBundle::ajax_layout.html.twig',
+            'dashboard' => 'SonataAdminBundle:Core:dashboard.html.twig',
+            'list' => 'SonataAdminBundle:CRUD:list.html.twig',
+            'filter' => 'SonataAdminBundle:Form:filter_admin_fields.html.twig',
+            'show' => 'SonataAdminBundle:CRUD:show.html.twig',
+            'show_compare' => 'SonataAdminBundle:CRUD:show_compare.html.twig',
+            'edit' => 'SonataAdminBundle:CRUD:edit.html.twig',
+            'history' => 'SonataAdminBundle:CRUD:history.html.twig',
+            'history_revision_timestamp' => 'SonataAdminBundle:CRUD:history_revision_timestamp.html.twig',
+            'acl' => 'SonataAdminBundle:CRUD:acl.html.twig',
+            'action' => 'SonataAdminBundle:CRUD:action.html.twig',
+            'short_object_description' => 'SonataAdminBundle:Helper:short-object-description.html.twig',
+            'preview' => 'SonataAdminBundle:CRUD:preview.html.twig',
+            'list_block' => 'SonataAdminBundle:Block:block_admin_list.html.twig',
+            'delete' => 'SonataAdminBundle:CRUD:delete.html.twig',
+            'batch' => 'SonataAdminBundle:CRUD:list__batch.html.twig',
+            'select' => 'SonataAdminBundle:CRUD:list__select.html.twig',
+            'batch_confirmation' => 'SonataAdminBundle:CRUD:batch_confirmation.html.twig',
+            'inner_list_row' => 'SonataAdminBundle:CRUD:list_inner_row.html.twig',
+            'base_list_field' => 'SonataAdminBundle:CRUD:base_list_field.html.twig',
+            'pager_links' => 'SonataAdminBundle:Pager:links.html.twig',
+            'pager_results' => 'SonataAdminBundle:Pager:results.html.twig',
+            'tab_menu_template' => 'SonataAdminBundle:Core:tab_menu_template.html.twig',
+            'knp_menu_template' => 'SonataAdminBundle:Menu:sonata_menu.html.twig',
+            'outer_list_rows_mosaic' => 'SonataAdminBundle:CRUD:list_outer_rows_mosaic.html.twig',
+            'outer_list_rows_list' => 'SonataAdminBundle:CRUD:list_outer_rows_list.html.twig',
+            'outer_list_rows_tree' => 'SonataAdminBundle:CRUD:list_outer_rows_tree.html.twig',
+        ));
         $container->setParameter('sonata.admin.configuration.admin_services', $config['admin_services']);
         $container->setParameter('sonata.admin.configuration.dashboard_groups', $config['dashboard']['groups']);
         $container->setParameter('sonata.admin.configuration.dashboard_blocks', $config['dashboard']['blocks']);


### PR DESCRIPTION
## Changelog

```markdown
### Added
- Reference %sonata.admin.configuration.templates% when possible
```

## Subject

This PR allows generating lighter containers by leveraging https://github.com/symfony/symfony/pull/23143
This prevents generating the same array again for all service blocks - and replacing them by a simple reference to the parameter's value.