### PR TITLE
Escape admin_code value for JavaScript in Twig template

### DIFF
--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -89,9 +89,9 @@ file that was distributed with this source code.
                                 // admin
                                 {% if sonata_admin.admin is not null %}
                                     'uniqid': '{{ sonata_admin.admin.uniqid }}',
-                                    'admin_code': '{{ sonata_admin.admin.code }}',
+                                    'admin_code': '{{ sonata_admin.admin.code|e('js') }}',
                                 {% elseif admin_code %}
-                                    'admin_code':  '{{ admin_code }}',
+                                    'admin_code':  '{{ admin_code|e('js') }}',
                                 {% endif %}
 
                                  // subclass


### PR DESCRIPTION
## Changelog
```markdown
### Changed
Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
```
## Subject

In a Symfony 3.3 app which uses autowiring, I have a service with the ID `App\Controller\Admin\BlogPostAdmin` which fails when using `sonata_type_model_autocomplete`. The error is:

![sonata-error](https://user-images.githubusercontent.com/73419/30321309-dd1e9e84-97b5-11e7-9735-2fbf19c7c160.png)

@greg0ire did all the work to investigate the cause of this error. At the end we found that the query string of the Ajax request related to the autocomplete included this parameter: `admin_code=AppControllerAdminBlogPostAdmin` so the error should be in the Twig template. @greg0ire also proposed the solution I include in this PR.

This change solved the problem to me, but @greg0ire wondered if we should apply `{% autoescape 'js' %}` to the entire JS code of this template.
