### PR TITLE
Delete html tags in custom head title

### DIFF
--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -91,7 +91,7 @@ file that was distributed with this source code.
             {{ 'Admin'|trans({}, 'SonataAdminBundle') }}
 
             {% if _title is not empty %}
-                {{ _title|raw }}
+                {{ _title|striptags|raw }}
             {% else %}
                 {% if action is defined %}
                     -


### PR DESCRIPTION
I am targeting this branch, because this PR is backwards compatible.

## Changelog

```markdown
### Fixed
- Html tags do not appear in the meta title
```

## Subject

If in the title block you insert the html tags, they are displayed in the meta title. This change removes the html tags and only then uses the raw filter.
