### PR TITLE
Fix JS loading in autocomplete form type

### DIFF
--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
     </div>
 
     <script>
-        (function ($) {
+        jQuery(function ($) {
             // Select2 v3 does not used same input as v4.
             // NEXT_MAJOR: Remove this BC layer while upgrading to v4.
             var usedInputRef = window.Select2 ? '#{{ id }}_autocomplete_input' : '#{{ id }}_autocomplete_input_v4';
@@ -237,6 +237,6 @@ file that was distributed with this source code.
                 $(usedInputRef).remove();
                 return true;
             });
-        })(jQuery);
+        });
     </script>
 {% endspaceless %}


### PR DESCRIPTION
I am targeting this branch, because this change is backward compatible.

## Changelog

```markdown
### Changed
- Run the Select2 code for autocomplete form type at onload event
```

## Subject

The autocomplete model form type uses Select2 to render the dropdown. However the code runs before the onload JS event, which is not compatible with loading the JS files at the end of the page.
This changes allows one to change the standard_layout template and move the JavaScript files (except jQuery) to the end of the HTML page.