### PR TITLE
Restore unstable version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/common": "^2.2",
         "doctrine/inflector": "^1.0",
         "knplabs/knp-menu-bundle": "^2.1.1",
-        "sonata-project/block-bundle": "^3.2",
+        "sonata-project/block-bundle": "^3.2 || 4.0@dev",
         "sonata-project/core-bundle": "^3.4",
         "sonata-project/exporter": "^1.7",
         "symfony/class-loader": "^2.3 || ^3.0",


### PR DESCRIPTION
It is necessary in order to be able to build the block bundle, which has
a dev dependency on this bundle, because of some optional features it
has that need to be tested. Those should probably be moved in an
integration bundle.
