### PR TITLE
Add the `set translation_domain` inside the else clause

### DIFF
--- a/Resources/views/Menu/sonata_menu.html.twig
+++ b/Resources/views/Menu/sonata_menu.html.twig
@@ -25,10 +25,11 @@
 
 {% block linkElement %}
     {% spaceless %}
-        {% set translation_domain = item.extra('label_catalogue', 'messages') %}
         {% if item.extra('on_top') is defined and not item.extra('on_top') %}
+            {% set translation_domain = item.extra('translation_domain') %}
             {% set icon = item.extra('icon')|default(item.level > 1 ? '<i class="fa fa-angle-double-right" aria-hidden="true"></i>' : '') %}
         {% else %}
+            {% set translation_domain = item.extra('label_catalogue') %}
             {% set icon = item.extra('icon') %}
         {% endif %}
         {% set is_link = true %}

--- a/Resources/views/Menu/sonata_menu.html.twig
+++ b/Resources/views/Menu/sonata_menu.html.twig
@@ -26,10 +26,10 @@
 {% block linkElement %}
     {% spaceless %}
         {% if item.extra('on_top') is defined and not item.extra('on_top') %}
-            {% set translation_domain = item.extra('translation_domain') %}
+            {% set translation_domain = item.extra('translation_domain', 'messages') %}
             {% set icon = item.extra('icon')|default(item.level > 1 ? '<i class="fa fa-angle-double-right" aria-hidden="true"></i>' : '') %}
         {% else %}
-            {% set translation_domain = item.extra('label_catalogue') %}
+            {% set translation_domain = item.extra('label_catalogue', 'messages') %}
             {% set icon = item.extra('icon') %}
         {% endif %}
         {% set is_link = true %}


### PR DESCRIPTION
I am targeting this branch, because this PR will not cause a BC.

## Changelog
```Markdown
### Fixed
- Fixed the setting of the `translation_domain` twig variable. The value must change depending if the item has on_top set to true or false.
```
## Subject

The line with the `set translation_domain` must be called in the IF clause and in the ELSE clause. The IF will happen when the item being translated is inside a treeview, which means that the label must be translated against the translation_domain option. The ELSE will happen when on_top is true, which means that the label shoule be translated against the label_catalogue option.
