### PR TITLE
fix set up header label in list mapper

### DIFF
--- a/Datagrid/ListMapper.php
+++ b/Datagrid/ListMapper.php
@@ -117,10 +117,15 @@ class ListMapper extends BaseMapper
             );
         }
 
-        if ($fieldDescription->getLabel() !== false) {
+        if ($fieldDescription->getLabel() === null) {
             $fieldDescription->setOption(
                 'label',
                 $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'list', 'label')
+            );
+        } elseif ($fieldDescription->getLabel() !== false) {
+            $fieldDescription->setOption(
+                'label',
+                $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getLabel(), 'list', 'label')
             );
         }
 

--- a/Tests/Datagrid/ListMapperTest.php
+++ b/Tests/Datagrid/ListMapperTest.php
@@ -110,14 +110,20 @@ class ListMapperTest extends PHPUnit_Framework_TestCase
     public function testAdd()
     {
         $this->listMapper->add('fooName');
+        $this->listMapper->add('fooNameLabelBar', null, array('label' => 'fooBar'));
+        $this->listMapper->add('fooNameLabelFalse', null, array('label' => false));
 
         $this->assertTrue($this->listMapper->has('fooName'));
 
         $fieldDescription = $this->listMapper->get('fooName');
+        $fieldLabelBar = $this->listMapper->get('fooNameLabelBar');
+        $fieldLabelFalse = $this->listMapper->get('fooNameLabelFalse');
 
         $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
         $this->assertSame('fooName', $fieldDescription->getName());
         $this->assertSame('fooName', $fieldDescription->getOption('label'));
+        $this->assertSame('fooBar', $fieldLabelBar->getOption('label'));
+        $this->assertFalse($fieldLabelFalse->getOption('label'));
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because this PR is backwards compatible.

## Changelog

```markdown
### Fixed
- setting the column title 
```

## Subject

In documentation you can read 
`label (o): the name used for the column’s title` 
but it does not work
