### PR TITLE
Fix sonata_help not showing for subfields and add the has-error class

### DIFF
--- a/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -87,13 +87,13 @@ class FormTypeFieldExtension extends AbstractTypeExtension
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $sonataAdmin = $form->getConfig()->getAttribute('sonata_admin');
+        $sonataAdminHelp = isset($options['sonata_help']) ? $options['sonata_help'] : null;
 
         /*
          * We have a child, so we need to upgrade block prefix
          */
         if ($view->parent && $view->parent->vars['sonata_admin_enabled'] && !$sonataAdmin['admin']) {
             $blockPrefixes = $view->vars['block_prefixes'];
-
             $baseName = str_replace('.', '_', $view->parent->vars['sonata_admin_code']);
 
             $baseType = $blockPrefixes[count($blockPrefixes) - 2];
@@ -115,12 +115,11 @@ class FormTypeFieldExtension extends AbstractTypeExtension
                 'class' => false,
                 'options' => $this->options,
             );
+            $view->vars['sonata_help'] = $sonataAdminHelp;
             $view->vars['sonata_admin_code'] = $view->parent->vars['sonata_admin_code'];
 
             return;
         }
-
-        $sonataAdminHelp = isset($options['sonata_help']) ? $options['sonata_help'] : null;
 
         // avoid to add extra information not required by non admin field
         if ($sonataAdmin && $form->getConfig()->getAttribute('sonata_admin_enabled', true)) {

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -422,6 +422,8 @@ file that was distributed with this source code.
 {% block sonata_type_immutable_array_widget %}
     {% spaceless %}
         <div {{ block('widget_container_attributes') }}>
+            {{ block('sonata_help') }}
+
             {{ form_errors(form) }}
 
             {% for key, child in form %}
@@ -435,7 +437,7 @@ file that was distributed with this source code.
 
 {% block sonata_type_immutable_array_widget_row %}
     {% spaceless %}
-        <div class="form-group{% if child.vars.errors|length > 0%} error{%endif%}" id="sonata-ba-field-container-{{ id }}-{{ key }}">
+        <div class="form-group{% if child.vars.errors|length > 0%} has-error{%endif%}" id="sonata-ba-field-container-{{ id }}-{{ key }}">
 
             {{ form_label(child) }}
 
@@ -446,6 +448,8 @@ file that was distributed with this source code.
 
             <div class="{{ div_class }} sonata-ba-field sonata-ba-field-{{ sonata_admin.edit }}-{{ sonata_admin.inline }} {% if child.vars.errors|length > 0 %}sonata-ba-field-error{% endif %}">
                 {{ form_widget(child, {'horizontal': false, 'horizontal_input_wrapper_class': ''}) }} {# {'horizontal': false, 'horizontal_input_wrapper_class': ''} needed to avoid MopaBootstrapBundle messing with the DOM #}
+                {% set sonata_help = child.vars.sonata_help %}
+                {{ block('sonata_help') }}
             </div>
 
             {% if child.vars.errors|length > 0 %}

--- a/Tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
+++ b/Tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
@@ -188,6 +188,7 @@ class FormTypeFieldExtensionTest extends PHPUnit_Framework_TestCase
                  'class' => false,
                  'options' => array(),
             ),
+            'sonata_help' => 'help text',
             'sonata_admin_code' => 'parent_code',
         );
 


### PR DESCRIPTION
I am targeting this branch, because this is a bugfix.

Closes #4656

## Changelog

```markdown
### Fixed
- Print of `sonata_help` for form subfields
- Error class for `sonata_type_immutable_array` form group
```

## Subject

Sonata help for subfields isn't shown, but it should be as explained [here](https://sonata-project.org/bundles/admin/master/doc/reference/form_help_message.html#help-messages-in-a-sub-field). When aan error occurs in a subfield, error message is not in red color as other form fields with errors.
