### PR TITLE
Force using precise for the 5.3 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ php:
   - nightly
 
 sudo: false
+dist: precise
 
 cache:
   pip: true


### PR DESCRIPTION
Trusty does not support 5.3

See https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default