### PR TITLE
Added refresh option to stats block

### DIFF
--- a/Block/AdminStatsBlockService.php
+++ b/Block/AdminStatsBlockService.php
@@ -12,16 +12,22 @@
 namespace Sonata\AdminBundle\Block;
 
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Model\Metadata;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Christian Gripp <mail@core23.de>
  */
-class AdminStatsBlockService extends AbstractBlockService
+class AdminStatsBlockService extends AbstractAdminBlockService
 {
     /**
      * @var Pool
@@ -29,15 +35,150 @@ class AdminStatsBlockService extends AbstractBlockService
     protected $pool;
 
     /**
-     * @param string          $name
-     * @param EngineInterface $templating
-     * @param Pool            $pool
+     * Colors available in AdminLTE 2.3.3 css for background with bg-xxx and bg-xxx-active.
+     *
+     * @var string[]
      */
-    public function __construct($name, EngineInterface $templating, Pool $pool)
+    private $colors = array(
+        'bg-red' => 'red',
+        'bg-yellow' => 'yellow',
+        'bg-aqua' => 'aqua',
+        'bg-blue' => 'blue',
+        'bg-light-blue' => 'light-blue',
+        'bg-green' => 'green',
+        'bg-navy' => 'navy',
+        'bg-teal' => 'teal',
+        'bg-olive' => 'olive',
+        'bg-lime' => 'lime',
+        'bg-orange' => 'orange',
+        'bg-fuchsia' => 'fuchsia',
+        'bg-purple' => 'purple',
+        'bg-maroon' => 'maroon',
+        'bg-black' => 'black',
+    );
+
+    /**
+     * Each template corresponds to the AdminLTE 2.3.3 widgets.
+     *
+     * @var string[]
+     */
+    private $templates = array(
+        'SonataAdminBundle:Block:block_stats_simple.html.twig' => 'simple',
+        'SonataAdminBundle:Block:block_stats_link.html.twig' => 'link',
+    );
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @param string                   $name
+     * @param EngineInterface          $templating
+     * @param Pool                     $pool
+     * @param TranslatorInterface|null $translator
+     *
+     * NEXT_MAJOR: make the translator required
+     */
+    public function __construct($name, EngineInterface $templating, Pool $pool, TranslatorInterface $translator = null)
     {
         parent::__construct($name, $templating);
 
         $this->pool = $pool;
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildEditForm(FormMapper $form, BlockInterface $block)
+    {
+        $admins = array();
+        foreach ($this->pool->getAdminGroups() as $group => $data) {
+            $groupLabel = $this->translator ?
+                $this->translator->trans($data['label'], array(), $data['label_catalogue']) :
+                $data['label'];
+
+            foreach ($data['items'] as $item) {
+                $label = $item['label'] && $this->translator ? $this->translator->trans($item['label'], array(), $data['label_catalogue']) : $item['admin'];
+
+                $admins[$groupLabel][$label] = $item['admin'];
+            }
+        }
+
+        $colorChoices = $this->colors;
+        $colorChoiceOptions = array(
+            'required' => true,
+            'label' => 'form.label_color',
+            'choice_translation_domain' => false,
+        );
+
+        $templateChoices = $this->templates;
+        $templateChoiceOptions = array(
+            'required' => true,
+            'label' => 'form.label_template',
+            'choice_label' => function ($value, $key, $index) {
+                return 'form.template_'.$index;
+            },
+        );
+
+        // NEXT_MAJOR: remove SF 2.7+ BC
+        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+            // choice_as_value options is not needed in SF 3.0+
+            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                $colorChoiceOptions['choices_as_values'] = true;
+            }
+            $colorChoices = array_flip($colorChoices);
+            $templateChoices = array_flip($templateChoices);
+        }
+        $colorChoiceOptions['choices'] = $colorChoices;
+        $templateChoiceOptions['choices'] = $templateChoices;
+
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        $arrayType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\CoreBundle\Form\Type\ImmutableArrayType' : 'sonata_type_immutable_array';
+        $choiceType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice';
+        $textType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\TextType' : 'text';
+        $yamlType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\YamlType' : 'sonata_type_yaml';
+        $numberType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\NumberType' : 'number';
+
+        $form->add('settings', $arrayType, array(
+            'keys' => array(
+                array('code', $choiceType, array(
+                   'required' => true,
+                   'label' => 'form.label_code',
+                   'choices' => $admins,
+                   'choice_translation_domain' => false,
+                )),
+                array('filters', $yamlType, array(
+                    'required' => false,
+                    'label' => 'form.label_filters',
+                )),
+                array('text', $textType, array(
+                    'required' => false,
+                    'label' => 'form.label_text',
+                )),
+                array('class', $textType, array(
+                    'required' => false,
+                    'label' => 'form.label_class',
+                )),
+                array('icon', $textType, array(
+                    'required' => false,
+                    'label' => 'form.label_icon',
+                )),
+                array('limit', $numberType, array(
+                    'required' => false,
+                    'label' => 'form.label_limit',
+                )),
+                array('color', $choiceType, $colorChoiceOptions),
+                array('template', $choiceType, $templateChoiceOptions),
+            ),
+            'translation_domain' => 'SonataAdminBundle',
+        ));
     }
 
     /**
@@ -74,9 +215,14 @@ class AdminStatsBlockService extends AbstractBlockService
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
     {
-        return 'Admin Stats';
+        if (($code = $block->getSetting('code')) && $code !== '' && !$this->pool->getAdminByAdminCode($code)) {
+            // If we specified a admin, check that it exists
+            $errorElement->with('code')
+                ->addViolation('sonata.admin.not_existing', array('code' => $code))
+            ->end();
+        }
     }
 
     /**
@@ -85,13 +231,54 @@ class AdminStatsBlockService extends AbstractBlockService
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'icon' => 'fa-line-chart',
+            'icon' => 'fa fa-line-chart',
             'text' => 'Statistics',
             'color' => 'bg-aqua',
             'code' => false,
+            'class' => '',
             'filters' => array(),
             'limit' => 1000,
-            'template' => 'SonataAdminBundle:Block:block_stats.html.twig',
+            'template' => 'SonataAdminBundle:Block:block_stats_simple.html.twig',
         ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockMetadata($code = null)
+    {
+        return new Metadata($this->getName(), (!is_null($code) ? $code : $this->getName()), false, 'SonataAdminBundle', array(
+            'class' => 'fa fa-dashboard',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJavascripts($media)
+    {
+        return array(
+            'bundles/sonataadmin/stats-block.js',
+        );
+    }
+
+    /**
+     * Set possible widget colors.
+     *
+     * @param string[] $colors
+     */
+    public function setColors(array $colors)
+    {
+        $this->colors = $colors;
+    }
+
+    /**
+     * Set possible templates.
+     *
+     * @param string[] $templates
+     */
+    public function setTemplates(array $templates)
+    {
+        $this->templates = $templates;
     }
 }

--- a/Form/Type/YamlType.php
+++ b/Form/Type/YamlType.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Yaml\Yaml;
+
+final class YamlType extends AbstractType implements DataTransformerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addModelTransformer($this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($array)
+    {
+        if (empty($array) || !is_array($array)) {
+            return '';
+        }
+
+        return Yaml::dump($array);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($text)
+    {
+        return Yaml::parse($text);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return 'Symfony\Component\Form\Extension\Core\Type\TextareaType';
+    }
+}

--- a/Resources/config/block.xml
+++ b/Resources/config/block.xml
@@ -19,6 +19,7 @@
             <argument>sonata.admin.block.stats</argument>
             <argument type="service" id="templating"/>
             <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="translator"/>
         </service>
     </services>
 </container>

--- a/Resources/config/form_types.xml
+++ b/Resources/config/form_types.xml
@@ -27,6 +27,9 @@
         <service id="sonata.admin.doctrine_orm.form.type.choice_field_mask" class="Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType">
             <tag name="form.type" alias="sonata_type_choice_field_mask"/>
         </service>
+        <service id="sonata.admin.form.type.yaml" class="Sonata\AdminBundle\Form\Type\YamlType">
+            <tag name="form.type" alias="sonata_type_yaml"/>
+        </service>
         <!-- Form Extension -->
         <service id="sonata.admin.form.extension.field" class="Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension">
             <tag name="form.type_extension" alias="form" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType"/>

--- a/Resources/config/routing/sonata_admin.xml
+++ b/Resources/config/routing/sonata_admin.xml
@@ -28,4 +28,7 @@
     <route id="sonata_admin_retrieve_autocomplete_items" path="/core/get-autocomplete-items">
         <default key="_controller">sonata.admin.controller.admin:retrieveAutocompleteItemsAction</default>
     </route>
+    <route id="sonata_admin_stats" path="/core/getöstats">
+        <default key="_controller">SonataAdminBundle:Core:stats</default>
+    </route>
 </routes>

--- a/Resources/public/stats-block.js
+++ b/Resources/public/stats-block.js
@@ -1,0 +1,37 @@
+/**
+ *
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+(function ($) {
+    function fetchBlock($block) {
+        var overlay = $('<div class="overlay"><div class="fa fa-refresh fa-spin"></div></div>');
+        // missing AdminLTE css for info-box necessary for overlay
+        $block.find('.overlay-wrapper').css('position', 'relative');
+        // show a loading indicator
+        $block.find('.overlay-wrapper').append(overlay);
+        return $.ajax($block.data('url')).done(function (json) {
+            // populate the block with html
+            $block.find('.url-count').html(json.count);
+        }).fail(function (xhr) {
+            // show an error symbol
+            $block.find('.url-count').html('<div class="fa fa-remove text-danger"></div>');
+        }).always(function () {
+            // hide the loading indicator
+            $block.find(overlay).remove();
+        })
+    }
+
+    $(function () {
+        $('.sonata-ajax-block').on('click', '.refresh-btn', function (event) {
+            var $block = $(event.target).closest('.sonata-ajax-block');
+            fetchBlock($block)
+        })
+    })
+}(jQuery));

--- a/Resources/translations/SonataAdminBundle.ar.xliff
+++ b/Resources/translations/SonataAdminBundle.ar.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>إدارة</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>حذف</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>أوافق</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>إنشاء</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>إنشاء</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>إنشاء وإضافة أخرى</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>إنشاء والعودة إلى قائمة</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>تصفية</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>btn_advanced_filters</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>تحديث</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>تحديث</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>تحديث و اغلاق</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>حذف</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>إضافة جديدة</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>العودة إلى القائمة</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>عرض</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>تعديل</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>إضافة جديدة</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>قائمة</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>إعادة تعيين</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>إنشاء</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>لوحة المشرف</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>تعديل "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>قائمة</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>التالي</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>السابق</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>الأول</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>الأخير</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>مشرف</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>توسيع / طي</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>لا نتائج</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>هل أنت متأكد؟</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>تعديل</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>عرض</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>جميع العناصر</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>الغاء العملية.لم يتم اختيار عنصر</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>العنصر "%name%" تم إنشاؤه بنجاح.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>حدث خطأ أثناء إنشاء العنصر "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>العنصر "%name%" تم تحديثه بنجاح.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>حدث خطأ أثناء إنشاء العنصر "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>flash_lock_error</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>تم حذف العناصر المحددة بنجاح.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>حدث خطأ أثناء حذف العناصر المحددة.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>حدث خطأ أثناء حذف العنصر "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>العنصر "%name%" تم حذفه بنجاح.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>form_not_available</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>تأكيد الحذف</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>هل أنت متأكد أنك تريد حذف العنصر المحدد؟</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>نعم، حذف</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>تأكيد العملية'%action%'</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>]1,Inf] هل أنت متأكد أنك تريد تأكيد و تنفيذ هذا العمل ل  %count% عناصر المحددة؟|{1} هل أنت متأكد أنك تريد تأكيد و تنفيذ هذا العمل للعنصر المحدد؟</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>هل أنت متأكد أنك تريد تأكيد هذا العمل وتنفيذه لجميع العناصر؟</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>نعم، وتنفيذ</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>نعم</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>لا</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>يحتوي</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>لا يحتوي</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>يساوي</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>لا تساوي</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>فارغة</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>ليس فارغا</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>بين</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>ليس بين</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>تصفية</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>أو</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>تنقيح</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>عملية</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>td_compare</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>تنقيح</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>تاريخ</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>الكاتب</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>td_role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>عرض مراجعة</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>label_compare_revision</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>list_results_count_prefix</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>%count% النتائج</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>تحميل</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>تحميل معلومات…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>معاينة</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>وافق</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>هبوط</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>في كل صفحة</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>إختر</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>لديك تغييرات غير محفوظة.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>تحرير ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>تحديث ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>تم تحديث ACL بنجاح.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>عدم التحديد</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>نتائج البحث: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>بحث</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>لا نتائج لبحثك</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>إضافة عنصر جديد</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>لائحة العمليات</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>noscript_warning</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>link_filters</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>stats_view_more</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>title_select_subclass</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>no_subclass_available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>إدارة</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>حذف</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>أوافق</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>إنشاء</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>إنشاء</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>إنشاء وإضافة أخرى</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>إنشاء والعودة إلى قائمة</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>تصفية</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>btn_advanced_filters</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>تحديث</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>تحديث</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>تحديث و اغلاق</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>حذف</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>إضافة جديدة</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>العودة إلى القائمة</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>عرض</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>تعديل</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>إضافة جديدة</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>قائمة</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>إعادة تعيين</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>إنشاء</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>لوحة المشرف</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>تعديل "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>قائمة</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>التالي</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>السابق</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>الأول</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>الأخير</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>مشرف</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>توسيع / طي</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>لا نتائج</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>هل أنت متأكد؟</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>تعديل</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>عرض</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>جميع العناصر</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>الغاء العملية.لم يتم اختيار عنصر</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>العنصر "%name%" تم إنشاؤه بنجاح.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>حدث خطأ أثناء إنشاء العنصر "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>العنصر "%name%" تم تحديثه بنجاح.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>حدث خطأ أثناء إنشاء العنصر "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>flash_lock_error</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>تم حذف العناصر المحددة بنجاح.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>حدث خطأ أثناء حذف العناصر المحددة.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>حدث خطأ أثناء حذف العنصر "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>العنصر "%name%" تم حذفه بنجاح.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>form_not_available</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>تأكيد الحذف</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>هل أنت متأكد أنك تريد حذف العنصر المحدد؟</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>نعم، حذف</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>تأكيد العملية'%action%'</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>]1,Inf] هل أنت متأكد أنك تريد تأكيد و تنفيذ هذا العمل ل  %count% عناصر المحددة؟|{1} هل أنت متأكد أنك تريد تأكيد و تنفيذ هذا العمل للعنصر المحدد؟</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>هل أنت متأكد أنك تريد تأكيد هذا العمل وتنفيذه لجميع العناصر؟</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>نعم، وتنفيذ</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>نعم</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>لا</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>يحتوي</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>لا يحتوي</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>يساوي</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>لا تساوي</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>فارغة</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>ليس فارغا</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>بين</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>ليس بين</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>تصفية</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>أو</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>تنقيح</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>عملية</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>td_compare</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>تنقيح</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>تاريخ</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>الكاتب</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>td_role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>عرض مراجعة</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>label_compare_revision</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>list_results_count_prefix</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>%count% النتائج</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>تحميل</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>تحميل معلومات…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>معاينة</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>وافق</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>هبوط</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>في كل صفحة</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>إختر</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>لديك تغييرات غير محفوظة.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>تحرير ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>تحديث ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>تم تحديث ACL بنجاح.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>عدم التحديد</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>نتائج البحث: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>بحث</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>لا نتائج لبحثك</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>إضافة عنصر جديد</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>لائحة العمليات</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>noscript_warning</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>message_form_group_empty</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>link_filters</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>stats_view_more</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>title_select_subclass</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>no_subclass_available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.bg.xliff
+++ b/Resources/translations/SonataAdminBundle.bg.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" target-language="bg" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Администрация</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Изтриване</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>Изпълнение</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Създаване</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Създаване</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Създаване и добавяне на нов елемент</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Създаване и обратно към списъка</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Филтриране</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Разширени филтри</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Запис</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Запис</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Запис и затваряне</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Изтриване</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Нов елемент</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Към списъка</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Преглед</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Редактиране</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Добавяне</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Преглед</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Отмяна</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Добавяне на елемент</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Начална страница</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Редактиране на „%name%“</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Списък</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Следваща</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Предишна</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Първа</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Последна</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Администрация</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>+/–</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Няма резултати</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Наистина ли?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Редактиране</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Преглед</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Всички елементи</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Действието беше прекъснато. Няма избрани елементи.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Елементът беше създаден.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Възникна грешка по време на създаването.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Елементът беше обновен.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Възникна грешка по време на обновяването.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Друг потребител междувременно е променил елемента "%name%". Моля, %link_start%презаредете страницата%link_end% и отново нанесете промените си.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Избраните елементи бяха изтрити.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Възникна грешка по време на изтриването на избраните елементи.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Възникна грешка по време на изтриването.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Елементът беше изтрит.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Формулярът не е достъпен.</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target>Начална страница</target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Потвърдете изтриването</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Наистина ли искате да изтриете избрания елемент?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Изтриване</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Потвърждение на действието</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Наистина ли искате да изпълните действието върху избрания елемент?|Наистина ли искате да изпълните действието върху избраните %count% елемента?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Наистина ли искате да изпълните действието върху всички елементи?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Да</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>да</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>не</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>съдържа</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>не съдържа</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>съвпада със</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>не съвпада със</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>е празно</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>не е празно</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>между</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>не е между</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Филтри</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>или</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Версии</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Действие</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Сравняване</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Версии</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Дата</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Автор</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Роля</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Преглед на версията</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Сравняване на версията</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>поне</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>Един резултат|%count% резултата</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Изтегляне</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Зареждане на информацията…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Предварителен преглед</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Одобряване</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Отказване</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>На страница</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Избор</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Имате незаписани промени.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Редактиране на ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Запис на ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>Списъкът за контрол на достъпа (ACL) беше обновен.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL (списък за контрол на достъпа)</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Нищо не е избрано</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Резултати от търсенето: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Търсене</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>Няма резултати</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>Добавяне на нов елемент</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Действия</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Ползването на джаваскрипт в браузъра е изключено. Някои функционалности няма да работят както трябва.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Не са налични формулярни полета.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Филтри</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Показване на още</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Избор на тип обект</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>Не са налични обектни типове</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>непознат</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" target-language="bg" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Администрация</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Изтриване</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>Изпълнение</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Създаване</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Създаване</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Създаване и добавяне на нов елемент</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Създаване и обратно към списъка</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Филтриране</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Разширени филтри</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Запис</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Запис</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Запис и затваряне</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Изтриване</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Нов елемент</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Към списъка</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Преглед</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Редактиране</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Добавяне</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Преглед</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Отмяна</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Добавяне на елемент</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Начална страница</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Редактиране на „%name%“</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Списък</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Следваща</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Предишна</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Първа</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Последна</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Администрация</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>+/–</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Няма резултати</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Наистина ли?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Редактиране</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Преглед</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Всички елементи</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Действието беше прекъснато. Няма избрани елементи.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Елементът беше създаден.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Възникна грешка по време на създаването.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Елементът беше обновен.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Възникна грешка по време на обновяването.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Друг потребител междувременно е променил елемента "%name%". Моля, %link_start%презаредете страницата%link_end% и отново нанесете промените си.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Избраните елементи бяха изтрити.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Възникна грешка по време на изтриването на избраните елементи.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Възникна грешка по време на изтриването.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Елементът беше изтрит.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Формулярът не е достъпен.</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target>Начална страница</target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Потвърдете изтриването</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Наистина ли искате да изтриете избрания елемент?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Изтриване</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Потвърждение на действието</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Наистина ли искате да изпълните действието върху избрания елемент?|Наистина ли искате да изпълните действието върху избраните %count% елемента?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Наистина ли искате да изпълните действието върху всички елементи?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Да</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>да</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>не</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>съдържа</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>не съдържа</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>съвпада със</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>не съвпада със</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>е празно</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>не е празно</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>между</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>не е между</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Филтри</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>или</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Версии</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Действие</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Сравняване</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Версии</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Дата</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Автор</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Роля</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Преглед на версията</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Сравняване на версията</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>поне</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>Един резултат|%count% резултата</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Изтегляне</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Зареждане на информацията…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Предварителен преглед</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Одобряване</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Отказване</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>На страница</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Избор</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Имате незаписани промени.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Редактиране на ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Запис на ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>Списъкът за контрол на достъпа (ACL) беше обновен.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL (списък за контрол на достъпа)</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Нищо не е избрано</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Резултати от търсенето: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Търсене</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>Няма резултати</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>Добавяне на нов елемент</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Действия</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Ползването на джаваскрипт в браузъра е изключено. Някои функционалности няма да работят както трябва.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Не са налични формулярни полета.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Филтри</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Показване на още</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Избор на тип обект</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>Не са налични обектни типове</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>непознат</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/Resources/translations/SonataAdminBundle.ca.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administració</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Esborrar</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>D'acord</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Crear</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Crear</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Crear i afegir un altre</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Crear i tornar al llistat</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtrar</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Filtres avançats</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Actualitzar</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Actualitzar</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Actualitzar i tancar</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Esborrar</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Afegir nou</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Tornar al llistat</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Mostrar</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Editar</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Afegir nou</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Llistar</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Restableix</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Crear</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>Mostrar "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Tauler principal</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Editar "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Llistar</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Següent</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Anterior</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Primer</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Últim</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Administrador</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>expandeix/contrau</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>No s'han trobat resultats.</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Estàs segur?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Editar</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Mostrar</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Tots els elements</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Acció interrompuda. Cap element ha estat seleccionat.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>L'element "%name%" ha estat creat amb èxit.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>S'ha produït un error a l'hora de crear l'element "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>L'element "%name%" s'ha actualitzat amb èxit.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>S'ha produït un error a l'hora d'actualitzar l'element "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Un altre usuari ha modificat l'element "%name%". Si us plau, %link_start%clica aquí%link_end% per recarregar la pàgina i aplicar els canvis de nou.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Els elements seleccionats han estat esborrats amb èxit.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>S'ha produït un error a l'hora d'esborrar els elements seleccionats.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>S'ha produït un error a l'hora d'esborrar l'element "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>L'element "%name%" s'ha esborrat correctament.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>El formulari no està disponible</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Confirma l'esborrat</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Estàs segur que vols esborrar l'element seleccionat "%object%"?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Sí, esborra</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Confirma l'acció per lots</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Estàs segur que vols confirmar i executar aquesta acció per l'element seleccionat?|Estàs segur que vols confirmar i executar aquesta acció per tots els %count% elements seleccionats?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Estàs segur que vols confirmar i executar aquesta acció per tots els elements?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Sí, executa</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>sí</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>no</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>conté</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>no conté</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>és igual a</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>no és igual a</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>està buit</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>no està buit</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>entre</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>no entre</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtres</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>o</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Revisions</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Acció</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Compara</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Revisions</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Data</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Autor</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Rol</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Veure Revisió</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Comparar la revisió</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>al menys</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 resultat|%count% resultats</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Exportar</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Carregant informació…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Vista prèvia</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Aprovar</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Cancel·lar</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Per pàgina</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Seleccionar</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Tens canvis sense guardar</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Editar ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Actualitzar ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL actualitzada correctament.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Cap selecció</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Resultats de la cerca: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Cercar</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>No s'han trobat resultats</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>afegir nova entrada</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Accions</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Javascript està deshabilitat al teu navegador. Algunes característiques no funcionaran correctament.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>No hi ha camps disponibles.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filtres</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Veure més</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Escull el tipus d'element</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>No hi ha cap tipus d'element disponible</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>desconegut</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>Llegir més</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>Tancar</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administració</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Esborrar</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>D'acord</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Crear</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Crear</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Crear i afegir un altre</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Crear i tornar al llistat</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtrar</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Filtres avançats</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Actualitzar</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Actualitzar</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Actualitzar i tancar</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Esborrar</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Afegir nou</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Tornar al llistat</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Mostrar</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Editar</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Afegir nou</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Llistar</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Restableix</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Crear</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>Mostrar "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Tauler principal</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Editar "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Llistar</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Següent</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Anterior</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Primer</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Últim</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Administrador</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>expandeix/contrau</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>No s'han trobat resultats.</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Estàs segur?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Editar</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Mostrar</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Tots els elements</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Acció interrompuda. Cap element ha estat seleccionat.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>L'element "%name%" ha estat creat amb èxit.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>S'ha produït un error a l'hora de crear l'element "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>L'element "%name%" s'ha actualitzat amb èxit.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>S'ha produït un error a l'hora d'actualitzar l'element "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Un altre usuari ha modificat l'element "%name%". Si us plau, %link_start%clica aquí%link_end% per recarregar la pàgina i aplicar els canvis de nou.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Els elements seleccionats han estat esborrats amb èxit.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>S'ha produït un error a l'hora d'esborrar els elements seleccionats.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>S'ha produït un error a l'hora d'esborrar l'element "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>L'element "%name%" s'ha esborrat correctament.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>El formulari no està disponible</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Confirma l'esborrat</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Estàs segur que vols esborrar l'element seleccionat "%object%"?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Sí, esborra</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Confirma l'acció per lots</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Estàs segur que vols confirmar i executar aquesta acció per l'element seleccionat?|Estàs segur que vols confirmar i executar aquesta acció per tots els %count% elements seleccionats?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Estàs segur que vols confirmar i executar aquesta acció per tots els elements?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Sí, executa</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>sí</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>no</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>conté</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>no conté</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>és igual a</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>no és igual a</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>està buit</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>no està buit</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>entre</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>no entre</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtres</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>o</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Revisions</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Acció</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Compara</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Revisions</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Data</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Rol</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Veure Revisió</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Comparar la revisió</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>al menys</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 resultat|%count% resultats</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Exportar</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Carregant informació…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Vista prèvia</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Aprovar</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Cancel·lar</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Per pàgina</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Seleccionar</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Tens canvis sense guardar</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Editar ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Actualitzar ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL actualitzada correctament.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Cap selecció</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Resultats de la cerca: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Cercar</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>No s'han trobat resultats</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>afegir nova entrada</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Accions</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Javascript està deshabilitat al teu navegador. Algunes característiques no funcionaran correctament.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>No hi ha camps disponibles.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filtres</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Veure més</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Escull el tipus d'element</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>No hi ha cap tipus d'element disponible</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>desconegut</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>Llegir més</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>Tancar</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/Resources/translations/SonataAdminBundle.cs.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administration</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Odstranit</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Vytvořit</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Vytvořit</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Vytvořit a přidat další</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Vytvořit a zpět do seznamu</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtrovat</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Pokročilé filtry</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Aktualizovat</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Aktualizovat</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Aktualizovat a zavřít</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Odstranit</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Přidat nový</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Zpět na výpis</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Zobrazit</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Upravit</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Přidat nový</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Výpis</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Reset</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Vytvořit</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Administrační panel</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Upravit "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Výpis</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Další</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Předchozí</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>První</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Poslední</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>rozbalit/zabalit</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Žádný výsledek</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Jste si jistí?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Upravit</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Zobrazit</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Všechny prvky</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Akce zrušena. Nebyly zvoleny žádné položky.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Položka úspěšně vytvořena.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Během vytváření položky nastala chyba.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Položka byla úspěšně upravena.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Během úpravy položky nastala chyba.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Jiný uživatel změnil položku "%name%". %link_start%Obnovit stránku a znovu aplikovat změny.%link_end%</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Zvolené položky byly úspěšně odstraněny.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Během odstraňování zvolených položek došlo k chybě.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Během odstraňování položky došlo k chybě.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Položka byla úspěšně odstraněna.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Formulář není k dispozici</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Potvrzení odstranění</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Opravdu chcete odstranit zvolený element?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Ano, odstranit</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Potvrďte dávkovou akci: '%action%'</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Jste si jistý, že chcete potvrdit tuto akci a spustit ji na vybranou položku?|Jste si jisti, že chcete potvrdit tuto akci a spustit ji na %count% prvky?|Jste si jisti, že chcete potvrdit tuto akci a spustit ji na %count% prvků?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Jste si jistý, že chcete potvrdit tuto akci a spustit ji na všechny prvky?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Ano, spustit</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>ano</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>ne</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>obsahuje</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>neobsahuje</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>rovná se</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>nerovná se</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>je prázdný</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>není prázdný</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>je mezi</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>není mezi</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtry</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>nebo</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Revize</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Akce</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Porovnat</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Revize</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Datum</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Autor</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>td_role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Zobrazit revizi</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Porovnejte revize</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>alespoň</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 záznam|%count% záznamy|%count% záznamů</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Stáhnout</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Načítání informací…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Náhled</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Schválit</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Odmítnout</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Zobrazit nejvíce</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Vybrat</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Máte neuložené změny.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Upravit</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Aktualizovat</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>Oprávnění byly úspěšně aktualizovány.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>Oprávnění</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target/>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Výsledky vyhledávání: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Hledat</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>Žádný výsledek</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>Přidat nový záznam</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Akce</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Javascript je zakázán ve vašem webovém prohlížeči. Některé funkce nebudou pracovat správně.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Žádné položky nejsou k dispozici.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filtry</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Zobrazit více</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>title_select_subclass</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>no_subclass_available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administration</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Odstranit</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Vytvořit</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Vytvořit</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Vytvořit a přidat další</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Vytvořit a zpět do seznamu</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtrovat</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Pokročilé filtry</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Aktualizovat</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Aktualizovat</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Aktualizovat a zavřít</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Odstranit</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Přidat nový</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Zpět na výpis</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Zobrazit</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Upravit</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Přidat nový</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Výpis</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Reset</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Vytvořit</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Administrační panel</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Upravit "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Výpis</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Další</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Předchozí</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>První</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Poslední</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>rozbalit/zabalit</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Žádný výsledek</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Jste si jistí?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Upravit</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Zobrazit</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Všechny prvky</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Akce zrušena. Nebyly zvoleny žádné položky.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Položka úspěšně vytvořena.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Během vytváření položky nastala chyba.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Položka byla úspěšně upravena.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Během úpravy položky nastala chyba.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Jiný uživatel změnil položku "%name%". %link_start%Obnovit stránku a znovu aplikovat změny.%link_end%</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Zvolené položky byly úspěšně odstraněny.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Během odstraňování zvolených položek došlo k chybě.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Během odstraňování položky došlo k chybě.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Položka byla úspěšně odstraněna.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Formulář není k dispozici</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Potvrzení odstranění</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Opravdu chcete odstranit zvolený element?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Ano, odstranit</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Potvrďte dávkovou akci: '%action%'</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Jste si jistý, že chcete potvrdit tuto akci a spustit ji na vybranou položku?|Jste si jisti, že chcete potvrdit tuto akci a spustit ji na %count% prvky?|Jste si jisti, že chcete potvrdit tuto akci a spustit ji na %count% prvků?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Jste si jistý, že chcete potvrdit tuto akci a spustit ji na všechny prvky?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Ano, spustit</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>ano</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>ne</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>obsahuje</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>neobsahuje</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>rovná se</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>nerovná se</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>je prázdný</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>není prázdný</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>je mezi</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>není mezi</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtry</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>nebo</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Revize</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Akce</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Porovnat</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Revize</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Datum</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>td_role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Zobrazit revizi</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Porovnejte revize</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>alespoň</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 záznam|%count% záznamy|%count% záznamů</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Stáhnout</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Načítání informací…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Náhled</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Schválit</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Odmítnout</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Zobrazit nejvíce</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Vybrat</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Máte neuložené změny.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Upravit</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Aktualizovat</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>Oprávnění byly úspěšně aktualizovány.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>Oprávnění</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target/>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Výsledky vyhledávání: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Hledat</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>Žádný výsledek</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>Přidat nový záznam</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Akce</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Javascript je zakázán ve vašem webovém prohlížeči. Některé funkce nebudou pracovat správně.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Žádné položky nejsou k dispozici.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filtry</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Zobrazit více</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>title_select_subclass</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>no_subclass_available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administration</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Löschen</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Hinzufügen</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Hinzufügen</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Hinzufügen und neu</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Hinzufügen und zur Übersicht</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtern</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Erweiterte Filter</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Speichern</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Speichern</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Speichern und schließen</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Löschen</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Neu</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Zurück zur Liste</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Anzeigen</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Bearbeiten</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Neu</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Liste</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Zurücksetzen</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Hinzufügen</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>"%name%" betrachten</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Startseite</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>"%name%" bearbeiten</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Liste</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Nächste</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Vorherige</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Erste Seite</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Letzte Seite</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>auf-/zuklappen</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Kein Ergebnis</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Sind Sie sicher?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Bearbeiten</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Anzeigen</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Alle Elemente</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Aktion abgebrochen. Es waren keine Elemente ausgewählt.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Das Element "%name%" wurde erfolgreich hinzugefügt.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Beim Hinzufügen des Elements "%name%" ist ein Fehler aufgetreten.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Das Element "%name%" wurde erfolgreich bearbeitet.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Beim Bearbeiten des Elements "%name%" ist ein Fehler aufgetreten.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Ein anderer Nutzer hat das Element "%name%" bearbeitet. Bitte %link_start%klicken Sie hier%link_end%, um die Seite neuzuladen und die neuesten Änderungen zu übernehmen.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Die ausgewählten Elemente wurden erfolgreich gelöscht.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Beim Löschen der ausgewählten Elemente ist ein Fehler aufgetreten.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Beim Löschen des Elements "%name%" ist ein Fehler aufgetreten.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Das Element "%name%" wurde erfolgreich gelöscht.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Form nicht verfügbar.</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Löschen bestätigen</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Sind Sie sicher, dass Sie das ausgewählte Element löschen wollen?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Ja, löschen</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Stapel-Aktion '%action%' bestätigen</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Sind Sie sicher, dass Sie diese Aktion bestätigen und für alle ausgewählten Elemente ausführen wollen?|Sind Sie sicher dass Sie diese Aktion bestätigen und für alle ausgewählten Elemente (%count%) ausführen wollen?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Sind Sie sicher, dass Sie diese Aktion bestätigen und für alle ausgewählten Elemente ausführen wollen?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Ja, ausführen</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>ja</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>nein</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>enthält</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>enthält nicht</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>ist gleich</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>ist nicht gleich</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>ist leer</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>ist nicht leer</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>zwischen</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>nicht zwischen</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filter</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>oder</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Versionen</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Aktion</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Vergleichen</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Versionen</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Datum</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Autor</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Rolle</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Version anzeigen</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Version vergleichen</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>mehr als</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 Ergebnis|%count% Ergebnisse</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Exportieren</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Informationen werden geladen…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Vorschau</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Bestätigen</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Ablehnen</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Einträge pro Seite</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Auswählen</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Es gibt ungespeicherte Änderungen.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Bearbeiten</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Speichern</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL Eintrag wurde erfolgreich gespeichert.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL Manager</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Nichts ausgewählt</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Suchergebnisse: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Suchen</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>Keine Suchergebnisse</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>Neuen Eintrag</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Aktionen</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Javascript ist in ihrem Browser deaktiviert. Einige Funktionen werden nicht korrekt funktionieren.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Keine Felder verfügbar.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filter</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>mehr</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Typ auswählen</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>Keine Typen verfügbar.</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>unbekannt</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>mehr anzeigen</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>weniger anzeigen</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administration</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Löschen</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Hinzufügen und neu</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Hinzufügen und zur Übersicht</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtern</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Erweiterte Filter</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Speichern</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Speichern</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Speichern und schließen</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Löschen</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Neu</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Zurück zur Liste</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Anzeigen</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Neu</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Liste</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Zurücksetzen</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>"%name%" betrachten</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Startseite</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>"%name%" bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Liste</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Nächste</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Vorherige</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Erste Seite</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Letzte Seite</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>auf-/zuklappen</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Kein Ergebnis</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Sind Sie sicher?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Anzeigen</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Alle Elemente</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Aktion abgebrochen. Es waren keine Elemente ausgewählt.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Das Element "%name%" wurde erfolgreich hinzugefügt.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Beim Hinzufügen des Elements "%name%" ist ein Fehler aufgetreten.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Das Element "%name%" wurde erfolgreich bearbeitet.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Beim Bearbeiten des Elements "%name%" ist ein Fehler aufgetreten.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Ein anderer Nutzer hat das Element "%name%" bearbeitet. Bitte %link_start%klicken Sie hier%link_end%, um die Seite neuzuladen und die neuesten Änderungen zu übernehmen.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Die ausgewählten Elemente wurden erfolgreich gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Beim Löschen der ausgewählten Elemente ist ein Fehler aufgetreten.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Beim Löschen des Elements "%name%" ist ein Fehler aufgetreten.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Das Element "%name%" wurde erfolgreich gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Form nicht verfügbar.</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Löschen bestätigen</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Sind Sie sicher, dass Sie das ausgewählte Element löschen wollen?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Ja, löschen</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Stapel-Aktion '%action%' bestätigen</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Sind Sie sicher, dass Sie diese Aktion bestätigen und für alle ausgewählten Elemente ausführen wollen?|Sind Sie sicher dass Sie diese Aktion bestätigen und für alle ausgewählten Elemente (%count%) ausführen wollen?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Sind Sie sicher, dass Sie diese Aktion bestätigen und für alle ausgewählten Elemente ausführen wollen?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Ja, ausführen</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>ja</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>nein</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>enthält</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>enthält nicht</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>ist gleich</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>ist nicht gleich</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>ist leer</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>ist nicht leer</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>zwischen</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>nicht zwischen</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filter</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>oder</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Versionen</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Aktion</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Vergleichen</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Versionen</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Datum</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Rolle</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Version anzeigen</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Version vergleichen</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>mehr als</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 Ergebnis|%count% Ergebnisse</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Exportieren</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Informationen werden geladen…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Vorschau</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Bestätigen</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Ablehnen</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Einträge pro Seite</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Auswählen</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Es gibt ungespeicherte Änderungen.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Bearbeiten</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Speichern</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL Eintrag wurde erfolgreich gespeichert.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL Manager</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Nichts ausgewählt</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Suchergebnisse: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Suchen</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>Keine Suchergebnisse</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>Neuen Eintrag</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Aktionen</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Javascript ist in ihrem Browser deaktiviert. Einige Funktionen werden nicht korrekt funktionieren.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Keine Felder verfügbar.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filter</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>mehr</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Typ auswählen</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>Keine Typen verfügbar.</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>unbekannt</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>mehr anzeigen</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>weniger anzeigen</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>Code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>Farbe</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>Text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>Beschreibung</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>Icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>Filter</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>CSS Klasse</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>Limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>Einfach</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>Verlinkt</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>Template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.en.xliff
+++ b/Resources/translations/SonataAdminBundle.en.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administration</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Delete</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Create</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Create</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Create and add another</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Create and return to list</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filter</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Advanced filters</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Update</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Update</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Update and close</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Delete</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Add new</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Return to list</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Show</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Edit</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Add new</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>List</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Reset</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Create</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>Show "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Dashboard</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Edit "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>List</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Next</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Previous</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>First</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Last</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>expand/collapse</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>No result</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Are you sure ?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Edit</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Show</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>All elements</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Action aborted. No items were selected.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Item "%name%" has been successfully created.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>An error has occurred during the creation of item "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Item "%name%" has been successfully updated.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>An error has occurred during update of item "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Another user has modified item "%name%". Please %link_start%click here%link_end% to reload the page and apply the changes again.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Selected items have been successfully deleted.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>An Error has occurred during selected items deletion.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>An Error has occurred during deletion of item "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Item "%name%" has been deleted successfully.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Form is not available.</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Confirm deletion</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Are you sure you want to delete the selected "%object%" element?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Yes, delete</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Confirm batch action "%action%"</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Are you sure you want to confirm this action and execute it for the selected element?|Are you sure you want to confirm this action and execute it for the %count% selected elements?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Are you sure you want to confirm this action and execute it for all the elements?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Yes, execute</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>yes</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>no</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>contains</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>does not contain</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>is equal to</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>is not equal to</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>is empty</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>is not empty</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>between</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>not between</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filters</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>or</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Revisions</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Action</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Compare</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Revisions</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Date</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Author</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>View Revision</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Compare revision</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>at least</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 result|%count% results</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Download</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Loading information…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Preview</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Approve</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Decline</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Per page</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Select</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>You have unsaved changes.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Edit ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Update ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL has been successfuly updated.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>No selection</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Search results: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Search</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>no result found</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>add new entry</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Actions</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Javascript is disabled in your web browser. Some features will not work properly.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>No fields available.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filters</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>View more</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Select object type</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>No object types available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>unknown</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>Read more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>Close</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administration</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Delete</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Create</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Create</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Create and add another</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Create and return to list</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filter</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Advanced filters</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Update</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Update</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Update and close</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Delete</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Add new</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Return to list</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Show</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Edit</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Add new</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>List</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Reset</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Create</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>Show "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Dashboard</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Edit "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>List</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Next</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Previous</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>First</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Last</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>expand/collapse</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>No result</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Are you sure ?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Edit</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Show</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>All elements</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Action aborted. No items were selected.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Item "%name%" has been successfully created.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>An error has occurred during the creation of item "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Item "%name%" has been successfully updated.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>An error has occurred during update of item "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Another user has modified item "%name%". Please %link_start%click here%link_end% to reload the page and apply the changes again.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Selected items have been successfully deleted.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>An Error has occurred during selected items deletion.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>An Error has occurred during deletion of item "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Item "%name%" has been deleted successfully.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Form is not available.</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Confirm deletion</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Are you sure you want to delete the selected "%object%" element?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Yes, delete</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Confirm batch action "%action%"</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Are you sure you want to confirm this action and execute it for the selected element?|Are you sure you want to confirm this action and execute it for the %count% selected elements?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Are you sure you want to confirm this action and execute it for all the elements?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Yes, execute</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>yes</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>no</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>contains</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>does not contain</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>is equal to</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>is not equal to</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>is empty</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>is not empty</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>between</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>not between</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filters</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>or</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Revisions</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Action</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Compare</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Revisions</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Date</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Author</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>View Revision</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Compare revision</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>at least</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 result|%count% results</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Download</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Loading information…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Preview</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Approve</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Decline</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Per page</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Select</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>You have unsaved changes.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Edit ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Update ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL has been successfuly updated.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>No selection</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Search results: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Search</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>no result found</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>add new entry</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Actions</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Javascript is disabled in your web browser. Some features will not work properly.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>No fields available.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filters</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>View more</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Select object type</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>No object types available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>unknown</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>Read more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>Close</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>Code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>Color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>Text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>Description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>Icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>Filter</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>CSS Class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>Limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>Simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>Linked</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>Template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.es.xliff
+++ b/Resources/translations/SonataAdminBundle.es.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administración</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Borrar</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Crear</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Crear y editar</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Crear y agregar otro</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Crear y regresar al listado</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtrar</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Filtros avanzados</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Actualizar</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Actualizar</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Actualizar y cerrar</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Borrar</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Agregar nuevo</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Volver al listado</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Mostrar</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Editar</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Agregar nuevo</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Listar</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Restablecer</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Crear</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>Mostrar "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Panel principal</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Editar "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Listar</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Siguiente</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Anterior</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Primero</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Último</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Administrador</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>expandir/ocultar</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>No hay resultados</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>¿Estás seguro?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Editar</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Mostrar</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Todos los elementos</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Acción cancelada. Ningún elemento ha sido seleccionado.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>El elemento "%name%" ha sido creado con éxito.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Se ha producido un error durante la creación del elemento "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>El elemento "%name%" ha sido actualizado con éxito.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Se ha producido un error durante la actualización del elemento "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Otro usuario ha modificado el elemento "%name%". Por favor %link_start%clica aquí%link_end% para recargar la página y aplicar los cambios de nuevo.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Los elementos seleccionados han sido eliminados con éxito.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Se ha producido un error durante la eliminación de los elementos seleccionados.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Se ha producido un error durante la eliminación del elemento "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>El elemento "%name%" se ha eliminado con éxito.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>El formulario no está disponible.</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Confirma el borrado</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>¿Estás seguro que quieres borrar el elemento seleccionado "%object%"?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Sí, borrar</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Confirma la operación "%action%"</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>¿Estás seguro que quieres confirmar y ejecutar esta acción para el elemento seleccionado?|¿Estás seguro que quieres confirmar y ejecutar esta acción para todos los %count% elementos seleccionados?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>¿Estás seguro que quieres confirmar y ejecutar esta acción para todos los elementos?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Sí, ejecutar</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>sí</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>no</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>contiene</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>no contiene</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>es igual a</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>no es igual a</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>está vacío</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>no está vacío</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>entre</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>no entre</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtros</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>o</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Revisiones</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Acción</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Compara</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Revisiones</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Fecha</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Autor</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Rol</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Ver Revisión</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Comparar la revision</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>al menos</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 resultado|%count% resultados</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Exportar</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Cargando información…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Vista previa</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Aprobar</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Cancelar</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Por página</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Seleccionar</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Tienes cambios sin guardar.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Editar ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Actualizar ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL actualizada correctamente.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Ninguna selección</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Resultados de la búsqueda: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Buscar</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>No se han encontrado resultados</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>añadir nueva entrada</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Acciones</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Javascript esta deshabilitado en tu navegador. Algunas características no funcionarán correctamente.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>No hay campos disponibles.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filtros</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Ver más</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Selecciona el tipo de elemento</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>No hay disponible ningún tipo de elemento</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>desconocido</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>Leer más</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>Cerrar</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administración</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Borrar</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Crear</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Crear y editar</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Crear y agregar otro</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Crear y regresar al listado</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtrar</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Filtros avanzados</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Actualizar</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Actualizar</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Actualizar y cerrar</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Borrar</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Agregar nuevo</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Volver al listado</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Mostrar</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Editar</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Agregar nuevo</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Listar</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Restablecer</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Crear</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>Mostrar "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Panel principal</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Editar "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Listar</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Siguiente</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Anterior</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Primero</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Último</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Administrador</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>expandir/ocultar</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>No hay resultados</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>¿Estás seguro?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Editar</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Mostrar</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Todos los elementos</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Acción cancelada. Ningún elemento ha sido seleccionado.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>El elemento "%name%" ha sido creado con éxito.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Se ha producido un error durante la creación del elemento "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>El elemento "%name%" ha sido actualizado con éxito.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Se ha producido un error durante la actualización del elemento "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Otro usuario ha modificado el elemento "%name%". Por favor %link_start%clica aquí%link_end% para recargar la página y aplicar los cambios de nuevo.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Los elementos seleccionados han sido eliminados con éxito.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Se ha producido un error durante la eliminación de los elementos seleccionados.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Se ha producido un error durante la eliminación del elemento "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>El elemento "%name%" se ha eliminado con éxito.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>El formulario no está disponible.</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Confirma el borrado</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>¿Estás seguro que quieres borrar el elemento seleccionado "%object%"?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Sí, borrar</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Confirma la operación "%action%"</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>¿Estás seguro que quieres confirmar y ejecutar esta acción para el elemento seleccionado?|¿Estás seguro que quieres confirmar y ejecutar esta acción para todos los %count% elementos seleccionados?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>¿Estás seguro que quieres confirmar y ejecutar esta acción para todos los elementos?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Sí, ejecutar</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>sí</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>no</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>contiene</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>no contiene</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>es igual a</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>no es igual a</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>está vacío</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>no está vacío</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>entre</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>no entre</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtros</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>o</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Revisiones</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Acción</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Compara</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Revisiones</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Fecha</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Rol</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Ver Revisión</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Comparar la revision</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>al menos</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 resultado|%count% resultados</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Exportar</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Cargando información…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Vista previa</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Aprobar</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Cancelar</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Por página</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Seleccionar</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Tienes cambios sin guardar.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Editar ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Actualizar ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL actualizada correctamente.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Ninguna selección</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Resultados de la búsqueda: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Buscar</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>No se han encontrado resultados</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>añadir nueva entrada</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Acciones</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Javascript esta deshabilitado en tu navegador. Algunas características no funcionarán correctamente.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>No hay campos disponibles.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filtros</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Ver más</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Selecciona el tipo de elemento</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>No hay disponible ningún tipo de elemento</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>desconocido</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>Leer más</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>Cerrar</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.eu.xliff
+++ b/Resources/translations/SonataAdminBundle.eu.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administration</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Ezabatu</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Sortu</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Sortu eta editatu</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Sortu eta berria gehitu</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Sortu eta zerrendara itzuli</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtratu</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>btn_advanced_filters</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Eguneratu</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Eguneratu eta berriz editatu</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Eguneratu eta zerrendara itzuli</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Ezabatu</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Sortu</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Zerrendara itzuli</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Ikusi</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Editatu</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Berria gehitu</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Zerrenda ikusi</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Filtroa kendu</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Sortu</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Hasiera</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>"%name%" editatu</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Zerrenda</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Hurrengoa</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Aurrekoa</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Lehenengoa</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Azkena</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>erakutsi/ezkutatu</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Ez dago emaitzarik</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Zihur zaude?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Editatu</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Erakutsi</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Guztiak</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Ekintza ezeztatua, ez dago ezer aukeratuta</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Behar bezala sortu da</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Arazoren bat izan da elementua sortzerakoan</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Elementua behar bezala eguneratu da</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Elementua ezin izan da behar bezala eguneratu</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>flash_lock_error</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Aukeratutako elementuak behar bezala ezabatu dira</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Ezin izan dira aukeratutako elementuak behar bezala ezabatu</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Ezin izan da behar bezala ezabatu</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Behar bezala ezabatu da</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>form_not_available</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Ezabatzea ziurtatu</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Ziur zaude ezabatu nahi duzula?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Ezabatu</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Eragiketa ziurtatu</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>{0}Ziur zaude aukeratutako elementu guztientzako ekintza hau burutu nahi duzula?|[1,+Inf[Ziur zaude aukeratutako %count% elementuentzat ekintza hau burutu nahi duzula?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Ziur zaude ekintza hau elementu guztientzako burutu nahi duzula?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Bai, aurrera</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>Bai</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>Ez</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>dauka</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>ez dauka</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>berdina da</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>ez da berdina</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>Utsik dago</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>Ez dago utsik</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>artean</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>artean ez</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtroak</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>edo</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Historikoa</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Ekintza</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>td_compare</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Rebisioak</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Data</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Erabiltzailea</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>td_role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Rebisioa erakutsi</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>label_compare_revision</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>list_results_count_prefix</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>Emaitza bat|%count% emaitza</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Esportatu</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Informazioa kargatzen</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Aurreikusi</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Onartu</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Ezeztatu</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Orrialdeko</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Aukeratu</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Aldaketak dituzu gordetzeko.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>ACLa editatu</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>ACLa eguneratu</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACLa behar bezala eguneratu da.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>short_object_description_placeholder</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>title_search_results</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>search_placeholder</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>no_results_found</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>add_new_entry</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>link_actions</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>noscript_warning</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>link_filters</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>stats_view_more</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>title_select_subclass</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>no_subclass_available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administration</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Ezabatu</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Sortu</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Sortu eta editatu</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Sortu eta berria gehitu</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Sortu eta zerrendara itzuli</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtratu</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>btn_advanced_filters</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Eguneratu</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Eguneratu eta berriz editatu</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Eguneratu eta zerrendara itzuli</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Ezabatu</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Sortu</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Zerrendara itzuli</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Ikusi</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Editatu</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Berria gehitu</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Zerrenda ikusi</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Filtroa kendu</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Sortu</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Hasiera</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>"%name%" editatu</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Zerrenda</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Hurrengoa</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Aurrekoa</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Lehenengoa</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Azkena</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>erakutsi/ezkutatu</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Ez dago emaitzarik</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Zihur zaude?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Editatu</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Erakutsi</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Guztiak</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Ekintza ezeztatua, ez dago ezer aukeratuta</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Behar bezala sortu da</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Arazoren bat izan da elementua sortzerakoan</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Elementua behar bezala eguneratu da</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Elementua ezin izan da behar bezala eguneratu</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>flash_lock_error</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Aukeratutako elementuak behar bezala ezabatu dira</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Ezin izan dira aukeratutako elementuak behar bezala ezabatu</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Ezin izan da behar bezala ezabatu</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Behar bezala ezabatu da</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>form_not_available</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Ezabatzea ziurtatu</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Ziur zaude ezabatu nahi duzula?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Ezabatu</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Eragiketa ziurtatu</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>{0}Ziur zaude aukeratutako elementu guztientzako ekintza hau burutu nahi duzula?|[1,+Inf[Ziur zaude aukeratutako %count% elementuentzat ekintza hau burutu nahi duzula?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Ziur zaude ekintza hau elementu guztientzako burutu nahi duzula?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Bai, aurrera</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>Bai</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>Ez</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>dauka</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>ez dauka</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>berdina da</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>ez da berdina</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>Utsik dago</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>Ez dago utsik</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>artean</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>artean ez</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtroak</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>edo</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Historikoa</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Ekintza</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>td_compare</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Rebisioak</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Data</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Erabiltzailea</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>td_role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Rebisioa erakutsi</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>label_compare_revision</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>list_results_count_prefix</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>Emaitza bat|%count% emaitza</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Esportatu</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Informazioa kargatzen</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Aurreikusi</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Onartu</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Ezeztatu</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Orrialdeko</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Aukeratu</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Aldaketak dituzu gordetzeko.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>ACLa editatu</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>ACLa eguneratu</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACLa behar bezala eguneratu da.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>short_object_description_placeholder</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>title_search_results</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>search_placeholder</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>no_results_found</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>add_new_entry</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>link_actions</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>noscript_warning</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>message_form_group_empty</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>link_filters</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>stats_view_more</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>title_select_subclass</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>no_subclass_available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.fa.xliff
+++ b/Resources/translations/SonataAdminBundle.fa.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>مدیریت</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>حذف</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>تایید</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>ایجاد</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>ایجاد</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>ایجاد و افزودن یکی دیگر</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>ایجاد و برگشت به فهرست</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>فیلتر</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>فیلترهای پیشرفته</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>به‌روزرسانی</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>به‌روزرسانی</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>به‌روزرسانی و برگشت به فهرست</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>حذف</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>افزودن</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>بازگشت به فهرست</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>نمایش</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>ویرایش</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>افزدون</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>فهرست</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>بازنشانی</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>ایجاد</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>داشبورد</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>ویرایش "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>فهرست</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>بعدی</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>قبلی</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>ابتدا</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>انتها</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>مدیریت</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>باز/بسته</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>نتیجه‌ای یافت نشد</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>آیا مطمئن هستید؟</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>ویرایش</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>نمایش</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>همه عناصر</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>عملیات ناتمام ماند. هیچ آیتم‌ای انتخاب نشد.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>آیتم "%name%" با موفقیت ایجاد شد.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>هنگام ایجاد آیتم "%name%" خطایی رخ داد.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>آیتم "%name%" با موفقیت به‌روزرسانی شد.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>هنگام به روزرسانی  آیتم "%name%" خطایی رخ داد.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>یک کاربر دیگر آیتم "%name%". لطفا %link_start%اینجا کلیک کنید%link_end% تا صفحه مجددا بارگزاری شود و تغییرات را مجددا اعمال کنید.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>آیتمهای انتخاب‌شده، با موفقیت حذف شدند.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>هنگام حذف آیتم‌های انتخاب شده خطایی رخ داد.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>هنگام حذف آیتم  "%name%" خطایی رخ داد.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>آیتم "%name%" با موفقیت حذف شد.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>فرم موجود نیست.</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>تایید حذف</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>آیا از حذف شی "%object%" که انتخاب کردید مطمئن هستید؟</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>بله، حذف کن</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>عملیات  '%action%' را تایید کن.</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>آیا از اعمال این عملیات بر روی عناصر انتخاب شده، مطمئن هستید؟؟ آیا انجام این عملیات روی %count% عنصر انتخاب شده رو تایید می‌کنید؟</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>آیا از اجرای این عملیات روی تمام عناصر انتخاب شده مطمئن هستید؟</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>بله، اجرا کن</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>بله</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>خیر</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>شامل می‌شود</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>شامل نمی‌شود</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>برابر است با</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>برابر نیست با</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>خالی است</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>خالی نیست</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>بین</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>خارج از</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>فیلترها</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>یا</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>اصلاحیه‌ها</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>عملیات</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>مقایسه</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>اصلاحیه‌ها</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>تاریخ</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>پدیدآورنده</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>نقش</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>مشاهده اصلاحیه</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>مقایسه اصلاحیه</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>حداقل</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>۱ نتیجه|%count% نتیجه</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>دانلود</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>در حال بارگزاری…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>پیش‌نمایش</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>قبول</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>رد</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>در صفحه</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>انتخاب</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>شما تغییرات ذخیره‌نشده دارید.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>ویرایش دسترسی</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>به‌روزرسانی دسترسی</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>دسترسی‌ها با موفقیت ویرایش شد.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>لیست دسترسی‌ها</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>بدون انتخاب</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>نتایج جستجو: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>جستجو</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>نتیجه‌ای یافت نشد</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>افزودن محتوای جدید</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>عملیات</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>جاوااسکریپت روی مرورگر شما فعال نیست و ممکن است بعضی از قابلیت‌ها به خوبی عمل نکنند.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>هیچ فیلدی موجود نیست.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>فیلترها</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>مشاهده بیشتر</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>انتخاب نوع شی</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>هیچ نوعی موجود نیست.</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>مدیریت</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>حذف</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>تایید</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>ایجاد</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>ایجاد</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>ایجاد و افزودن یکی دیگر</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>ایجاد و برگشت به فهرست</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>فیلتر</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>فیلترهای پیشرفته</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>به‌روزرسانی</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>به‌روزرسانی</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>به‌روزرسانی و برگشت به فهرست</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>حذف</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>افزودن</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>بازگشت به فهرست</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>نمایش</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>ویرایش</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>افزدون</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>فهرست</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>بازنشانی</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>ایجاد</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>داشبورد</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>ویرایش "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>فهرست</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>بعدی</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>قبلی</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>ابتدا</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>انتها</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>مدیریت</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>باز/بسته</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>نتیجه‌ای یافت نشد</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>آیا مطمئن هستید؟</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>ویرایش</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>نمایش</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>همه عناصر</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>عملیات ناتمام ماند. هیچ آیتم‌ای انتخاب نشد.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>آیتم "%name%" با موفقیت ایجاد شد.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>هنگام ایجاد آیتم "%name%" خطایی رخ داد.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>آیتم "%name%" با موفقیت به‌روزرسانی شد.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>هنگام به روزرسانی  آیتم "%name%" خطایی رخ داد.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>یک کاربر دیگر آیتم "%name%". لطفا %link_start%اینجا کلیک کنید%link_end% تا صفحه مجددا بارگزاری شود و تغییرات را مجددا اعمال کنید.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>آیتمهای انتخاب‌شده، با موفقیت حذف شدند.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>هنگام حذف آیتم‌های انتخاب شده خطایی رخ داد.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>هنگام حذف آیتم  "%name%" خطایی رخ داد.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>آیتم "%name%" با موفقیت حذف شد.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>فرم موجود نیست.</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>تایید حذف</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>آیا از حذف شی "%object%" که انتخاب کردید مطمئن هستید؟</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>بله، حذف کن</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>عملیات  '%action%' را تایید کن.</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>آیا از اعمال این عملیات بر روی عناصر انتخاب شده، مطمئن هستید؟؟ آیا انجام این عملیات روی %count% عنصر انتخاب شده رو تایید می‌کنید؟</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>آیا از اجرای این عملیات روی تمام عناصر انتخاب شده مطمئن هستید؟</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>بله، اجرا کن</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>بله</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>خیر</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>شامل می‌شود</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>شامل نمی‌شود</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>برابر است با</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>برابر نیست با</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>خالی است</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>خالی نیست</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>بین</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>خارج از</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>فیلترها</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>یا</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>اصلاحیه‌ها</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>عملیات</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>مقایسه</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>اصلاحیه‌ها</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>تاریخ</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>پدیدآورنده</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>نقش</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>مشاهده اصلاحیه</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>مقایسه اصلاحیه</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>حداقل</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>۱ نتیجه|%count% نتیجه</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>دانلود</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>در حال بارگزاری…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>پیش‌نمایش</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>قبول</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>رد</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>در صفحه</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>انتخاب</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>شما تغییرات ذخیره‌نشده دارید.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>ویرایش دسترسی</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>به‌روزرسانی دسترسی</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>دسترسی‌ها با موفقیت ویرایش شد.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>لیست دسترسی‌ها</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>بدون انتخاب</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>نتایج جستجو: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>جستجو</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>نتیجه‌ای یافت نشد</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>افزودن محتوای جدید</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>عملیات</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>جاوااسکریپت روی مرورگر شما فعال نیست و ممکن است بعضی از قابلیت‌ها به خوبی عمل نکنند.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>هیچ فیلدی موجود نیست.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>فیلترها</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>مشاهده بیشتر</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>انتخاب نوع شی</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>هیچ نوعی موجود نیست.</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/Resources/translations/SonataAdminBundle.fr.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administration</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Supprimer</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Créer</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Créer</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Créer et ajouter</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Créer et retourner à la liste</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtrer</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Filtres avancés</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Mettre à jour</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Mettre à jour</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Mettre à jour et fermer</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Supprimer</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Ajouter</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Retourner à la liste</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Afficher</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Editer</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Ajouter</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Liste</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Effacer</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Créer</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>Afficher "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Tableau de bord</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Éditer "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Liste</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Suivant</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Précédent</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Première</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Dernière</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>Étendre/Réduire</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Aucun résultat</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Êtes-vous sûr ?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Éditer</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Afficher</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Tous les éléments</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Action interrompue. Aucun élément n'a été séléctionné.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>L'élément "%name%" a été créé avec succès.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Une erreur est intervenue lors de la création de l'élément "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>L'élément "%name%" a été mis à jour avec succès.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Une erreur est intervenue lors de la mise à jour de l'élément "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Un autre utilisateur a modifié l'élément "%name%". Veuillez %link_start%cliquer ici%link_end% pour recharger la page et appliquer les changements à nouveau.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Les éléments séléctionnés ont été supprimés avec succès.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Une erreur est intervenue lors de la suppression des éléments séléctionnés.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Une erreur est intervenue lors de la suppression de l'élément "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>L'élément "%name%" a été supprimé avec succès.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Formulaire non disponible</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Confirmation de suppression</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Êtes-vous sûr de vouloir supprimer l'élément "%object%" sélectionné?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Oui, supprimer</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Confirmation d'un traitement par lots : '%action%'</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Êtes-vous sûr de vouloir confirmer cette action et de l'exécuter pour l'élément sélectionné?|Êtes-vous sûr de vouloir confirmer cette action et de l'exécuter pour les %count% éléments sélectionnés?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Êtes-vous sûr de vouloir confirmer cette action et de l'exécuter pour tous les éléments?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Oui, exécuter</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>oui</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>non</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>contient</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>ne contient pas</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>est égal à</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>n'est pas égal à</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>est vide</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>n'est pas vide</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>est entre</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>n'est pas entre</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtres</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>ou</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Révisions</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Action</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Comparer</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Révisions</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Date</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Auteur</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Rôle</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Afficher la révision</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Comparer la révision</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>au moins</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 résultat|%count% résultats</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Export</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Chargement des informations…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Prévisualiser</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Accepter</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Refuser</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Par page</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Sélectionner</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Vous avez effectué des modifications non sauvegardées.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Editer les permissions</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Mettre à jour les permissions</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>Les permissions ont été mises à jour avec succès.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>Permissions</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Aucune sélection</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Résultats de recherche : %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Rechercher</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>pas de résultats</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>rajouter un élément</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Liste d'actions</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Certaines fonctionnalités ne fonctionnent pas sans JavaScript. Merci de l'activer sur votre navigateur.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Pas de champs disponibles.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filtres</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Voir plus</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>title_select_subclass</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>no_subclass_available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>Voir plus</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>Fermer</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administration</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Supprimer</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Créer</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Créer</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Créer et ajouter</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Créer et retourner à la liste</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtrer</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Filtres avancés</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Mettre à jour</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Mettre à jour</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Mettre à jour et fermer</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Supprimer</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Ajouter</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Retourner à la liste</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Afficher</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Editer</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Ajouter</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Liste</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Effacer</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Créer</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>Afficher "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Tableau de bord</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Éditer "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Liste</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Suivant</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Précédent</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Première</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Dernière</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>Étendre/Réduire</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Aucun résultat</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Êtes-vous sûr ?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Éditer</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Afficher</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Tous les éléments</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Action interrompue. Aucun élément n'a été séléctionné.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>L'élément "%name%" a été créé avec succès.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Une erreur est intervenue lors de la création de l'élément "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>L'élément "%name%" a été mis à jour avec succès.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Une erreur est intervenue lors de la mise à jour de l'élément "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Un autre utilisateur a modifié l'élément "%name%". Veuillez %link_start%cliquer ici%link_end% pour recharger la page et appliquer les changements à nouveau.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Les éléments séléctionnés ont été supprimés avec succès.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Une erreur est intervenue lors de la suppression des éléments séléctionnés.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Une erreur est intervenue lors de la suppression de l'élément "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>L'élément "%name%" a été supprimé avec succès.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Formulaire non disponible</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Confirmation de suppression</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Êtes-vous sûr de vouloir supprimer l'élément "%object%" sélectionné?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Oui, supprimer</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Confirmation d'un traitement par lots : '%action%'</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Êtes-vous sûr de vouloir confirmer cette action et de l'exécuter pour l'élément sélectionné?|Êtes-vous sûr de vouloir confirmer cette action et de l'exécuter pour les %count% éléments sélectionnés?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Êtes-vous sûr de vouloir confirmer cette action et de l'exécuter pour tous les éléments?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Oui, exécuter</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>oui</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>non</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>contient</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>ne contient pas</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>est égal à</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>n'est pas égal à</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>est vide</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>n'est pas vide</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>est entre</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>n'est pas entre</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtres</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>ou</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Révisions</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Action</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Comparer</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Révisions</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Date</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Auteur</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Rôle</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Afficher la révision</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Comparer la révision</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>au moins</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 résultat|%count% résultats</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Export</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Chargement des informations…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Prévisualiser</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Accepter</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Refuser</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Par page</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Sélectionner</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Vous avez effectué des modifications non sauvegardées.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Editer les permissions</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Mettre à jour les permissions</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>Les permissions ont été mises à jour avec succès.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>Permissions</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Aucune sélection</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Résultats de recherche : %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Rechercher</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>pas de résultats</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>rajouter un élément</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Liste d'actions</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Certaines fonctionnalités ne fonctionnent pas sans JavaScript. Merci de l'activer sur votre navigateur.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Pas de champs disponibles.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filtres</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Voir plus</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>title_select_subclass</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>no_subclass_available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>Voir plus</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>Fermer</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/Resources/translations/SonataAdminBundle.hr.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administracija</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Izbriši</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Spremi</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Spremi</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Spremi i dodaj još jedan</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Spremi i zatvori</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtriraj</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>btn_advanced_filters</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Promijeni</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Promijeni</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Promijeni i zatvori</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Izbriši</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Novi unos</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Povratak na listu</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Pregled</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Promijeni</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Novi unos</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Lista</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Resetiraj</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Novi unos</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Početna stranica</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Uređivanje "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Lista</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Sljedeća</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Prethodna</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Prva</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Zadnja</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Administracija</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>proširi/skupi</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Nijedan unos</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Jeste li sigurni?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Promijeni</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Prikaži</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Svi unosi</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Naredba nije izvršena jer nijedan unos nije odabran.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Novi unos je uspješno spremljen.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Došlo je do greške prilikom spremanja novog unosa.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Unos je uspješno promijenjen.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Došlo je do greške prilikom promjene unosa.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>flash_lock_error</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Odabrani unosi su uspješno izbrisani.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Došlo je do greške prilikom brisanja odabranih unosa.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Došlo je do greške prilikom brisanja unosa.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Unos je uspješno izbrisan.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>form_not_available</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target>Početna stranica</target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Potvrdite brisanje</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Jeste li sigurni da želite izbrisati odabrani unos?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Da, izbriši</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Potvrdite naredbu</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Jeste li sigurni da ovu naredbu želite izvršiti nad odabranim unosom?|Jeste li sigurni da ovu naredbu želite izvršiti nad %count% odabranih unosa?|Jeste li sigurni da ovu naredbu želite izvršiti nad %count% odabrana unosa?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Jeste li sigurni da ovu naredbu želite izvršiti nad svim unosima?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Da, izvrši</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>da</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>ne</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>sadrži</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>ne sadrži</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>jednak</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>nije jednak</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>prazan</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>nije prazan</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>u periodu</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>nije u periodu</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filteri</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>ili</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Revizije</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Naredba</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Usporedi</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Revizije</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Datum</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Autor</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>td_role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Vidi reviziju</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Usporedi reviziju</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>list_results_count_prefix</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>%count% rezultat|%count% rezultata|%count% rezultata</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Preuzmi</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Učitavam podatke...</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Pregled</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Odobri</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Odbij</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Po stranici</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Odaberi</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Promjene nisu spremljene.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Uredi ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Ažuriraj ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL je uspješno ažuriran.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Nema odabira</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Rezultati pretraživanja: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Upiši pojam...</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>ništa nije pronađeno</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>dodaj novi unos</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Akcije</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Vaš internet preglednik ne podržava JavaScript. Neke mogućnosti neće raditi ispravno.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Nijedno polje.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>link_filters</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>stats_view_more</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>title_select_subclass</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>no_subclass_available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administracija</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Izbriši</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Spremi</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Spremi</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Spremi i dodaj još jedan</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Spremi i zatvori</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtriraj</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>btn_advanced_filters</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Promijeni</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Promijeni</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Promijeni i zatvori</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Izbriši</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Novi unos</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Povratak na listu</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Pregled</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Promijeni</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Novi unos</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Lista</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Resetiraj</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Novi unos</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Početna stranica</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Uređivanje "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Lista</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Sljedeća</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Prethodna</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Prva</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Zadnja</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Administracija</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>proširi/skupi</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Nijedan unos</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Jeste li sigurni?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Promijeni</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Prikaži</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Svi unosi</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Naredba nije izvršena jer nijedan unos nije odabran.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Novi unos je uspješno spremljen.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Došlo je do greške prilikom spremanja novog unosa.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Unos je uspješno promijenjen.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Došlo je do greške prilikom promjene unosa.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>flash_lock_error</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Odabrani unosi su uspješno izbrisani.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Došlo je do greške prilikom brisanja odabranih unosa.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Došlo je do greške prilikom brisanja unosa.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Unos je uspješno izbrisan.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>form_not_available</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target>Početna stranica</target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Potvrdite brisanje</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Jeste li sigurni da želite izbrisati odabrani unos?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Da, izbriši</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Potvrdite naredbu</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Jeste li sigurni da ovu naredbu želite izvršiti nad odabranim unosom?|Jeste li sigurni da ovu naredbu želite izvršiti nad %count% odabranih unosa?|Jeste li sigurni da ovu naredbu želite izvršiti nad %count% odabrana unosa?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Jeste li sigurni da ovu naredbu želite izvršiti nad svim unosima?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Da, izvrši</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>da</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>ne</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>sadrži</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>ne sadrži</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>jednak</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>nije jednak</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>prazan</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>nije prazan</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>u periodu</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>nije u periodu</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filteri</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>ili</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Revizije</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Naredba</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Usporedi</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Revizije</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Datum</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>td_role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Vidi reviziju</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Usporedi reviziju</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>list_results_count_prefix</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>%count% rezultat|%count% rezultata|%count% rezultata</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Preuzmi</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Učitavam podatke...</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Pregled</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Odobri</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Odbij</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Po stranici</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Odaberi</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Promjene nisu spremljene.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Uredi ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Ažuriraj ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL je uspješno ažuriran.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Nema odabira</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Rezultati pretraživanja: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Upiši pojam...</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>ništa nije pronađeno</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>dodaj novi unos</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Akcije</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Vaš internet preglednik ne podržava JavaScript. Neke mogućnosti neće raditi ispravno.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Nijedno polje.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>link_filters</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>stats_view_more</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>title_select_subclass</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>no_subclass_available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.hu.xliff
+++ b/Resources/translations/SonataAdminBundle.hu.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" target-language="hu" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Adminisztráció</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Törlés</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Létrehozás</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Létrehozás</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Létrehozás és új hozzáadása</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Létrehozás és visszalépés a listára</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Szűrés</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Fejlett szűrés</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Frissítés</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Frissítés</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Frissítés és bezárás</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Törlés</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Új hozzáadása</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Vissza a listára</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Megjelenítés</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Szerkesztés</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Új hozzáadása</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Lista</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Visszaállítás</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Hozzáadás</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>"%name%" megjelenítése</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Vezérlőpult</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>"%name%" szerkesztése</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Lista</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Következő</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Előző</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Első</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Utolsó</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>kinyit/összecsuk</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Nincs találat</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Biztos benne?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Szerkesztés</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Megjelenítés</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Minden elem</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Megszakítva. Nincs kijelölt elem.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Elem sikeresen hozzáadva.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Hiba történt az elem hozzáadásakor.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Az elem sikeresen frissült.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Hiba történt az elem frissítésekor.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Egy másik felhasználó módosította a(z) "%name%" elemet. %link_start%Ide%link_end% kattintva a változtatások betöltésre kerülnek.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>A kijelölt elemek sikeresen törölve lettek.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Hiba történt a kijelölt elemek törlésekor.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Hiba történt az elem törlésekor.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Az elem sikeresen törölve lett.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Az űrlap nem elérhető.</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target>&lt;i class="fa fa-home"&gt;&lt;/i&gt;</target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Törlés megerősítése</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Biztosan ki akarja törölni a kijelölt elemet?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Igen, törlés</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Tömeges törlés megerősítése</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Biztosan végre akarja hajtani a műveletet az összes kijelölt elemen?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Biztosan végre akarja hajtani a műveletet az összes elemen?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Igen, végrehajtás</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>igen</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>nem</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>tartalmazza</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>nem tartalmazza</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>egyenlő</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>nem egyenlő</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>üres</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>nem üres</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>között</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>nem közte</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Szűrők</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>vagy</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Verziók</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Műveletek</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Összehasonlítás</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Verziószám</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Dátum</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Szerző</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Szerepkör</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Verzió mutatása</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Összehasonlítás ezzel a verzióval</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>legalább</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 eredmény|%count% eredmény</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Letöltés</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Információ betöltése…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Előnézet</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Jóváhagy</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Elutasítás</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Oldalanként</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Kijelölés</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Nem mentett minden változtatást. Biztosan kilép?</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Jogosultságok (ACL) módosítása</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Jogosultságok (ACL) mentése</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>Jogosultságok (ACL) sikeresen mentve</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>Jogosultságok (ACL)</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Nincs kijelölés</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Találatok a következőre: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Keresés</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>nincs találat</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>új elem hozzáadása</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Műveletek</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>A böngészőben a Javascript le van tiltva, emiatt néhány funkció nem fog megfelelően működni.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Nincs elérhető mező.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Szűrők</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Több megjelenítése</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Objektum típus kiválasztása</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>Nem található objektum típus</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" target-language="hu" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Adminisztráció</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Törlés</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Létrehozás</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Létrehozás</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Létrehozás és új hozzáadása</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Létrehozás és visszalépés a listára</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Szűrés</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Fejlett szűrés</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Frissítés</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Frissítés</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Frissítés és bezárás</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Törlés</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Új hozzáadása</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Vissza a listára</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Megjelenítés</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Szerkesztés</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Új hozzáadása</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Lista</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Visszaállítás</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Hozzáadás</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>"%name%" megjelenítése</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Vezérlőpult</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>"%name%" szerkesztése</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Lista</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Következő</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Előző</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Első</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Utolsó</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>kinyit/összecsuk</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Nincs találat</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Biztos benne?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Szerkesztés</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Megjelenítés</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Minden elem</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Megszakítva. Nincs kijelölt elem.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Elem sikeresen hozzáadva.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Hiba történt az elem hozzáadásakor.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Az elem sikeresen frissült.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Hiba történt az elem frissítésekor.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Egy másik felhasználó módosította a(z) "%name%" elemet. %link_start%Ide%link_end% kattintva a változtatások betöltésre kerülnek.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>A kijelölt elemek sikeresen törölve lettek.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Hiba történt a kijelölt elemek törlésekor.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Hiba történt az elem törlésekor.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Az elem sikeresen törölve lett.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Az űrlap nem elérhető.</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target>&lt;i class="fa fa-home"&gt;&lt;/i&gt;</target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Törlés megerősítése</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Biztosan ki akarja törölni a kijelölt elemet?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Igen, törlés</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Tömeges törlés megerősítése</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Biztosan végre akarja hajtani a műveletet az összes kijelölt elemen?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Biztosan végre akarja hajtani a műveletet az összes elemen?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Igen, végrehajtás</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>igen</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>nem</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>tartalmazza</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>nem tartalmazza</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>egyenlő</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>nem egyenlő</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>üres</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>nem üres</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>között</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>nem közte</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Szűrők</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>vagy</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Verziók</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Műveletek</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Összehasonlítás</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Verziószám</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Dátum</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Szerző</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Szerepkör</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Verzió mutatása</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Összehasonlítás ezzel a verzióval</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>legalább</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 eredmény|%count% eredmény</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Letöltés</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Információ betöltése…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Előnézet</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Jóváhagy</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Elutasítás</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Oldalanként</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Kijelölés</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Nem mentett minden változtatást. Biztosan kilép?</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Jogosultságok (ACL) módosítása</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Jogosultságok (ACL) mentése</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>Jogosultságok (ACL) sikeresen mentve</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>Jogosultságok (ACL)</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Nincs kijelölés</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Találatok a következőre: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Keresés</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>nincs találat</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>új elem hozzáadása</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Műveletek</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>A böngészőben a Javascript le van tiltva, emiatt néhány funkció nem fog megfelelően működni.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Nincs elérhető mező.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Szűrők</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Több megjelenítése</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Objektum típus kiválasztása</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>Nem található objektum típus</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.it.xliff
+++ b/Resources/translations/SonataAdminBundle.it.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Amministrazione</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Elimina</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>Vai</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Crea</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Crea</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Crea e aggiungi</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Crea e torna alla lista</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtra</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Filtri avanzati</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Aggiorna</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Aggiorna e modifica</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Aggiorna e torna alla lista</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Elimina</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Aggiungi nuovo</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Torna alla lista</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Mostra</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Modifica</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Aggiungi nuovo</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Lista</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Azzera</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Crea</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>Mostra "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Dashboard</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Modifica "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Lista</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Pagina successiva</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Pagina precedente</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Prima pagina</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Ultima pagina</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>Espandi/Riduci</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Nessun risultato</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Sei sicuro?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Modifica</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Mostra</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Tutti gli elementi</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Azione interrotta. Nessun elemento selezionato.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Elemento creato con successo.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Si è verificato un errore durante la creazione dell'elemento.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Elemento aggiornato con successo.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Si è verificato un errore durante la modifica dell'elemento.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Un altro utente ha modificato l'oggetto "%name%". Per favore %link_start%clicca qui%link_end% per ricaricare la pagina e applicare di nuovo le modifiche.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Gli elementi selezionati sono stati eliminati con successo.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Si è verificato un errore durante l'eliminazione degli elementi.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Si è verificato un errore durante l'eliminazione dell'elemento.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Elemento eliminato con successo.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Form non disponibile</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Conferma eliminazione</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Sei sicuro di voler eliminare l'elemento selezionato?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Sì, elimina</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Conferma l'azione multipla</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Sei sicuro di voler eseguire l'azione sull'elemento selezionato?|Sei sicuro di voler eseguire l'azione su %count% elementi selezionati?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Sei sicuro di voler eseguire l'azione su tutti gli elementi?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Sì, esegui</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>sì</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>no</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>contiene</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>non contiene</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>è uguale a</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>non è uguale a</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>è vuoto</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>non è vuoto</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_range">
-                <source>label_date_type_range</source>
-                <target>periodo</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>al di fuori del periodo</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtra</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>oppure</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Revisioni</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Azione</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Confronta</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Revisioni</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Data</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Utente</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Ruolo</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Visualizza revisione</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Confronta revisione</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>almeno</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 risultato|%count% risultati</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Esporta in formato</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Caricamento informazioni…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Anteprima</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Approva</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Rifiuta</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Risultati per pagina</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Seleziona</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Le modifiche non salvate verranno perse.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Modifica ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Aggiorna ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL aggiornata con successo.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Nessuna selezione</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Risultati della ricerca: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Cerca</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>nessun risultato</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>aggiungi</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Azioni</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Javascript è disattivato nel tuo browser. Alcune funzioni non funzioneranno correttamente.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Nessun campo disponibile.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filtri</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Mostra dettagli</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Seleziona il tipo</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>Nessun tipo disponibile</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>sconosciuto</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Amministrazione</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Elimina</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>Vai</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Crea</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Crea</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Crea e aggiungi</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Crea e torna alla lista</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtra</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Filtri avanzati</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Aggiorna</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Aggiorna e modifica</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Aggiorna e torna alla lista</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Elimina</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Aggiungi nuovo</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Torna alla lista</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Mostra</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Modifica</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Aggiungi nuovo</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Lista</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Azzera</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Crea</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>Mostra "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Dashboard</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Modifica "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Lista</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Pagina successiva</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Pagina precedente</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Prima pagina</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Ultima pagina</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>Espandi/Riduci</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Nessun risultato</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Sei sicuro?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Modifica</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Mostra</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Tutti gli elementi</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Azione interrotta. Nessun elemento selezionato.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Elemento creato con successo.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Si è verificato un errore durante la creazione dell'elemento.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Elemento aggiornato con successo.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Si è verificato un errore durante la modifica dell'elemento.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Un altro utente ha modificato l'oggetto "%name%". Per favore %link_start%clicca qui%link_end% per ricaricare la pagina e applicare di nuovo le modifiche.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Gli elementi selezionati sono stati eliminati con successo.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Si è verificato un errore durante l'eliminazione degli elementi.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Si è verificato un errore durante l'eliminazione dell'elemento.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Elemento eliminato con successo.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Form non disponibile</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Conferma eliminazione</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Sei sicuro di voler eliminare l'elemento selezionato?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Sì, elimina</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Conferma l'azione multipla</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Sei sicuro di voler eseguire l'azione sull'elemento selezionato?|Sei sicuro di voler eseguire l'azione su %count% elementi selezionati?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Sei sicuro di voler eseguire l'azione su tutti gli elementi?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Sì, esegui</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>sì</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>no</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>contiene</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>non contiene</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>è uguale a</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>non è uguale a</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>è vuoto</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>non è vuoto</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_range">
+        <source>label_date_type_range</source>
+        <target>periodo</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>al di fuori del periodo</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtra</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>oppure</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Revisioni</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Azione</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Confronta</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Revisioni</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Data</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Utente</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Ruolo</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Visualizza revisione</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Confronta revisione</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>almeno</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 risultato|%count% risultati</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Esporta in formato</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Caricamento informazioni…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Anteprima</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Approva</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Rifiuta</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Risultati per pagina</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Seleziona</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Le modifiche non salvate verranno perse.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Modifica ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Aggiorna ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL aggiornata con successo.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Nessuna selezione</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Risultati della ricerca: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Cerca</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>nessun risultato</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>aggiungi</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Azioni</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Javascript è disattivato nel tuo browser. Alcune funzioni non funzioneranno correttamente.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Nessun campo disponibile.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filtri</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Mostra dettagli</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Seleziona il tipo</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>Nessun tipo disponibile</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>sconosciuto</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/Resources/translations/SonataAdminBundle.ja.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>管理</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>削除</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>作成</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>作成して編集を続ける</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>作成してもう一つ追加</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>作成して一覧に戻る</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>絞り込み</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>btn_advanced_filters</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>更新</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>更新して編集を続ける</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>更新して一覧に戻る</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>削除</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>新規作成</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>一覧に戻る</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>表示</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>編集</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>追加</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>一覧</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>リセット</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>作成</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>ダッシュボード</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>編集 "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>一覧</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>次へ</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>前へ</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>最初</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>最後</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>管理</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>展開/折り畳む</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>データがありません</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>よろしいですか？</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>編集</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>表示</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>すべて</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>アクションは中止されました。アイテムが選択されていません。</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>正常に作成されました。</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>作成に失敗しました。</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>正常に更新されました。</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>更新に失敗しました。</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>flash_lock_error</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>選択したアイテムは正常に削除されました。</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>選択したアイテムの削除に失敗しました。</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>削除に失敗しました。</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>正常に削除されました。</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>form_not_available</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>削除の確認</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>削除してもよろしいですか？</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>削除する</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>一括削除の確認</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>選択されたアイテムを削除してよろしいですか？</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>全て削除してよろしいですか？</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>一括処理を実行</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>はい</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>いいえ</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>含む</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>含まない</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>等しくない</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>未指定</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>未指定以外</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>範囲内</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>範囲外</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>絞り込む</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>又は</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>履歴</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>アクション</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>td_compare</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>リビジョン</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>日付</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>作成者</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>td_role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>リビジョンを見る</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>label_compare_revision</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>list_results_count_prefix</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>%count%件</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>エクスポート</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>情報を読み込んでいます…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>プレビュー</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>キャンセル</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>1ページの件数</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>選択</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>編集内容が保存されていません。</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>ACLを編集する</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>ACLを更新する</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACLの編集が完了しました。</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>選択してください</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>検索結果：%query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>検索</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>該当するデータがありません。</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>新規作成</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>link_actions</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>noscript_warning</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>link_filters</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>stats_view_more</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>title_select_subclass</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>no_subclass_available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>管理</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>削除</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>作成</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>作成して編集を続ける</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>作成してもう一つ追加</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>作成して一覧に戻る</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>絞り込み</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>btn_advanced_filters</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>更新</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>更新して編集を続ける</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>更新して一覧に戻る</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>削除</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>新規作成</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>一覧に戻る</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>表示</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>編集</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>追加</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>一覧</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>リセット</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>作成</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>ダッシュボード</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>編集 "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>一覧</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>次へ</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>前へ</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>最初</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>最後</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>管理</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>展開/折り畳む</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>データがありません</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>よろしいですか？</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>編集</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>表示</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>すべて</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>アクションは中止されました。アイテムが選択されていません。</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>正常に作成されました。</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>作成に失敗しました。</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>正常に更新されました。</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>更新に失敗しました。</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>flash_lock_error</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>選択したアイテムは正常に削除されました。</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>選択したアイテムの削除に失敗しました。</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>削除に失敗しました。</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>正常に削除されました。</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>form_not_available</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>削除の確認</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>削除してもよろしいですか？</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>削除する</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>一括削除の確認</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>選択されたアイテムを削除してよろしいですか？</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>全て削除してよろしいですか？</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>一括処理を実行</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>はい</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>いいえ</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>含む</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>含まない</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>等しくない</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>未指定</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>未指定以外</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>範囲内</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>範囲外</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>絞り込む</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>又は</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>履歴</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>アクション</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>td_compare</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>リビジョン</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>日付</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>作成者</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>td_role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>リビジョンを見る</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>label_compare_revision</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>list_results_count_prefix</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>%count%件</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>エクスポート</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>情報を読み込んでいます…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>プレビュー</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>キャンセル</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>1ページの件数</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>選択</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>編集内容が保存されていません。</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>ACLを編集する</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>ACLを更新する</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACLの編集が完了しました。</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>選択してください</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>検索結果：%query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>検索</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>該当するデータがありません。</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>新規作成</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>link_actions</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>noscript_warning</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>message_form_group_empty</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>link_filters</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>stats_view_more</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>title_select_subclass</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>no_subclass_available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/Resources/translations/SonataAdminBundle.lb.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administration</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Läschen</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Dobäisetzen</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Dobäisetzen</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Dobäisetzen an nei creéieren</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Create and return to list</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filteren</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>btn_advanced_filters</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Späicheren</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Späicheren</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Späicheren an zoumaachen</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Läschen</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Nei</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Zréck bei d'Lëscht</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Weisen</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Beaarbechten</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Nei</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Lëscht</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Läschen</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Dobäisetzen</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Startsäit</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>"%name%" beaarbechten</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Lëscht</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Weider</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Zréck</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>link_first_pager</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>link_last_pager</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>op-/zouklappen</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Kee Resultat</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Bass Du sécher?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Beaarbechten</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Weisen</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>All d'Elementer</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Aktioun ofgebrach. Et war keen Element ausgewielt.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>D'Element gouf erfollegräich dobäigesat.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Beim Dobäisetze vum Element ass e Feeler opgetratt.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>D'Element gouf erfollegräich beaarbecht.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Beim Beaarbechte vum Element ass e Feeler opgetratt.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>flash_lock_error</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Déi ausgewielten Elementer goufen erfollegräich geläscht.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Beim Läsche vun den ausgewielten Elementer ass e Feeler opgetratt.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Beim Läsche vum Element ass e Feeler opgetratt.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>D'Element gouf erfollegräich geläscht.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>form_not_available</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Läsche bestätegen</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Bass Du sécher dass Du déi ausgewielten Elementer läsche wëlls?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Jo, läschen</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Stapel-Aktioun bestätegen</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Bass Du sécher dass Du dës Aktioun bestätegen a fir all d'ausgewielten Elementer ausféiere wëlls?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>message_batch_all_confirmation</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Jo, ausféieren</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>jo</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>nee</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>enthält</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>enthält net</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>ass gläich</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>label_type_not_equals</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>ass eidel</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>ass net eidel</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>tëschent</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>net tëschent</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filteren</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>oder</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Versiounen</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Aktioun</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>td_compare</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Versioun</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Datum</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Auteur</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>td_role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Versioune weisen</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>label_compare_revision</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>list_results_count_prefix</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 Resultat|%count% Resultater</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Eroflueden</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Informatioune gi gelueden …</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Virschau</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Bestätegen</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Refuséieren</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Anträg pro Säit</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Auswielen</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Et gëtt ongespäichert Ännerungen</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Beaarbechten</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Späicheren</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>Zougankskontrolllëscht gouf erfollegräich gespäichert</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>Zougankskontrolllëscht</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Näischt ausgewielt</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Sichresultater: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Sichen</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>Keng Sichresultater fonnt</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>Neien Antrag</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Aktiounen</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>JavaScript ass an dengem Browser deaktivéiert. Eng Rei Funktioune wäerten net korrekt funktionéieren.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Keng Felder disponibel</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filter</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Méi</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Typ auswielen</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>Keng Typen disponibel</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>onbekannt</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>méi uweisen</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>manner uweisen</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administration</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Läschen</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Dobäisetzen</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Dobäisetzen</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Dobäisetzen an nei creéieren</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Create and return to list</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filteren</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>btn_advanced_filters</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Späicheren</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Späicheren</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Späicheren an zoumaachen</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Läschen</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Nei</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Zréck bei d'Lëscht</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Weisen</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Beaarbechten</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Nei</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Lëscht</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Läschen</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Dobäisetzen</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Startsäit</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>"%name%" beaarbechten</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Lëscht</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Weider</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Zréck</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>link_first_pager</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>link_last_pager</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>op-/zouklappen</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Kee Resultat</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Bass Du sécher?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Beaarbechten</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Weisen</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>All d'Elementer</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Aktioun ofgebrach. Et war keen Element ausgewielt.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>D'Element gouf erfollegräich dobäigesat.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Beim Dobäisetze vum Element ass e Feeler opgetratt.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>D'Element gouf erfollegräich beaarbecht.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Beim Beaarbechte vum Element ass e Feeler opgetratt.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>flash_lock_error</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Déi ausgewielten Elementer goufen erfollegräich geläscht.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Beim Läsche vun den ausgewielten Elementer ass e Feeler opgetratt.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Beim Läsche vum Element ass e Feeler opgetratt.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>D'Element gouf erfollegräich geläscht.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>form_not_available</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Läsche bestätegen</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Bass Du sécher dass Du déi ausgewielten Elementer läsche wëlls?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Jo, läschen</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Stapel-Aktioun bestätegen</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Bass Du sécher dass Du dës Aktioun bestätegen a fir all d'ausgewielten Elementer ausféiere wëlls?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>message_batch_all_confirmation</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Jo, ausféieren</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>jo</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>nee</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>enthält</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>enthält net</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>ass gläich</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>label_type_not_equals</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>ass eidel</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>ass net eidel</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>tëschent</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>net tëschent</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filteren</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>oder</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Versiounen</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Aktioun</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>td_compare</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Versioun</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Datum</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Auteur</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>td_role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Versioune weisen</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>label_compare_revision</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>list_results_count_prefix</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 Resultat|%count% Resultater</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Eroflueden</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Informatioune gi gelueden …</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Virschau</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Bestätegen</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Refuséieren</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Anträg pro Säit</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Auswielen</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Et gëtt ongespäichert Ännerungen</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Beaarbechten</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Späicheren</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>Zougankskontrolllëscht gouf erfollegräich gespäichert</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>Zougankskontrolllëscht</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Näischt ausgewielt</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Sichresultater: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Sichen</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>Keng Sichresultater fonnt</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>Neien Antrag</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Aktiounen</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>JavaScript ass an dengem Browser deaktivéiert. Eng Rei Funktioune wäerten net korrekt funktionéieren.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Keng Felder disponibel</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filter</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Méi</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Typ auswielen</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>Keng Typen disponibel</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>onbekannt</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>méi uweisen</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>manner uweisen</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.lt.xliff
+++ b/Resources/translations/SonataAdminBundle.lt.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="lt" datatype="plaintext" original="">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Valdymas</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Ištrinti</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>Vykdyti</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Sukurti</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Sukurti ir redaguoti</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Sukurti ir kurti naują</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Sukurti ir eiti į sąrašą</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtruoti</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>btn_advanced_filters</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Saugoti</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Saugoti</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Saugoti ir uždaryti</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Ištrinti</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Sukurti naują</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Grįžti į sąrašą</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Rodyti</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Redaguoti</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Sukurti naują</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Sąrašas</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Atšaukti</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Sukurti</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Titulinis</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Redaguojama "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Sąrašas</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Kitas</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Ankstesnis</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Pirmas</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Paskutinis</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Administravimas</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>išskleisti/suskleisti</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Nėra rezultatų</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Ar Jūs įsitikinęs?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Redaguoti</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Rodyti</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Visi</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Nepasirinktas nei vienas įrašas - veiksmai atšaukiami.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Sėkmingai sukurta.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Kūrimo metu įvyko klaida.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Sėkmingai išsaugota.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Išsaugant įrašą įvyko klaida.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>flash_lock_error</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Pasirinkti įrašai sėkmingai ištrinti.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Trinant Jūsų pasirinktus įrašus įvyko klaida.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Trinant įrašą įvyko klaida.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Įrašas sėkmingai ištrintas.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>form_not_available</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Trynimo patvirtinimas</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Ar Jūs tkrai norite ištrinti pasirinktą elementą?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Taip, ištrinti</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Keleto veiksmų patvirtinimas</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Ar tikrai norite atlikti šį veiksmą su pažymėtam įrašui?|Ar tikrai norite patvirtinti šį veiksmą ir įvykdyti %count% pažymėtiems elementams?|Ar tikrai norite patvirtinti šį veiksmą ir įvykdyti %count% pažymėtų elementų?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Ar tikrai norite patvirtinti šį veiksmą ir įvykdyti jį visiems įrašams?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Taip, vykdyti</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>taip</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>ne</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>turi</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>neturi</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>yra lygus</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>nelygus</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>yra tuščia</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>nėra tuščia</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>tarp</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>nėra tarp</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtrai</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>arba</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Revizijos</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Veiksmas</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>td_compare</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Revizijos</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Data</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Autorius</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>td_role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Peržiūrėti reviziją</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>label_compare_revision</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>list_results_count_prefix</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 rezultatas|%count% resultatai|%count% resultatų</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Atsisiųsti</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Informacija ruošiama…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Peržiūrėti</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Patvirtinti</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Atmesti</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>per psl.</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Pasirinkite</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Esate neišsaugojęs pakeitimų</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Redaguoti ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Atnaujinti ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL sėkmingai atnaujintas.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Nepasirinkta</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Paieškos rezultatai: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Paieška</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>atitikmenų nerasta</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>sukurti įrašą</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Veiksmai</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>noscript_warning</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>link_filters</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>stats_view_more</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>title_select_subclass</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>no_subclass_available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="lt" datatype="plaintext" original="">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Valdymas</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Ištrinti</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>Vykdyti</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Sukurti</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Sukurti ir redaguoti</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Sukurti ir kurti naują</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Sukurti ir eiti į sąrašą</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtruoti</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>btn_advanced_filters</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Saugoti</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Saugoti</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Saugoti ir uždaryti</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Ištrinti</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Sukurti naują</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Grįžti į sąrašą</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Rodyti</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Redaguoti</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Sukurti naują</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Sąrašas</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Atšaukti</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Sukurti</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Titulinis</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Redaguojama "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Sąrašas</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Kitas</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Ankstesnis</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Pirmas</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Paskutinis</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Administravimas</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>išskleisti/suskleisti</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Nėra rezultatų</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Ar Jūs įsitikinęs?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Redaguoti</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Rodyti</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Visi</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Nepasirinktas nei vienas įrašas - veiksmai atšaukiami.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Sėkmingai sukurta.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Kūrimo metu įvyko klaida.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Sėkmingai išsaugota.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Išsaugant įrašą įvyko klaida.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>flash_lock_error</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Pasirinkti įrašai sėkmingai ištrinti.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Trinant Jūsų pasirinktus įrašus įvyko klaida.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Trinant įrašą įvyko klaida.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Įrašas sėkmingai ištrintas.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>form_not_available</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Trynimo patvirtinimas</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Ar Jūs tkrai norite ištrinti pasirinktą elementą?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Taip, ištrinti</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Keleto veiksmų patvirtinimas</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Ar tikrai norite atlikti šį veiksmą su pažymėtam įrašui?|Ar tikrai norite patvirtinti šį veiksmą ir įvykdyti %count% pažymėtiems elementams?|Ar tikrai norite patvirtinti šį veiksmą ir įvykdyti %count% pažymėtų elementų?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Ar tikrai norite patvirtinti šį veiksmą ir įvykdyti jį visiems įrašams?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Taip, vykdyti</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>taip</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>ne</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>turi</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>neturi</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>yra lygus</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>nelygus</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>yra tuščia</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>nėra tuščia</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>tarp</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>nėra tarp</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtrai</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>arba</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Revizijos</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Veiksmas</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>td_compare</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Revizijos</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Data</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Autorius</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>td_role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Peržiūrėti reviziją</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>label_compare_revision</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>list_results_count_prefix</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 rezultatas|%count% resultatai|%count% resultatų</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Atsisiųsti</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Informacija ruošiama…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Peržiūrėti</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Patvirtinti</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Atmesti</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>per psl.</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Pasirinkite</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Esate neišsaugojęs pakeitimų</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Redaguoti ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Atnaujinti ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL sėkmingai atnaujintas.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Nepasirinkta</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Paieškos rezultatai: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Paieška</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>atitikmenų nerasta</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>sukurti įrašą</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Veiksmai</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>noscript_warning</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>message_form_group_empty</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>link_filters</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>stats_view_more</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>title_select_subclass</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>no_subclass_available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.lv.xliff
+++ b/Resources/translations/SonataAdminBundle.lv.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administrācija</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Dzēst</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Izveidot</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Izveidot</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Izveidot un pievienot vēl vienu</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Izveidot un atgriezties sarakstā</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtrēt</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Uzlabotie filtri</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Atjaunināt</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Atjaunināt</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Atjaunināt un aizvērt</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Dzēst</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Pievienot jaunu</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Atgriezties sarakstā</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Parādīt</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Rediģēt</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Pievienot jaunu</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Saraksts</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Atiestatīt</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Izveidot</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>Parādīt "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Informācijas panelis</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Rediģēt "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Saraksts</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Nākošā</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Iepriekšējā</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Pirmā</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Pēdējā</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Administrācija</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>paplašināt/samazināt</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Nav rezultātu</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Vai Jūs esat pārliecināti ?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Rediģēt</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Parādīt</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Pielietot visiem</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Darbība ir pārtraukta. Neviens objekts netika izvēlēts</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Objekts "%name%" bija veiksmīgi izveidots.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Radusies kļūda objekta "%name%" izveidošanas laikā.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Objekts "%name%" bija veiksmīgi atjaunināts.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Radusies kļūda objekta "%name%" atjaunināšanas laikā.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Cits lietotājs ir modificējis objektu "%name%". Lūdzu, %link_start%click here%link_end%, lai pārlādētu lapu un pielietotu izmaiņas vēlreiz.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Izvēlētie objekti tika veiksmīgi dzēsti.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Radusies kļūda izvēlētā objekta dzēšanas laikā.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Radusies kļūda objekta "%name%" dzēšanas laikā.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Objekts "%name%" tika veiksmīgi dzēsts.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Forma nav pieejama.</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Apstipriniet dzēšanu</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Vai tiešām vēlaties dzēst izvēlēto "%object%" elementu?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Jā, dzēst</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Apstipriniet partijas darbību "%action%"</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Vai tiešām vēlaties apstiprināt šo darbību un izpildīt to atlasītajam elementam?|Vai tiešām vēlaties apstiprināt šo darbību un izpildīt to %count% atlasītajiem elementiem?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Vai tiešām vēlaties apstiprināt šo darbību un izpildīt to visiem atlasītajiem elementiem?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Jā, izpildīt</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>jā</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>nē</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>satur</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>nesatur</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>ir vienāds</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>nav vienāds</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>ir tukšs</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>nav tukšs</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>starp</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>ne starp</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtri</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>vai</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Pārskatīšana</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Darbība</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Salīdzināt</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Pārskatīšana</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Datums</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Autors</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Loma</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Skatīt izmaiņas</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Salīdzināt izmaiņas</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>vismaz</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>{1} rezultāts|]1,Inf[ Ir %count% rezultāti</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Lejupielādēt</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Informācijas lejupielādēšana…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Priekšskatījums</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Apstiprināt</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Atteikties</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Ierakstu vienā lapā</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Izvēlieties</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Jums ir nesaglabātas izmaiņas.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Rediģēt ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Atjaunināt ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL tika veiksmīgi atjaunināts.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Nekas nav atlasīts</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Meklēšanas rezultāti: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Meklēšana</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>rezultāts nav atrasts</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>pievienot jaunu ierakstu</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Darbības</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Javascript ir izslēgts Jūsu pārlūkprogrammā. Dažas funkcijas var nedarboties pareizi.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Nav pieejamu lauku.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filtri</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Skatīt vēl</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Izvēlieties objekta veidu</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>Nav pieejami objekta veidi</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>nezināms</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>Lasīt vairāk</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>Aizvērt</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administrācija</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Dzēst</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Izveidot</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Izveidot</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Izveidot un pievienot vēl vienu</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Izveidot un atgriezties sarakstā</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtrēt</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Uzlabotie filtri</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Atjaunināt</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Atjaunināt</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Atjaunināt un aizvērt</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Dzēst</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Pievienot jaunu</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Atgriezties sarakstā</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Parādīt</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Rediģēt</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Pievienot jaunu</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Saraksts</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Atiestatīt</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Izveidot</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>Parādīt "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Informācijas panelis</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Rediģēt "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Saraksts</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Nākošā</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Iepriekšējā</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Pirmā</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Pēdējā</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Administrācija</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>paplašināt/samazināt</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Nav rezultātu</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Vai Jūs esat pārliecināti ?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Rediģēt</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Parādīt</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Pielietot visiem</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Darbība ir pārtraukta. Neviens objekts netika izvēlēts</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Objekts "%name%" bija veiksmīgi izveidots.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Radusies kļūda objekta "%name%" izveidošanas laikā.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Objekts "%name%" bija veiksmīgi atjaunināts.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Radusies kļūda objekta "%name%" atjaunināšanas laikā.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Cits lietotājs ir modificējis objektu "%name%". Lūdzu, %link_start%click here%link_end%, lai pārlādētu lapu un pielietotu izmaiņas vēlreiz.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Izvēlētie objekti tika veiksmīgi dzēsti.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Radusies kļūda izvēlētā objekta dzēšanas laikā.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Radusies kļūda objekta "%name%" dzēšanas laikā.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Objekts "%name%" tika veiksmīgi dzēsts.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Forma nav pieejama.</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Apstipriniet dzēšanu</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Vai tiešām vēlaties dzēst izvēlēto "%object%" elementu?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Jā, dzēst</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Apstipriniet partijas darbību "%action%"</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Vai tiešām vēlaties apstiprināt šo darbību un izpildīt to atlasītajam elementam?|Vai tiešām vēlaties apstiprināt šo darbību un izpildīt to %count% atlasītajiem elementiem?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Vai tiešām vēlaties apstiprināt šo darbību un izpildīt to visiem atlasītajiem elementiem?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Jā, izpildīt</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>jā</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>nē</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>satur</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>nesatur</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>ir vienāds</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>nav vienāds</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>ir tukšs</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>nav tukšs</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>starp</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>ne starp</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtri</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>vai</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Pārskatīšana</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Darbība</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Salīdzināt</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Pārskatīšana</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Datums</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Autors</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Loma</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Skatīt izmaiņas</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Salīdzināt izmaiņas</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>vismaz</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>{1} rezultāts|]1,Inf[ Ir %count% rezultāti</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Lejupielādēt</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Informācijas lejupielādēšana…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Priekšskatījums</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Apstiprināt</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Atteikties</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Ierakstu vienā lapā</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Izvēlieties</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Jums ir nesaglabātas izmaiņas.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Rediģēt ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Atjaunināt ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL tika veiksmīgi atjaunināts.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Nekas nav atlasīts</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Meklēšanas rezultāti: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Meklēšana</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>rezultāts nav atrasts</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>pievienot jaunu ierakstu</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Darbības</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Javascript ir izslēgts Jūsu pārlūkprogrammā. Dažas funkcijas var nedarboties pareizi.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Nav pieejamu lauku.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filtri</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Skatīt vēl</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Izvēlieties objekta veidu</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>Nav pieejami objekta veidi</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>nezināms</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>Lasīt vairāk</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>Aizvērt</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/Resources/translations/SonataAdminBundle.nl.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administratie</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Verwijderen</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Aanmaken</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Aanmaken</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Aanmaken en nieuwe toevoegen</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Aanmaken en terug naar de lijst</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filter</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Geavanceerde filters</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Bijwerken</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Bijwerken</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Bijwerken en sluiten</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Verwijderen</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Nieuwe toevoegen</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Terug naar lijst</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Tonen</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Bijwerken</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Nieuwe toevoegen</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Lijst</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Herstellen</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Aanmaken</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Dashboard</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Wijzig "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Lijst</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Volgende</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Vorige</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Eerste</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Laatste</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Beheer</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>Uitklappen/inklappen</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Geen resultaten</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Weet je het zeker?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Bijwerken</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Tonen</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Alle items</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Handeling gestopt. Geen items geselecteerd.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Het item is succesvol aangemaakt.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Het item kon door een fout niet worden aangemaakt.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Het item is succesvol bijgewerkt.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Het item kon door een fout niet worden bijgewerkt.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Een andere gebruiker heeft item "%name%" bewerkt. %link_start%Klik hier%link_end% om de pagina te herladen en de wijzigingen opnieuw toe te passen.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>De geselecteerde items zijn succesvol verwijderd.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>De geselecteerde items konden door een fout niet worden verwijderd.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Het item kon door een fout niet worden verwijderd.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Het item is succesvol verwijderd.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Form is niet beschikbaar</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Bevestig verwijdering</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Weet je zeker dat het geselecteerde item moet worden verwijderd?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Ja, verwijder</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Bevestig groep handeling</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Weet je zeker dat de handeling moet worden uitgevoerd voor het geselecteerde item?|Weet je zeker dat voor de %count% geselecteerde items de handeling moet worden uitgevoerd?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Weet je zeker dat voor alle items de handeling moet worden uitgevoerd?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Ja, voer uit</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>ja</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>nee</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>bevat</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>bevat niet</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>is gelijk aan</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>is niet gelijk aan</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>is leeg</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>is niet leeg</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>tussen</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>niet tussen</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filters</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>of</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Revisies</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Handeling</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Vergelijk</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Revisies</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Datum</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Auteur</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Rol</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Toon revisie</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Vergelijk revisie</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>minstens</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 resultaat|%count% resultaten</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Download</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Laden van informatie...</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Voorvertoning</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Goedkeuren</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Afkeuren</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Aantal per pagina</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Selecteer</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Je hebt niet opgeslagen wijzigingen!</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Bewerk ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Update ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL aangepast</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Geen selectie</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Zoek resultaten</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Zoeken</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>Geen resultaten gevonden</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>Nieuw item toevoegen</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Acties</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Javascript is uitgeschakeld in uw browser. Sommige functies zullen niet goed werken.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Geen velden beschikbaar.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filters</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Bekijk meer</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Selecteer object type</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>Geen object types beschikbaar</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>onbekend</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administratie</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Verwijderen</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Aanmaken</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Aanmaken</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Aanmaken en nieuwe toevoegen</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Aanmaken en terug naar de lijst</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filter</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Geavanceerde filters</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Bijwerken</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Bijwerken</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Bijwerken en sluiten</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Verwijderen</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Nieuwe toevoegen</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Terug naar lijst</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Tonen</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Bijwerken</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Nieuwe toevoegen</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Lijst</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Herstellen</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Aanmaken</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Dashboard</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Wijzig "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Lijst</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Volgende</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Vorige</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Eerste</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Laatste</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Beheer</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>Uitklappen/inklappen</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Geen resultaten</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Weet je het zeker?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Bijwerken</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Tonen</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Alle items</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Handeling gestopt. Geen items geselecteerd.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Het item is succesvol aangemaakt.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Het item kon door een fout niet worden aangemaakt.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Het item is succesvol bijgewerkt.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Het item kon door een fout niet worden bijgewerkt.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Een andere gebruiker heeft item "%name%" bewerkt. %link_start%Klik hier%link_end% om de pagina te herladen en de wijzigingen opnieuw toe te passen.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>De geselecteerde items zijn succesvol verwijderd.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>De geselecteerde items konden door een fout niet worden verwijderd.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Het item kon door een fout niet worden verwijderd.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Het item is succesvol verwijderd.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Form is niet beschikbaar</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Bevestig verwijdering</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Weet je zeker dat het geselecteerde item moet worden verwijderd?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Ja, verwijder</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Bevestig groep handeling</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Weet je zeker dat de handeling moet worden uitgevoerd voor het geselecteerde item?|Weet je zeker dat voor de %count% geselecteerde items de handeling moet worden uitgevoerd?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Weet je zeker dat voor alle items de handeling moet worden uitgevoerd?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Ja, voer uit</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>ja</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>nee</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>bevat</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>bevat niet</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>is gelijk aan</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>is niet gelijk aan</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>is leeg</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>is niet leeg</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>tussen</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>niet tussen</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filters</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>of</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Revisies</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Handeling</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Vergelijk</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Revisies</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Datum</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Auteur</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Rol</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Toon revisie</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Vergelijk revisie</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>minstens</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 resultaat|%count% resultaten</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Download</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Laden van informatie...</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Voorvertoning</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Goedkeuren</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Afkeuren</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Aantal per pagina</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Selecteer</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Je hebt niet opgeslagen wijzigingen!</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Bewerk ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Update ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL aangepast</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Geen selectie</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Zoek resultaten</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Zoeken</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>Geen resultaten gevonden</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>Nieuw item toevoegen</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Acties</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Javascript is uitgeschakeld in uw browser. Sommige functies zullen niet goed werken.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Geen velden beschikbaar.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filters</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Bekijk meer</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Selecteer object type</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>Geen object types beschikbaar</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>onbekend</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.no.xliff
+++ b/Resources/translations/SonataAdminBundle.no.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administrasjon</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Slett</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Opprett</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Lagre</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Lagre og legg til ny</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Lagre og returner til liste</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtrer</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Avanserte filter</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Oppdater</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Oppdater og rediger videre</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Oppdater og returner til liste</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Slett</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Lag ny</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Returner til liste</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Vis</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Endre</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Legg til ny</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Liste</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Tøm filter</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Lag ny</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Dashboard</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Endre "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Liste</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Neste</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Forrige</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Første</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Siste</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>utvid/skjul</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Ingen treff</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Er du sikker?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Endre</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Vis</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Alle element</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Handling kansellert. Ingen objekt ble valgt.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Objekt "%name%" har blitt opprettet</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Det skjedde en feil under oppretting av "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Objekt "%name%" Har blitt oppdatert</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Det skjedde en feil under oppdatering av "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>flash_lock_error</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Valgte objekt har blitt slettet</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Det oppstod en feil under sletting av objekter</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Det oppstod en feil under sletting av objektet "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Objektet "%name%" har blitt slettet</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>form_not_available</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Bekreft sletting</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Er du sikker på at du vil slette det valgte objektet"%object%" ?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Ja, slett</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Bekreft flerhandling: '%action%'</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Er du sikker på at du vil bekrefte denne handlingen og utføre den for det valgte elementet?|Er du sikker på at du vil bekrefte denne handlingen og utføre den for de %count% valgte elementene?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Er du sikker på at du vil bekrefte denne handlingen for alle elementene?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Ja, utfør</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>Ja</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>Nei</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>inneholder</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>inneholder ikke</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>er lik som</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>er ikke lik som</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>er tom</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>er ikke tom</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>mellom</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>ikke mellom</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filter</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>eller</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Revisjoner</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Handling</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Sammenlign</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Revisjoner</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Dato</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Bruker</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Rolle</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Se revisjon</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Sammenlign revisjoner</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>minimum</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 resultat|%count% resultat</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Last ned</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Laster informasjon…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Forhondsvis</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Godkjenn</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Avvis</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Per side</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Velg</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Du har ulagrede endringer.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Endre ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Oppdater ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL har blitt endret.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Ingen utvalg</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Søkeresultat: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Søk</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>Ingen resultat funnet</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>Legg til ny</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Handlinger</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Javascript er skrudd av i din nettleser. Noen funksjoner vil ikke virke.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Ingen felt tilgjengelige</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filter</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>stats_view_more</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Velg objekttype</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>Ingen objektttyper er tilgjengelige</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administrasjon</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Slett</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Opprett</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Lagre</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Lagre og legg til ny</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Lagre og returner til liste</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtrer</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Avanserte filter</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Oppdater</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Oppdater og rediger videre</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Oppdater og returner til liste</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Slett</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Lag ny</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Returner til liste</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Vis</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Endre</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Legg til ny</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Liste</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Tøm filter</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Lag ny</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Dashboard</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Endre "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Liste</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Neste</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Forrige</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Første</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Siste</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>utvid/skjul</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Ingen treff</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Er du sikker?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Endre</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Vis</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Alle element</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Handling kansellert. Ingen objekt ble valgt.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Objekt "%name%" har blitt opprettet</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Det skjedde en feil under oppretting av "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Objekt "%name%" Har blitt oppdatert</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Det skjedde en feil under oppdatering av "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>flash_lock_error</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Valgte objekt har blitt slettet</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Det oppstod en feil under sletting av objekter</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Det oppstod en feil under sletting av objektet "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Objektet "%name%" har blitt slettet</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>form_not_available</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Bekreft sletting</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Er du sikker på at du vil slette det valgte objektet"%object%" ?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Ja, slett</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Bekreft flerhandling: '%action%'</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Er du sikker på at du vil bekrefte denne handlingen og utføre den for det valgte elementet?|Er du sikker på at du vil bekrefte denne handlingen og utføre den for de %count% valgte elementene?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Er du sikker på at du vil bekrefte denne handlingen for alle elementene?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Ja, utfør</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>Ja</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>Nei</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>inneholder</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>inneholder ikke</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>er lik som</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>er ikke lik som</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>er tom</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>er ikke tom</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>mellom</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>ikke mellom</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filter</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>eller</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Revisjoner</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Handling</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Sammenlign</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Revisjoner</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Dato</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Bruker</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Rolle</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Se revisjon</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Sammenlign revisjoner</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>minimum</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 resultat|%count% resultat</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Last ned</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Laster informasjon…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Forhondsvis</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Godkjenn</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Avvis</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Per side</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Velg</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Du har ulagrede endringer.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Endre ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Oppdater ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL har blitt endret.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Ingen utvalg</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Søkeresultat: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Søk</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>Ingen resultat funnet</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>Legg til ny</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Handlinger</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Javascript er skrudd av i din nettleser. Noen funksjoner vil ikke virke.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Ingen felt tilgjengelige</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filter</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>stats_view_more</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Velg objekttype</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>Ingen objektttyper er tilgjengelige</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/Resources/translations/SonataAdminBundle.pl.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Panel administracyjny</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Usuń</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Zapisz</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Zapisz</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Zapisz i dodaj kolejny</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Zapisz i wróć do listy</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtruj</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Zaawansowane filtry</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Zapisz zmiany</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Zapisz zmiany</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Zapisz zmiany i zamknij</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Usuń</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Dodaj nowy</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Powrót do listy</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Pokaż</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Edytuj</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Dodaj</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Zarządzaj</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Cofnij</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Stwórz</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>Pokaż "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Pulpit</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Edytuj "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Wylistuj</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Następna</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Poprzednia</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Pierwsza</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Ostatnia</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Panel administracyjny</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>pokaż/ukryj</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Brak wyników</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Czy jesteś pewien?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Edytuj</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Pokaż</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Wszystkie</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Akcja anulowana. Żadne elementy nie zostały zaznaczone.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Element "%name%" został pomyślnie dodany.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Pojawił się błąd przy tworzeniu elementu "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Element "%name%" został pomyślnie zaktualizowany.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Pojawił się błąd przy aktualizowaniu elementu "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>flash_lock_error</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Wybrane elementy zostały pomyślnie usunięte.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Pojawił się błąd przy usuwaniu wybranych elementów.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Pojawił się błąd przy usuwaniu elementu "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Element "%name%" został pomyślnie usunięty.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Formularz niedostępny</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Potwierdzenie usuwania</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Jesteś pewien(na), że chcesz usunąć element "%object%"?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Tak, usuń</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Potwierdź wykonanie akcji "%action%"</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Jesteś pewny(na), że chcesz potwierdzić tę akcję i wykonać ją dla jednego zaznaczonego elementu?|Jesteś pewny(na), że chcesz potwierdzić tę akcję i wykonać ją dla %count% zaznaczonych elementów?|Jesteś pewny(na), że chcesz potwierdzić tę akcję i wykonać ją dla %count% zaznaczonych elementów?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Jesteś pewny(na), że chcesz potwierdzić tę akcję i wykonać ją dla wszystkich elementów?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Tak, wykonaj</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>tak</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>nie</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>zawiera</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>nie zawiera</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>jest równe</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>nie jest równe</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>jest puste</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>nie jest puste</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>jest pomiędzy</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>nie jest pomiędzy</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtry</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>albo</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Historia zmian</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Akcja</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>td_compare</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Wersja</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Data</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Użytkownik</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>td_role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Pokaż wersję</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>label_compare_revision</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>Co najmniej</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>%count% wynik|%count% wyniki|%count% wyników</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Eksportuj</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Ładowanie informacji…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Podgląd</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Zatwierdź</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Odrzuć</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Na stronie</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Wybierz</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Posiadasz niezapisane zmiany</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Edytuj ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Aktualizuj ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL zostało pomyślnie zaktualizowane</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Nie wybrano</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Wyniki wyszukiwania: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Szukaj</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>Brak wyników</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>Dodaj nowy</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Akcje</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Twoja przeglądarka ma wyłączoną obsługę JavaScript. Niektóre funkcje mogą nie działać poprawnie.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Brak dostępnych pól.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filtry</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Zobacz więcej</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>title_select_subclass</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>no_subclass_available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Panel administracyjny</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Usuń</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Zapisz</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Zapisz</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Zapisz i dodaj kolejny</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Zapisz i wróć do listy</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtruj</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Zaawansowane filtry</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Zapisz zmiany</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Zapisz zmiany</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Zapisz zmiany i zamknij</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Usuń</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Dodaj nowy</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Powrót do listy</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Pokaż</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Edytuj</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Dodaj</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Zarządzaj</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Cofnij</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Stwórz</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>Pokaż "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Pulpit</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Edytuj "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Wylistuj</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Następna</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Poprzednia</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Pierwsza</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Ostatnia</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Panel administracyjny</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>pokaż/ukryj</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Brak wyników</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Czy jesteś pewien?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Edytuj</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Pokaż</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Wszystkie</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Akcja anulowana. Żadne elementy nie zostały zaznaczone.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Element "%name%" został pomyślnie dodany.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Pojawił się błąd przy tworzeniu elementu "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Element "%name%" został pomyślnie zaktualizowany.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Pojawił się błąd przy aktualizowaniu elementu "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>flash_lock_error</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Wybrane elementy zostały pomyślnie usunięte.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Pojawił się błąd przy usuwaniu wybranych elementów.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Pojawił się błąd przy usuwaniu elementu "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Element "%name%" został pomyślnie usunięty.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Formularz niedostępny</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Potwierdzenie usuwania</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Jesteś pewien(na), że chcesz usunąć element "%object%"?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Tak, usuń</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Potwierdź wykonanie akcji "%action%"</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Jesteś pewny(na), że chcesz potwierdzić tę akcję i wykonać ją dla jednego zaznaczonego elementu?|Jesteś pewny(na), że chcesz potwierdzić tę akcję i wykonać ją dla %count% zaznaczonych elementów?|Jesteś pewny(na), że chcesz potwierdzić tę akcję i wykonać ją dla %count% zaznaczonych elementów?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Jesteś pewny(na), że chcesz potwierdzić tę akcję i wykonać ją dla wszystkich elementów?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Tak, wykonaj</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>tak</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>nie</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>zawiera</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>nie zawiera</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>jest równe</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>nie jest równe</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>jest puste</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>nie jest puste</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>jest pomiędzy</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>nie jest pomiędzy</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtry</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>albo</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Historia zmian</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Akcja</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>td_compare</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Wersja</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Data</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Użytkownik</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>td_role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Pokaż wersję</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>label_compare_revision</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>Co najmniej</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>%count% wynik|%count% wyniki|%count% wyników</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Eksportuj</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Ładowanie informacji…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Podgląd</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Zatwierdź</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Odrzuć</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Na stronie</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Wybierz</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Posiadasz niezapisane zmiany</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Edytuj ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Aktualizuj ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL zostało pomyślnie zaktualizowane</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Nie wybrano</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Wyniki wyszukiwania: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Szukaj</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>Brak wyników</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>Dodaj nowy</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Akcje</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Twoja przeglądarka ma wyłączoną obsługę JavaScript. Niektóre funkcje mogą nie działać poprawnie.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Brak dostępnych pól.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filtry</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Zobacz więcej</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>title_select_subclass</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>no_subclass_available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pt.xliff
+++ b/Resources/translations/SonataAdminBundle.pt.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administration</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Apagar</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Criar</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Criar e editar</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Criar e adicionar outro</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Criar e voltar à lista</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtrar</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>btn_advanced_filters</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Atualizar</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Atualizar</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Atualizar e fechar</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Apagar</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Adicionar novo</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Voltar à lista</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Ver</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Editar</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Novo</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Listar</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Redefinir</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Criar</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Visão Geral</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Editar "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Listar</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Próximo</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Anterior</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Primeiro</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Último</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>expandir/recolher</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Sem resultados</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Têm a certeza?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Editar</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Ver</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Todos os elementos</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Ação abortada. Nenhum item selecionado.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>O item foi criado com sucesso.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Ocorreu um erro durante a criação do item.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>O item foi atualizado com sucesso.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Ocorreu um erro durante a atualização do item.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>flash_lock_error</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Os itens selecionados foram apagados com sucesso.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Ocorreu um erro enquanto os itens selecionados eram apagados.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Ocorreu um erro enquanto o item era apagado.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>O item foi apagado com sucesso.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>form_not_available</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target>Visão Geral</target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Confirmar eliminação</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Tem a certeza de que deseja eliminar o item selecionado?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Sim, eliminar</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Confirmar ação</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Tem a certeza de que deseja confirmar esta ação e executá-la para todos os elementos selecionados?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Tem a certeza que quer confirmar esta ação e executá-la para todos os elementos?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Sim, executar</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>sim</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>não</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>contêm</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>não contêm</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>é igual a</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>não é igual a</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>está vazio</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>não está vazio</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>entre</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>não entre os</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtros</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>ou</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Revisões</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Ação</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>td_compare</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Revisões</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Data</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Autor</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>td_role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Ver Revisão</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>label_compare_revision</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>list_results_count_prefix</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 resultado|%count% resultados</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Download</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Carregando informação…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Visualizar</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Aprovado</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Rejeitar</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Por página</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Selecionar</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>confirm_exit</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>link_edit_acl</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>btn_update_acl</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>flash_acl_update_success</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>link_action_acl</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Nenhuma selecção</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>title_search_results</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>search_placeholder</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>no_results_found</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>add_new_entry</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>link_actions</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>noscript_warning</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>link_filters</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>stats_view_more</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>title_select_subclass</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>no_subclass_available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administration</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Apagar</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Criar</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Criar e editar</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Criar e adicionar outro</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Criar e voltar à lista</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtrar</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>btn_advanced_filters</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Atualizar</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Atualizar</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Atualizar e fechar</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Apagar</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Adicionar novo</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Voltar à lista</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Ver</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Editar</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Novo</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Listar</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Redefinir</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Criar</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Visão Geral</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Editar "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Listar</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Próximo</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Anterior</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Primeiro</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Último</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>expandir/recolher</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Sem resultados</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Têm a certeza?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Editar</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Ver</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Todos os elementos</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Ação abortada. Nenhum item selecionado.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>O item foi criado com sucesso.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Ocorreu um erro durante a criação do item.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>O item foi atualizado com sucesso.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Ocorreu um erro durante a atualização do item.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>flash_lock_error</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Os itens selecionados foram apagados com sucesso.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Ocorreu um erro enquanto os itens selecionados eram apagados.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Ocorreu um erro enquanto o item era apagado.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>O item foi apagado com sucesso.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>form_not_available</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target>Visão Geral</target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Confirmar eliminação</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Tem a certeza de que deseja eliminar o item selecionado?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Sim, eliminar</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Confirmar ação</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Tem a certeza de que deseja confirmar esta ação e executá-la para todos os elementos selecionados?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Tem a certeza que quer confirmar esta ação e executá-la para todos os elementos?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Sim, executar</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>sim</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>não</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>contêm</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>não contêm</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>é igual a</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>não é igual a</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>está vazio</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>não está vazio</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>entre</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>não entre os</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtros</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>ou</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Revisões</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Ação</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>td_compare</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Revisões</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Data</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>td_role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Ver Revisão</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>label_compare_revision</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>list_results_count_prefix</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 resultado|%count% resultados</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Download</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Carregando informação…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Visualizar</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Aprovado</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Rejeitar</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Por página</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Selecionar</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>confirm_exit</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>link_edit_acl</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>btn_update_acl</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>flash_acl_update_success</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>link_action_acl</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Nenhuma selecção</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>title_search_results</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>search_placeholder</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>no_results_found</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>add_new_entry</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>link_actions</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>noscript_warning</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>message_form_group_empty</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>link_filters</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>stats_view_more</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>title_select_subclass</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>no_subclass_available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administração</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Excluir</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Criar</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Criar</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Criar e adicionar outro</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Criar e retornar para a lista</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtrar</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Fitros Avançados</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Atualizar</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Atualizar</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Atualizar e sair</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Deletar</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Adicionar novo</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Retornar para a listagem</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Exibir</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Editar</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Adicionar novo</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Listar</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Limpar Filtros</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Criar</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>Exibir "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Visão Geral</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Editar "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Listar</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Próximo</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Anterior</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Primeiro</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Último</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>Expandir/Contrair</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Nenhum resultado</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Você tem certeza?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Editar</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Exibir</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Todos os elementos</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Ação abortada. Nenhum item foi selecionado.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>O item "%name%" foi criado com sucesso.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Um erro ocorreu durante a criação do item "%name%".</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>O item foi atualizado com sucesso.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Um erro ocorreu durante a atualização do item.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Outro usuário modificou o item "%name%". Por favor, %link_start%clique aqui%link_end% para recarregar a página e aplicar as mudanças novamente.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Itens selecionados foram deletados com sucesso.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Um erro ocorreu durante a remoção dos itens selecionados.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Um erro ocorreu durante a remoção do item.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>O item foi removido com sucesso.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>O formulário não está disponível</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Confirmar a remoção</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Você tem certeza que deseja remover o item "%object%" selecionado?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Sim, remover</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Confirmar ação em massa</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Você tem certeza que deseja executar isso para o elemento selecionado?|Você tem certeza que deseja executar a ação para os %count% elementos selecionados?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Você tem certeza que deseja executar essa ação para todos os elementos?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Sim, executar</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>sim</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>não</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>contém</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>não contém</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>é igual a</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>não é igual a</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>é vazio</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>não é vazio</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>entre</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>não está entre</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtro</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>ou</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Revisões</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Ação</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Comparar</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Revisão</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Data</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Autor</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Função</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Ver revisão</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Comparar revisão</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>pelo menos</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 resultado|%count% resultados</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Download</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Carregando…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Pré-visualização</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Aprovar</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Rejeitar</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Por página</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Selecionar</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Você tem mudanças não salvas.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Editar ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Atualizar ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL foi atualizada com sucesso.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Nenhuma seleção</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Resultados da busca: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Busca</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>nenhum resultado encontrado</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>Adicionar novo item</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Ações</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Javascript está desativado no seu navegador. Algumas recursos não funcionarão corretamente.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Nenhum campo disponível</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filtros</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Ver mais</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Selecione o tipo do objeto</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>Nenhum tipo de objeto disponível</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>Usuário desconhecido</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administração</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Excluir</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Criar</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Criar</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Criar e adicionar outro</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Criar e retornar para a lista</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtrar</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Fitros Avançados</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Atualizar</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Atualizar</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Atualizar e sair</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Deletar</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Adicionar novo</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Retornar para a listagem</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Exibir</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Editar</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Adicionar novo</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Listar</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Limpar Filtros</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Criar</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>Exibir "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Visão Geral</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Editar "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Listar</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Próximo</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Anterior</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Primeiro</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Último</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>Expandir/Contrair</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Nenhum resultado</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Você tem certeza?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Editar</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Exibir</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Todos os elementos</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Ação abortada. Nenhum item foi selecionado.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>O item "%name%" foi criado com sucesso.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Um erro ocorreu durante a criação do item "%name%".</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>O item foi atualizado com sucesso.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Um erro ocorreu durante a atualização do item.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Outro usuário modificou o item "%name%". Por favor, %link_start%clique aqui%link_end% para recarregar a página e aplicar as mudanças novamente.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Itens selecionados foram deletados com sucesso.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Um erro ocorreu durante a remoção dos itens selecionados.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Um erro ocorreu durante a remoção do item.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>O item foi removido com sucesso.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>O formulário não está disponível</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Confirmar a remoção</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Você tem certeza que deseja remover o item "%object%" selecionado?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Sim, remover</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Confirmar ação em massa</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Você tem certeza que deseja executar isso para o elemento selecionado?|Você tem certeza que deseja executar a ação para os %count% elementos selecionados?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Você tem certeza que deseja executar essa ação para todos os elementos?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Sim, executar</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>sim</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>não</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>contém</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>não contém</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>é igual a</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>não é igual a</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>é vazio</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>não é vazio</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>entre</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>não está entre</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtro</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>ou</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Revisões</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Ação</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Comparar</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Revisão</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Data</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Função</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Ver revisão</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Comparar revisão</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>pelo menos</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 resultado|%count% resultados</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Download</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Carregando…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Pré-visualização</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Aprovar</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Rejeitar</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Por página</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Selecionar</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Você tem mudanças não salvas.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Editar ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Atualizar ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL foi atualizada com sucesso.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Nenhuma seleção</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Resultados da busca: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Busca</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>nenhum resultado encontrado</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>Adicionar novo item</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Ações</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Javascript está desativado no seu navegador. Algumas recursos não funcionarão corretamente.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Nenhum campo disponível</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filtros</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Ver mais</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Selecione o tipo do objeto</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>Nenhum tipo de objeto disponível</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>Usuário desconhecido</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ro.xliff
+++ b/Resources/translations/SonataAdminBundle.ro.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administration</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Ștergeți</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Creați</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Aplicați</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Creați și adăugați unul nou</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Creați și reveniți la listă</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filtru</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Filtre avansate</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Actualizați</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Actualizați și editați</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Actualizați și închideți</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Ștergeți</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Adăugați</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Reveniți la listă</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Vizualizare</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Editați</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Adăugați</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Lista</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Resetați</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Creați</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Panoul principal</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Editați "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Lista</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Următoarea</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Precedenta</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Prima</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Ultima</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>extindeți/restrângeți</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Nici un rezultat</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Sunteți sigur?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Editați</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Vizualizați</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Toți itemii</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Acțiune anulată. Nici un item nu fost selectat.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Itemul a fost creat cu succes.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>O eroare a apărut în timpul creării itemului.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Itemul a fost actualizat cu succes.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>O eroare a apărut în timpul actualizării itemului.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>flash_lock_error</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Itemii selectați au fost șterși cu succes.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>O eroare a apărut în timpul ștergerii itemilor selectați.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>O eroare a apărut în timpul ștergerii itemului.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Itemul a fost șters cu succes.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>form_not_available</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Confirmați ștergerea</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Sunteți sigur că doriți să ștergeți itemul selectat?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Da, ștergeți</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Confirmați acțiunea în serie</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Sunteți sigur că doriți să confirmați și să executați această acțiune pentru itemul selectat? | Sunteți sigur că doriți să confirmați și să executați această acțiune pentru %count% itemi selectați?| Sunteți sigur că doriți să confirmați și să executați această acțiune pentru %count% itemi selectați?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Sunteți sigur că doriți să confirmați și să executați această acțiune pentru toți itemii?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Da, executați</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>da</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>nu</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>conține</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>nu conține</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>este egal cu</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>nu este egal cu</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>este gol</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>nu este gol</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>între</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>nu este între</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtre</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>sau</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Modificări</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Acțiune</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>td_compare</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Modificări</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Data</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Autor</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>td_role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Vezi Modificările</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>label_compare_revision</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>list_results_count_prefix</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 rezultat|%count% rezultate|%count% rezultate</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Descarcă</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Se încarcă informația ...</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Previzualizare</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Aprobă</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Declină</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Per pagină</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Selectați</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Există modificări care nu au fost salvate</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Editează ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Actualizează ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL actualizat cu succes</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Nimic nu este selectat</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Rezultatele căutării: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Căutare</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>nici un rezultat</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>Adăugați item nou</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Acțiuni</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Javascript este dezactivat în browser-ul dvs. Unele funcții nu vor funcționa corect.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Nici un câmp nu este disponibil</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filtre</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>stats_view_more</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>title_select_subclass</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>no_subclass_available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administration</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Ștergeți</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Creați</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Aplicați</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Creați și adăugați unul nou</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Creați și reveniți la listă</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filtru</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Filtre avansate</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Actualizați</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Actualizați și editați</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Actualizați și închideți</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Ștergeți</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Adăugați</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Reveniți la listă</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Vizualizare</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Editați</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Adăugați</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Lista</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Resetați</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Creați</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Panoul principal</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Editați "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Lista</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Următoarea</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Precedenta</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Prima</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Ultima</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>extindeți/restrângeți</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Nici un rezultat</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Sunteți sigur?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Editați</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Vizualizați</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Toți itemii</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Acțiune anulată. Nici un item nu fost selectat.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Itemul a fost creat cu succes.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>O eroare a apărut în timpul creării itemului.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Itemul a fost actualizat cu succes.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>O eroare a apărut în timpul actualizării itemului.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>flash_lock_error</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Itemii selectați au fost șterși cu succes.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>O eroare a apărut în timpul ștergerii itemilor selectați.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>O eroare a apărut în timpul ștergerii itemului.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Itemul a fost șters cu succes.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>form_not_available</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Confirmați ștergerea</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Sunteți sigur că doriți să ștergeți itemul selectat?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Da, ștergeți</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Confirmați acțiunea în serie</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Sunteți sigur că doriți să confirmați și să executați această acțiune pentru itemul selectat? | Sunteți sigur că doriți să confirmați și să executați această acțiune pentru %count% itemi selectați?| Sunteți sigur că doriți să confirmați și să executați această acțiune pentru %count% itemi selectați?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Sunteți sigur că doriți să confirmați și să executați această acțiune pentru toți itemii?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Da, executați</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>da</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>nu</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>conține</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>nu conține</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>este egal cu</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>nu este egal cu</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>este gol</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>nu este gol</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>între</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>nu este între</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtre</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>sau</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Modificări</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Acțiune</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>td_compare</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Modificări</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Data</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>td_role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Vezi Modificările</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>label_compare_revision</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>list_results_count_prefix</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 rezultat|%count% rezultate|%count% rezultate</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Descarcă</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Se încarcă informația ...</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Previzualizare</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Aprobă</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Declină</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Per pagină</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Selectați</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Există modificări care nu au fost salvate</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Editează ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Actualizează ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL actualizat cu succes</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Nimic nu este selectat</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Rezultatele căutării: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Căutare</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>nici un rezultat</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>Adăugați item nou</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Acțiuni</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Javascript este dezactivat în browser-ul dvs. Unele funcții nu vor funcționa corect.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Nici un câmp nu este disponibil</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filtre</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>stats_view_more</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>title_select_subclass</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>no_subclass_available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/Resources/translations/SonataAdminBundle.ru.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administration</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Удалить</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Создать</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Создать и редактировать</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Создать и добавить новый</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Создать и вернуться к списку</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Фильтровать</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Расширенные фильтры</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Сохранить</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Сохранить</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Сохранить и вернуться к списку</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Удалить</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Добавить новый</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Вернуться к списку</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Показать</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Редактировать</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Добавить новый</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Список</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Сбросить</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Создать</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>Показать "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Панель администрирования</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Редактировать "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Список</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Следующая</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Предыдущая</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Первая</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Последняя</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Администрирование</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>развернуть/свернуть</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Нет результатов</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Вы уверены?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Редактировать</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Показать</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Применить для всех</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Действие отменено. Нет выбранных объектов.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Элемент создан успешно</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>При создании элемента произошла ошибка.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Элемент успешно обновлен.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Во время обновления элемента произошла ошибка.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Другой пользователь изменил элемент "%name%". Пожалуйста, %link_start%нажмите здесь%link_end%, чтобы перезагрузить страницу и применить изменения снова.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Выбранные элементы были успешно удалены.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Во время удаления выбранных элементов произошла ошибка.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Во время удаления элемента произошла ошибка.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Элемент успешно удален.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Форма не доступна.</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Подтверждение удаления</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Вы действительно хотите удалить выбранный элемент?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Да, удалить</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Подтверждение пакетного действия "%action%"</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Вы действительно хотите произвести выбранное действие для данного элемента?|Вы действительно хотите произвести выбранное действие для данных элементов?|Вы действительно хотите произвести выбранное действие для %count% выбранных элементов?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Вы действительно хотите произвести выбранное действие для всех элементов?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Да, выполнить</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>да</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>нет</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>содержит</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>не содержит</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>равен</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>не равен</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>пусто</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>не пуст</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>между</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>не между</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Фильтры</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>или</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Изменения</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Действие</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Сравнить</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Изменения</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Дата</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Автор</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Роль</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Просмотр изменений</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Сравнить изменения</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>Как минимум</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>{0} Нет данных |{1} Всего %count% запись |{2,3,4} Всего %count% записи |[5,Inf] Всего %count% записей</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Экспорт</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Загрузка информации…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Предпросмотр</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Одобрить</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Отклонить</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Записей на страницу</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Выбрать</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>У вас есть несохраненные данные</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Редактировать ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Обновить ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL успешно отредактирован</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Ничего не выбрано</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Результат поиска: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Поиск</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>Ничего не найдено</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>Добавить новую запись</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Действия</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>В вашем браузере отключен Javascipt. Некоторые функции сайта будут недоступны.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Нет доступных полей</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Фильтры</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Показать еще</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Выберите тип объекта</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>Нет доступных типов объекта</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>неизвестный</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>Читать далее</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>Закрыть</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administration</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Удалить</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Создать</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Создать и редактировать</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Создать и добавить новый</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Создать и вернуться к списку</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Фильтровать</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Расширенные фильтры</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Сохранить</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Сохранить</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Сохранить и вернуться к списку</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Удалить</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Добавить новый</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Вернуться к списку</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Показать</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Редактировать</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Добавить новый</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Список</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Сбросить</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Создать</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>Показать "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Панель администрирования</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Редактировать "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Список</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Следующая</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Предыдущая</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Первая</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Последняя</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Администрирование</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>развернуть/свернуть</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Нет результатов</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Вы уверены?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Редактировать</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Показать</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Применить для всех</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Действие отменено. Нет выбранных объектов.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Элемент создан успешно</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>При создании элемента произошла ошибка.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Элемент успешно обновлен.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Во время обновления элемента произошла ошибка.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Другой пользователь изменил элемент "%name%". Пожалуйста, %link_start%нажмите здесь%link_end%, чтобы перезагрузить страницу и применить изменения снова.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Выбранные элементы были успешно удалены.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Во время удаления выбранных элементов произошла ошибка.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Во время удаления элемента произошла ошибка.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Элемент успешно удален.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Форма не доступна.</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Подтверждение удаления</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Вы действительно хотите удалить выбранный элемент?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Да, удалить</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Подтверждение пакетного действия "%action%"</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Вы действительно хотите произвести выбранное действие для данного элемента?|Вы действительно хотите произвести выбранное действие для данных элементов?|Вы действительно хотите произвести выбранное действие для %count% выбранных элементов?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Вы действительно хотите произвести выбранное действие для всех элементов?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Да, выполнить</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>да</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>нет</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>содержит</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>не содержит</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>равен</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>не равен</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>пусто</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>не пуст</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>между</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>не между</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Фильтры</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>или</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Изменения</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Действие</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Сравнить</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Изменения</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Дата</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Автор</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Роль</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Просмотр изменений</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Сравнить изменения</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>Как минимум</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>{0} Нет данных |{1} Всего %count% запись |{2,3,4} Всего %count% записи |[5,Inf] Всего %count% записей</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Экспорт</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Загрузка информации…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Предпросмотр</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Одобрить</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Отклонить</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Записей на страницу</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Выбрать</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>У вас есть несохраненные данные</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Редактировать ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Обновить ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL успешно отредактирован</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Ничего не выбрано</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Результат поиска: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Поиск</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>Ничего не найдено</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>Добавить новую запись</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Действия</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>В вашем браузере отключен Javascipt. Некоторые функции сайта будут недоступны.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Нет доступных полей</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Фильтры</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Показать еще</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Выберите тип объекта</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>Нет доступных типов объекта</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>неизвестный</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>Читать далее</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>Закрыть</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/Resources/translations/SonataAdminBundle.sk.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administration</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Vymazať</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Vytvoriť</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Vytvoriť</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Vytvoriť a pridať ďalší</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Vytvoriť a vrátiť sa do zoznamu</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filter</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Rozšírené filtre</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Aktualizovať</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Aktualizovať</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Aktualizovať a zavrieť</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Vymazať</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Pridať nový</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Späť na zoznam</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Ukázať</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Upraviť</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Pridať nový</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Zoznam</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Reset</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Vytvoriť</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Administračný panel</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Upraviť "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Zoznam</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Ďalší</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Predchádzajúci</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Prvý</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Posledný</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>rozbaliť/zbaliť</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Žiadny výsledok</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Ste si naozaj istý?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Upraviť</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Zobraziť</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Všetky prvky</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Akcia bola prerušená. Neboli vybrané žiadne položky.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Položka bola úspešne vytvorená.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Pri vytváraní položky nastala chyba.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Položka bola úspešne upravená.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Pri úprave položky nastala chyba.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Iný používateľ zmenil položku "%name%". %link_start%Obnoviť stránku a opätovne aplikovať zmeny.%link_end%</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Vybrané položky boli úspešne odstránené.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Pri odstraňovaní vybraných položiek nastala chyba.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Pri odstraňovaní položky nastala chyba.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Položka bola úspešne odstránená.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Formulár nie je k dispozícii.</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Potvrdiť odstránenie</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Naozaj chcete odstrániť vybraný prvok?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Áno, odstrániť</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Potvrdiť dávkovú operáciu: '%action%'</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Ste si istý, že chcete potvrdiť túto akciu a spustiť ju na vybranú položku?|Ste si istý, že chcete potvrdiť túto akciu a spustiť ju na %count% položky?|Ste si istý, že chcete potvrdiť túto akciu a spustiť ju na %count% položiek?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Ste si istý, že chcete potvrdiť túto akciu a spustiť ju na všetky položky?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Áno, spustiť</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>áno</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>nie</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>obsahuje</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>neobsahuje</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>sa rovná</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>sa nerovná</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>je prázdny</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>nie je prázdny</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>je medzi</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>nie je medzi</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtre</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>alebo</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Revízie</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Akcia</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Porovnať</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Revízie</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Dátum</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Autor</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>td_role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Zobraziť revíziu</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Porovnať revízie</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>aspoň</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 záznam|%count% záznamy|%count% záznamov</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Exportovať</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Načítavajú sa informácie…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Náhľad</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Schváliť</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Odmietnúť</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Zobraziť najviac</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Vybrať</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Máte neuložené zmeny.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Upraviť</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Aktualizovať</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>Oprávnenia boli úspešne aktualizované.</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>Oprávnenia</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target/>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Výsledky vyhľadávania: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Hľadať</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>Žiadny výsledok</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>Pridať nový záznam</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Akcie</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Javascript je zakázaný vo vašom webovom prehliadači. Niektoré funkcie nebudú pracovať správne.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Žiadne položky nie sú k dispozícii.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filtre</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Zobraziť viac</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>title_select_subclass</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>no_subclass_available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administration</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Vymazať</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Vytvoriť</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Vytvoriť</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Vytvoriť a pridať ďalší</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Vytvoriť a vrátiť sa do zoznamu</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filter</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Rozšírené filtre</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Aktualizovať</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Aktualizovať</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Aktualizovať a zavrieť</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Vymazať</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Pridať nový</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Späť na zoznam</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Ukázať</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Upraviť</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Pridať nový</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Zoznam</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Reset</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Vytvoriť</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Administračný panel</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Upraviť "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Zoznam</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Ďalší</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Predchádzajúci</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Prvý</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Posledný</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>rozbaliť/zbaliť</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Žiadny výsledok</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Ste si naozaj istý?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Upraviť</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Zobraziť</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Všetky prvky</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Akcia bola prerušená. Neboli vybrané žiadne položky.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Položka bola úspešne vytvorená.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Pri vytváraní položky nastala chyba.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Položka bola úspešne upravená.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Pri úprave položky nastala chyba.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Iný používateľ zmenil položku "%name%". %link_start%Obnoviť stránku a opätovne aplikovať zmeny.%link_end%</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Vybrané položky boli úspešne odstránené.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Pri odstraňovaní vybraných položiek nastala chyba.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Pri odstraňovaní položky nastala chyba.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Položka bola úspešne odstránená.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Formulár nie je k dispozícii.</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Potvrdiť odstránenie</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Naozaj chcete odstrániť vybraný prvok?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Áno, odstrániť</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Potvrdiť dávkovú operáciu: '%action%'</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Ste si istý, že chcete potvrdiť túto akciu a spustiť ju na vybranú položku?|Ste si istý, že chcete potvrdiť túto akciu a spustiť ju na %count% položky?|Ste si istý, že chcete potvrdiť túto akciu a spustiť ju na %count% položiek?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Ste si istý, že chcete potvrdiť túto akciu a spustiť ju na všetky položky?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Áno, spustiť</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>áno</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>nie</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>obsahuje</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>neobsahuje</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>sa rovná</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>sa nerovná</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>je prázdny</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>nie je prázdny</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>je medzi</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>nie je medzi</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtre</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>alebo</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Revízie</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Akcia</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Porovnať</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Revízie</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Dátum</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>td_role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Zobraziť revíziu</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Porovnať revízie</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>aspoň</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 záznam|%count% záznamy|%count% záznamov</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Exportovať</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Načítavajú sa informácie…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Náhľad</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Schváliť</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Odmietnúť</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Zobraziť najviac</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Vybrať</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Máte neuložené zmeny.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Upraviť</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Aktualizovať</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>Oprávnenia boli úspešne aktualizované.</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>Oprávnenia</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target/>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Výsledky vyhľadávania: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Hľadať</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>Žiadny výsledok</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>Pridať nový záznam</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Akcie</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Javascript je zakázaný vo vašom webovom prehliadači. Niektoré funkcie nebudú pracovať správne.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Žiadne položky nie sú k dispozícii.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filtre</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Zobraziť viac</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>title_select_subclass</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>no_subclass_available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/Resources/translations/SonataAdminBundle.sl.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administracija</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Izbriši</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>V redu</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Ustvari</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Ustvari</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Ustvari in dodaj nov predmet</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Ustvari in se vrni na seznam</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Prikaži</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Napredni filtri</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Posodobi</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Posodobi</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Posodobi in zapri</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Izbriši</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Dodaj</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Vrnitev na seznam</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Prikaži</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Uredi</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Dodaj</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Seznam</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Počisti</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Ustvari</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Kontrolna plošča</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Urejanje "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Seznam</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Naslednja</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Prejšnja</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Prva</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Zadnja</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>razširi/skrči</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Ni rezultatov.</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Ste prepričani?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Uredi</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Prikaži</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Vsi predmeti</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Akcija prekinjena. Predmeti niso bili izbrani.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Predmet je bil uspešno ustvarjen.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Pri ustvarjanju predmeta se je pojavila napaka.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Predmet je bil uspešno posodobljen.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Pri posodabljanju predmeta je prišlo do napake.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Drug uporabnik je spremenil element "%name%". Prosimo, %link_start%kliknite tu%link_end%, da osvežite stran in ponovno uporabite spremembe.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Izbrani predmeti so bili uspešno izbrisani.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Prišlo je do napake pri brisanju izbranih predmetov.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Pri brisanju predmetov je prišlo do napake.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Predmet je bil uspešno izbrisan.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Obrazec ni na voljo.</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Potrditev brisanja</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Ste prepričani, da želite izbrisati ta predmet?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Da, izbriši</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Potrditev večih akcij</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Ste prepričani, da želite nadaljevati in izvesti to akcijo za vse izbrane predmete?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Ali ste prepričani, da želite potrditi to akcijo in jo izvesti za vse elemente?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Da, izvedi</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>da</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>ne</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>vsebuje</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>ne vsebuje</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>je točno enako</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>ni enako</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>je prazno</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>ni prazno</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>med</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>ni med</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Filtri</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>ali</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Revizije</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Akcija</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Primerjaj</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Revizije</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Datum</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Avtor</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Vloga</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Poglej revizijo</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Primerjaj revizijo</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>vsaj</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 rezultat|%count% rezultata|%count% rezultati|%count% rezultatov</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Prenesi izvoz</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Nalaganje informacij…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Predogled</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Odobritev</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Zavrnitev</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Na stran</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Izberi</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>Imate neshranjene spremembe.</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Uredi ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Posodobi ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL uspešno posodobljen</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Ni izbire</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Rezultati iskanja: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Iskanje</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>Rezultatov ni bilo mogoče najti</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>Dodaj nov vnos</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Dejanja</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>JavaScript je v vašem brskalniku onemogočen. Nekatere lastnosti ne bodo ustrezno delovale.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Polja niso na voljo.</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Filtri</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Poglej več</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Izberi tip objekta</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>Tip objekta ni na voljo</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>neznan</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administracija</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Izbriši</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>V redu</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Ustvari</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Ustvari</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Ustvari in dodaj nov predmet</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Ustvari in se vrni na seznam</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Prikaži</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Napredni filtri</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Posodobi</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Posodobi</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Posodobi in zapri</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Izbriši</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Dodaj</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Vrnitev na seznam</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Prikaži</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Uredi</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Dodaj</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Seznam</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Počisti</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Ustvari</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Kontrolna plošča</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Urejanje "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Seznam</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Naslednja</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Prejšnja</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Prva</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Zadnja</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>razširi/skrči</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Ni rezultatov.</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Ste prepričani?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Uredi</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Prikaži</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Vsi predmeti</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Akcija prekinjena. Predmeti niso bili izbrani.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Predmet je bil uspešno ustvarjen.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Pri ustvarjanju predmeta se je pojavila napaka.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Predmet je bil uspešno posodobljen.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Pri posodabljanju predmeta je prišlo do napake.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Drug uporabnik je spremenil element "%name%". Prosimo, %link_start%kliknite tu%link_end%, da osvežite stran in ponovno uporabite spremembe.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Izbrani predmeti so bili uspešno izbrisani.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Prišlo je do napake pri brisanju izbranih predmetov.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Pri brisanju predmetov je prišlo do napake.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Predmet je bil uspešno izbrisan.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Obrazec ni na voljo.</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Potrditev brisanja</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Ste prepričani, da želite izbrisati ta predmet?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Da, izbriši</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Potrditev večih akcij</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Ste prepričani, da želite nadaljevati in izvesti to akcijo za vse izbrane predmete?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Ali ste prepričani, da želite potrditi to akcijo in jo izvesti za vse elemente?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Da, izvedi</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>da</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>ne</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>vsebuje</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>ne vsebuje</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>je točno enako</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>ni enako</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>je prazno</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>ni prazno</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>med</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>ni med</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Filtri</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>ali</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Revizije</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Akcija</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Primerjaj</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Revizije</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Datum</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Avtor</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Vloga</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Poglej revizijo</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Primerjaj revizijo</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>vsaj</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 rezultat|%count% rezultata|%count% rezultati|%count% rezultatov</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Prenesi izvoz</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Nalaganje informacij…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Predogled</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Odobritev</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Zavrnitev</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Na stran</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Izberi</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>Imate neshranjene spremembe.</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Uredi ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Posodobi ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL uspešno posodobljen</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Ni izbire</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Rezultati iskanja: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Iskanje</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>Rezultatov ni bilo mogoče najti</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>Dodaj nov vnos</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Dejanja</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>JavaScript je v vašem brskalniku onemogočen. Nekatere lastnosti ne bodo ustrezno delovale.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Polja niso na voljo.</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Filtri</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Poglej več</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Izberi tip objekta</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>Tip objekta ni na voljo</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>neznan</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.sv_SE.xliff
+++ b/Resources/translations/SonataAdminBundle.sv_SE.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>sonata_administration</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Ta bort</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>Ok</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Skapa</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Skapa</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Skapa och lägga till en annan</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>btn_create_and_return_to_list</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Filter</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>btn_advanced_filters</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>btn_update</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Uppdatera</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Uppdatera och nära</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>link_delete</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Lägg till ny</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Tillbaka till listan</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Visa</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Redigera</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Lägg till ny</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Lista</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Återställ</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Skapa</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Dashboard</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Redigera</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Lista</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Nästa</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Föregående</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>link_first_pager</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>link_last_pager</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Admin</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>expandera / kollapsa</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Inget resultat</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Är du säker?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Redigera</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Visa</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Alla element</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Action avbryts. Det finns inget exemplar där utvalda.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Artikel har skapats.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>Ett fel har uppstått under punkt skapas.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Artikel har uppdaterats.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>Ett fel har uppstått under punkt uppdatering.</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>flash_lock_error</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Valda objekt har tagits bort.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Ett fel har uppstått under valt objekt raderingen.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Ett fel har uppstått under punkt raderingen.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Artikel har tagits bort.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>form_not_available</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>title_delete</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>message_delete_confirmation</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>btn_delete</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>title_batch_confirmation</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>message_batch_confirmation</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>message_batch_all_confirmation</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>btn_execute_batch_action</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>label_type_yes</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>label_type_no</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>contains</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>does not contain</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>label_type_equals</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>label_type_not_equals</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>label_date_type_null</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>label_date_type_not_null</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>label_date_type_between</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>label_date_type_not_between</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>label_filters</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>delete_or</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>link_action_history</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>td_action</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>td_compare</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>td_revision</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>td_timestamp</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>td_username</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>td_role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>label_view_revision</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>label_compare_revision</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>list_results_count_prefix</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>list_results_count</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>label_export_download</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>loading_information</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>btn_preview</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>btn_preview_approve</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>btn_preview_decline</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>label_per_page</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>list_select</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>confirm_exit</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>link_edit_acl</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>btn_update_acl</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>flash_acl_edit_success</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>link_action_acl</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>short_object_description_placeholder</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>title_search_results</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>search_placeholder</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>no_results_found</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>add_new_entry</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>link_actions</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>noscript_warning</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>message_form_group_empty</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>link_filters</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>stats_view_more</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>title_select_subclass</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>no_subclass_available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>sonata_administration</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Ta bort</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>Ok</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Skapa</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Skapa</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Skapa och lägga till en annan</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>btn_create_and_return_to_list</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Filter</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>btn_advanced_filters</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>btn_update</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Uppdatera</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Uppdatera och nära</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>link_delete</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Lägg till ny</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Tillbaka till listan</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Visa</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Redigera</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Lägg till ny</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Lista</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Återställ</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Skapa</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Dashboard</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Redigera</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Lista</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Nästa</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Föregående</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>link_first_pager</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>link_last_pager</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>expandera / kollapsa</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Inget resultat</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Är du säker?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Redigera</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Visa</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Alla element</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Action avbryts. Det finns inget exemplar där utvalda.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Artikel har skapats.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>Ett fel har uppstått under punkt skapas.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Artikel har uppdaterats.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>Ett fel har uppstått under punkt uppdatering.</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>flash_lock_error</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Valda objekt har tagits bort.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Ett fel har uppstått under valt objekt raderingen.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Ett fel har uppstått under punkt raderingen.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Artikel har tagits bort.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>form_not_available</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>title_delete</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>message_delete_confirmation</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>btn_delete</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>title_batch_confirmation</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>message_batch_confirmation</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>message_batch_all_confirmation</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>btn_execute_batch_action</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>label_type_yes</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>label_type_no</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>contains</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>does not contain</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>label_type_equals</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>label_type_not_equals</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>label_date_type_null</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>label_date_type_not_null</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>label_date_type_between</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>label_date_type_not_between</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>label_filters</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>delete_or</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>link_action_history</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>td_action</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>td_compare</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>td_revision</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>td_timestamp</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>td_username</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>td_role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>label_view_revision</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>label_compare_revision</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>list_results_count_prefix</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>list_results_count</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>label_export_download</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>loading_information</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>btn_preview</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>btn_preview_approve</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>btn_preview_decline</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>label_per_page</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>list_select</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>confirm_exit</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>link_edit_acl</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>btn_update_acl</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>flash_acl_edit_success</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>link_action_acl</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>short_object_description_placeholder</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>title_search_results</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>search_placeholder</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>no_results_found</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>add_new_entry</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>link_actions</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>noscript_warning</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>message_form_group_empty</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>link_filters</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>stats_view_more</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>title_select_subclass</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>no_subclass_available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/Resources/translations/SonataAdminBundle.uk.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>Administration</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>Видалити</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>OK</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>Створити</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>Створити й редагувати</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>Створити й додати новий</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>Створити й повернутись до списку</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>Фільтрувати</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>Розширені фільтри</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>Зберегти</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>Зберегти</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>Зберегти й повернутись до списку</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>Видалити</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>Додати новий</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>Повернутись до списку</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>Показати</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>Редагувати</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>Додати новий</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>Список</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>Скинути</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>Створити</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>Показати "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>Панель</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>Редагувати "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>Список</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>Наступні</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>Попередні</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>Перша сторінка</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>Остання сторінка</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>Адмін</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>розгорнути/згорнути</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>Безрезультатно</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>Ви впевнені?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>Редагувати</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>Показувати</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>Застосувати до усіх</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>Невибрано жодного об’єкта.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>Успіх! Елемент створено.</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>При створенні об’єкта виникла помилка.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>Успіх! Елемент зредаговано.</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>При редагуванні об’єкта виникла помилка</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>Інший користувач змінив елемент "%name%". Будь ласка, %link_start%натисніть тут%link_end%, щоб перезавантажити сторінку і застосувати зміни знову.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>Вибрані елементи виделені.</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>Під час видалення вибраних елементів виникла помилка.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>Під час видалення елемента виникла помилка.</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>Об’єкт видалено.</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>Форма не доступна.</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>Підтвердження видалення</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>Ви справді хочете видалити вибраний об’єкт?</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>Так, видалити</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>Підтвердження гуртової дії</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>Ви дійсно хочете провести обрану дію для цього елемента?|Ви дійсно прагнете провести обрану дію для даних елементів?|Ви дійсно прагнете провести обрану дію для %count% елементів?</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>Ви дійсно хочете провести обрану дію всіх елементів?</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>Так, виконати</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>так</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>немає</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>містить</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>не містить</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>дорівнює</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>не дорівнює</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>порожній</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>не порожній</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>між</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>не між</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>Фільтри</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>або</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>Зміни</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>Дія</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>Порівняти</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>Зміни</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>Дата</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>Автор</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>Роль</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>Перегляд змін</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>Порівняти зміни</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>Як мінімум</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>{0} Данні відсутні |{1} Всього %count% запис |{2,3,4} Всього %count% записи |[5,Inf] Всього %count% записів</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>Експорт</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>Завантаження інформації…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>Попередній перегляд</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>Схвалити</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>Відмінити</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>Записів на сторінку</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>Вибрати</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>У вас є незбережені дані</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>Редагувати ACL</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>Зберегти ACL</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL успішно збережений</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>Нічого не вибрано</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>Результат пошуку: %query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>Пошук</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>Нічого не знайдено</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>Додати новий запис</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>Дії</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>Javascript вимкнений у вашому браузері. Деякі функції не будуть працювати належним чином.</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>Немає доступних полів</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>Фільтри</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>Показати ще</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>Оберіть тип об'єкта</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>Немає доступних типів об'єкта</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>невідомий</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>Administration</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>Видалити</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>OK</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>Створити</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>Створити й редагувати</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>Створити й додати новий</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>Створити й повернутись до списку</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>Фільтрувати</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>Розширені фільтри</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>Зберегти</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>Зберегти</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>Зберегти й повернутись до списку</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>Видалити</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>Додати новий</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>Повернутись до списку</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>Показати</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>Редагувати</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>Додати новий</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>Список</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>Скинути</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>Створити</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>Показати "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>Панель</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>Редагувати "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>Список</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>Наступні</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>Попередні</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>Перша сторінка</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>Остання сторінка</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>Адмін</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>розгорнути/згорнути</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>Безрезультатно</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>Ви впевнені?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>Редагувати</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>Показувати</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>Застосувати до усіх</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>Невибрано жодного об’єкта.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>Успіх! Елемент створено.</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>При створенні об’єкта виникла помилка.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>Успіх! Елемент зредаговано.</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>При редагуванні об’єкта виникла помилка</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>Інший користувач змінив елемент "%name%". Будь ласка, %link_start%натисніть тут%link_end%, щоб перезавантажити сторінку і застосувати зміни знову.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>Вибрані елементи виделені.</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>Під час видалення вибраних елементів виникла помилка.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>Під час видалення елемента виникла помилка.</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>Об’єкт видалено.</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>Форма не доступна.</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>Підтвердження видалення</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>Ви справді хочете видалити вибраний об’єкт?</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>Так, видалити</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>Підтвердження гуртової дії</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>Ви дійсно хочете провести обрану дію для цього елемента?|Ви дійсно прагнете провести обрану дію для даних елементів?|Ви дійсно прагнете провести обрану дію для %count% елементів?</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>Ви дійсно хочете провести обрану дію всіх елементів?</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>Так, виконати</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>так</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>немає</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>містить</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>не містить</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>дорівнює</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>не дорівнює</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>порожній</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>не порожній</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>між</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>не між</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>Фільтри</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>або</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>Зміни</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>Дія</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>Порівняти</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>Зміни</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>Дата</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>Автор</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>Роль</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>Перегляд змін</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>Порівняти зміни</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>Як мінімум</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>{0} Данні відсутні |{1} Всього %count% запис |{2,3,4} Всього %count% записи |[5,Inf] Всього %count% записів</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>Експорт</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>Завантаження інформації…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>Попередній перегляд</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>Схвалити</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>Відмінити</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>Записів на сторінку</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>Вибрати</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>У вас є незбережені дані</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>Редагувати ACL</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>Зберегти ACL</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL успішно збережений</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>Нічого не вибрано</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>Результат пошуку: %query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>Пошук</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>Нічого не знайдено</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>Додати новий запис</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>Дії</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>Javascript вимкнений у вашому браузері. Деякі функції не будуть працювати належним чином.</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>Немає доступних полів</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>Фільтри</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>Показати ще</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>Оберіть тип об'єкта</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>Немає доступних типів об'єкта</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>невідомий</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -1,483 +1,527 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="">
-        <body>
-            <trans-unit id="sonata_administration">
-                <source>sonata_administration</source>
-                <target>管理员</target>
-            </trans-unit>
-            <trans-unit id="action_delete">
-                <source>action_delete</source>
-                <target>删除</target>
-            </trans-unit>
-            <trans-unit id="btn_batch">
-                <source>btn_batch</source>
-                <target>确定</target>
-            </trans-unit>
-            <trans-unit id="btn_create">
-                <source>btn_create</source>
-                <target>创建</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_edit_again">
-                <source>btn_create_and_edit_again</source>
-                <target>创建</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_create_a_new_one">
-                <source>btn_create_and_create_a_new_one</source>
-                <target>创建并添加另一个</target>
-            </trans-unit>
-            <trans-unit id="btn_create_and_return_to_list">
-                <source>btn_create_and_return_to_list</source>
-                <target>创建并返回列表</target>
-            </trans-unit>
-            <trans-unit id="btn_filter">
-                <source>btn_filter</source>
-                <target>过滤器</target>
-            </trans-unit>
-            <trans-unit id="btn_advanced_filters">
-                <source>btn_advanced_filters</source>
-                <target>btn_advanced_filters</target>
-            </trans-unit>
-            <trans-unit id="btn_update">
-                <source>btn_update</source>
-                <target>更新</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_edit_again">
-                <source>btn_update_and_edit_again</source>
-                <target>更新</target>
-            </trans-unit>
-            <trans-unit id="btn_update_and_return_to_list">
-                <source>btn_update_and_return_to_list</source>
-                <target>更新并返回列表</target>
-            </trans-unit>
-            <trans-unit id="link_delete">
-                <source>link_delete</source>
-                <target>删除</target>
-            </trans-unit>
-            <trans-unit id="link_action_create">
-                <source>link_action_create</source>
-                <target>添加</target>
-            </trans-unit>
-            <trans-unit id="link_action_list">
-                <source>link_action_list</source>
-                <target>返回列表</target>
-            </trans-unit>
-            <trans-unit id="link_action_show">
-                <source>link_action_show</source>
-                <target>查看</target>
-            </trans-unit>
-            <trans-unit id="link_action_edit">
-                <source>link_action_edit</source>
-                <target>编辑</target>
-            </trans-unit>
-            <trans-unit id="link_add">
-                <source>link_add</source>
-                <target>添加</target>
-            </trans-unit>
-            <trans-unit id="link_list">
-                <source>link_list</source>
-                <target>列表</target>
-            </trans-unit>
-            <trans-unit id="link_reset_filter">
-                <source>link_reset_filter</source>
-                <target>重置</target>
-            </trans-unit>
-            <trans-unit id="title_create">
-                <source>title_create</source>
-                <target>创建</target>
-            </trans-unit>
-            <trans-unit id="title_show">
-                <source>title_show</source>
-                <target>title_show</target>
-            </trans-unit>
-            <trans-unit id="title_dashboard">
-                <source>title_dashboard</source>
-                <target>控制面板</target>
-            </trans-unit>
-            <trans-unit id="title_edit">
-                <source>title_edit</source>
-                <target>编辑 "%name%"</target>
-            </trans-unit>
-            <trans-unit id="title_list">
-                <source>title_list</source>
-                <target>列表</target>
-            </trans-unit>
-            <trans-unit id="link_next_pager">
-                <source>link_next_pager</source>
-                <target>下一个</target>
-            </trans-unit>
-            <trans-unit id="link_previous_pager">
-                <source>link_previous_pager</source>
-                <target>上一个</target>
-            </trans-unit>
-            <trans-unit id="link_first_pager">
-                <source>link_first_pager</source>
-                <target>第一个</target>
-            </trans-unit>
-            <trans-unit id="link_last_pager">
-                <source>link_last_pager</source>
-                <target>最后一个</target>
-            </trans-unit>
-            <trans-unit id="Admin">
-                <source>Admin</source>
-                <target>管理员</target>
-            </trans-unit>
-            <trans-unit id="link_expand">
-                <source>link_expand</source>
-                <target>展开/缩进</target>
-            </trans-unit>
-            <trans-unit id="no_result">
-                <source>no_result</source>
-                <target>没有结果</target>
-            </trans-unit>
-            <trans-unit id="confirm_msg">
-                <source>confirm_msg</source>
-                <target>你确定 ?</target>
-            </trans-unit>
-            <trans-unit id="action_edit">
-                <source>action_edit</source>
-                <target>编辑</target>
-            </trans-unit>
-            <trans-unit id="action_show">
-                <source>action_show</source>
-                <target>显示</target>
-            </trans-unit>
-            <trans-unit id="all_elements">
-                <source>all_elements</source>
-                <target>所有元素</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_empty">
-                <source>flash_batch_empty</source>
-                <target>暂停操作，没有选择数据</target>
-            </trans-unit>
-            <trans-unit id="flash_create_success">
-                <source>flash_create_success</source>
-                <target>数据已被成功创建</target>
-            </trans-unit>
-            <trans-unit id="flash_create_error">
-                <source>flash_create_error</source>
-                <target>创建时有错误发生</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_success">
-                <source>flash_edit_success</source>
-                <target>数据已被成功更新</target>
-            </trans-unit>
-            <trans-unit id="flash_edit_error">
-                <source>flash_edit_error</source>
-                <target>更新时有错误发生</target>
-            </trans-unit>
-            <trans-unit id="flash_lock_error">
-                <source>flash_lock_error</source>
-                <target>flash_lock_error</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_success">
-                <source>flash_batch_delete_success</source>
-                <target>所选择的数据已经被删除</target>
-            </trans-unit>
-            <trans-unit id="flash_batch_delete_error">
-                <source>flash_batch_delete_error</source>
-                <target>删除时有错误发生</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_error">
-                <source>flash_delete_error</source>
-                <target>删除时有错误发生</target>
-            </trans-unit>
-            <trans-unit id="flash_delete_success">
-                <source>flash_delete_success</source>
-                <target>成功删除</target>
-            </trans-unit>
-            <trans-unit id="form_not_available">
-                <source>form_not_available</source>
-                <target>form_not_available</target>
-            </trans-unit>
-            <trans-unit id="link_breadcrumb_dashboard">
-                <source>link_breadcrumb_dashboard</source>
-                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
-            </trans-unit>
-            <trans-unit id="title_delete">
-                <source>title_delete</source>
-                <target>确认删除</target>
-            </trans-unit>
-            <trans-unit id="message_delete_confirmation">
-                <source>message_delete_confirmation</source>
-                <target>删除所选数据么？请确定。</target>
-            </trans-unit>
-            <trans-unit id="btn_delete">
-                <source>btn_delete</source>
-                <target>是的，请删除</target>
-            </trans-unit>
-            <trans-unit id="title_batch_confirmation">
-                <source>title_batch_confirmation</source>
-                <target>确认批量操作</target>
-            </trans-unit>
-            <trans-unit id="message_batch_confirmation">
-                <source>message_batch_confirmation</source>
-                <target>你确定要执行这次批量操作么？</target>
-            </trans-unit>
-            <trans-unit id="message_batch_all_confirmation">
-                <source>message_batch_all_confirmation</source>
-                <target>你确定要执行这次批量操作么？</target>
-            </trans-unit>
-            <trans-unit id="btn_execute_batch_action">
-                <source>btn_execute_batch_action</source>
-                <target>是的，请执行</target>
-            </trans-unit>
-            <trans-unit id="label_type_yes">
-                <source>label_type_yes</source>
-                <target>是</target>
-            </trans-unit>
-            <trans-unit id="label_type_no">
-                <source>label_type_no</source>
-                <target>否</target>
-            </trans-unit>
-            <trans-unit id="label_type_contains">
-                <source>label_type_contains</source>
-                <target>包含</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_contains">
-                <source>label_type_not_contains</source>
-                <target>不包含</target>
-            </trans-unit>
-            <trans-unit id="label_type_equals">
-                <source>label_type_equals</source>
-                <target>等于</target>
-            </trans-unit>
-            <trans-unit id="label_type_not_equals">
-                <source>label_type_not_equals</source>
-                <target>不等于</target>
-            </trans-unit>
-            <trans-unit id="label_type_equal">
-                <source>label_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_equal">
-                <source>label_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_greater_than">
-                <source>label_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_equal">
-                <source>label_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_type_less_than">
-                <source>label_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_equal">
-                <source>label_date_type_equal</source>
-                <target>=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_equal">
-                <source>label_date_type_greater_equal</source>
-                <target>&gt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_greater_than">
-                <source>label_date_type_greater_than</source>
-                <target>&gt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_equal">
-                <source>label_date_type_less_equal</source>
-                <target>&lt;=</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_less_than">
-                <source>label_date_type_less_than</source>
-                <target>&lt;</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_null">
-                <source>label_date_type_null</source>
-                <target>为空</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_not_null">
-                <source>label_date_type_not_null</source>
-                <target>不为空</target>
-            </trans-unit>
-            <trans-unit id="label_date_type_between">
-                <source>label_date_type_between</source>
-                <target>在...之内</target>
-            </trans-unit>
-            <trans-unit id="label_date_not_between">
-                <source>label_date_type_not_between</source>
-                <target>不在...之内</target>
-            </trans-unit>
-            <trans-unit id="label_filters">
-                <source>label_filters</source>
-                <target>过滤器</target>
-            </trans-unit>
-            <trans-unit id="delete_or">
-                <source>delete_or</source>
-                <target>或</target>
-            </trans-unit>
-            <trans-unit id="link_action_history">
-                <source>link_action_history</source>
-                <target>版本</target>
-            </trans-unit>
-            <trans-unit id="td_action">
-                <source>td_action</source>
-                <target>操作</target>
-            </trans-unit>
-            <trans-unit id="td_compare">
-                <source>td_compare</source>
-                <target>td_compare</target>
-            </trans-unit>
-            <trans-unit id="td_revision">
-                <source>td_revision</source>
-                <target>版本</target>
-            </trans-unit>
-            <trans-unit id="td_timestamp">
-                <source>td_timestamp</source>
-                <target>日期</target>
-            </trans-unit>
-            <trans-unit id="td_username">
-                <source>td_username</source>
-                <target>作者</target>
-            </trans-unit>
-            <trans-unit id="td_role">
-                <source>td_role</source>
-                <target>td_role</target>
-            </trans-unit>
-            <trans-unit id="label_view_revision">
-                <source>label_view_revision</source>
-                <target>查看版本</target>
-            </trans-unit>
-            <trans-unit id="label_compare_revision">
-                <source>label_compare_revision</source>
-                <target>label_compare_revision</target>
-            </trans-unit>
-            <trans-unit id="list_results_count_prefix">
-                <source>list_results_count_prefix</source>
-                <target>list_results_count_prefix</target>
-            </trans-unit>
-            <trans-unit id="list_results_count">
-                <source>list_results_count</source>
-                <target>1 条数据|%count% 条数据</target>
-            </trans-unit>
-            <trans-unit id="label_export_download">
-                <source>label_export_download</source>
-                <target>下载</target>
-            </trans-unit>
-            <trans-unit id="export_format_json">
-                <source>export_format_json</source>
-                <target>JSON</target>
-            </trans-unit>
-            <trans-unit id="export_format_xml">
-                <source>export_format_xml</source>
-                <target>XML</target>
-            </trans-unit>
-            <trans-unit id="export_format_csv">
-                <source>export_format_csv</source>
-                <target>CSV</target>
-            </trans-unit>
-            <trans-unit id="export_format_xls">
-                <source>export_format_xls</source>
-                <target>XLS</target>
-            </trans-unit>
-            <trans-unit id="loading_information">
-                <source>loading_information</source>
-                <target>数据载入中…</target>
-            </trans-unit>
-            <trans-unit id="btn_preview">
-                <source>btn_preview</source>
-                <target>预览</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_approve">
-                <source>btn_preview_approve</source>
-                <target>批准</target>
-            </trans-unit>
-            <trans-unit id="btn_preview_decline">
-                <source>btn_preview_decline</source>
-                <target>拒绝</target>
-            </trans-unit>
-            <trans-unit id="label_per_page">
-                <source>label_per_page</source>
-                <target>每页数据</target>
-            </trans-unit>
-            <trans-unit id="list_select">
-                <source>list_select</source>
-                <target>选择</target>
-            </trans-unit>
-            <trans-unit id="confirm_exit">
-                <source>confirm_exit</source>
-                <target>确认退出</target>
-            </trans-unit>
-            <trans-unit id="link_edit_acl">
-                <source>link_edit_acl</source>
-                <target>编辑ACL权限</target>
-            </trans-unit>
-            <trans-unit id="btn_update_acl">
-                <source>btn_update_acl</source>
-                <target>更新ACL权限</target>
-            </trans-unit>
-            <trans-unit id="flash_acl_update_success">
-                <source>flash_acl_edit_success</source>
-                <target>ACL权限更新成功</target>
-            </trans-unit>
-            <trans-unit id="link_action_acl">
-                <source>link_action_acl</source>
-                <target>ACL权限管理</target>
-            </trans-unit>
-            <trans-unit id="short_object_description_placeholder">
-                <source>short_object_description_placeholder</source>
-                <target>请填写：</target>
-            </trans-unit>
-            <trans-unit id="title_search_results">
-                <source>title_search_results</source>
-                <target>查询结果：%query%</target>
-            </trans-unit>
-            <trans-unit id="search_placeholder">
-                <source>search_placeholder</source>
-                <target>查询：</target>
-            </trans-unit>
-            <trans-unit id="no_results_found">
-                <source>no_results_found</source>
-                <target>没有找到结果</target>
-            </trans-unit>
-            <trans-unit id="add_new_entry">
-                <source>add_new_entry</source>
-                <target>添加新的纪录</target>
-            </trans-unit>
-            <trans-unit id="link_actions">
-                <source>link_actions</source>
-                <target>其他功能</target>
-            </trans-unit>
-            <trans-unit id="noscript_warning">
-                <source>noscript_warning</source>
-                <target>你的浏览器并不支持Javascript，所以有些功能不能正常使用</target>
-            </trans-unit>
-            <trans-unit id="message_form_group_empty">
-                <source>message_form_group_empty</source>
-                <target>没有可用的列</target>
-            </trans-unit>
-            <trans-unit id="link_filters">
-                <source>link_filters</source>
-                <target>link_filters</target>
-            </trans-unit>
-            <trans-unit id="stats_view_more">
-                <source>stats_view_more</source>
-                <target>stats_view_more</target>
-            </trans-unit>
-            <trans-unit id="title_select_subclass">
-                <source>title_select_subclass</source>
-                <target>title_select_subclass</target>
-            </trans-unit>
-            <trans-unit id="no_subclass_available">
-                <source>no_subclass_available</source>
-                <target>no_subclass_available</target>
-            </trans-unit>
-            <trans-unit id="label_unknown_user">
-                <source>label_unknown_user</source>
-                <target>label_unknown_user</target>
-            </trans-unit>
-            <trans-unit id="read_more">
-                <source>read_more</source>
-                <target>read_more</target>
-            </trans-unit>
-            <trans-unit id="read_less">
-                <source>read_less</source>
-                <target>read_less</target>
-            </trans-unit>
-        </body>
-    </file>
+  <file source-language="en" datatype="plaintext" original="">
+    <body>
+      <trans-unit id="sonata_administration">
+        <source>sonata_administration</source>
+        <target>管理员</target>
+      </trans-unit>
+      <trans-unit id="action_delete">
+        <source>action_delete</source>
+        <target>删除</target>
+      </trans-unit>
+      <trans-unit id="btn_batch">
+        <source>btn_batch</source>
+        <target>确定</target>
+      </trans-unit>
+      <trans-unit id="btn_create">
+        <source>btn_create</source>
+        <target>创建</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_edit_again">
+        <source>btn_create_and_edit_again</source>
+        <target>创建</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_create_a_new_one">
+        <source>btn_create_and_create_a_new_one</source>
+        <target>创建并添加另一个</target>
+      </trans-unit>
+      <trans-unit id="btn_create_and_return_to_list">
+        <source>btn_create_and_return_to_list</source>
+        <target>创建并返回列表</target>
+      </trans-unit>
+      <trans-unit id="btn_filter">
+        <source>btn_filter</source>
+        <target>过滤器</target>
+      </trans-unit>
+      <trans-unit id="btn_advanced_filters">
+        <source>btn_advanced_filters</source>
+        <target>btn_advanced_filters</target>
+      </trans-unit>
+      <trans-unit id="btn_update">
+        <source>btn_update</source>
+        <target>更新</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_edit_again">
+        <source>btn_update_and_edit_again</source>
+        <target>更新</target>
+      </trans-unit>
+      <trans-unit id="btn_update_and_return_to_list">
+        <source>btn_update_and_return_to_list</source>
+        <target>更新并返回列表</target>
+      </trans-unit>
+      <trans-unit id="link_delete">
+        <source>link_delete</source>
+        <target>删除</target>
+      </trans-unit>
+      <trans-unit id="link_action_create">
+        <source>link_action_create</source>
+        <target>添加</target>
+      </trans-unit>
+      <trans-unit id="link_action_list">
+        <source>link_action_list</source>
+        <target>返回列表</target>
+      </trans-unit>
+      <trans-unit id="link_action_show">
+        <source>link_action_show</source>
+        <target>查看</target>
+      </trans-unit>
+      <trans-unit id="link_action_edit">
+        <source>link_action_edit</source>
+        <target>编辑</target>
+      </trans-unit>
+      <trans-unit id="link_add">
+        <source>link_add</source>
+        <target>添加</target>
+      </trans-unit>
+      <trans-unit id="link_list">
+        <source>link_list</source>
+        <target>列表</target>
+      </trans-unit>
+      <trans-unit id="link_reset_filter">
+        <source>link_reset_filter</source>
+        <target>重置</target>
+      </trans-unit>
+      <trans-unit id="title_create">
+        <source>title_create</source>
+        <target>创建</target>
+      </trans-unit>
+      <trans-unit id="title_show">
+        <source>title_show</source>
+        <target>title_show</target>
+      </trans-unit>
+      <trans-unit id="title_dashboard">
+        <source>title_dashboard</source>
+        <target>控制面板</target>
+      </trans-unit>
+      <trans-unit id="title_edit">
+        <source>title_edit</source>
+        <target>编辑 "%name%"</target>
+      </trans-unit>
+      <trans-unit id="title_list">
+        <source>title_list</source>
+        <target>列表</target>
+      </trans-unit>
+      <trans-unit id="link_next_pager">
+        <source>link_next_pager</source>
+        <target>下一个</target>
+      </trans-unit>
+      <trans-unit id="link_previous_pager">
+        <source>link_previous_pager</source>
+        <target>上一个</target>
+      </trans-unit>
+      <trans-unit id="link_first_pager">
+        <source>link_first_pager</source>
+        <target>第一个</target>
+      </trans-unit>
+      <trans-unit id="link_last_pager">
+        <source>link_last_pager</source>
+        <target>最后一个</target>
+      </trans-unit>
+      <trans-unit id="Admin">
+        <source>Admin</source>
+        <target>管理员</target>
+      </trans-unit>
+      <trans-unit id="link_expand">
+        <source>link_expand</source>
+        <target>展开/缩进</target>
+      </trans-unit>
+      <trans-unit id="no_result">
+        <source>no_result</source>
+        <target>没有结果</target>
+      </trans-unit>
+      <trans-unit id="confirm_msg">
+        <source>confirm_msg</source>
+        <target>你确定 ?</target>
+      </trans-unit>
+      <trans-unit id="action_edit">
+        <source>action_edit</source>
+        <target>编辑</target>
+      </trans-unit>
+      <trans-unit id="action_show">
+        <source>action_show</source>
+        <target>显示</target>
+      </trans-unit>
+      <trans-unit id="all_elements">
+        <source>all_elements</source>
+        <target>所有元素</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_empty">
+        <source>flash_batch_empty</source>
+        <target>暂停操作，没有选择数据</target>
+      </trans-unit>
+      <trans-unit id="flash_create_success">
+        <source>flash_create_success</source>
+        <target>数据已被成功创建</target>
+      </trans-unit>
+      <trans-unit id="flash_create_error">
+        <source>flash_create_error</source>
+        <target>创建时有错误发生</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_success">
+        <source>flash_edit_success</source>
+        <target>数据已被成功更新</target>
+      </trans-unit>
+      <trans-unit id="flash_edit_error">
+        <source>flash_edit_error</source>
+        <target>更新时有错误发生</target>
+      </trans-unit>
+      <trans-unit id="flash_lock_error">
+        <source>flash_lock_error</source>
+        <target>flash_lock_error</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_success">
+        <source>flash_batch_delete_success</source>
+        <target>所选择的数据已经被删除</target>
+      </trans-unit>
+      <trans-unit id="flash_batch_delete_error">
+        <source>flash_batch_delete_error</source>
+        <target>删除时有错误发生</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_error">
+        <source>flash_delete_error</source>
+        <target>删除时有错误发生</target>
+      </trans-unit>
+      <trans-unit id="flash_delete_success">
+        <source>flash_delete_success</source>
+        <target>成功删除</target>
+      </trans-unit>
+      <trans-unit id="form_not_available">
+        <source>form_not_available</source>
+        <target>form_not_available</target>
+      </trans-unit>
+      <trans-unit id="link_breadcrumb_dashboard">
+        <source>link_breadcrumb_dashboard</source>
+        <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+      </trans-unit>
+      <trans-unit id="title_delete">
+        <source>title_delete</source>
+        <target>确认删除</target>
+      </trans-unit>
+      <trans-unit id="message_delete_confirmation">
+        <source>message_delete_confirmation</source>
+        <target>删除所选数据么？请确定。</target>
+      </trans-unit>
+      <trans-unit id="btn_delete">
+        <source>btn_delete</source>
+        <target>是的，请删除</target>
+      </trans-unit>
+      <trans-unit id="title_batch_confirmation">
+        <source>title_batch_confirmation</source>
+        <target>确认批量操作</target>
+      </trans-unit>
+      <trans-unit id="message_batch_confirmation">
+        <source>message_batch_confirmation</source>
+        <target>你确定要执行这次批量操作么？</target>
+      </trans-unit>
+      <trans-unit id="message_batch_all_confirmation">
+        <source>message_batch_all_confirmation</source>
+        <target>你确定要执行这次批量操作么？</target>
+      </trans-unit>
+      <trans-unit id="btn_execute_batch_action">
+        <source>btn_execute_batch_action</source>
+        <target>是的，请执行</target>
+      </trans-unit>
+      <trans-unit id="label_type_yes">
+        <source>label_type_yes</source>
+        <target>是</target>
+      </trans-unit>
+      <trans-unit id="label_type_no">
+        <source>label_type_no</source>
+        <target>否</target>
+      </trans-unit>
+      <trans-unit id="label_type_contains">
+        <source>label_type_contains</source>
+        <target>包含</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_contains">
+        <source>label_type_not_contains</source>
+        <target>不包含</target>
+      </trans-unit>
+      <trans-unit id="label_type_equals">
+        <source>label_type_equals</source>
+        <target>等于</target>
+      </trans-unit>
+      <trans-unit id="label_type_not_equals">
+        <source>label_type_not_equals</source>
+        <target>不等于</target>
+      </trans-unit>
+      <trans-unit id="label_type_equal">
+        <source>label_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_equal">
+        <source>label_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_greater_than">
+        <source>label_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_equal">
+        <source>label_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_type_less_than">
+        <source>label_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_equal">
+        <source>label_date_type_equal</source>
+        <target>=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_equal">
+        <source>label_date_type_greater_equal</source>
+        <target>&gt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_greater_than">
+        <source>label_date_type_greater_than</source>
+        <target>&gt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_equal">
+        <source>label_date_type_less_equal</source>
+        <target>&lt;=</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_less_than">
+        <source>label_date_type_less_than</source>
+        <target>&lt;</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_null">
+        <source>label_date_type_null</source>
+        <target>为空</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_not_null">
+        <source>label_date_type_not_null</source>
+        <target>不为空</target>
+      </trans-unit>
+      <trans-unit id="label_date_type_between">
+        <source>label_date_type_between</source>
+        <target>在...之内</target>
+      </trans-unit>
+      <trans-unit id="label_date_not_between">
+        <source>label_date_type_not_between</source>
+        <target>不在...之内</target>
+      </trans-unit>
+      <trans-unit id="label_filters">
+        <source>label_filters</source>
+        <target>过滤器</target>
+      </trans-unit>
+      <trans-unit id="delete_or">
+        <source>delete_or</source>
+        <target>或</target>
+      </trans-unit>
+      <trans-unit id="link_action_history">
+        <source>link_action_history</source>
+        <target>版本</target>
+      </trans-unit>
+      <trans-unit id="td_action">
+        <source>td_action</source>
+        <target>操作</target>
+      </trans-unit>
+      <trans-unit id="td_compare">
+        <source>td_compare</source>
+        <target>td_compare</target>
+      </trans-unit>
+      <trans-unit id="td_revision">
+        <source>td_revision</source>
+        <target>版本</target>
+      </trans-unit>
+      <trans-unit id="td_timestamp">
+        <source>td_timestamp</source>
+        <target>日期</target>
+      </trans-unit>
+      <trans-unit id="td_username">
+        <source>td_username</source>
+        <target>作者</target>
+      </trans-unit>
+      <trans-unit id="td_role">
+        <source>td_role</source>
+        <target>td_role</target>
+      </trans-unit>
+      <trans-unit id="label_view_revision">
+        <source>label_view_revision</source>
+        <target>查看版本</target>
+      </trans-unit>
+      <trans-unit id="label_compare_revision">
+        <source>label_compare_revision</source>
+        <target>label_compare_revision</target>
+      </trans-unit>
+      <trans-unit id="list_results_count_prefix">
+        <source>list_results_count_prefix</source>
+        <target>list_results_count_prefix</target>
+      </trans-unit>
+      <trans-unit id="list_results_count">
+        <source>list_results_count</source>
+        <target>1 条数据|%count% 条数据</target>
+      </trans-unit>
+      <trans-unit id="label_export_download">
+        <source>label_export_download</source>
+        <target>下载</target>
+      </trans-unit>
+      <trans-unit id="export_format_json">
+        <source>export_format_json</source>
+        <target>JSON</target>
+      </trans-unit>
+      <trans-unit id="export_format_xml">
+        <source>export_format_xml</source>
+        <target>XML</target>
+      </trans-unit>
+      <trans-unit id="export_format_csv">
+        <source>export_format_csv</source>
+        <target>CSV</target>
+      </trans-unit>
+      <trans-unit id="export_format_xls">
+        <source>export_format_xls</source>
+        <target>XLS</target>
+      </trans-unit>
+      <trans-unit id="loading_information">
+        <source>loading_information</source>
+        <target>数据载入中…</target>
+      </trans-unit>
+      <trans-unit id="btn_preview">
+        <source>btn_preview</source>
+        <target>预览</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_approve">
+        <source>btn_preview_approve</source>
+        <target>批准</target>
+      </trans-unit>
+      <trans-unit id="btn_preview_decline">
+        <source>btn_preview_decline</source>
+        <target>拒绝</target>
+      </trans-unit>
+      <trans-unit id="label_per_page">
+        <source>label_per_page</source>
+        <target>每页数据</target>
+      </trans-unit>
+      <trans-unit id="list_select">
+        <source>list_select</source>
+        <target>选择</target>
+      </trans-unit>
+      <trans-unit id="confirm_exit">
+        <source>confirm_exit</source>
+        <target>确认退出</target>
+      </trans-unit>
+      <trans-unit id="link_edit_acl">
+        <source>link_edit_acl</source>
+        <target>编辑ACL权限</target>
+      </trans-unit>
+      <trans-unit id="btn_update_acl">
+        <source>btn_update_acl</source>
+        <target>更新ACL权限</target>
+      </trans-unit>
+      <trans-unit id="flash_acl_update_success">
+        <source>flash_acl_edit_success</source>
+        <target>ACL权限更新成功</target>
+      </trans-unit>
+      <trans-unit id="link_action_acl">
+        <source>link_action_acl</source>
+        <target>ACL权限管理</target>
+      </trans-unit>
+      <trans-unit id="short_object_description_placeholder">
+        <source>short_object_description_placeholder</source>
+        <target>请填写：</target>
+      </trans-unit>
+      <trans-unit id="title_search_results">
+        <source>title_search_results</source>
+        <target>查询结果：%query%</target>
+      </trans-unit>
+      <trans-unit id="search_placeholder">
+        <source>search_placeholder</source>
+        <target>查询：</target>
+      </trans-unit>
+      <trans-unit id="no_results_found">
+        <source>no_results_found</source>
+        <target>没有找到结果</target>
+      </trans-unit>
+      <trans-unit id="add_new_entry">
+        <source>add_new_entry</source>
+        <target>添加新的纪录</target>
+      </trans-unit>
+      <trans-unit id="link_actions">
+        <source>link_actions</source>
+        <target>其他功能</target>
+      </trans-unit>
+      <trans-unit id="noscript_warning">
+        <source>noscript_warning</source>
+        <target>你的浏览器并不支持Javascript，所以有些功能不能正常使用</target>
+      </trans-unit>
+      <trans-unit id="message_form_group_empty">
+        <source>message_form_group_empty</source>
+        <target>没有可用的列</target>
+      </trans-unit>
+      <trans-unit id="link_filters">
+        <source>link_filters</source>
+        <target>link_filters</target>
+      </trans-unit>
+      <trans-unit id="stats_view_more">
+        <source>stats_view_more</source>
+        <target>stats_view_more</target>
+      </trans-unit>
+      <trans-unit id="title_select_subclass">
+        <source>title_select_subclass</source>
+        <target>title_select_subclass</target>
+      </trans-unit>
+      <trans-unit id="no_subclass_available">
+        <source>no_subclass_available</source>
+        <target>no_subclass_available</target>
+      </trans-unit>
+      <trans-unit id="label_unknown_user">
+        <source>label_unknown_user</source>
+        <target>label_unknown_user</target>
+      </trans-unit>
+      <trans-unit id="read_more">
+        <source>read_more</source>
+        <target>read_more</target>
+      </trans-unit>
+      <trans-unit id="read_less">
+        <source>read_less</source>
+        <target>read_less</target>
+      </trans-unit>
+      <trans-unit id="form.label_code">
+        <source>form.label_code</source>
+        <target>form.label_code</target>
+      </trans-unit>
+      <trans-unit id="form.label_color">
+        <source>form.label_color</source>
+        <target>form.label_color</target>
+      </trans-unit>
+      <trans-unit id="form.label_text">
+        <source>form.label_text</source>
+        <target>form.label_text</target>
+      </trans-unit>
+      <trans-unit id="form.label_description">
+        <source>form.label_description</source>
+        <target>form.label_description</target>
+      </trans-unit>
+      <trans-unit id="form.label_icon">
+        <source>form.label_icon</source>
+        <target>form.label_icon</target>
+      </trans-unit>
+      <trans-unit id="form.label_filters">
+        <source>form.label_filters</source>
+        <target>form.label_filters</target>
+      </trans-unit>
+      <trans-unit id="form.label_class">
+        <source>form.label_class</source>
+        <target>form.label_class</target>
+      </trans-unit>
+      <trans-unit id="form.label_limit">
+        <source>form.label_limit</source>
+        <target>form.label_limit</target>
+      </trans-unit>
+      <trans-unit id="form.template_simple">
+        <source>form.template_simple</source>
+        <target>form.template_simple</target>
+      </trans-unit>
+      <trans-unit id="form.template_link">
+        <source>form.template_link</source>
+        <target>form.template_link</target>
+      </trans-unit>
+      <trans-unit id="form.label_template">
+        <source>form.label_template</source>
+        <target>form.label_template</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/views/Block/block_stats.html.twig
+++ b/Resources/views/Block/block_stats.html.twig
@@ -9,21 +9,5 @@ file that was distributed with this source code.
 
 #}
 
-{% extends sonata_block.templates.block_base %}
-
-{% block block %}
-    <!-- small box -->
-    <div class="small-box {{ settings.color }}">
-        <div class="inner">
-            <h3>{{ pager.count() }}</h3>
-
-            <p>{{ settings.text|trans({}, admin.translationDomain) }}</p>
-        </div>
-        <div class="icon">
-            <i class="fa {{ settings.icon }}"></i>
-        </div>
-        <a href="{{ admin.generateUrl('list', {filter: settings.filters}) }}" class="small-box-footer">
-            {{ 'stats_view_more'|trans({}, 'SonataAdminBundle') }} <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-        </a>
-    </div>
-{% endblock %}
+{# NEXT_MAJOR: Remove this template #}
+{% extends 'SonataAdminBundle:Block:block_stats_simple.html.twig' %}

--- a/Resources/views/Block/block_stats_base.html.twig
+++ b/Resources/views/Block/block_stats_base.html.twig
@@ -1,0 +1,20 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+{% extends sonata_block.templates.block_base %}
+
+{% block block %}
+    <div class="sonata-ajax-block {{ settings.class }}"
+        id="block-{{ block.id }}"
+        data-url="{{ path('sonata_admin_stats', { code: settings.code, limit: settings.limit, filters: settings.filters } ) }}"
+    >
+        {% block block_content %}{% endblock block_content %}
+    </div>
+{% endblock block %}

--- a/Resources/views/Block/block_stats_link.html.twig
+++ b/Resources/views/Block/block_stats_link.html.twig
@@ -1,0 +1,26 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+{% extends 'SonataAdminBundle:Block:block_stats_base.html.twig' %}
+
+{% block block_content %}
+    <div class="small-box {{ settings.color }}">
+        <div class="inner overlay-wrapper refresh-btn">
+            <h3 class="url-count">{{ pager.count() }}</h3>
+            <p>{{ settings.text }}</p>
+        </div>
+        <div class="icon">
+            <i class="{{ settings.icon }}"></i>
+        </div>
+        <a href="{{ admin.generateUrl('list', { filter: settings.filters }) }}" class="small-box-footer">
+            {{ 'stats_view_more'|trans({}, 'SonataAdminBundle') }} <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+        </a>
+    </div>
+{% endblock block_content %}

--- a/Resources/views/Block/block_stats_simple.html.twig
+++ b/Resources/views/Block/block_stats_simple.html.twig
@@ -1,0 +1,23 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+{% extends 'SonataAdminBundle:Block:block_stats_base.html.twig' %}
+
+{% block block_content %}
+    <div class="overlay-wrapper refresh-btn">
+        <div class="info-box">
+            <span class="info-box-icon {{ settings.color }}"><i class="{{ settings.icon }}"></i></span>
+            <div class="info-box-content">
+                <span class="info-box-text">{{ settings.text }}</span>
+                <span class="info-box-number url-count">{{ pager.count() }}</span>
+            </div>
+        </div>
+    </div>
+{% endblock block_content %}

--- a/Tests/Block/AdminStatsBlockServiceTest.php
+++ b/Tests/Block/AdminStatsBlockServiceTest.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Tests\Block;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Block\AdminStatsBlockService;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
@@ -25,26 +26,33 @@ class AdminStatsBlockServiceTest extends AbstractBlockServiceTestCase
      */
     private $pool;
 
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
     protected function setUp()
     {
         parent::setUp();
 
         $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
+        $this->translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->disableOriginalConstructor()->getMock();
     }
 
     public function testDefaultSettings()
     {
-        $blockService = new AdminStatsBlockService('foo', $this->templating, $this->pool);
+        $blockService = new AdminStatsBlockService('foo', $this->templating, $this->pool, $this->translator);
         $blockContext = $this->getBlockContext($blockService);
 
         $this->assertSettings(array(
-            'icon' => 'fa-line-chart',
+            'icon' => 'fa fa-line-chart',
             'text' => 'Statistics',
             'color' => 'bg-aqua',
             'code' => false,
+            'class' => '',
             'filters' => array(),
             'limit' => 1000,
-            'template' => 'SonataAdminBundle:Block:block_stats.html.twig',
+            'template' => 'SonataAdminBundle:Block:block_stats_simple.html.twig',
         ), $blockContext);
     }
 }

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,14 @@
 UPGRADE 3.x
 ===========
 
+
+UPGRADE FROM 3.21 to 3.XX
+=========================
+
+## Deprecated AdminStatsBlockService template
+
+The `Block\block_stats.html.twig` template was deprecated in favor of different widget styles.
+
 UPGRADE FROM 3.20 to 3.21
 =========================
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added a refresh option to `AdminStatsBlockService`
- Added configuration form to `AdminStatsBlockService`

### Deprecated
 - deprecated `Block\block_stats.html.twig` template
```

## Subject
This added PR adds a configuration form to `AdminStatsBlockService`, so it can be used in page or dashboard composers. You can also refresh the stats by clicking on the widget.

Before
<img width="341" alt="bildschirmfoto 2017-08-10 um 22 44 31" src="https://user-images.githubusercontent.com/3440437/29192356-73f10062-7e21-11e7-8703-07f78848f60e.PNG">

After
<img width="350" alt="bildschirmfoto 2017-08-10 um 22 44 45" src="https://user-images.githubusercontent.com/3440437/29192355-73f110ca-7e21-11e7-83d4-1e595d5bef5a.PNG">
