### PR TITLE
Removed white space before colon

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -162,7 +162,7 @@ class CRUDController extends Controller
         $object = $this->admin->getObject($id);
 
         if (!$object) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
+            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
         }
 
         $this->admin->checkAccess('delete', $object);
@@ -240,7 +240,7 @@ class CRUDController extends Controller
         $existingObject = $this->admin->getObject($id);
 
         if (!$existingObject) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
+            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
         }
 
         $this->admin->checkAccess('edit', $existingObject);
@@ -596,7 +596,7 @@ class CRUDController extends Controller
         $object = $this->admin->getObject($id);
 
         if (!$object) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
+            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
         }
 
         $this->admin->checkAccess('show', $object);
@@ -633,7 +633,7 @@ class CRUDController extends Controller
         $object = $this->admin->getObject($id);
 
         if (!$object) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
+            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
         }
 
         $this->admin->checkAccess('history', $object);
@@ -680,7 +680,7 @@ class CRUDController extends Controller
         $object = $this->admin->getObject($id);
 
         if (!$object) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
+            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
         }
 
         $this->admin->checkAccess('historyViewRevision', $object);
@@ -744,7 +744,7 @@ class CRUDController extends Controller
         $object = $this->admin->getObject($id);
 
         if (!$object) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
+            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
         }
 
         $manager = $this->get('sonata.admin.audit.manager');
@@ -877,7 +877,7 @@ class CRUDController extends Controller
         $object = $this->admin->getObject($id);
 
         if (!$object) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id : %s', $id));
+            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
         }
 
         $this->admin->checkAccess('acl', $object);

--- a/Resources/doc/cookbook/recipe_custom_action.rst
+++ b/Resources/doc/cookbook/recipe_custom_action.rst
@@ -101,7 +101,7 @@ to implement a ``clone`` action.
             $object = $this->admin->getSubject();
 
             if (!$object) {
-                throw new NotFoundHttpException(sprintf('unable to find the object with id : %s', $id));
+                throw new NotFoundHttpException(sprintf('unable to find the object with id: %s', $id));
             }
 
             // Be careful, you may need to overload the __clone method of your object

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -2913,7 +2913,7 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
 
     public function testHistoryViewRevisionActionNotFoundException()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the object with id : 123');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the object with id: 123');
 
         $this->request->query->set('id', 123);
 
@@ -3071,7 +3071,7 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
 
     public function testHistoryCompareRevisionsActionNotFoundException()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the object with id : 123');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the object with id: 123');
 
         $this->request->query->set('id', 123);
 


### PR DESCRIPTION
I am targeting this branch, because this PR is backwards compatible.

## Changelog

```markdown
### Changed
- Removed white space before colon in message of exception
```

## Subject

In polish language before the colon has no spaces. How about in other languages?
