### PR TITLE
Added support for the ‘has’ getter prefix

### DIFF
--- a/Admin/BaseFieldDescription.php
+++ b/Admin/BaseFieldDescription.php
@@ -340,6 +340,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         }
         $getters[] = 'get'.$camelizedFieldName;
         $getters[] = 'is'.$camelizedFieldName;
+        $getters[] = 'has'.$camelizedFieldName;
 
         foreach ($getters as $getter) {
             if (method_exists($object, $getter)) {

--- a/Tests/Admin/BaseFieldDescriptionTest.php
+++ b/Tests/Admin/BaseFieldDescriptionTest.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Tests\Admin;
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\FieldDescription;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
+use Sonata\AdminBundle\Tests\Fixtures\Entity\FooBoolean;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooCall;
 use Sonata\AdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
@@ -145,13 +146,15 @@ class BaseFieldDescriptionTest extends PHPUnit_Framework_TestCase
         /*
          * Test with underscored attribute name
          */
-        $description3 = new FieldDescription();
-        $mock3 = $this->getMockBuilder('stdClass')
-            ->setMethods(array('getFake'))
-            ->getMock();
+        foreach (array('getFake', 'isFake', 'hasFake') as $method) {
+            $description3 = new FieldDescription();
+            $mock3 = $this->getMockBuilder('stdClass')
+                ->setMethods(array($method))
+                ->getMock();
 
-        $mock3->expects($this->once())->method('getFake')->will($this->returnValue(42));
-        $this->assertSame(42, $description3->getFieldValue($mock3, '_fake'));
+            $mock3->expects($this->once())->method($method)->will($this->returnValue(42));
+            $this->assertSame(42, $description3->getFieldValue($mock3, '_fake'));
+        }
     }
 
     /**
@@ -224,6 +227,14 @@ class BaseFieldDescriptionTest extends PHPUnit_Framework_TestCase
 
         $description = new FieldDescription();
         $this->assertSame('Bar', $description->getFieldValue($foo, 'bar'));
+
+        $foo = new FooBoolean();
+        $foo->setBar(true);
+        $foo->setBaz(false);
+
+        $description = new FieldDescription();
+        $this->assertSame(true, $description->getFieldValue($foo, 'bar'));
+        $this->assertSame(false, $description->getFieldValue($foo, 'baz'));
 
         $this->expectException('Sonata\AdminBundle\Exception\NoValueException');
         $description->getFieldValue($foo, 'inexistantMethod');

--- a/Tests/Fixtures/Entity/FooBoolean.php
+++ b/Tests/Fixtures/Entity/FooBoolean.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Entity;
+
+class FooBoolean
+{
+    private $bar;
+
+    private $baz;
+
+    public function hasBar()
+    {
+        return $this->bar;
+    }
+
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+    }
+
+    public function isBaz()
+    {
+        return $this->baz;
+    }
+
+    public function setBaz($baz)
+    {
+        $this->baz = $baz;
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the fix I'm proposing seems like a bug fix to me and does not break BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed the BaseFieldDescription class to also support 'has' prefixed getter methods for boolean properties on entities (besides the 'is' prefixed getters)
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
- [x] Update the tests

## Subject

Twig supports both 'is' and 'has' getters for boolean properties (`$user->hasSuperPowers()` and `$user->isSuperHero()` translate to `user.superPowers` and `user.superHero` in Twig). The PHP Mess Detector will also suggest using either an 'is' or 'has' prefix for boolean getters, instead of 'get'.

However, SonataAdminBundle only seems to support 'get' and 'is' as prefixes. Wouldn't it be a good idea to add the 'has' prefix as well or has it been omitted on purpose? I now need to refactor my code to use the 'is' prefix, which semantically doesn't make sense (`$user->isSuperPowers()` sounds a bit silly, right?).

