### PR TITLE
Always apply "global_search.empty_boxes" setting to never searched admins

### DIFF
--- a/Resources/views/Block/block_search_result.html.twig
+++ b/Resources/views/Block/block_search_result.html.twig
@@ -13,9 +13,9 @@ file that was distributed with this source code.
 
 {% block block %}
     {% set show_empty_boxes = sonata_admin.adminPool.container.getParameter('sonata.admin.configuration.global_search.empty_boxes') %}
-    {% set visibility_class = '' %}
-    {% if pager and not pager.getResults()|length %}
-        {% set visibility_class = 'sonata-search-result-' ~ show_empty_boxes %}
+    {% set visibility_class = 'sonata-search-result-' ~ show_empty_boxes %}
+    {% if pager and pager.getResults()|length %}
+        {% set visibility_class = 'sonata-search-result-show' %}
     {% endif %}
 
     <div class="col-lg-4 col-md-6 search-box-item {{ visibility_class }}">


### PR DESCRIPTION
I am targeting this branch, because it's just a little fix on template for the current release.

## Changelog

```markdown
### Fixed
- Always apply "global_search.empty_boxes" setting to never searched admins
```

## Subject

  Currently the `sonata-search-result-[fade,hide]` CSS class is only applied when there is a pager returned by the SearchHandler and this pager has no results.

  But if the Admin has no `global_search` filter set or no filter at all, the SearchHandler returns _false_ instead of a pager. Therefore, such Admins, with no `global_search` filters, which won't ever be queried by the SearchHandler, are always shown empty on the results page as is.

  That's why I propose to set the CSS class first, and then change/remove it if there is results.

  Feel free to set an empty string to the visibility class when there is results if it better suits you.