### PR TITLE
Use fully qualified hidden type

### DIFF
--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -52,7 +52,15 @@ class ModelAutocompleteType extends AbstractType
 
         if ($options['multiple']) {
             $resizeListener = new ResizeFormListener(
-                'hidden', array(), true, true, true
+                // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+                // (when requirement of Symfony is >= 2.8)
+                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+                    : 'hidden',
+                array(),
+                true,
+                true,
+                true
             );
 
             $builder->addEventSubscriber($resizeListener);


### PR DESCRIPTION
I am targeting this branch, because this fixes a deprecation warning.

## Changelog

```markdown
### Fixed
- Fixed deprecation when using hidden form type in model autocomplete
```

## Subject
Fixed deprecation warning.
