### PR TITLE
Fix group menu sub items translation domain

### DIFF
--- a/Menu/Provider/GroupMenuProvider.php
+++ b/Menu/Provider/GroupMenuProvider.php
@@ -109,7 +109,7 @@ class GroupMenuProvider implements MenuProviderInterface
                     $label = $admin->getLabel();
                     $options = $admin->generateMenuUrl('list', array(), $item['route_absolute']);
                     $options['extras'] = array(
-                        'translation_domain' => $admin->getTranslationDomain(),
+                        'label_catalogue' => $admin->getTranslationDomain(),
                         'admin' => $admin,
                     );
                 } else {
@@ -128,7 +128,7 @@ class GroupMenuProvider implements MenuProviderInterface
                         'routeParameters' => $item['route_params'],
                         'routeAbsolute' => $item['route_absolute'],
                         'extras' => array(
-                            'translation_domain' => $group['label_catalogue'],
+                            'label_catalogue' => $group['label_catalogue'],
                         ),
                     );
                 }

--- a/Resources/views/Menu/sonata_menu.html.twig
+++ b/Resources/views/Menu/sonata_menu.html.twig
@@ -25,11 +25,10 @@
 
 {% block linkElement %}
     {% spaceless %}
+        {% set translation_domain = item.extra('label_catalogue', 'messages') %}
         {% if item.extra('on_top') is defined and not item.extra('on_top') %}
-            {% set translation_domain = item.extra('translation_domain', 'messages') %}
             {% set icon = item.extra('icon')|default(item.level > 1 ? '<i class="fa fa-angle-double-right" aria-hidden="true"></i>' : '') %}
         {% else %}
-            {% set translation_domain = item.extra('label_catalogue', 'messages') %}
             {% set icon = item.extra('icon') %}
         {% endif %}
         {% set is_link = true %}

--- a/Tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/Tests/Menu/Provider/GroupMenuProviderTest.php
@@ -94,6 +94,14 @@ class GroupMenuProviderTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('route_label', $children);
         $this->assertInstanceOf('Knp\Menu\MenuItem', $menu['foo_admin_label']);
         $this->assertSame('foo_admin_label', $menu['foo_admin_label']->getLabel());
+
+        $extras = $menu['foo_admin_label']->getExtras();
+        $this->assertArrayHasKey('label_catalogue', $extras);
+        $this->assertSame($extras['label_catalogue'], 'SonataAdminBundle');
+
+        $extras = $menu['route_label']->getExtras();
+        $this->assertArrayHasKey('label_catalogue', $extras);
+        $this->assertSame($extras['label_catalogue'], 'SonataAdminBundle');
     }
 
     /**
@@ -141,6 +149,10 @@ class GroupMenuProviderTest extends PHPUnit_Framework_TestCase
         $this->assertArrayNotHasKey('route_label', $children);
         $this->assertInstanceOf('Knp\Menu\MenuItem', $menu['foo_admin_label']);
         $this->assertSame('foo_admin_label', $menu['foo_admin_label']->getLabel());
+
+        $extras = $menu['foo_admin_label']->getExtras();
+        $this->assertArrayHasKey('label_catalogue', $extras);
+        $this->assertSame($extras['label_catalogue'], 'SonataAdminBundle');
     }
 
     /**
@@ -177,6 +189,14 @@ class GroupMenuProviderTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('route_label', $children);
         $this->assertInstanceOf('Knp\Menu\MenuItem', $menu['foo_admin_label']);
         $this->assertSame('foo_admin_label', $menu['foo_admin_label']->getLabel());
+
+        $extras = $menu['foo_admin_label']->getExtras();
+        $this->assertArrayHasKey('label_catalogue', $extras);
+        $this->assertSame($extras['label_catalogue'], 'SonataAdminBundle');
+
+        $extras = $menu['route_label']->getExtras();
+        $this->assertArrayHasKey('label_catalogue', $extras);
+        $this->assertSame($extras['label_catalogue'], 'SonataAdminBundle');
     }
 
     /**
@@ -380,6 +400,10 @@ class GroupMenuProviderTest extends PHPUnit_Framework_TestCase
         $admin->expects($this->any())
             ->method('generateMenuUrl')
             ->will($this->returnValue(array()));
+
+        $admin->expects($this->any())
+            ->method('getTranslationDomain')
+            ->will($this->returnValue('SonataAdminBundle'));
 
         return $admin;
     }


### PR DESCRIPTION
Related to #4601 and #4614

## Changelog
```markdown
### Fixed
- Fix knp menu extra configuration for domain translations in Group Menu
```
<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

The menu extras uses **label_catalogue**, not **translation_domain**.
