### PR TITLE
Remove unwanted raw filter on list headers.

### DIFF
--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -79,7 +79,7 @@ file that was distributed with this source code.
                                                     {% if field_description.getOption('label_icon') %}
                                                         <i class="sonata-ba-list-field-header-label-icon {{ field_description.getOption('label_icon') }}" aria-hidden="true"></i>
                                                     {% endif %}
-                                                    {{ field_description.label|trans({}, field_description.translationDomain)|raw }}
+                                                    {{ field_description.label|trans({}, field_description.translationDomain) }}
                                                     {% if sortable %}</a>{% endif %}
                                                 </th>
                                             {% endspaceless %}


### PR DESCRIPTION
I am targeting this branch, because this is a fix.

## Changelog

```markdown
### Fixed
- Escaping of list headers.
```

## Subject

This was overlooked in https://github.com/sonata-project/SonataAdminBundle/pull/4551.

The original purpose of the PR was to let user add raw html to list headers.
We wanted to avoid the use of a `raw` filter, so we agreed to introduce a `label_icon` option
for this particular purpose.
But we ended up with a `raw` filter and the `label_icon`...

This PR removes the `raw` filter.