### PR TITLE
Fix typo in german translation of "noscript_warning"

### DIFF
--- a/Resources/translations/SonataAdminBundle.de.xliff
+++ b/Resources/translations/SonataAdminBundle.de.xliff
@@ -444,7 +444,7 @@
             </trans-unit>
             <trans-unit id="noscript_warning">
                 <source>noscript_warning</source>
-                <target>Javascript ist in ihrem Brwoser deaktiviert. Einige Funktionen werden nicht korrekt funktionieren.</target>
+                <target>Javascript ist in ihrem Browser deaktiviert. Einige Funktionen werden nicht korrekt funktionieren.</target>
             </trans-unit>
             <trans-unit id="message_form_group_empty">
                 <source>message_form_group_empty</source>


### PR DESCRIPTION
## Changelog

 - Fix typo in german translation of "noscript_warning"

## Subject

Fix a typo in german translation "noscript_warning": _Brwoser_ => _Browser_
