### PR TITLE
Fix bug with creating new object while editing

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -130,6 +130,7 @@ class CRUDController extends Controller
         $this->admin->checkAccess('batchDelete');
 
         $modelManager = $this->admin->getModelManager();
+
         try {
             $modelManager->batchDelete($this->admin->getClass(), $query);
             $this->addFlash('sonata_flash_success', 'flash_batch_delete_success');
@@ -250,6 +251,7 @@ class CRUDController extends Controller
         }
 
         $this->admin->setSubject($existingObject);
+        $objectId = $this->admin->getNormalizedIdentifier($existingObject);
 
         /** @var $form Form */
         $form = $this->admin->getForm();
@@ -274,7 +276,7 @@ class CRUDController extends Controller
                     if ($this->isXmlHttpRequest()) {
                         return $this->renderJson(array(
                             'result' => 'ok',
-                            'objectId' => $this->admin->getNormalizedIdentifier($existingObject),
+                            'objectId' => $objectId,
                             'objectName' => $this->escapeHtml($this->admin->toString($existingObject)),
                         ), 200, array());
                     }
@@ -330,6 +332,7 @@ class CRUDController extends Controller
             'action' => 'edit',
             'form' => $formView,
             'object' => $existingObject,
+            'objectId' => $objectId,
         ), null);
     }
 
@@ -571,6 +574,7 @@ class CRUDController extends Controller
             'action' => 'create',
             'form' => $formView,
             'object' => $newObject,
+            'objectId' => null,
         ), null);
     }
 
@@ -1106,6 +1110,7 @@ class CRUDController extends Controller
             foreach (array('edit', 'show') as $route) {
                 if ($this->admin->hasRoute($route) && $this->admin->hasAccess($route, $object)) {
                     $url = $this->admin->generateObjectUrl($route, $object);
+
                     break;
                 }
             }

--- a/Resources/views/CRUD/base_edit.html.twig
+++ b/Resources/views/CRUD/base_edit.html.twig
@@ -12,7 +12,8 @@ file that was distributed with this source code.
 {% extends base_template %}
 
 {% block title %}
-    {% if admin.id(object) is not null %}
+    {# NEXT_MAJOR: remove default filter #}
+    {% if objectId|default(admin.id(object)) is not null %}
         {{ "title_edit"|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
     {% else %}
         {{ "title_create"|trans({}, 'SonataAdminBundle') }}

--- a/Resources/views/CRUD/base_edit_form.html.twig
+++ b/Resources/views/CRUD/base_edit_form.html.twig
@@ -2,7 +2,8 @@
     {% import "SonataAdminBundle:CRUD:base_edit_form_macro.html.twig" as form_helper %}
     {{ sonata_block_render_event('sonata.admin.edit.form.top', { 'admin': admin, 'object': object }) }}
 
-    {% set url = admin.id(object) is not null ? 'edit' : 'create' %}
+    {# NEXT_MAJOR: remove default filter #}
+    {% set url = objectId|default(admin.id(object)) is not null ? 'edit' : 'create' %}
 
     {% if not admin.hasRoute(url)%}
         <div>
@@ -12,7 +13,8 @@
         <form
               {% if sonata_admin.adminPool.getOption('form_type') == 'horizontal' %}class="form-horizontal"{% endif %}
               role="form"
-              action="{% block sonata_form_action_url %}{{ admin.generateUrl(url, {'id': admin.id(object), 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}) }}{% endblock %}"
+              {# NEXT_MAJOR: remove default filter #}
+              action="{% block sonata_form_action_url %}{{ admin.generateUrl(url, {'id': objectId|default(admin.id(object)), 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}) }}{% endblock %}"
               {% if form.vars.multipart %} enctype="multipart/form-data"{% endif %}
               method="POST"
               {% if not sonata_admin.adminPool.getOption('html5_validate') %}novalidate="novalidate"{% endif %}
@@ -68,7 +70,8 @@
                 <div class="sonata-ba-form-actions well well-small form-actions">
                 {% block sonata_form_actions %}
                     {% if app.request.isxmlhttprequest %}
-                        {% if admin.id(object) is not null %}
+                        {# NEXT_MAJOR: remove default filter #}
+                        {% if objectId|default(admin.id(object)) is not null %}
                             <button type="submit" class="btn btn-success" name="btn_update"><i class="fa fa-save" aria-hidden="true"></i> {{ 'btn_update'|trans({}, 'SonataAdminBundle') }}</button>
                         {% else %}
                             <button type="submit" class="btn btn-success" name="btn_create"><i class="fa fa-plus-circle" aria-hidden="true"></i> {{ 'btn_create'|trans({}, 'SonataAdminBundle') }}</button>
@@ -80,7 +83,8 @@
                                 {{ 'btn_preview'|trans({}, 'SonataAdminBundle') }}
                             </button>
                         {% endif %}
-                        {% if admin.id(object) is not null %}
+                        {# NEXT_MAJOR: remove default filter #}
+                        {% if objectId|default(admin.id(object)) is not null %}
                             <button type="submit" class="btn btn-success" name="btn_update_and_edit"><i class="fa fa-save" aria-hidden="true"></i> {{ 'btn_update_and_edit_again'|trans({}, 'SonataAdminBundle') }}</button>
 
                             {% if admin.hasRoute('list') and admin.hasAccess('list') %}


### PR DESCRIPTION
Closes #4545

## Changelog

```markdown
### Changed
- Passing object id in edit form from CRUD controller instead of getting it in twig
```

## Subject
Passing object id from controller prevent situation when in twig we can't get object id because model manager reopened. It geting id before starts operations with database and will always open edit form even we have some database exception.