### PR TITLE
Fix set up header label in list mapper

### DIFF
--- a/Datagrid/ListMapper.php
+++ b/Datagrid/ListMapper.php
@@ -122,11 +122,6 @@ class ListMapper extends BaseMapper
                 'label',
                 $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'list', 'label')
             );
-        } elseif ($fieldDescription->getLabel() !== false) {
-            $fieldDescription->setOption(
-                'label',
-                $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getLabel(), 'list', 'label')
-            );
         }
 
         // add the field with the FormBuilder

--- a/Tests/Datagrid/ListMapperTest.php
+++ b/Tests/Datagrid/ListMapperTest.php
@@ -110,7 +110,7 @@ class ListMapperTest extends PHPUnit_Framework_TestCase
     public function testAdd()
     {
         $this->listMapper->add('fooName');
-        $this->listMapper->add('fooNameLabelBar', null, array('label' => 'fooBar'));
+        $this->listMapper->add('fooNameLabelBar', null, array('label' => 'Foo Bar'));
         $this->listMapper->add('fooNameLabelFalse', null, array('label' => false));
 
         $this->assertTrue($this->listMapper->has('fooName'));
@@ -122,7 +122,7 @@ class ListMapperTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
         $this->assertSame('fooName', $fieldDescription->getName());
         $this->assertSame('fooName', $fieldDescription->getOption('label'));
-        $this->assertSame('fooBar', $fieldLabelBar->getOption('label'));
+        $this->assertSame('Foo Bar', $fieldLabelBar->getOption('label'));
         $this->assertFalse($fieldLabelFalse->getOption('label'));
     }
 


### PR DESCRIPTION
I am targeting this branch, because this PR is backwards compatible.

fix #4615

## Changelog

```markdown
### Fixed
- setting the column title 
```

## Subject

What we will put in the configuration of the field in the label will not be processed by LabelTranslatorStrategy.
