### PR TITLE
Remove IE8 event compatibility

### DIFF
--- a/Resources/public/Admin.js
+++ b/Resources/public/Admin.js
@@ -199,22 +199,9 @@ var Admin = {
     },
 
     stopEvent: function(event) {
-        // https://github.com/sonata-project/SonataAdminBundle/issues/151
-        //if it is a standard browser use preventDefault otherwise it is IE then return false
-        if(event.preventDefault) {
-            event.preventDefault();
-        } else {
-            event.returnValue = false;
-        }
+        event.preventDefault();
 
-        //if it is a standard browser get target otherwise it is IE then adapt syntax and get target
-        if (typeof event.target != 'undefined') {
-            targetElement = event.target;
-        } else {
-            targetElement = event.srcElement;
-        }
-
-        return targetElement;
+        return event.target;
     },
 
     add_filters: function(subject) {


### PR DESCRIPTION
I am targeting this branch, because this is a removal of useless code part.

This is a patch because it also fixes a not declared variable issue.

## Changelog

```markdown
### Fixed
- Not declared variable trowing errors on some browsers

### Removed
- Useless IE8 compatibility code
```

## Subject

No need because admin-lte does not support IE8.

https://adminlte.io/themes/AdminLTE/documentation/index.html#browsers