### PR TITLE
Fix a typo in block_search_result.html.twig

### DIFF
--- a/Resources/views/Block/block_search_result.html.twig
+++ b/Resources/views/Block/block_search_result.html.twig
@@ -19,7 +19,7 @@ file that was distributed with this source code.
     {% endif %}
 
     <div class="col-lg-4 col-md-6 search-box-item {{ visibility_class }}">
-        <div class="box box-solid box-primary{{ visibility_class }}">
+        <div class="box box-solid box-primary {{ visibility_class }}">
             <div class="box-header with-border {{ visibility_class }}">
                 {% set icon = settings.icon|default('') %}
                 {{ icon|raw }}


### PR DESCRIPTION
I am targeting this branch, because it's just a typo in the current release.

## Changelog

```markdown
### Fixed
- Fixed a typo in CSS classes in `block_search_result.html.twig`
```

## Subject

`box-primary` wasn't separated from `{{ visibility_class }}`, causing weird uncoloured styling on several search results blocks.

