### PR TITLE
Fix admin code escaping in autocomplete

### DIFF
--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -37,6 +37,7 @@ file that was distributed with this source code.
     </div>
 
     <script>
+        {% autoescape 'js' %}
         jQuery(function ($) {
             // Select2 v3 does not used same input as v4.
             // NEXT_MAJOR: Remove this BC layer while upgrading to v4.
@@ -63,7 +64,7 @@ file that was distributed with this source code.
                 containerCssClass: '{{ container_css_class ~ ' form-control' }}',
                 dropdownCssClass: '{{ dropdown_css_class }}',
                 ajax: {
-                    url:  '{{ url ?: path(route.name, route.parameters|default([]))|e('js') }}',
+                    url:  '{{ url ?: path(route.name, route.parameters|default([])) }}',
                     dataType: 'json',
                     quietMillis: {{ quiet_millis }},
                     cache: {{ cache ? 'true' : 'false' }},
@@ -109,7 +110,7 @@ file that was distributed with this source code.
                                 // other parameters
                                 {% if req_params is not empty %},
                                     {%- for key, value in req_params -%}
-                                        '{{- key|e('js') -}}': '{{- value|e('js') -}}'
+                                        '{{- key -}}': '{{- value -}}'
                                         {%- if not loop.last -%}, {% endif -%}
                                     {%- endfor -%}
                                 {% endif %}
@@ -220,7 +221,7 @@ file that was distributed with this source code.
                 data = {%- if multiple -%}[ {%- endif -%}
                 {%- for idx, val  in value if idx~'' != '_labels' -%}
                     {%- if not loop.first -%}, {% endif -%}
-                    {id: '{{ val|e('js') }}', label:'{{ value['_labels'][idx]|e('js') }}'}
+                    {id: '{{ val }}', label:'{{ value['_labels'][idx] }}'}
                 {%- endfor -%}
                 {%- if multiple -%} ] {%- endif -%};
             {% endif -%}
@@ -238,5 +239,6 @@ file that was distributed with this source code.
                 return true;
             });
         });
+        {% endautoescape %}
     </script>
 {% endspaceless %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes -

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed autocomplete for cases when admin code uses service id and service id is equal to FQCN ('AppBundle\Admin\CompanyAdmin')
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Use `autoescape js`

## Subject

<!-- Describe your Pull Request content here -->
