### PR TITLE
KnpMenu - Set translation_domain even if on_top is true

### DIFF
--- a/Resources/views/Menu/sonata_menu.html.twig
+++ b/Resources/views/Menu/sonata_menu.html.twig
@@ -25,7 +25,7 @@
 
 {% block linkElement %}
     {% spaceless %}
-        {% set translation_domain = item.extra('translation_domain', 'messages') %}
+        {% set translation_domain = item.extra('label_catalogue', 'messages') %}
         {% if item.extra('on_top') is defined and not item.extra('on_top') %}
             {% set icon = item.extra('icon')|default(item.level > 1 ? '<i class="fa fa-angle-double-right" aria-hidden="true"></i>' : '') %}
         {% else %}

--- a/Resources/views/Menu/sonata_menu.html.twig
+++ b/Resources/views/Menu/sonata_menu.html.twig
@@ -25,8 +25,8 @@
 
 {% block linkElement %}
     {% spaceless %}
+        {% set translation_domain = item.extra('translation_domain', 'messages') %}
         {% if item.extra('on_top') is defined and not item.extra('on_top') %}
-            {% set translation_domain = item.extra('translation_domain', 'messages') %}
             {% set icon = item.extra('icon')|default(item.level > 1 ? '<i class="fa fa-angle-double-right" aria-hidden="true"></i>' : '') %}
         {% else %}
             {% set icon = item.extra('icon') %}


### PR DESCRIPTION
I am targeting this branch, because this PR is backwards compatible.

Closes #4598
Closes #4568 

## Changelog
```markdown
### Fixed
- Make [this line](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/Resources/views/Menu/sonata_menu.html.twig#L29) execute, even on_top is true. Before, this line would not be called and the labels would be translated against the messages catalogue.
- Fixed the extra option being retrieved. The translation catalogue to be used is inside the label_catalogue option, not translation_domain.
```

## Subject

Consider a admin with on_top set to true, the catalogue used to translate the labels would always be the messages catalogue, because the line that sets the `translation_domain` variable would never be executed. This PR fix this problem calling the line that sets `translation_domain` variable before the if statemente, that way the translation_domain will always be called. Also, the option being retrived in the line was translation_domain, but the catalogue to be used is inside the label_catalogue option.
