### PR TITLE
Adding a function that grabs the ID from the request

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -164,7 +164,9 @@ class CRUDController extends Controller
     public function deleteAction($id)
     {
         $request = $this->getRequest();
-        $id = $request->get($this->admin->getIdParameter());
+
+        $id = $this->getObjectIdFromRouteIdHandler();
+
         $object = $this->admin->getObject($id);
 
         if (!$object) {
@@ -238,11 +240,11 @@ class CRUDController extends Controller
      */
     public function editAction($id = null)
     {
-        $request = $this->getRequest();
         // the key used to lookup the template
         $templateKey = 'edit';
 
-        $id = $request->get($this->admin->getIdParameter());
+        $request = $this->getRequest();
+        $id = $this->getObjectIdFromRouteIdHandler();
         $existingObject = $this->admin->getObject($id);
 
         if (!$existingObject) {
@@ -600,7 +602,7 @@ class CRUDController extends Controller
     public function showAction($id = null)
     {
         $request = $this->getRequest();
-        $id = $request->get($this->admin->getIdParameter());
+        $id = $this->getObjectIdFromRouteIdHandler();
 
         $object = $this->admin->getObject($id);
 
@@ -637,7 +639,7 @@ class CRUDController extends Controller
     public function historyAction($id = null)
     {
         $request = $this->getRequest();
-        $id = $request->get($this->admin->getIdParameter());
+        $id = $this->getObjectIdFromRouteIdHandler();
 
         $object = $this->admin->getObject($id);
 
@@ -684,7 +686,7 @@ class CRUDController extends Controller
     public function historyViewRevisionAction($id = null, $revision = null)
     {
         $request = $this->getRequest();
-        $id = $request->get($this->admin->getIdParameter());
+        $id = $this->getObjectIdFromRouteIdHandler();
 
         $object = $this->admin->getObject($id);
 
@@ -748,7 +750,7 @@ class CRUDController extends Controller
 
         $this->admin->checkAccess('historyCompareRevisions');
 
-        $id = $request->get($this->admin->getIdParameter());
+        $id = $this->getObjectIdFromRouteIdHandler();
 
         $object = $this->admin->getObject($id);
 
@@ -881,7 +883,7 @@ class CRUDController extends Controller
             throw $this->createNotFoundException('ACL are not enabled for this admin');
         }
 
-        $id = $request->get($this->admin->getIdParameter());
+        $id = $this->getObjectIdFromRouteIdHandler();
 
         $object = $this->admin->getObject($id);
 
@@ -1399,6 +1401,15 @@ class CRUDController extends Controller
         $domain = $domain ?: $this->admin->getTranslationDomain();
 
         return $this->get('translator')->trans($id, $parameters, $domain, $locale);
+    }
+
+    /**
+     * @return int|string
+     */
+    protected function getObjectIdFromRouteIdHandler()
+    {
+        return $this->get('sonata.admin.route_id_handler')
+            ->getIdFromRequest($this->getRequest(), $this->admin);
     }
 
     /**

--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -274,6 +274,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             'translator' => 'translator',
             'configuration_pool' => 'sonata.admin.pool',
             'route_generator' => 'sonata.admin.route.default_generator',
+            'route_id_handler' => 'sonata.admin.default_route_id_handler',
             'validator' => 'validator',
             'security_handler' => 'sonata.admin.security.handler',
             'menu_factory' => 'knp_menu.factory',

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -255,6 +255,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('translator')->defaultNull()->end()
                             ->scalarNode('configuration_pool')->defaultNull()->end()
                             ->scalarNode('route_generator')->defaultNull()->end()
+                            ->scalarNode('route_id_handler')->defaultNull()->end()
                             ->scalarNode('validator')->defaultNull()->end()
                             ->scalarNode('security_handler')->defaultNull()->end()
                             ->scalarNode('label')->defaultNull()->end()

--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -27,6 +27,8 @@
         <service id="sonata.admin.breadcrumbs_builder" class="Sonata\AdminBundle\Admin\BreadcrumbsBuilder">
             <argument>%sonata.admin.configuration.breadcrumbs%</argument>
         </service>
+        <service id="sonata.admin.route_id_handler" class="Sonata\AdminBundle\Route\RouteIdHandler"/>
+        <service id="sonata.admin.default_route_id_handler" alias="sonata.admin.route_id_handler"/>
         <!-- Services used to format the label, default is sonata.admin.label.strategy.noop -->
         <service id="sonata.admin.label.strategy.bc" class="Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy"/>
         <service id="sonata.admin.label.strategy.native" class="Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy"/>

--- a/Resources/doc/cookbook/recipe_hashid.rst
+++ b/Resources/doc/cookbook/recipe_hashid.rst
@@ -1,0 +1,126 @@
+Securing route id's with HashId
+===============================
+
+If you're working on an app where you need to hide the ID's from the
+routes then a good way to do it would be to use HashId_. There is
+a `HashId Symfony Bundle`_ which you can install and configure.
+
+Overriding the output of all URLs
+---------------------------------
+
+First you will need to encoding all the URLs that Sonata outputs,
+below I have chosen to use the ``encodeHex`` function but there is
+also an ``encode`` function. For more information on this see the
+documentation in the `HashId Symfony Bundle`_
+
+.. code:: php
+
+    class MyAdmin extends AbstractAdmin
+    {
+        /**
+         * @var HashId
+         */
+        private $hashId
+
+        /**
+         * @param string $code
+         * @param string $class
+         * @param string $baseControllerName
+         * @param HashId $hashId
+         */
+        public function __construct($code, $class, $baseControllerName, HashId $hashId)
+        {
+            parent::__construct($code, $class, $baseControllerName);
+            $this->hashId = $hashId
+        }
+
+        ... other configurations
+
+        /**
+         * @param string $name
+         * @param mixed $object
+         * @param array $parameters
+         * @param bool|int $absolute
+         * @return string
+         */
+        public function generateObjectUrl($name, $object, array $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
+        {
+            $parameters['id'] = $this->hashId->encodeHex($this->getUrlsafeIdentifier($object));
+
+            return $this->generateUrl($name, $parameters, $absolute);
+        }
+    }
+
+
+Now your routes will change from ``/product/1/edit`` to
+``/product/af5/edit``, child routes will also be changed if you have
+chosen to use them e.g. ``product/af5/child/e6D/edit``. So now you will
+have to tell your controllers to decode these. For this implement a
+class that uses the ``RouteIdHandlerInterface`` to decode the id held
+in the request. For example
+
+.. code:: php
+
+    class HashIdRouteIdHandler implements RouteIdHandlerInterface
+    {
+        /**
+         * @var HashId
+         */
+        private $hashId
+
+        /**
+         * @param HashId $hashId
+         */
+        public function __construct(HashId $hashId)
+        {
+            $this->hashId = $hashId
+        }
+
+        /**
+         * @param Request $request
+         * @param AdminInterface $admin
+         *
+         * @return int|string
+         */
+        public function getIdFromRequest(Request $request, AdminInterface $admin)
+        {
+            return $this->hashId->decodeHex($request->get($admin->getIdParameter()));
+        }
+    }
+
+You'll need to tell Sonata admin to use your new handler which will use
+the new handler for all routes of your admin suite
+
+.. code:: php
+
+    # config.yml
+
+    sonata_admin:
+        route_id_handler: hashid_route_id_handler
+
+
+However, If you want to selectively implement this into some of your Admin
+sections and not others then we would advise that you create an
+interface, and make your Admin implement that and then detect it as
+required. E.g
+
+.. code:: php
+
+    /**
+     * @return int|string
+     */
+    public function getIdFromRequest(Request $request, AdminInterface $admin)
+    {
+        if ($admin instanceof HashedAdminInterface) {
+            return $this->hashId->decodeHex($request->get($admin->getIdParameter()));
+        }
+
+        return $request->get($admin->getIdParameter());
+    }
+
+Be aware that this is just an example of ``HashedAdminInterface`` it is
+not included with Sonata Admin and you can use any sort of test to
+determine if your request will need decoding.
+
+.. _HashId: http://hashids.org/
+.. _HashId Symfony Bundle: https://github.com/roukmoute/HashidsBundle

--- a/Resources/doc/cookbook/recipe_overwrite_admin_configuration.rst
+++ b/Resources/doc/cookbook/recipe_overwrite_admin_configuration.rst
@@ -19,6 +19,7 @@ From the configuration file, you can add a new section named ``admin_services`` 
                 translator:                 translator
                 configuration_pool:         sonata.admin.pool
                 route_generator:            sonata.admin.route.default_generator
+                route_id_handler:           sonata.admin.default_route_id_handler
                 validator:                  validator
                 security_handler:           sonata.admin.security.handler
                 menu_factory:               knp_menu.factory

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -83,6 +83,7 @@ The demo website can be found at http://demo.sonata-project.org.
    cookbook/recipe_knp_menu
    cookbook/recipe_file_uploads
    cookbook/recipe_image_previews
+   cookbook/recipe_hashid
    cookbook/recipe_row_templates
    cookbook/recipe_sortable_listing
    cookbook/recipe_dynamic_form_modification

--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -119,6 +119,7 @@ Full Configuration Options
                 translator:           null
                 configuration_pool:   null
                 route_generator:      null
+                route_id_handler:     null
                 validator:            null
                 security_handler:     null
                 label:                null

--- a/Route/Handler/RouteIdHandler.php
+++ b/Route/Handler/RouteIdHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Route\Handler;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class RouteIdHandler implements RouteIdHandlerInterface
+{
+    /**
+     * @param Request        $request
+     * @param AdminInterface $admin
+     *
+     * @return int|string
+     */
+    public function getIdFromRequest(Request $request, AdminInterface $admin)
+    {
+        return $request->get($admin->getIdParameter());
+    }
+}

--- a/Route/Handler/RouteIdHandlerInterface.php
+++ b/Route/Handler/RouteIdHandlerInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Route\Handler;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+interface RouteIdHandlerInterface
+{
+    /**
+     * @param Request        $request
+     * @param AdminInterface $admin
+     *
+     * @return int|string
+     */
+    public function getIdFromRequest(Request $request, AdminInterface $admin);
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -77,6 +77,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
             'translator' => null,
             'configuration_pool' => null,
             'route_generator' => null,
+            'route_id_handler' => null,
             'validator' => null,
             'security_handler' => null,
             'label' => null,

--- a/Tests/Route/RouteIdHandlerTest.php
+++ b/Tests/Route/RouteIdHandlerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Route;
+
+use Sonata\AdminBundle\Route\Handler\RouteIdHandler;
+
+class RouteIdHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetIdFromRequest()
+    {
+        $idParameter = 'id';
+        $requestId = 1;
+
+        $adminInterface = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $adminInterface->expects($this->once())
+            ->method('getIdParameter')
+            ->will($this->returnValue($idParameter));
+
+        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->getMock();
+        $request->expects($this->once())
+            ->method('get')
+            ->with($idParameter)
+            ->will($this->returnValue($requestId));
+
+        $routeIdHandler = new RouteIdHandler();
+        $returnId = $routeIdHandler->getIdFromRequest($request, $adminInterface);
+        $this->assertEquals($requestId, $returnId);
+    }
+}


### PR DESCRIPTION
## Subject

Added a `RouteIdHandlerInterface` component that will allow developers to change how the ID is taken from the route in the request. By default, it will take the ID from the ID parameter. But the intention is to be able to easily add a component that will decode any encoded IDs. For example using something like [HashIds](https://github.com/roukmoute/HashidsBundle) to secure routes from users.

## Changelog

```markdown
### Added
- RouteIdHandler that decides how to process the ID in the route on CRUDController
```
