### PR TITLE
Added missing throws annotations

### DIFF
--- a/Model/ModelManagerInterface.php
+++ b/Model/ModelManagerInterface.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Model;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Exception\ModelManagerException;
 
 /**
  * A model manager is a bridge between the model classes and the admin
@@ -35,19 +36,21 @@ interface ModelManagerInterface
     /**
      * @param mixed $object
      *
-     * @return mixed
+     * @throws ModelManagerException
      */
     public function create($object);
 
     /**
      * @param mixed $object
      *
-     * @return mixed
+     * @throws ModelManagerException
      */
     public function update($object);
 
     /**
-     * @param object $object
+     * @param mixed $object
+     *
+     * @throws ModelManagerException
      */
     public function delete($object);
 
@@ -78,6 +81,8 @@ interface ModelManagerInterface
     /**
      * @param string              $class
      * @param ProxyQueryInterface $queryProxy
+     *
+     * @throws ModelManagerException
      */
     public function batchDelete($class, ProxyQueryInterface $queryProxy);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is only PHPdoc.

## Subject

According to the implementations (https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/Model/ModelManager.php, https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/blob/1.x/Model/ModelManager.php), the following PHPdoc was wrong.