### PR TITLE
Fixed documentation typo

### DIFF
--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -252,7 +252,7 @@ to_string_callback
     ;
 
 multiple
-  defaults to false. Set to true, if you're field is in many-to-many relation.
+  defaults to false. Set to true, if your field is in a many-to-many relation.
 
 placeholder
   defaults to "". Placeholder is shown when no item is selected.


### PR DESCRIPTION
I am targeting this branch, because it is the documentation of the current version.

## Subject
I found and fixed a typo in the documentation of form types (sonata_type_model_autocomplete, options, multiple)