### PR TITLE
Document how to display a child admin

### DIFF
--- a/Resources/doc/reference/architecture.rst
+++ b/Resources/doc/reference/architecture.rst
@@ -356,6 +356,32 @@ Then, you have to set the CommentAdmin ``parentAssociationMapping`` attribute to
         }
     }
 
+To display the CommentAdmin extend the menu in your ``PostAdmin`` class:
+
+.. code-block:: php
+
+    <?php
+    namespace Sonata\NewsBundle\Admin;
+
+    class PostAdmin extends Admin
+    {
+        // ...
+
+        protected function configureSideMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
+        {
+            if (!$childAdmin && !in_array($action, array('edit', 'show'))) { return; }
+
+            $admin = $this->isChild() ? $this->getParent() : $this;
+            $id = $admin->getRequest()->get('id');
+
+            $menu->addChild('Show Post', array('uri' => $admin->generateUrl('show', array('id' => $id))));
+            $menu->addChild('Edit Post', array('uri' => $admin->generateUrl('edit', array('id' => $id))));
+            $menu->addChild('Manage Comments', array(
+                'uri' => $admin->generateUrl('sonata.news.admin.comment.list', array('id' => $id))
+            ));
+        }
+    }
+
 It also possible to set a dot-separated value, like ``post.author``, if your parent and child admins are not directly related.
 
 Be wary that being a child admin is optional, which means that regular routes

--- a/Resources/doc/reference/architecture.rst
+++ b/Resources/doc/reference/architecture.rst
@@ -369,7 +369,7 @@ To display the ``CommentAdmin`` extend the menu in your ``PostAdmin`` class:
     {
         // ...
 
-        protected function configureSideMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
+        protected function configureTabMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
         {
             if (!$childAdmin && !in_array($action, array('edit', 'show'))) {
 

--- a/Resources/doc/reference/architecture.rst
+++ b/Resources/doc/reference/architecture.rst
@@ -316,26 +316,26 @@ template files, administration panel title and logo.
 Create child admins
 -------------------
 
-Let us say you have a ``PostAdmin`` and a ``CommentAdmin``. You can optionally declare the ``CommentAdmin``
-to be a child of the ``PostAdmin``. This will create new routes like, for example, ``/post/{id}/comment/list``,
-where the comments will automatically be filtered by post.
+Let us say you have a ``PlaylistAdmin`` and a ``VideoAdmin``. You can optionally declare the ``VideoAdmin``
+to be a child of the ``PlaylistAdmin``. This will create new routes like, for example, ``/playlist/{id}/video/list``,
+where the videos will automatically be filtered by post.
 
-To do this, you first need to call the ``addChild`` method in your PostAdmin service configuration :
+To do this, you first need to call the ``addChild`` method in your ``PlaylistAdmin`` service configuration:
 
 .. configuration-block::
 
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <service id="sonata.news.admin.post" class="AppBundle\Admin\PostAdmin">
+        <service id="sonata.admin.playlist" class="AppBundle\Admin\PlaylistAdmin">
             <!-- ... -->
 
             <call method="addChild">
-                <argument type="service" id="sonata.news.admin.comment" />
+                <argument type="service" id="sonata.admin.video" />
             </call>
         </service>
 
-Then, you have to set the CommentAdmin ``parentAssociationMapping`` attribute to ``post`` :
+Then, you have to set the VideoAdmin ``parentAssociationMapping`` attribute to ``playlist`` :
 
 .. code-block:: php
 
@@ -345,19 +345,19 @@ Then, you have to set the CommentAdmin ``parentAssociationMapping`` attribute to
 
     // ...
 
-    class CommentAdmin extends AbstractAdmin
+    class VideoAdmin extends AbstractAdmin
     {
-        protected $parentAssociationMapping = 'post';
+        protected $parentAssociationMapping = 'playlist';
 
         // OR
 
         public function getParentAssociationMapping()
         {
-            return 'post';
+            return 'playlist';
         }
     }
 
-To display the ``CommentAdmin`` extend the menu in your ``PostAdmin`` class:
+To display the ``VideoAdmin`` extend the menu in your ``PlaylistAdmin`` class:
 
 .. code-block:: php
 
@@ -365,28 +365,28 @@ To display the ``CommentAdmin`` extend the menu in your ``PostAdmin`` class:
 
     namespace AppBundle\Admin;
 
-    class PostAdmin extends Admin
+    class PlaylistAdmin extends Admin
     {
         // ...
 
         protected function configureTabMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
         {
             if (!$childAdmin && !in_array($action, array('edit', 'show'))) {
-
                 return;
             }
 
             $admin = $this->isChild() ? $this->getParent() : $this;
             $id = $admin->getRequest()->get('id');
 
-            $menu->addChild('Show Post', array('uri' => $admin->generateUrl('show', array('id' => $id))));
+            $menu->addChild('View Playlist', array('uri' => $admin->generateUrl('show', array('id' => $id))));
+
             if (is_granted('EDIT') {
-                $menu->addChild('Edit Post', array('uri' => $admin->generateUrl('edit', array('id' => $id))));
+                $menu->addChild('Edit Playlist', array('uri' => $admin->generateUrl('edit', array('id' => $id))));
             }
 
             if (is_granted('LIST', $admin) {
-                $menu->addChild('Manage Comments', array(
-                    'uri' => $admin->generateUrl('sonata.news.admin.comment.list', array('id' => $id))
+                $menu->addChild('Manage Videos', array(
+                    'uri' => $admin->generateUrl('sonata.admin.video.list', array('id' => $id))
                 ));
             }
         }

--- a/Resources/doc/reference/architecture.rst
+++ b/Resources/doc/reference/architecture.rst
@@ -327,11 +327,11 @@ To do this, you first need to call the ``addChild`` method in your PostAdmin ser
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <service id="sonata.news.admin.post" class="Sonata\NewsBundle\Admin\PostAdmin">
+        <service id="sonata.news.admin.post" class="AppBundle\Admin\PostAdmin">
             <!-- ... -->
 
             <call method="addChild">
-                <argument type="serv/home/layton/Projects/SonataAdminBundleice" id="sonata.news.admin.comment" />
+                <argument type="service" id="sonata.news.admin.comment" />
             </call>
         </service>
 

--- a/Resources/doc/reference/architecture.rst
+++ b/Resources/doc/reference/architecture.rst
@@ -331,7 +331,7 @@ To do this, you first need to call the ``addChild`` method in your PostAdmin ser
             <!-- ... -->
 
             <call method="addChild">
-                <argument type="service" id="sonata.news.admin.comment" />
+                <argument type="serv/home/layton/Projects/SonataAdminBundleice" id="sonata.news.admin.comment" />
             </call>
         </service>
 
@@ -340,7 +340,8 @@ Then, you have to set the CommentAdmin ``parentAssociationMapping`` attribute to
 .. code-block:: php
 
     <?php
-    namespace Sonata\NewsBundle\Admin;
+
+    namespace AppBundle\Admin;
 
     // ...
 
@@ -356,12 +357,13 @@ Then, you have to set the CommentAdmin ``parentAssociationMapping`` attribute to
         }
     }
 
-To display the CommentAdmin extend the menu in your ``PostAdmin`` class:
+To display the ``CommentAdmin`` extend the menu in your ``PostAdmin`` class:
 
 .. code-block:: php
 
     <?php
-    namespace Sonata\NewsBundle\Admin;
+
+    namespace AppBundle\Admin;
 
     class PostAdmin extends Admin
     {
@@ -369,16 +371,24 @@ To display the CommentAdmin extend the menu in your ``PostAdmin`` class:
 
         protected function configureSideMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
         {
-            if (!$childAdmin && !in_array($action, array('edit', 'show'))) { return; }
+            if (!$childAdmin && !in_array($action, array('edit', 'show'))) {
+
+                return;
+            }
 
             $admin = $this->isChild() ? $this->getParent() : $this;
             $id = $admin->getRequest()->get('id');
 
             $menu->addChild('Show Post', array('uri' => $admin->generateUrl('show', array('id' => $id))));
-            $menu->addChild('Edit Post', array('uri' => $admin->generateUrl('edit', array('id' => $id))));
-            $menu->addChild('Manage Comments', array(
-                'uri' => $admin->generateUrl('sonata.news.admin.comment.list', array('id' => $id))
-            ));
+            if (is_granted('EDIT') {
+                $menu->addChild('Edit Post', array('uri' => $admin->generateUrl('edit', array('id' => $id))));
+            }
+
+            if (is_granted('LIST', $admin) {
+                $menu->addChild('Manage Comments', array(
+                    'uri' => $admin->generateUrl('sonata.news.admin.comment.list', array('id' => $id))
+                ));
+            }
         }
     }
 

--- a/Resources/doc/reference/architecture.rst
+++ b/Resources/doc/reference/architecture.rst
@@ -365,11 +365,15 @@ To display the ``VideoAdmin`` extend the menu in your ``PlaylistAdmin`` class:
 
     namespace AppBundle\Admin;
 
-    class PlaylistAdmin extends Admin
+    use Knp\Menu\ItemInterface as MenuItemInterface;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Admin\AdminInterface;
+
+    class PlaylistAdmin extends AbstractAdmin
     {
         // ...
 
-        protected function configureTabMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
+        protected function configureSideMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
         {
             if (!$childAdmin && !in_array($action, array('edit', 'show'))) {
                 return;
@@ -380,11 +384,11 @@ To display the ``VideoAdmin`` extend the menu in your ``PlaylistAdmin`` class:
 
             $menu->addChild('View Playlist', array('uri' => $admin->generateUrl('show', array('id' => $id))));
 
-            if (is_granted('EDIT') {
+            if ($this->isGranted('EDIT')) {
                 $menu->addChild('Edit Playlist', array('uri' => $admin->generateUrl('edit', array('id' => $id))));
             }
 
-            if (is_granted('LIST', $admin) {
+            if ($this->isGranted('LIST')) {
                 $menu->addChild('Manage Videos', array(
                     'uri' => $admin->generateUrl('sonata.admin.video.list', array('id' => $id))
                 ));
@@ -401,6 +405,7 @@ of them, you may override the ``configureRoutes`` method::
     <?php
     namespace Sonata\NewsBundle\Admin;
 
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
     use Sonata\AdminBundle\Route\RouteCollection;
 
     class CommentAdmin extends AbstractAdmin


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a doc change for the latest stable.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
Rebase of #3807 


## Subject

Improved getting architecture docs.
