### PR TITLE
Fix getSubject method when admin has parentFieldDescription

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1688,7 +1688,7 @@ EOT;
      */
     public function getSubject()
     {
-        if ($this->subject === null && $this->request) {
+        if ($this->subject === null && $this->request && !$this->hasParentFieldDescription()) {
             $id = $this->request->get($this->getIdParameter());
             $this->subject = $this->getModelManager()->find($this->class, $id);
         }

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -23,6 +23,7 @@ use Sonata\AdminBundle\Tests\Fixtures\Admin\FilteredAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\ModelAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\PostWithCustomRouteAdmin;
+use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Comment;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Tag;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
@@ -1649,6 +1650,36 @@ class AdminTest extends PHPUnit_Framework_TestCase
         $admin->setRequest(new Request(array('id' => $id)));
         $this->assertSame($entity, $admin->getSubject());
         $this->assertSame($entity, $admin->getSubject()); // model manager must be used only once
+    }
+
+    public function testGetSubjectWithParentDescription()
+    {
+        $adminId = 1;
+
+        $comment = new Comment();
+
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager
+            ->expects($this->any())
+            ->method('find')
+            ->with('NewsBundle\Entity\Comment', $adminId)
+            ->will($this->returnValue($comment));
+
+        $request = new Request(array('id' => $adminId));
+
+        $postAdmin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $postAdmin->setRequest($request);
+
+        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
+        $commentAdmin->setRequest($request);
+        $commentAdmin->setModelManager($modelManager);
+
+        $this->assertEquals($comment, $commentAdmin->getSubject());
+
+        $commentAdmin->setSubject(null);
+        $commentAdmin->setParentFieldDescription(new FieldDescription());
+
+        $this->assertNull($commentAdmin->getSubject());
     }
 
     /**


### PR DESCRIPTION

## Changelog
```markdown
### Fixed
- Fixed AbstractAdmin::getSubject on admins with parentFieldDescription
```

## To do
- [x] Update the tests

## Subject

When an admin has a `parentFieldDescription`, the `AbstractAdmin::getSubject` method should not use the url id parameter to load the object (because the id correspond to the root object only).

Example: I have an issue when submitting a form with a collection which contains an `AdminType` field. In `AdminType`, this line loads a (random) collection element by using the url id (which is the root object id) : https://github.com/sonata-project/SonataAdminBundle/blob/3.x/Form/Type/AdminType.php#L57

Should fix https://github.com/sonata-project/SonataAdminBundle/issues/2879