### PR TITLE
Update services.yml folder comment to avoid mistakes in creating_an_admin.rst

### DIFF
--- a/Resources/doc/getting_started/creating_an_admin.rst
+++ b/Resources/doc/getting_started/creating_an_admin.rst
@@ -175,9 +175,8 @@ SonataAdminBundle of the existence of this Admin class, you have to create a
 service and tag it with the ``sonata.admin`` tag:
 
 .. code-block:: yaml
-
-    # app/config/services.yml
-
+    
+    # src/AppBundle/Resources/config/services.yml
     services:
         # ...
         admin.category:


### PR DESCRIPTION
The service can't be created in app/config/services.yml 
If the service needs to access to AppBundle\Entity\Category the service needs to be in src/AppBundle/Resources/config/services.yml otherwise it will not works.
I just updated the comment to avoid any mistake since I did it copying the tutorial.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
Comment for the services.yml file.
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
