### PR TITLE
Remove unnecessary bundle from docs

### DIFF
--- a/Resources/doc/getting_started/installation.rst
+++ b/Resources/doc/getting_started/installation.rst
@@ -158,7 +158,44 @@ The translator service is required by SonataAdmin to display all labels properly
     framework:
         translator: { fallbacks: [en] }
 
-Step 6: Preparing your Environment
+Step 6: Define routes
+---------------------
+
+To be able to access SonataAdminBundle's pages, you need to add its routes
+to your application's routing file:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/routing.yml
+
+        admin:
+            resource: '@SonataAdminBundle/Resources/config/routing/sonata_admin.xml'
+            prefix: /admin
+
+        _sonata_admin:
+            resource: .
+            type: sonata_admin
+            prefix: /admin
+
+.. note::
+
+    If you're using XML or PHP to specify your application's configuration,
+    the above routing configuration must be placed in routing.xml or
+    routing.php according to your format (i.e. XML or PHP).
+
+.. note::
+
+    For those curious about the ``resource: .`` setting: it is unusual syntax but used
+    because Symfony requires a resource to be defined (which points to a real file).
+    Once this validation passes Sonata's ``AdminPoolLoader`` is in charge of processing
+    this route and it simply ignores the resource setting.
+
+At this point you can already access the (empty) admin dashboard by visiting the URL:
+``http://yoursite.local/admin/dashboard``.
+
+Step 7: Preparing your Environment
 ----------------------------------
 
 As with all bundles you install, it's a good practice to clear the cache and

--- a/Resources/doc/getting_started/installation.rst
+++ b/Resources/doc/getting_started/installation.rst
@@ -71,7 +71,6 @@ line in the `app/AppKernel.php` file of your project:
                 new Knp\Bundle\MenuBundle\KnpMenuBundle(),
 
                 // And finally, the storage and SonataAdminBundle
-                new Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle(),
                 new Sonata\AdminBundle\SonataAdminBundle(),
             );
 

--- a/Resources/doc/reference/getting_started.rst
+++ b/Resources/doc/reference/getting_started.rst
@@ -6,48 +6,9 @@ but inaccessible. You first need to configure it for your models before you can
 start using it. Here is a quick checklist of what is needed to quickly setup
 SonataAdminBundle and create your first admin interface for the models of your application:
 
-* Step 1: Define SonataAdminBundle routes
-* Step 2: Create an Admin class
-* Step 3: Create an Admin service
-* Step 4: Configuration
-
-Define SonataAdminBundle routes
--------------------------------
-
-To be able to access SonataAdminBundle's pages, you need to add its routes
-to your application's routing file:
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # app/config/routing.yml
-
-        admin:
-            resource: '@SonataAdminBundle/Resources/config/routing/sonata_admin.xml'
-            prefix: /admin
-
-        _sonata_admin:
-            resource: .
-            type: sonata_admin
-            prefix: /admin
-
-.. note::
-
-    If you're using XML or PHP to specify your application's configuration,
-    the above routing configuration must be placed in routing.xml or
-    routing.php according to your format (i.e. XML or PHP).
-
-.. note::
-
-    For those curious about the ``resource: .`` setting: it is unusual syntax but used
-    because Symfony requires a resource to be defined (which points to a real file).
-    Once this validation passes Sonata's ``AdminPoolLoader`` is in charge of processing
-    this route and it simply ignores the resource setting.
-
-At this point you can already access the (empty) admin dashboard by visiting the URL:
-``http://yoursite.local/admin/dashboard``.
-
+* Step 1: Create an Admin class
+* Step 2: Create an Admin service
+* Step 3: Configuration
 
 Create an Admin class
 ---------------------


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a doc change.

## Subject

- Remove unnecessary bundle information from docs
- Moved route config to installation docs 
