### PR TITLE
[WIP] Remove compatibility with old versions of SF and PHP

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -45,7 +45,6 @@ use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -353,7 +352,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     protected $securityHandler = null;
 
     /**
-     * @var ValidatorInterface|LegacyValidatorInterface
+     * @var ValidatorInterface
      */
     protected $validator = null;
 
@@ -2637,11 +2636,10 @@ EOT;
      */
     public function setValidator($validator)
     {
-        // TODO: Remove it when bumping requirements to SF 2.5+
-        if (!$validator instanceof ValidatorInterface && !$validator instanceof LegacyValidatorInterface) {
+        // NEXT_MAJOR: Remove this and add a type-hint to the method
+        if (!$validator instanceof ValidatorInterface) {
             throw new \InvalidArgumentException(
                 'Argument 1 must be an instance of Symfony\Component\Validator\Validator\ValidatorInterface'
-                .' or Symfony\Component\Validator\ValidatorInterface'
             );
         }
 
@@ -3361,12 +3359,7 @@ EOT;
         $admin = $this;
 
         // add the custom inline validation option
-        // TODO: Remove conditional method when bumping requirements to SF 2.5+
-        if (method_exists($this->validator, 'getMetadataFor')) {
-            $metadata = $this->validator->getMetadataFor($this->getClass());
-        } else {
-            $metadata = $this->validator->getMetadataFactory()->getMetadataFor($this->getClass());
-        }
+        $metadata = $this->validator->getMetadataFor($this->getClass());
 
         $metadata->addConstraint(new InlineConstraint([
             'service' => $this,

--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -18,9 +18,6 @@ use Sonata\AdminBundle\Util\FormBuilderIterator;
 use Sonata\AdminBundle\Util\FormViewIterator;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
-use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
-use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -273,7 +270,7 @@ class AdminHelper
             $currentPath .= empty($currentPath) ? $part : '_'.$part;
             $separator = empty($totalPath) ? '' : '.';
 
-            if ($this->pathExists($propertyAccessor, $entity, $totalPath.$separator.$currentPath)) {
+            if ($propertyAccessor->isReadable($entity, $totalPath.$separator.$currentPath)) {
                 $totalPath .= $separator.$currentPath;
                 $currentPath = '';
             }
@@ -305,34 +302,5 @@ class AdminHelper
         }
 
         return $this->getEntityClassName($associationAdmin, $elements);
-    }
-
-    /**
-     * Check if given path exists in $entity.
-     *
-     * @param PropertyAccessorInterface $propertyAccessor
-     * @param mixed                     $entity
-     * @param string                    $path
-     *
-     * @return bool
-     *
-     * @throws \RuntimeException
-     */
-    private function pathExists(PropertyAccessorInterface $propertyAccessor, $entity, $path)
-    {
-        // Symfony <= 2.3 did not have isReadable method for PropertyAccessor
-        if (method_exists($propertyAccessor, 'isReadable')) {
-            return $propertyAccessor->isReadable($entity, $path);
-        }
-
-        try {
-            $propertyAccessor->getValue($entity, $path);
-
-            return true;
-        } catch (NoSuchPropertyException $e) {
-            return false;
-        } catch (UnexpectedTypeException $e) {
-            return false;
-        }
     }
 }

--- a/Admin/AdminInterface.php
+++ b/Admin/AdminInterface.php
@@ -26,7 +26,6 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -299,12 +298,12 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function id($entity);
 
     /**
-     * @param ValidatorInterface|LegacyValidatorInterface $validator
+     * @param ValidatorInterface $validator
      */
     public function setValidator($validator);
 
     /**
-     * @return ValidatorInterface|LegacyValidatorInterface
+     * @return ValidatorInterface
      */
     public function getValidator();
 

--- a/Admin/Extension/LockExtension.php
+++ b/Admin/Extension/LockExtension.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Model\LockInterface;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
@@ -36,10 +37,7 @@ class LockExtension extends AbstractAdminExtension
         $admin = $form->getAdmin();
         $formBuilder = $form->getFormBuilder();
 
-        // PHP 5.3 BC
-        $fieldName = $this->fieldName;
-
-        $formBuilder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($admin, $fieldName) {
+        $formBuilder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($admin) {
             $data = $event->getData();
             $form = $event->getForm();
 
@@ -57,17 +55,10 @@ class LockExtension extends AbstractAdminExtension
                 return;
             }
 
-            $form->add(
-                $fieldName,
-                // NEXT_MAJOR: remove the check and add the FQCN
-                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-                    : 'hidden',
-                [
-                    'mapped' => false,
-                    'data' => $lockVersion,
-                ]
-            );
+            $form->add($this->fieldName, HiddenType::class, [
+                'mapped' => false,
+                'data' => $lockVersion,
+            ]);
         });
     }
 

--- a/Block/AdminListBlockService.php
+++ b/Block/AdminListBlockService.php
@@ -74,17 +74,7 @@ class AdminListBlockService extends AbstractBlockService
      */
     public function configureSettings(OptionsResolver $resolver)
     {
-        $resolver->setDefaults([
-            'groups' => false,
-        ]);
-
-        // Symfony < 2.6 BC
-        if (method_exists($resolver, 'setNormalizer')) {
-            $resolver->setAllowedTypes('groups', ['bool', 'array']);
-        } else {
-            $resolver->setAllowedTypes([
-                'groups' => ['bool', 'array'],
-            ]);
-        }
+        $resolver->setDefaults(['groups' => false]);
+        $resolver->setAllowedTypes('groups', ['bool', 'array']);
     }
 }

--- a/Command/QuestionableCommand.php
+++ b/Command/QuestionableCommand.php
@@ -33,20 +33,7 @@ abstract class QuestionableCommand extends ContainerAwareCommand
     final protected function askAndValidate(InputInterface $input, OutputInterface $output, $questionText, $default, $validator)
     {
         $questionHelper = $this->getQuestionHelper();
-
-        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
-        if ($questionHelper instanceof DialogHelper) {
-            return $questionHelper->askAndValidate(
-                $output,
-                $questionHelper->getQuestion($questionText, $default),
-                $validator,
-                false,
-                $default
-            );
-        }
-
         $question = new Question($questionHelper->getQuestion($questionText, $default), $default);
-
         $question->setValidator($validator);
 
         return $questionHelper->ask($input, $output, $question);
@@ -64,14 +51,6 @@ abstract class QuestionableCommand extends ContainerAwareCommand
     final protected function askConfirmation(InputInterface $input, OutputInterface $output, $questionText, $default, $separator)
     {
         $questionHelper = $this->getQuestionHelper();
-
-        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
-        if ($questionHelper instanceof DialogHelper) {
-            $question = $questionHelper->getQuestion($questionText, $default, $separator);
-
-            return $questionHelper->askConfirmation($output, $question, ($default === 'no' ? false : true));
-        }
-
         $question = new ConfirmationQuestion($questionHelper->getQuestion(
             $questionText,
             $default,
@@ -86,21 +65,11 @@ abstract class QuestionableCommand extends ContainerAwareCommand
      */
     final protected function getQuestionHelper()
     {
-        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
-        if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
-            $questionHelper = $this->getHelper('dialog');
+        $questionHelper = $this->getHelper('question');
 
-            if (!$questionHelper instanceof DialogHelper) {
-                $questionHelper = new DialogHelper();
-                $this->getHelperSet()->set($questionHelper);
-            }
-        } else {
-            $questionHelper = $this->getHelper('question');
-
-            if (!$questionHelper instanceof QuestionHelper) {
-                $questionHelper = new QuestionHelper();
-                $this->getHelperSet()->set($questionHelper);
-            }
+        if (!$questionHelper instanceof QuestionHelper) {
+            $questionHelper = new QuestionHelper();
+            $this->getHelperSet()->set($questionHelper);
         }
 
         return $questionHelper;

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -1246,25 +1246,6 @@ class CRUDController extends Controller
     }
 
     /**
-     * Adds a flash message for type.
-     *
-     * @param string $type
-     * @param string $message
-     *
-     * @TODO Remove this method when bumping requirements to Symfony >= 2.6
-     */
-    protected function addFlash($type, $message)
-    {
-        if (method_exists('Symfony\Bundle\FrameworkBundle\Controller\Controller', 'addFlash')) {
-            parent::addFlash($type, $message);
-        } else {
-            $this->get('session')
-                ->getFlashBag()
-                ->add($type, $message);
-        }
-    }
-
-    /**
      * Validate CSRF token for action without form.
      *
      * @param string $intention
@@ -1276,10 +1257,8 @@ class CRUDController extends Controller
         $request = $this->getRequest();
         $token = $request->request->get('_sonata_csrf_token', false);
 
-        if ($this->container->has('security.csrf.token_manager')) { // SF3.0
+        if ($this->container->has('security.csrf.token_manager')) {
             $valid = $this->container->get('security.csrf.token_manager')->isTokenValid(new CsrfToken($intention, $token));
-        } elseif ($this->container->has('form.csrf_provider')) { // < SF3.0
-            $valid = $this->container->get('form.csrf_provider')->isCsrfTokenValid($intention, $token);
         } else {
             return;
         }
@@ -1312,11 +1291,6 @@ class CRUDController extends Controller
     {
         if ($this->container->has('security.csrf.token_manager')) {
             return $this->container->get('security.csrf.token_manager')->getToken($intention)->getValue();
-        }
-
-        // TODO: Remove it when bumping requirements to SF 2.4+
-        if ($this->container->has('form.csrf_provider')) {
-            return $this->container->get('form.csrf_provider')->generateCsrfToken($intention);
         }
 
         return false;

--- a/Controller/CoreController.php
+++ b/Controller/CoreController.php
@@ -169,11 +169,6 @@ class CoreController extends Controller
      */
     private function getCurrentRequest()
     {
-        // NEXT_MAJOR: simplify this when dropping sf < 2.4
-        if ($this->container->has('request_stack')) {
-            return $this->container->get('request_stack')->getCurrentRequest();
-        }
-
-        return $this->container->get('request');
+        return $this->container->get('request_stack')->getCurrentRequest();
     }
 }

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -23,7 +23,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -46,11 +45,13 @@ class HelperController
     protected $pool;
 
     /**
-     * @var ValidatorInterface|ValidatorInterface
+     * @var ValidatorInterface
      */
     protected $validator;
 
     /**
+     * NEXT_MAJOR: Add ValidatorInterface type-hint.
+     *
      * @param \Twig_Environment  $twig
      * @param Pool               $pool
      * @param AdminHelper        $helper
@@ -58,11 +59,9 @@ class HelperController
      */
     public function __construct(\Twig_Environment $twig, Pool $pool, AdminHelper $helper, $validator)
     {
-        if (!($validator instanceof ValidatorInterface) && !($validator instanceof LegacyValidatorInterface)) {
+        if (!($validator instanceof ValidatorInterface)) {
             throw new \InvalidArgumentException(
-                'Argument 4 is an instance of '.get_class($validator).', expecting an instance of'
-                .' \Symfony\Component\Validator\Validator\ValidatorInterface or'
-                .' \Symfony\Component\Validator\ValidatorInterface'
+                'Argument 4 is an instance of '.get_class($validator).', expecting an instance of \Symfony\Component\Validator\Validator\ValidatorInterface'
             );
         }
 

--- a/Datagrid/Datagrid.php
+++ b/Datagrid/Datagrid.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 
@@ -124,12 +125,7 @@ class Datagrid implements DatagridInterface
             $this->formBuilder->add($filter->getFormName(), $type, $options);
         }
 
-        // NEXT_MAJOR: Remove BC trick when bumping Symfony requirement to 2.8+
-        $hiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-            : 'hidden';
-
-        $this->formBuilder->add('_sort_by', $hiddenType);
+        $this->formBuilder->add('_sort_by', HiddenType::class);
         $this->formBuilder->get('_sort_by')->addViewTransformer(new CallbackTransformer(
             function ($value) {
                 return $value;
@@ -139,9 +135,9 @@ class Datagrid implements DatagridInterface
             }
         ));
 
-        $this->formBuilder->add('_sort_order', $hiddenType);
-        $this->formBuilder->add('_page', $hiddenType);
-        $this->formBuilder->add('_per_page', $hiddenType);
+        $this->formBuilder->add('_sort_order', HiddenType::class);
+        $this->formBuilder->add('_page', HiddenType::class);
+        $this->formBuilder->add('_per_page', HiddenType::class);
 
         $this->form = $this->formBuilder->getForm();
         $this->form->submit($this->values);
@@ -166,11 +162,8 @@ class Datagrid implements DatagridInterface
 
         $maxPerPage = 25;
         if (isset($this->values['_per_page'])) {
-            // check for `is_array` can be safely removed if php 5.3 support will be dropped
-            if (is_array($this->values['_per_page'])) {
-                if (isset($this->values['_per_page']['value'])) {
-                    $maxPerPage = $this->values['_per_page']['value'];
-                }
+            if (isset($this->values['_per_page']['value'])) {
+                $maxPerPage = $this->values['_per_page']['value'];
             } else {
                 $maxPerPage = $this->values['_per_page'];
             }
@@ -179,11 +172,8 @@ class Datagrid implements DatagridInterface
 
         $page = 1;
         if (isset($this->values['_page'])) {
-            // check for `is_array` can be safely removed if php 5.3 support will be dropped
-            if (is_array($this->values['_page'])) {
-                if (isset($this->values['_page']['value'])) {
-                    $page = $this->values['_page']['value'];
-                }
+            if (isset($this->values['_page']['value'])) {
+                $page = $this->values['_page']['value'];
             } else {
                 $page = $this->values['_page'];
             }

--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -16,7 +16,6 @@ use Sonata\AdminBundle\Datagrid\Pager;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
@@ -254,12 +253,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
     {
         $definition = $container->getDefinition($serviceId);
         $settings = $container->getParameter('sonata.admin.configuration.admin_services');
-
-        if (method_exists($definition, 'setShared')) { // Symfony 2.8+
-            $definition->setShared(false);
-        } else { // For Symfony <2.8 compatibility
-            $definition->setScope(ContainerInterface::SCOPE_PROTOTYPE);
-        }
+        $definition->setShared(false);
 
         $manager_type = $attributes['manager_type'];
 

--- a/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
+++ b/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
@@ -13,7 +13,6 @@ namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -30,12 +29,7 @@ class AddFilterTypeCompilerPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('sonata.admin.filter.type') as $id => $attributes) {
             $serviceDefinition = $container->getDefinition($id);
-
-            if (method_exists($definition, 'setShared')) { // Symfony 2.8+
-                $serviceDefinition->setShared(false);
-            } else { // For Symfony <2.8 compatibility
-                $serviceDefinition->setScope(ContainerInterface::SCOPE_PROTOTYPE);
-            }
+            $serviceDefinition->setShared(false);
 
             $types[$serviceDefinition->getClass()] = $id;
 

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -65,20 +65,9 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         }
 
         // NEXT_MAJOR : remove this block
-        if (method_exists('Symfony\Component\DependencyInjection\Definition', 'setDeprecated')) {
-            $container->getDefinition('sonata.admin.exporter')->setDeprecated(
-                'The service "%service_id%" is deprecated in favor of the "sonata.exporter.exporter" service'
-            );
-        }
-
-        // TODO: Go back on xml configuration when bumping requirements to SF 2.6+
-        $sidebarMenu = $container->getDefinition('sonata.admin.sidebar_menu');
-        if (method_exists($sidebarMenu, 'setFactory')) {
-            $sidebarMenu->setFactory([new Reference('sonata.admin.menu_builder'), 'createSidebarMenu']);
-        } else {
-            $sidebarMenu->setFactoryService('sonata.admin.menu_builder');
-            $sidebarMenu->setFactoryMethod('createSidebarMenu');
-        }
+        $container->getDefinition('sonata.admin.exporter')->setDeprecated(
+            'The service "%service_id%" is deprecated in favor of the "sonata.exporter.exporter" service'
+        );
 
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
@@ -176,32 +165,6 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
 
         $loader->load('security.xml');
 
-        // Set the SecurityContext for Symfony <2.6
-        // NEXT_MAJOR: Go back to simple xml configuration when bumping requirements to SF 2.6+
-        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
-            $tokenStorageReference = new Reference('security.token_storage');
-            $authorizationCheckerReference = new Reference('security.authorization_checker');
-        } else {
-            $tokenStorageReference = new Reference('security.context');
-            $authorizationCheckerReference = new Reference('security.context');
-        }
-
-        $container
-            ->getDefinition('sonata.admin.security.handler.role')
-            ->replaceArgument(0, $authorizationCheckerReference)
-        ;
-
-        $container
-            ->getDefinition('sonata.admin.security.handler.acl')
-            ->replaceArgument(0, $tokenStorageReference)
-            ->replaceArgument(1, $authorizationCheckerReference)
-        ;
-
-        $container
-            ->getDefinition('sonata.admin.menu.group_provider')
-            ->replaceArgument(2, $authorizationCheckerReference)
-        ;
-
         $container->setParameter('sonata.admin.extension.map', $config['extensions']);
 
         /*
@@ -246,10 +209,6 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $container->setParameter('sonata.admin.configuration.show.mosaic.button', $config['show_mosaic_button']);
 
         $container->setParameter('sonata.admin.configuration.translate_group_label', $config['translate_group_label']);
-
-        if (\PHP_VERSION_ID < 70000) {
-            $this->configureClassesToCompile();
-        }
 
         $this->replacePropertyAccessor($container);
     }
@@ -314,90 +273,6 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
                 'annotation_patterns' => $annotationPatterns,
             ]
         );
-    }
-
-    public function configureClassesToCompile()
-    {
-        $this->addClassesToCompile([
-            'Sonata\\AdminBundle\\Admin\\AbstractAdmin',
-            'Sonata\\AdminBundle\\Admin\\AbstractAdminExtension',
-            'Sonata\\AdminBundle\\Admin\\AdminExtensionInterface',
-            'Sonata\\AdminBundle\\Admin\\AdminHelper',
-            'Sonata\\AdminBundle\\Admin\\AdminInterface',
-            'Sonata\\AdminBundle\\Admin\\BaseFieldDescription',
-            'Sonata\\AdminBundle\\Admin\\FieldDescriptionCollection',
-            'Sonata\\AdminBundle\\Admin\\FieldDescriptionInterface',
-            'Sonata\\AdminBundle\\Admin\\Pool',
-            'Sonata\\AdminBundle\\Block\\AdminListBlockService',
-            'Sonata\\AdminBundle\\Builder\\DatagridBuilderInterface',
-            'Sonata\\AdminBundle\\Builder\\FormContractorInterface',
-            'Sonata\\AdminBundle\\Builder\\ListBuilderInterface',
-            'Sonata\\AdminBundle\\Builder\\RouteBuilderInterface',
-            'Sonata\\AdminBundle\\Builder\\ShowBuilderInterface',
-            'Sonata\\AdminBundle\\Datagrid\\Datagrid',
-            'Sonata\\AdminBundle\\Datagrid\\DatagridInterface',
-            'Sonata\\AdminBundle\\Datagrid\\DatagridMapper',
-            'Sonata\\AdminBundle\\Datagrid\\ListMapper',
-            'Sonata\\AdminBundle\\Datagrid\\Pager',
-            'Sonata\\AdminBundle\\Datagrid\\PagerInterface',
-            'Sonata\\AdminBundle\\Datagrid\\ProxyQueryInterface',
-            'Sonata\\AdminBundle\\Exception\\ModelManagerException',
-            'Sonata\\AdminBundle\\Exception\\NoValueException',
-            'Sonata\\AdminBundle\\Filter\\Filter',
-            'Sonata\\AdminBundle\\Filter\\FilterFactory',
-            'Sonata\\AdminBundle\\Filter\\FilterFactoryInterface',
-            'Sonata\\AdminBundle\\Filter\\FilterInterface',
-            'Sonata\\AdminBundle\\Form\\DataTransformer\\ArrayToModelTransformer',
-            'Sonata\\AdminBundle\\Form\\DataTransformer\\ModelsToArrayTransformer',
-            'Sonata\\AdminBundle\\Form\\DataTransformer\\ModelToIdTransformer',
-            'Sonata\\AdminBundle\\Form\\EventListener\\MergeCollectionListener',
-            'Sonata\\AdminBundle\\Form\\Extension\\Field\\Type\\FormTypeFieldExtension',
-            'Sonata\\AdminBundle\\Form\\FormMapper',
-            'Sonata\\AdminBundle\\Form\\Type\\AdminType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\ChoiceType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DateRangeType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DateTimeRangeType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DateTimeType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DateType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DefaultType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\NumberType',
-            'Sonata\\AdminBundle\\Form\\Type\\ModelReferenceType',
-            'Sonata\\AdminBundle\\Form\\Type\\ModelType',
-            'Sonata\\AdminBundle\\Form\\Type\\ModelListType',
-            'Sonata\\AdminBundle\\Guesser\\TypeGuesserChain',
-            'Sonata\\AdminBundle\\Guesser\\TypeGuesserInterface',
-            'Sonata\\AdminBundle\\Model\\AuditManager',
-            'Sonata\\AdminBundle\\Model\\AuditManagerInterface',
-            'Sonata\\AdminBundle\\Model\\AuditReaderInterface',
-            'Sonata\\AdminBundle\\Model\\ModelManagerInterface',
-            'Sonata\\AdminBundle\\Route\\AdminPoolLoader',
-            'Sonata\\AdminBundle\\Route\\DefaultRouteGenerator',
-            'Sonata\\AdminBundle\\Route\\PathInfoBuilder',
-            'Sonata\\AdminBundle\\Route\\QueryStringBuilder',
-            'Sonata\\AdminBundle\\Route\\RouteCollection',
-            'Sonata\\AdminBundle\\Route\\RouteGeneratorInterface',
-            'Sonata\\AdminBundle\\Security\\Acl\\Permission\\AdminPermissionMap',
-            'Sonata\\AdminBundle\\Security\\Acl\\Permission\\MaskBuilder',
-            'Sonata\\AdminBundle\\Security\\Handler\\AclSecurityHandler',
-            'Sonata\\AdminBundle\\Security\\Handler\\AclSecurityHandlerInterface',
-            'Sonata\\AdminBundle\\Security\\Handler\\NoopSecurityHandler',
-            'Sonata\\AdminBundle\\Security\\Handler\\RoleSecurityHandler',
-            'Sonata\\AdminBundle\\Security\\Handler\\SecurityHandlerInterface',
-            'Sonata\\AdminBundle\\Show\\ShowMapper',
-            'Sonata\\AdminBundle\\Translator\\BCLabelTranslatorStrategy',
-            'Sonata\\AdminBundle\\Translator\\FormLabelTranslatorStrategy',
-            'Sonata\\AdminBundle\\Translator\\LabelTranslatorStrategyInterface',
-            'Sonata\\AdminBundle\\Translator\\NativeLabelTranslatorStrategy',
-            'Sonata\\AdminBundle\\Translator\\NoopLabelTranslatorStrategy',
-            'Sonata\\AdminBundle\\Translator\\UnderscoreLabelTranslatorStrategy',
-            'Sonata\\AdminBundle\\Twig\\Extension\\SonataAdminExtension',
-            'Sonata\\AdminBundle\\Util\\AdminAclManipulator',
-            'Sonata\\AdminBundle\\Util\\AdminAclManipulatorInterface',
-            'Sonata\\AdminBundle\\Util\\FormBuilderIterator',
-            'Sonata\\AdminBundle\\Util\\FormViewIterator',
-            'Sonata\\AdminBundle\\Util\\ObjectAclManipulator',
-            'Sonata\\AdminBundle\\Util\\ObjectAclManipulatorInterface',
-        ]);
     }
 
     /**

--- a/Filter/Filter.php
+++ b/Filter/Filter.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\AdminBundle\Filter;
 
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
@@ -93,12 +95,7 @@ abstract class Filter implements FilterInterface
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
-        // (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-            : 'text'
-        );
+        return $this->getOption('field_type', TextType::class);
     }
 
     /**

--- a/Form/Extension/ChoiceTypeExtension.php
+++ b/Form/Extension/ChoiceTypeExtension.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -37,14 +38,7 @@ class ChoiceTypeExtension extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $optionalOptions = ['sortable'];
-
-        if (method_exists($resolver, 'setDefined')) {
-            $resolver->setDefined($optionalOptions);
-        } else {
-            // To keep Symfony <2.6 support
-            $resolver->setOptional($optionalOptions);
-        }
+        $resolver->setDefined(['sortable']);
     }
 
     /**
@@ -60,12 +54,6 @@ class ChoiceTypeExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        /*
-         * NEXT_MAJOR: Remove when dropping Symfony <2.8 support. It should
-         * simply be return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
-         */
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice';
+        return ChoiceType::class;
     }
 }

--- a/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -14,11 +14,11 @@ namespace Sonata\AdminBundle\Form\Extension\Field\Type;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Exception\NoValueException;
 use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -164,10 +164,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\FormType' :
-            'form';
+        return FormType::class;
     }
 
     /**
@@ -231,11 +228,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
     protected function getClass(FormBuilderInterface $formBuilder)
     {
         foreach ($this->getTypes($formBuilder) as $type) {
-            if (!method_exists($type, 'getName')) { // SF3.0+
-                $name = get_class($type);
-            } else {
-                $name = $type->getName();
-            }
+            $name = get_class($type);
 
             if (isset($this->defaultClasses[$name])) {
                 return $this->defaultClasses[$name];

--- a/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
+++ b/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Form\Extension\Field\Type;
 
 use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -62,12 +63,6 @@ class MopaCompatibilityTypeFieldExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        /*
-         * NEXT_MAJOR: Remove when dropping Symfony <2.8 support. It should
-         * simply be return 'Symfony\Component\Form\Extension\Core\Type\FormType';
-         */
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\FormType'
-            : 'form';
+        return FormType::class;
     }
 }

--- a/Form/Type/AclMatrixType.php
+++ b/Form/Type/AclMatrixType.php
@@ -12,9 +12,10 @@
 namespace Sonata\AdminBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -33,24 +34,10 @@ class AclMatrixType extends AbstractType
         $aclValueType = $options['acl_value'] instanceof UserInterface ? 'user' : 'role';
         $aclValueData = $options['acl_value'] instanceof UserInterface ? $options['acl_value']->getUsername() : $options['acl_value'];
 
-        $builder->add(
-            $aclValueType,
-            // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-                : 'hidden',
-            ['data' => $aclValueData]
-        );
+        $builder->add($aclValueType, HiddenType::class, ['data' => $aclValueData]);
 
         foreach ($options['permissions'] as $permission => $attributes) {
-            $builder->add(
-                $permission,
-                // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Symfony\Component\Form\Extension\Core\Type\CheckboxType'
-                    : 'checkbox',
-                $attributes
-            );
+            $builder->add($permission, CheckboxType::class, $attributes);
         }
     }
 
@@ -74,15 +61,8 @@ class AclMatrixType extends AbstractType
             'acl_value',
         ]);
 
-        if (method_exists($resolver, 'setDefined')) {
-            $resolver->setAllowedTypes('permissions', 'array');
-            $resolver->setAllowedTypes('acl_value', ['string', '\Symfony\Component\Security\Core\User\UserInterface']);
-        } else {
-            $resolver->setAllowedTypes([
-                'permissions' => 'array',
-                'acl_value' => ['string', '\Symfony\Component\Security\Core\User\UserInterface'],
-            ]);
-        }
+        $resolver->setAllowedTypes('permissions', 'array');
+        $resolver->setAllowedTypes('acl_value', ['string', '\Symfony\Component\Security\Core\User\UserInterface']);
     }
 
     /**

--- a/Form/Type/AdminType.php
+++ b/Form/Type/AdminType.php
@@ -11,11 +11,11 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
-use Doctrine\Common\Collections\Collection;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Form\DataTransformer\ArrayToModelTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -57,23 +57,7 @@ class AdminType extends AbstractType
             try {
                 $parentSubject = $admin->getParentFieldDescription()->getAdmin()->getSubject();
                 if ($parentSubject !== null && $parentSubject !== false) {
-                    // for PropertyAccessor < 2.5
-                    // NEXT_MAJOR: remove this code for old PropertyAccessor after dropping support for Symfony 2.3
-                    if (!method_exists($p, 'isReadable')) {
-                        $subjectCollection = $p->getValue(
-                            $parentSubject,
-                            $this->getFieldDescription($options)->getFieldName()
-                        );
-                        if ($subjectCollection instanceof Collection) {
-                            $subject = $subjectCollection->get(trim($options['property_path'], '[]'));
-                        }
-                    } else {
-                        // for PropertyAccessor >= 2.5
-                        $subject = $p->getValue(
-                            $parentSubject,
-                            $options['property_path']
-                        );
-                    }
+                    $subject = $p->getValue($parentSubject, $options['property_path']);
                     $builder->setData($subject);
                 }
             } catch (NoSuchIndexException $e) {
@@ -119,10 +103,7 @@ class AdminType extends AbstractType
                 return $options['btn_delete'] !== false;
             },
             'delete_options' => [
-                // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-                'type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Symfony\Component\Form\Extension\Core\Type\CheckboxType'
-                    : 'checkbox',
+                'type' => CheckboxType::class,
                 'type_options' => [
                     'required' => false,
                     'mapped' => false,

--- a/Form/Type/ChoiceFieldMaskType.php
+++ b/Form/Type/ChoiceFieldMaskType.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -61,12 +62,7 @@ class ChoiceFieldMaskType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        // NEXT_MAJOR: Remove conditional parent call when bumping requirements to SF 2.7+
-        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            parent::configureOptions($resolver);
-        } else {
-            parent::setDefaultOptions($resolver);
-        }
+        parent::configureOptions($resolver);
 
         $resolver->setDefaults([
             'map' => [],
@@ -78,10 +74,7 @@ class ChoiceFieldMaskType extends AbstractType
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice';
+        return ChoiceType::class;
     }
 
     /**

--- a/Form/Type/CollectionType.php
+++ b/Form/Type/CollectionType.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType as SymfonyCollectionType;
 
 /**
  * This type wrap native `collection` form type and render `add` and `delete`
@@ -26,10 +27,7 @@ class CollectionType extends AbstractType
      */
     public function getParent()
     {
-        return
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\CollectionType' :
-            'collection';
+        return SymfonyCollectionType::class;
     }
 
     /**

--- a/Form/Type/Filter/ChoiceType.php
+++ b/Form/Type/Filter/ChoiceType.php
@@ -12,9 +12,9 @@
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType as SymfonyChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -75,25 +75,14 @@ class ChoiceType extends AbstractType
         ];
         $operatorChoices = [];
 
-        // NEXT_MAJOR: Remove first check (when requirement of Symfony is >= 2.8)
-        if ($options['operator_type'] !== 'hidden' && $options['operator_type'] !== 'Symfony\Component\Form\Extension\Core\Type\HiddenType') {
-            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
-            if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-                $choices = array_flip($choices);
-                foreach ($choices as $key => $value) {
-                    $choices[$key] = $this->translator->trans($value, [], 'SonataAdminBundle');
-                }
-            } else {
-                $operatorChoices['choice_translation_domain'] = 'SonataAdminBundle';
+        $operatorChoices['choice_translation_domain'] = 'SonataAdminBundle';
 
-                // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-                if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                    $operatorChoices['choices_as_values'] = true;
-                }
-            }
-
-            $operatorChoices['choices'] = $choices;
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $operatorChoices['choices_as_values'] = true;
         }
+
+        $operatorChoices['choices'] = $choices;
 
         $builder
             ->add('type', $options['operator_type'], array_merge(['required' => false], $options['operator_options'], $operatorChoices))
@@ -119,9 +108,7 @@ class ChoiceType extends AbstractType
         $resolver->setDefaults([
             'field_type' => 'choice',
             'field_options' => [],
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-                : 'choice', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'operator_type' => SymfonyChoiceType::class,
             'operator_options' => [],
         ]);
     }

--- a/Form/Type/Filter/DateRangeType.php
+++ b/Form/Type/Filter/DateRangeType.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -73,35 +74,24 @@ class DateRangeType extends AbstractType
             'required' => false,
         ];
 
-        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, [], 'SonataAdminBundle');
-            }
-        } else {
-            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
-            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $choiceOptions['choices_as_values'] = true;
-            }
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choiceOptions['choices_as_values'] = true;
         }
 
         $choiceOptions['choices'] = $choices;
 
         $builder
-            // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-            ->add('type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-                : 'choice', $choiceOptions)
+            ->add('type', ChoiceType::class, $choiceOptions)
             ->add('value', $options['field_type'], $options['field_options'])
         ;
     }
 
-    // NEXT_MAJOR: Remove method, when bumping requirements to SF 2.7+
-
     /**
+     * NEXT_MAJOR: Remove method, when bumping requirements to SF 2.7+.
+     *
      * {@inheritdoc}
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)

--- a/Form/Type/Filter/DateTimeRangeType.php
+++ b/Form/Type/Filter/DateTimeRangeType.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -73,28 +74,17 @@ class DateTimeRangeType extends AbstractType
             'required' => false,
         ];
 
-        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, [], 'SonataAdminBundle');
-            }
-        } else {
-            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
-            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $choiceOptions['choices_as_values'] = true;
-            }
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choiceOptions['choices_as_values'] = true;
         }
 
         $choiceOptions['choices'] = $choices;
 
         $builder
-            // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-            ->add('type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-                : 'choice', $choiceOptions)
+            ->add('type', ChoiceType::class, $choiceOptions)
             ->add('value', $options['field_type'], $options['field_options'])
         ;
     }

--- a/Form/Type/Filter/DateTimeType.php
+++ b/Form/Type/Filter/DateTimeType.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -89,28 +90,17 @@ class DateTimeType extends AbstractType
             'required' => false,
         ];
 
-        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, [], 'SonataAdminBundle');
-            }
-        } else {
-            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
-            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $choiceOptions['choices_as_values'] = true;
-            }
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choiceOptions['choices_as_values'] = true;
         }
 
         $choiceOptions['choices'] = $choices;
 
         $builder
-            // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-            ->add('type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-                : 'choice', $choiceOptions)
+            ->add('type', ChoiceType::class, $choiceOptions)
             ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
         ;
     }

--- a/Form/Type/Filter/DateType.php
+++ b/Form/Type/Filter/DateType.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Optionsresolver\OptionsResolverInterface;
@@ -89,28 +90,17 @@ class DateType extends AbstractType
             'required' => false,
         ];
 
-        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, [], 'SonataAdminBundle');
-            }
-        } else {
-            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
-            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $choiceOptions['choices_as_values'] = true;
-            }
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choiceOptions['choices_as_values'] = true;
         }
 
         $choiceOptions['choices'] = $choices;
 
         $builder
-            // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-            ->add('type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-                : 'choice', $choiceOptions)
+            ->add('type', ChoiceType::class, $choiceOptions)
             ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
         ;
     }

--- a/Form/Type/Filter/DefaultType.php
+++ b/Form/Type/Filter/DefaultType.php
@@ -12,6 +12,8 @@
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -66,13 +68,9 @@ class DefaultType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-                : 'hidden', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'operator_type' => HiddenType::class,
             'operator_options' => [],
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                : 'text', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'field_type' => TextType::class,
             'field_options' => [],
         ]);
     }

--- a/Form/Type/Filter/NumberType.php
+++ b/Form/Type/Filter/NumberType.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -84,28 +85,17 @@ class NumberType extends AbstractType
             'required' => false,
         ];
 
-        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, [], 'SonataAdminBundle');
-            }
-        } else {
-            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
-            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $choiceOptions['choices_as_values'] = true;
-            }
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choiceOptions['choices_as_values'] = true;
         }
 
         $choiceOptions['choices'] = $choices;
 
         $builder
-            // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-            ->add('type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-                : 'choice', $choiceOptions)
+            ->add('type', ChoiceType::class, $choiceOptions)
             ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
         ;
     }

--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Form\Type;
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdPropertyTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -44,25 +45,12 @@ class ModelAutocompleteType extends AbstractType
         $builder->setAttribute(
             'disabled',
             $options['disabled']
-            // NEXT_MAJOR: Remove this when bumping Symfony constraint to 2.8+
-            || (array_key_exists('read_only', $options) && $options['read_only'])
         );
         $builder->setAttribute('to_string_callback', $options['to_string_callback']);
         $builder->setAttribute('target_admin_access_action', $options['target_admin_access_action']);
 
         if ($options['multiple']) {
-            $resizeListener = new ResizeFormListener(
-                // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-                // (when requirement of Symfony is >= 2.8)
-                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-                    : 'hidden',
-                [],
-                true,
-                true,
-                true
-            );
-
+            $resizeListener = new ResizeFormListener(HiddenType::class, [], true, true, true);
             $builder->addEventSubscriber($resizeListener);
         }
     }

--- a/Form/Type/ModelHiddenType.php
+++ b/Form/Type/ModelHiddenType.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Form\Type;
 
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -60,10 +61,7 @@ class ModelHiddenType extends AbstractType
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-            : 'hidden';
+        return HiddenType::class;
     }
 
     /**

--- a/Form/Type/ModelListType.php
+++ b/Form/Type/ModelListType.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Form\Type;
 
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -96,10 +97,7 @@ class ModelListType extends AbstractType
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-            : 'text';
+        return TextType::class;
     }
 
     /**

--- a/Form/Type/ModelReferenceType.php
+++ b/Form/Type/ModelReferenceType.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Form\Type;
 
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -57,10 +58,7 @@ class ModelReferenceType extends AbstractType
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-            : 'text';
+        return TextType::class;
     }
 
     /**

--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -11,13 +11,12 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
-use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
-use Sonata\AdminBundle\Form\DataTransformer\LegacyModelsToArrayTransformer;
 use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
 use Sonata\AdminBundle\Form\EventListener\MergeCollectionListener;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -49,21 +48,12 @@ class ModelType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if ($options['multiple']) {
-            if (array_key_exists('choice_loader', $options) && $options['choice_loader'] !== null) { // SF2.7+
-                $builder->addViewTransformer(new ModelsToArrayTransformer(
-                    $options['model_manager'],
-                    $options['class']), true);
-            } else {
-                $builder->addViewTransformer(new LegacyModelsToArrayTransformer($options['choice_list']), true);
-            }
-
+            $builder->addViewTransformer(new ModelsToArrayTransformer($options['model_manager'], $options['class']), true);
             $builder
-                ->addEventSubscriber(new MergeCollectionListener($options['model_manager']))
-            ;
+                ->addEventSubscriber(new MergeCollectionListener($options['model_manager']));
         } else {
             $builder
-                ->addViewTransformer(new ModelToIdTransformer($options['model_manager'], $options['class']), true)
-            ;
+                ->addViewTransformer(new ModelToIdTransformer($options['model_manager'], $options['class']), true);
         }
     }
 
@@ -94,41 +84,24 @@ class ModelType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $options = [];
-        $propertyAccessor = $this->propertyAccessor;
-        if (interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) { // SF2.7+
-            $options['choice_loader'] = function (Options $options, $previousValue) use ($propertyAccessor) {
-                if ($previousValue && count($choices = $previousValue->getChoices())) {
-                    return $choices;
-                }
 
-                return new ModelChoiceLoader(
-                    $options['model_manager'],
-                    $options['class'],
-                    $options['property'],
-                    $options['query'],
-                    $options['choices'],
-                    $propertyAccessor
-                );
-            };
-            // NEXT_MAJOR: Remove this when dropping support for SF 2.8
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $options['choices_as_values'] = true;
+        $options['choice_loader'] = function (Options $options, $previousValue) {
+            if ($previousValue && count($choices = $previousValue->getChoices())) {
+                return $choices;
             }
-        } else {
-            $options['choice_list'] = function (Options $options, $previousValue) use ($propertyAccessor) {
-                if ($previousValue && count($choices = $previousValue->getChoices())) {
-                    return $choices;
-                }
 
-                return new ModelChoiceList(
-                    $options['model_manager'],
-                    $options['class'],
-                    $options['property'],
-                    $options['query'],
-                    $options['choices'],
-                    $propertyAccessor
-                );
-            };
+            return new ModelChoiceLoader(
+                $options['model_manager'],
+                $options['class'],
+                $options['property'],
+                $options['query'],
+                $options['choices'],
+                $this->propertyAccessor
+            );
+        };
+        // NEXT_MAJOR: Remove this when dropping support for SF 2.8
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $options['choices_as_values'] = true;
         }
 
         $resolver->setDefaults(array_merge($options, [
@@ -173,10 +146,7 @@ class ModelType extends AbstractType
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice';
+        return ChoiceType::class;
     }
 
     /**

--- a/Mapper/BaseGroupedMapper.php
+++ b/Mapper/BaseGroupedMapper.php
@@ -72,7 +72,7 @@ abstract class BaseGroupedMapper extends BaseMapper
             'class' => false,
             'description' => false,
             'label' => $name, // NEXT_MAJOR: Remove this line and uncomment the next one
-//            'label' => $this->admin->getLabelTranslatorStrategy()->getLabel($name, $this->getName(), 'group'),
+            // 'label' => $this->admin->getLabelTranslatorStrategy()->getLabel($name, $this->getName(), 'group'),
             'translation_domain' => null,
             'name' => $name,
             'box_class' => 'box box-primary',

--- a/Mapper/BaseMapper.php
+++ b/Mapper/BaseMapper.php
@@ -70,13 +70,14 @@ abstract class BaseMapper
      */
     abstract public function remove($key);
 
-    // To be uncommented on 4.0.
     /**
+     * NEXT_MAJOR: To be uncommented on 4.0.
+     *
      * Returns configured keys.
      *
      * @return string[]
      */
-    //abstract public function keys();
+    // abstract public function keys();
 
     /**
      * @param array $keys field names

--- a/Menu/Provider/GroupMenuProvider.php
+++ b/Menu/Provider/GroupMenuProvider.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Menu\Provider;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * Menu provider based on group options.
@@ -33,20 +34,14 @@ class GroupMenuProvider implements MenuProviderInterface
     private $pool;
 
     /**
-     * NEXT_MAJOR: Use AuthorizationCheckerInterface when bumping requirements to >=Symfony 2.6.
-     *
-     * @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface|\Symfony\Component\Security\Core\SecurityContextInterface
+     * @var AuthorizationCheckerInterface
      */
     private $checker;
 
     /**
-     * NEXT_MAJOR: Remove default value null of $checker.
-     * NEXT_MAJOR: Allow only injection of AuthorizationCheckerInterface when bumping requirements to >=Symfony 2.6.
-     *
-     * @param FactoryInterface $menuFactory
-     * @param Pool             $pool
-     * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface|
-     *        \Symfony\Component\Security\Core\SecurityContextInterface|null  $checker
+     * @param FactoryInterface              $menuFactory
+     * @param Pool                          $pool
+     * @param AuthorizationCheckerInterface $checker
      */
     public function __construct(FactoryInterface $menuFactory, Pool $pool, $checker = null)
     {
@@ -63,9 +58,7 @@ class GroupMenuProvider implements MenuProviderInterface
                 Pass Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface as 3rd argument.',
                 E_USER_DEPRECATED
             );
-        } elseif (!$checker instanceof \Symfony\Component\Security\Core\SecurityContextInterface
-            && !$checker instanceof \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface
-        ) {
+        } elseif (!$checker instanceof AuthorizationCheckerInterface) {
             throw new \InvalidArgumentException(
                 'Argument 3 must be an instance of either \Symfony\Component\Security\Core\SecurityContextInterface or
                 \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'

--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -8,13 +8,13 @@
             <argument type="service" id="event_dispatcher"/>
         </service>
         <service id="sonata.admin.sidebar_menu" class="Knp\Menu\MenuItem">
+            <factory service="sonata.admin.menu_builder" method="createSidebarMenu"/>
             <tag name="knp_menu.menu" alias="sonata_admin_sidebar"/>
         </service>
-        <!--NEXT_MAJOR: Replace empty argument with security.authorization_checker service when bumping requirements to >=Symfony 2.6 -->
         <service id="sonata.admin.menu.group_provider" class="Sonata\AdminBundle\Menu\Provider\GroupMenuProvider" public="false">
             <argument type="service" id="knp_menu.factory"/>
             <argument type="service" id="sonata.admin.pool"/>
-            <argument/>
+            <argument type="service" id="security.authorization_checker"/>
             <tag name="knp_menu.provider"/>
         </service>
         <service id="sonata.admin.menu.matcher.voter.admin" class="Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter">

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -11,17 +11,14 @@
     <services>
         <service id="sonata.admin.security.handler.noop" class="%sonata.admin.security.handler.noop.class%" public="false"/>
         <service id="sonata.admin.security.handler.role" class="%sonata.admin.security.handler.role.class%" public="false">
-            <argument/>
-            <!-- security.authorization_checker or security.context for Symfony <2.6 -->
+            <argument type="service" id="security.authorization_checker"/>
             <argument type="collection">
                 <argument>ROLE_SUPER_ADMIN</argument>
             </argument>
         </service>
         <service id="sonata.admin.security.handler.acl" class="%sonata.admin.security.handler.acl.class%" public="false">
-            <argument/>
-            <!-- security.token_storage or security.context for Symfony <2.6 -->
-            <argument/>
-            <!-- security.authorization_checker or security.context for Symfony <2.6 -->
+            <argument type="service" id="security.token_storage"/>
+            <argument type="service" id="security.authorization_checker"/>
             <argument type="service" id="security.acl.provider" on-invalid="null"/>
             <argument>%sonata.admin.security.mask.builder.class%</argument>
             <argument type="collection">

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -178,7 +178,6 @@ file that was distributed with this source code.
                                     {% endif %}
                                 </div>
 
-
                                 {# NEXT_MAJOR : remove this assignment #}
                                 {% set export_formats = export_formats|default(admin.exportFormats) %}
 

--- a/Security/Handler/AclSecurityHandler.php
+++ b/Security/Handler/AclSecurityHandler.php
@@ -23,7 +23,6 @@ use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -31,12 +30,12 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 class AclSecurityHandler implements AclSecurityHandlerInterface
 {
     /**
-     * @var TokenStorageInterface|SecurityContextInterface
+     * @var TokenStorageInterface
      */
     protected $tokenStorage;
 
     /**
-     * @var AuthorizationCheckerInterface|SecurityContextInterface
+     * @var AuthorizationCheckerInterface
      */
     protected $authorizationChecker;
 
@@ -66,21 +65,19 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
     protected $maskBuilderClass;
 
     /**
-     * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
-     *
-     * @param TokenStorageInterface|SecurityContextInterface $tokenStorage
-     * @param TokenStorageInterface|SecurityContextInterface $authorizationChecker
-     * @param MutableAclProviderInterface                    $aclProvider
-     * @param string                                         $maskBuilderClass
-     * @param array                                          $superAdminRoles
+     * @param TokenStorageInterface         $tokenStorage
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     * @param MutableAclProviderInterface   $aclProvider
+     * @param string                        $maskBuilderClass
+     * @param array                         $superAdminRoles
      */
     public function __construct($tokenStorage, $authorizationChecker, MutableAclProviderInterface $aclProvider, $maskBuilderClass, array $superAdminRoles)
     {
-        if (!$tokenStorage instanceof TokenStorageInterface && !$tokenStorage instanceof SecurityContextInterface) {
-            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        if (!$tokenStorage instanceof TokenStorageInterface) {
+            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         }
-        if (!$authorizationChecker instanceof AuthorizationCheckerInterface && !$authorizationChecker instanceof SecurityContextInterface) {
-            throw new \InvalidArgumentException('Argument 2 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        if (!$authorizationChecker instanceof AuthorizationCheckerInterface) {
+            throw new \InvalidArgumentException('Argument 2 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         }
 
         $this->tokenStorage = $tokenStorage;

--- a/Security/Handler/RoleSecurityHandler.php
+++ b/Security/Handler/RoleSecurityHandler.php
@@ -14,7 +14,6 @@ namespace Sonata\AdminBundle\Security\Handler;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -22,7 +21,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 class RoleSecurityHandler implements SecurityHandlerInterface
 {
     /**
-     * @var AuthorizationCheckerInterface|SecurityContextInterface
+     * @var AuthorizationCheckerInterface
      */
     protected $authorizationChecker;
 
@@ -32,15 +31,13 @@ class RoleSecurityHandler implements SecurityHandlerInterface
     protected $superAdminRoles;
 
     /**
-     * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
-     *
-     * @param AuthorizationCheckerInterface|SecurityContextInterface $authorizationChecker
-     * @param array                                                  $superAdminRoles
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     * @param array                         $superAdminRoles
      */
     public function __construct($authorizationChecker, array $superAdminRoles)
     {
-        if (!$authorizationChecker instanceof AuthorizationCheckerInterface && !$authorizationChecker instanceof SecurityContextInterface) {
-            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        if (!$authorizationChecker instanceof AuthorizationCheckerInterface) {
+            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         }
 
         $this->authorizationChecker = $authorizationChecker;

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -2171,6 +2171,7 @@ class AdminTest extends TestCase
             ->will($this->returnCallback(function ($label, $context = '', $type = '') {
                 return $context.'.'.$type.'_'.$label;
             }));
+
         $admin->expects($this->any())
             ->method('trans')
             ->will($this->returnCallback(function ($label) {

--- a/Tests/Admin/Extension/LockExtensionTest.php
+++ b/Tests/Admin/Extension/LockExtensionTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\Extension\LockExtension;
 use Sonata\AdminBundle\Form\FormMapper;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -72,14 +73,8 @@ class LockExtensionTest extends TestCase
 
         $this->modelManager->getLockVersion([])->willReturn(1);
 
-        $form->add(
-            '_lock_version',
-            // NEXT_MAJOR: remove the check and add the FQCN
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-                : 'hidden',
-            ['mapped' => false, 'data' => 1]
-        )->shouldBeCalled();
+        $form->add('_lock_version', HiddenType::class, ['mapped' => false, 'data' => 1])
+            ->shouldBeCalled();
 
         $this->lockExtension->configureFormFields($formMapper);
         $this->eventDispatcher->dispatch(FormEvents::PRE_SET_DATA, $event);

--- a/Tests/Command/ExplainAdminCommandTest.php
+++ b/Tests/Command/ExplainAdminCommandTest.php
@@ -187,27 +187,14 @@ class ExplainAdminCommandTest extends TestCase
 
     public function testExecute()
     {
-        // NEXT_MAJOR: Remove check, when bumping requirements to SF 2.5+
-        if (interface_exists('Symfony\Component\Validator\Mapping\MetadataInterface')) { //sf2.5+
-            $metadata = $this->createMock('Symfony\Component\Validator\Mapping\MetadataInterface');
-        } else {
-            $metadata = $this->createMock('Symfony\Component\Validator\MetadataInterface');
-        }
+        $metadata = $this->createMock('Symfony\Component\Validator\Mapping\MetadataInterface');
 
         $this->validatorFactory->expects($this->once())
             ->method('getMetadataFor')
             ->with($this->equalTo('Acme\Entity\Foo'))
             ->will($this->returnValue($metadata));
 
-        // NEXT_MAJOR: Remove check, when bumping requirements to SF 2.5+
-        if (class_exists('Symfony\Component\Validator\Mapping\GenericMetadata')) {
-            $class = 'GenericMetadata';
-        } else {
-            // Symfony <2.5 compatibility
-            $class = 'ElementMetadata';
-        }
-
-        $propertyMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\\'.$class);
+        $propertyMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\GenericMetadata');
         $propertyMetadata->constraints = [
             new NotNull(),
             new Length(['min' => 2, 'max' => 50, 'groups' => ['create', 'edit']]),
@@ -215,7 +202,7 @@ class ExplainAdminCommandTest extends TestCase
 
         $metadata->properties = ['firstName' => $propertyMetadata];
 
-        $getterMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\\'.$class);
+        $getterMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\GenericMetadata');
         $getterMetadata->constraints = [
             new NotNull(),
             new Email(['groups' => ['registration', 'edit']]),

--- a/Tests/Command/GenerateAdminCommandTest.php
+++ b/Tests/Command/GenerateAdminCommandTest.php
@@ -199,107 +199,50 @@ class GenerateAdminCommandTest extends TestCase
 
         $command = $this->application->find('sonata:admin:generate');
 
-        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
-        // DialogHelper does not exist in SensioGeneratorBundle 2.5+
-        if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
-            $dialog = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')
-                ->setMethods(['askConfirmation', 'askAndValidate'])
-                ->getMock();
+        $questionHelper = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper')
+            ->setMethods(['ask'])
+            ->getMock();
 
-            $dialog->expects($this->any())
-                ->method('askConfirmation')
-                ->will($this->returnCallback(function (OutputInterface $output, $question, $default) {
-                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
+        $questionHelper->expects($this->any())
+            ->method('ask')
+            ->will($this->returnCallback(function (InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity) {
+                $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>') - 6);
 
-                    switch ($questionClean) {
-                        case 'Do you want to generate a controller':
-                            return 'yes';
+                switch ($questionClean) {
+                    // confirmations
+                    case 'Do you want to generate a controller':
+                        return 'yes';
 
-                        case 'Do you want to update the services YAML configuration file':
-                            return 'yes';
-                    }
+                    case 'Do you want to update the services YAML configuration file':
+                        return 'yes';
 
-                    return $default;
-                }));
+                    // inputs
+                    case 'The fully qualified model class':
+                        return $modelEntity;
 
-            $dialog->expects($this->any())
-                ->method('askAndValidate')
-                ->will($this->returnCallback(function (OutputInterface $output, $question, $validator, $attempts = false, $default = null) use ($modelEntity) {
-                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
+                    case 'The bundle name':
+                        return 'AcmeDemoBundle';
 
-                    switch ($questionClean) {
-                        case 'The fully qualified model class':
-                            return $modelEntity;
+                    case 'The admin class basename':
+                        return 'FooAdmin';
 
-                        case 'The bundle name':
-                            return 'AcmeDemoBundle';
+                    case 'The controller class basename':
+                        return 'FooAdminController';
 
-                        case 'The admin class basename':
-                            return 'FooAdmin';
+                    case 'The services YAML configuration file':
+                        return 'admin.yml';
 
-                        case 'The controller class basename':
-                            return 'FooAdminController';
+                    case 'The admin service ID':
+                        return 'acme_demo_admin.admin.foo';
 
-                        case 'The services YAML configuration file':
-                            return 'admin.yml';
+                    case 'The manager type':
+                        return 'foo';
+                }
 
-                        case 'The admin service ID':
-                            return 'acme_demo_admin.admin.foo';
+                return false;
+            }));
 
-                        case 'The manager type':
-                            return 'foo';
-                    }
-
-                    return $default;
-                }));
-
-            $command->getHelperSet()->set($dialog, 'dialog');
-        } else {
-            $questionHelper = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper')
-                ->setMethods(['ask'])
-                ->getMock();
-
-            $questionHelper->expects($this->any())
-                ->method('ask')
-                ->will($this->returnCallback(function (InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity) {
-                    $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>') - 6);
-
-                    switch ($questionClean) {
-                        // confirmations
-                        case 'Do you want to generate a controller':
-                            return 'yes';
-
-                        case 'Do you want to update the services YAML configuration file':
-                            return 'yes';
-
-                        // inputs
-                        case 'The fully qualified model class':
-                            return $modelEntity;
-
-                        case 'The bundle name':
-                            return 'AcmeDemoBundle';
-
-                        case 'The admin class basename':
-                            return 'FooAdmin';
-
-                        case 'The controller class basename':
-                            return 'FooAdminController';
-
-                        case 'The services YAML configuration file':
-                            return 'admin.yml';
-
-                        case 'The admin service ID':
-                            return 'acme_demo_admin.admin.foo';
-
-                        case 'The manager type':
-                            return 'foo';
-                    }
-
-                    return false;
-                }));
-
-            $command->getHelperSet()->set($questionHelper, 'question');
-        }
+        $command->getHelperSet()->set($questionHelper, 'question');
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([
@@ -398,95 +341,38 @@ class GenerateAdminCommandTest extends TestCase
 
         $command = $this->application->find('sonata:admin:generate');
 
-        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
-        // DialogHelper does not exist in SensioGeneratorBundle 2.5+
-        if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
-            $dialog = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')
-                ->setMethods(['askConfirmation', 'askAndValidate'])
-                ->getMock();
+        $questionHelper = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper')
+            ->setMethods(['ask'])
+            ->getMock();
 
-            $dialog->expects($this->any())
-                ->method('askConfirmation')
-                ->will($this->returnCallback(function (OutputInterface $output, $question, $default) {
-                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
+        $questionHelper->expects($this->any())
+            ->method('ask')
+            ->will($this->returnCallback(function (InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity) {
+                $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>') - 6);
 
-                    switch ($questionClean) {
-                        case 'Do you want to generate a controller':
-                            return false;
+                switch ($questionClean) {
+                    // confirmations
+                    case 'Do you want to generate a controller':
+                        return false;
 
-                        case 'Do you want to update the services YAML configuration file':
-                            return false;
-                    }
+                    case 'Do you want to update the services YAML configuration file':
+                        return false;
 
-                    return $default;
-                }));
+                    // inputs
+                    case 'The fully qualified model class':
+                        return $modelEntity;
 
-            $dialog->expects($this->any())
-                ->method('askAndValidate')
-                ->will($this->returnCallback(function (OutputInterface $output, $question, $validator, $attempts = false, $default = null) use ($modelEntity) {
-                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
+                    case 'The bundle name':
+                        return 'AcmeDemoBundle';
 
-                    switch ($questionClean) {
-                        case 'The fully qualified model class':
-                            return $modelEntity;
+                    case 'The admin class basename':
+                        return 'FooAdmin';
+                }
 
-                        case 'The bundle name':
-                            return 'AcmeDemoBundle';
+                return false;
+            }));
 
-                        case 'The admin class basename':
-                            return 'FooAdmin';
-
-                        case 'The controller class basename':
-                            return 'FooAdminController';
-
-                        case 'The services YAML configuration file':
-                            return 'admin.yml';
-
-                        case 'The admin service ID':
-                            return 'acme_demo_admin.admin.foo';
-
-                        case 'The manager type':
-                            return 'foo';
-                    }
-
-                    return $default;
-                }));
-
-            $command->getHelperSet()->set($dialog, 'dialog');
-        } else {
-            $questionHelper = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper')
-                ->setMethods(['ask'])
-                ->getMock();
-
-            $questionHelper->expects($this->any())
-                ->method('ask')
-                ->will($this->returnCallback(function (InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity) {
-                    $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>') - 6);
-
-                    switch ($questionClean) {
-                        // confirmations
-                        case 'Do you want to generate a controller':
-                            return false;
-
-                        case 'Do you want to update the services YAML configuration file':
-                            return false;
-
-                        // inputs
-                        case 'The fully qualified model class':
-                            return $modelEntity;
-
-                        case 'The bundle name':
-                            return 'AcmeDemoBundle';
-
-                        case 'The admin class basename':
-                            return 'FooAdmin';
-                    }
-
-                    return false;
-                }));
-
-            $command->getHelperSet()->set($questionHelper, 'question');
-        }
+        $command->getHelperSet()->set($questionHelper, 'question');
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -32,7 +32,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -240,50 +239,24 @@ class CRUDControllerTest extends TestCase
         $auditManager = $this->auditManager;
         $adminObjectAclManipulator = $this->adminObjectAclManipulator;
 
-        // Prefer Symfony 2.x interfaces
-        if (interface_exists('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface')) {
-            $this->csrfProvider = $this->getMockBuilder(
-                'Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface'
-            )
-                ->getMock();
+        $this->csrfProvider = $this->getMockBuilder('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface')
+            ->getMock();
 
-            $this->csrfProvider->expects($this->any())
-                ->method('generateCsrfToken')
-                ->will($this->returnCallback(function ($intention) {
-                    return 'csrf-token-123_'.$intention;
-                }));
+        $this->csrfProvider->expects($this->any())
+            ->method('getToken')
+            ->will($this->returnCallback(function ($intention) {
+                return new CsrfToken($intention, 'csrf-token-123_'.$intention);
+            }));
 
-            $this->csrfProvider->expects($this->any())
-                ->method('isCsrfTokenValid')
-                ->will($this->returnCallback(function ($intention, $token) {
-                    if ($token == 'csrf-token-123_'.$intention) {
-                        return true;
-                    }
+        $this->csrfProvider->expects($this->any())
+            ->method('isTokenValid')
+            ->will($this->returnCallback(function (CsrfToken $token) {
+                if ($token->getValue() == 'csrf-token-123_'.$token->getId()) {
+                    return true;
+                }
 
-                    return false;
-                }));
-        } else {
-            $this->csrfProvider = $this->getMockBuilder(
-                'Symfony\Component\Security\Csrf\CsrfTokenManagerInterface'
-            )
-                ->getMock();
-
-            $this->csrfProvider->expects($this->any())
-                ->method('getToken')
-                ->will($this->returnCallback(function ($intention) {
-                    return new CsrfToken($intention, 'csrf-token-123_'.$intention);
-                }));
-
-            $this->csrfProvider->expects($this->any())
-                ->method('isTokenValid')
-                ->will($this->returnCallback(function (CsrfToken $token) {
-                    if ($token->getValue() == 'csrf-token-123_'.$token->getId()) {
-                        return true;
-                    }
-
-                    return false;
-                }));
-        }
+                return false;
+            }));
 
         $this->adminRouteIdHandler = $this->getMockBuilder(
             'Sonata\AdminBundle\Route\Handler\RouteIdHandlerInterface'
@@ -367,11 +340,7 @@ class CRUDControllerTest extends TestCase
         $this->container->expects($this->any())
             ->method('has')
             ->will($this->returnCallback(function ($id) use ($tthis) {
-                if ($id == 'form.csrf_provider' && Kernel::MAJOR_VERSION == 2 && $tthis->getCsrfProvider() !== null) {
-                    return true;
-                }
-
-                if ($id == 'security.csrf.token_manager' && Kernel::MAJOR_VERSION >= 3 && $tthis->getCsrfProvider() !== null) {
+                if ($id == 'security.csrf.token_manager' && $tthis->getCsrfProvider() !== null) {
                     return true;
                 }
 

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -90,13 +90,9 @@ class HelperControllerTest extends TestCase
         $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
         $helper = new AdminHelper($pool);
 
-        // NEXT_MAJOR: Remove this when dropping support for SF < 2.8
-        if (interface_exists('Symfony\Component\Validator\ValidatorInterface')) {
-            $validator = $this->createMock('Symfony\Component\Validator\ValidatorInterface');
-        } else {
-            $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
-        }
-        $this->controller = new HelperController($twig, $pool, $helper, $validator);
+        $this->validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+
+        $this->controller = new HelperController($twig, $pool, $helper, $this->validator);
 
         // php 5.3 BC
         $admin = $this->admin;
@@ -113,9 +109,8 @@ class HelperControllerTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @dataProvider getValidatorInterfaces
      */
-    public function testgetShortObjectDescriptionActionInvalidAdmin($validatorInterface)
+    public function testgetShortObjectDescriptionActionInvalidAdmin()
     {
         $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
@@ -127,8 +122,7 @@ class HelperControllerTest extends TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(['sonata.post.admin']);
         $helper = new AdminHelper($pool);
-        $validator = $this->createMock($validatorInterface);
-        $controller = new HelperController($twig, $pool, $helper, $validator);
+        $controller = new HelperController($twig, $pool, $helper, $this->validator);
 
         $controller->getShortObjectDescriptionAction($request);
     }
@@ -136,10 +130,8 @@ class HelperControllerTest extends TestCase
     /**
      * @expectedException \RuntimeException
      * @exceptionMessage Invalid format
-     *
-     * @dataProvider getValidatorInterfaces
      */
-    public function testgetShortObjectDescriptionActionObjectDoesNotExist($validatorInterface)
+    public function testgetShortObjectDescriptionActionObjectDoesNotExist()
     {
         $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('setUniqid');
@@ -160,16 +152,12 @@ class HelperControllerTest extends TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->createMock($validatorInterface);
-        $controller = new HelperController($twig, $pool, $helper, $validator);
+        $controller = new HelperController($twig, $pool, $helper, $this->validator);
 
         $controller->getShortObjectDescriptionAction($request);
     }
 
-    /**
-     * @dataProvider getValidatorInterfaces
-     */
-    public function testgetShortObjectDescriptionActionEmptyObjectId($validatorInterface)
+    public function testgetShortObjectDescriptionActionEmptyObjectId()
     {
         $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('setUniqid');
@@ -191,16 +179,12 @@ class HelperControllerTest extends TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->createMock($validatorInterface);
-        $controller = new HelperController($twig, $pool, $helper, $validator);
+        $controller = new HelperController($twig, $pool, $helper, $this->validator);
 
         $controller->getShortObjectDescriptionAction($request);
     }
 
-    /**
-     * @dataProvider getValidatorInterfaces
-     */
-    public function testgetShortObjectDescriptionActionObject($validatorInterface)
+    public function testgetShortObjectDescriptionActionObject()
     {
         $mockTemplate = 'AdminHelperTest:mock-short-object-description.html.twig';
 
@@ -240,9 +224,7 @@ class HelperControllerTest extends TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->createMock($validatorInterface);
-
-        $controller = new HelperController($twig, $pool, $helper, $validator);
+        $controller = new HelperController($twig, $pool, $helper, $this->validator);
 
         $response = $controller->getShortObjectDescriptionAction($request);
 
@@ -250,10 +232,7 @@ class HelperControllerTest extends TestCase
         $this->assertSame($expected, $response->getContent());
     }
 
-    /**
-     * @dataProvider getValidatorInterfaces
-     */
-    public function testsetObjectFieldValueAction($validatorInterface)
+    public function testsetObjectFieldValueAction()
     {
         $object = new AdminControllerHelper_Foo();
 
@@ -280,12 +259,7 @@ class HelperControllerTest extends TestCase
 
         $loader = $this->createMock('\Twig_LoaderInterface');
 
-        // NEXT_MAJOR: Remove this check when dropping support for twig < 2
-        if (method_exists('\Twig_LoaderInterface', 'getSourceContext')) {
-            $loader->method('getSourceContext')->will($this->returnValue(new \Twig_Source('<foo />', 'foo')));
-        } else {
-            $loader->method('getSource')->will($this->returnValue('<foo />'));
-        }
+        $loader->method('getSourceContext')->will($this->returnValue(new \Twig_Source('<foo />', 'foo')));
 
         $twig = new \Twig_Environment($loader);
         $twig->addExtension($adminExtension);
@@ -299,19 +273,14 @@ class HelperControllerTest extends TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->createMock($validatorInterface);
-
-        $controller = new HelperController($twig, $pool, $helper, $validator);
+        $controller = new HelperController($twig, $pool, $helper, $this->validator);
 
         $response = $controller->setObjectFieldValueAction($request);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    /**
-     * @dataProvider getValidatorInterfaces
-     */
-    public function testappendFormFieldElementAction($validatorInterface)
+    public function testappendFormFieldElementAction()
     {
         $object = new AdminControllerHelper_Foo();
 
@@ -366,8 +335,6 @@ class HelperControllerTest extends TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(['sonata.post.admin']);
 
-        $validator = $this->createMock($validatorInterface);
-
         $mockView = $this->getMockBuilder('Symfony\Component\Form\FormView')
             ->disableOriginalConstructor()
             ->getMock();
@@ -389,16 +356,13 @@ class HelperControllerTest extends TestCase
         ]));
         $helper->expects($this->once())->method('getChildFormView')->will($this->returnValue($mockView));
 
-        $controller = new HelperController($twig, $pool, $helper, $validator);
+        $controller = new HelperController($twig, $pool, $helper, $this->validator);
         $response = $controller->appendFormFieldElementAction($request);
 
         $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
     }
 
-    /**
-     * @dataProvider getValidatorInterfaces
-     */
-    public function testRetrieveFormFieldElementAction($validatorInterface)
+    public function testRetrieveFormFieldElementAction()
     {
         $object = new AdminControllerHelper_Foo();
 
@@ -471,24 +435,19 @@ class HelperControllerTest extends TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(['sonata.post.admin']);
 
-        $validator = $this->createMock($validatorInterface);
-
         $helper = $this->getMockBuilder('Sonata\AdminBundle\Admin\AdminHelper')
             ->setMethods(['getChildFormView'])
             ->setConstructorArgs([$pool])
             ->getMock();
         $helper->expects($this->once())->method('getChildFormView')->will($this->returnValue($mockView));
 
-        $controller = new HelperController($twig, $pool, $helper, $validator);
+        $controller = new HelperController($twig, $pool, $helper, $this->validator);
         $response = $controller->retrieveFormFieldElementAction($request);
 
         $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
     }
 
-    /**
-     * @dataProvider getValidatorInterfaces
-     */
-    public function testSetObjectFieldValueActionWithViolations($validatorInterface)
+    public function testSetObjectFieldValueActionWithViolations()
     {
         $bar = new AdminControllerHelper_Bar();
 
@@ -525,16 +484,14 @@ class HelperControllerTest extends TestCase
             new ConstraintViolation('error2', null, [], null, 'enabled', null),
         ]);
 
-        $validator = $this->createMock($validatorInterface);
-
-        $validator
+        $this->validator
             ->expects($this->once())
             ->method('validate')
             ->with($bar)
             ->will($this->returnValue($violations))
         ;
 
-        $controller = new HelperController($twig, $pool, $helper, $validator);
+        $controller = new HelperController($twig, $pool, $helper, $this->validator);
 
         $response = $controller->setObjectFieldValueAction($request);
 
@@ -890,26 +847,5 @@ class HelperControllerTest extends TestCase
         $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
-    }
-
-    /**
-     * Symfony Validator has 2 API version (2.4 and 2.5)
-     * This data provider ensure tests pass on each one.
-     */
-    public function getValidatorInterfaces()
-    {
-        $data = [];
-
-        // For Symfony <= 2.8
-        if (interface_exists('Symfony\Component\Validator\ValidatorInterface')) {
-            $data['2.4'] = ['Symfony\Component\Validator\ValidatorInterface'];
-        }
-
-        // For Symfony >= 2.5
-        if (interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
-            $data['2.5'] = ['Symfony\Component\Validator\Validator\ValidatorInterface'];
-        }
-
-        return $data;
     }
 }

--- a/Tests/Datagrid/DatagridMapperTest.php
+++ b/Tests/Datagrid/DatagridMapperTest.php
@@ -105,9 +105,7 @@ class DatagridMapperTest extends TestCase
         $this->assertInstanceOf('Sonata\AdminBundle\Filter\FilterInterface', $filter);
         $this->assertSame('foo.name', $filter->getName());
         $this->assertSame('foo__name', $filter->getFormName());
-        $this->assertSame(method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-            : 'text', $filter->getFieldType());
+        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\TextType', $filter->getFieldType());
         $this->assertSame('fooLabel', $filter->getLabel());
         $this->assertSame(['required' => false], $filter->getFieldOptions());
         $this->assertSame([

--- a/Tests/Filter/FilterTest.php
+++ b/Tests/Filter/FilterTest.php
@@ -20,9 +20,7 @@ class FilterTest extends TestCase
     {
         $filter = new FooFilter();
 
-        $this->assertSame(method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-            : 'text', $filter->getFieldType());
+        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\TextType', $filter->getFieldType());
         $this->assertSame(['required' => false], $filter->getFieldOptions());
         $this->assertNull($filter->getLabel());
 

--- a/Tests/Form/ChoiceList/ModelChoiceLoaderTest.php
+++ b/Tests/Form/ChoiceList/ModelChoiceLoaderTest.php
@@ -21,10 +21,6 @@ class ModelChoiceLoaderTest extends TestCase
 
     public function setUp()
     {
-        if (false === interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
-            $this->markTestSkipped('Test only available for > SF2.7');
-        }
-
         $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
     }
 

--- a/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -38,10 +38,7 @@ class ModelsToArrayTransformerTest extends TestCase
      */
     public function testLegacyConstructor()
     {
-        $choiceListClass = interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')
-            ? 'Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader'
-            : 'Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList'
-        ;
+        $choiceListClass = 'Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader';
 
         $choiceList = $this->prophesize($choiceListClass)->reveal();
 

--- a/Tests/Form/Extension/ChoiceTypeExtensionTest.php
+++ b/Tests/Form/Extension/ChoiceTypeExtensionTest.php
@@ -20,70 +20,51 @@ class ChoiceTypeExtensionTest extends TestCase
 {
     protected function setup()
     {
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
-            $container->expects($this->any())->method('has')->will($this->returnValue(true));
-            $container->expects($this->any())->method('get')
-                ->with($this->equalTo('sonata.admin.form.choice_extension'))
-                ->will($this->returnValue(new ChoiceTypeExtension()));
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->any())->method('has')->will($this->returnValue(true));
+        $container->expects($this->any())->method('get')
+            ->with($this->equalTo('sonata.admin.form.choice_extension'))
+            ->will($this->returnValue(new ChoiceTypeExtension()));
 
-            $typeServiceIds = [];
-            $typeExtensionServiceIds = [];
-            $guesserServiceIds = [];
-            $mappingTypes = [
-                'choice' => 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
-            ];
-            $extensionTypes = [
-                'choice' => [
-                    'sonata.admin.form.choice_extension',
-                ],
-            ];
+        $typeServiceIds = [];
+        $typeExtensionServiceIds = [];
+        $guesserServiceIds = [];
+        $mappingTypes = [
+            'choice' => 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+        ];
+        $extensionTypes = [
+            'choice' => [
+                'sonata.admin.form.choice_extension',
+            ],
+        ];
 
-            $dependency = new DependencyInjectionExtension(
-                $container,
-                $typeServiceIds,
-                $typeExtensionServiceIds,
-                $guesserServiceIds,
-                $mappingTypes,
-                $extensionTypes
-            );
+        $dependency = new DependencyInjectionExtension(
+            $container,
+            $typeServiceIds,
+            $typeExtensionServiceIds,
+            $guesserServiceIds,
+            $mappingTypes,
+            $extensionTypes
+        );
 
-            $this->factory = Forms::createFormFactoryBuilder()
-                ->addExtension($dependency)
-                ->getFormFactory();
-        } else {
-            $this->factory = Forms::createFormFactoryBuilder()
-                  ->addTypeExtension(new ChoiceTypeExtension())
-                  ->getFormFactory();
-        }
+        $this->factory = Forms::createFormFactoryBuilder()
+            ->addExtension($dependency)
+            ->getFormFactory();
     }
 
     public function testExtendedType()
     {
         $extension = new ChoiceTypeExtension();
 
-        /*
-         * NEXT_MAJOR: Remove when dropping Symfony <2.8 support. It should
-         * simply be:
-         *
-         * $this->assertSame(
-         *     'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
-         *     $extension->getExtendedType()
-         * );
-         */
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->assertSame(
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
-                $extension->getExtendedType()
-            );
-        } else {
-            $this->assertSame('choice', $extension->getExtendedType());
-        }
+        $this->assertSame(
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+            $extension->getExtendedType()
+        );
     }
 
     public function testDefaultOptionsWithSortable()
     {
-        $name = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice';
+        $name = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
 
         $view = $this->factory
             ->create($name, null, [
@@ -97,7 +78,7 @@ class ChoiceTypeExtensionTest extends TestCase
 
     public function testDefaultOptionsWithoutSortable()
     {
-        $name = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice';
+        $name = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
 
         $view = $this->factory
             ->create($name, null, [])

--- a/Tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
+++ b/Tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
@@ -25,9 +25,7 @@ class FormTypeFieldExtensionTest extends TestCase
         $extension = new FormTypeFieldExtension([], []);
 
         $this->assertSame(
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\FormType' :
-            'form',
+            'Symfony\Component\Form\Extension\Core\Type\FormType',
             $extension->getExtendedType()
         );
     }
@@ -37,11 +35,7 @@ class FormTypeFieldExtensionTest extends TestCase
         $extension = new FormTypeFieldExtension([], []);
 
         $resolver = new OptionsResolver();
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $extension->setDefaultOptions($resolver);
-        } else {
-            $extension->configureOptions($resolver);
-        }
+        $extension->configureOptions($resolver);
 
         $options = $resolver->resolve();
 

--- a/Tests/Form/FormMapperTest.php
+++ b/Tests/Form/FormMapperTest.php
@@ -51,17 +51,14 @@ class FormMapperTest extends TestCase
 
         $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
 
-        // php 5.3 BC
-        $fieldDescription = $this->getFieldDescriptionMock();
-
         $this->modelManager->expects($this->any())
             ->method('getNewFieldDescriptionInstance')
-            ->will($this->returnCallback(function ($class, $name, array $options = []) use ($fieldDescription) {
-                $fieldDescriptionClone = clone $fieldDescription;
-                $fieldDescriptionClone->setName($name);
-                $fieldDescriptionClone->setOptions($options);
+            ->will($this->returnCallback(function ($class, $name, array $options = []) {
+                $fieldDescription = $this->getFieldDescriptionMock();
+                $fieldDescription->setName($name);
+                $fieldDescription->setOptions($options);
 
-                return $fieldDescriptionClone;
+                return $fieldDescription;
             }));
 
         $this->admin->setModelManager($this->modelManager);

--- a/Tests/Form/Type/AclMatrixTypeTest.php
+++ b/Tests/Form/Type/AclMatrixTypeTest.php
@@ -36,11 +36,7 @@ class AclMatrixTypeTest extends TypeTestCase
 
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $type->setDefaultOptions($optionResolver);
-        } else {
-            $type->configureOptions($optionResolver);
-        }
+        $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve([
             'acl_value' => $user,

--- a/Tests/Form/Type/AdminTypeTest.php
+++ b/Tests/Form/Type/AdminTypeTest.php
@@ -44,11 +44,6 @@ class AdminTypeTest extends TypeTestCase
 
     public function testSubmitValidData()
     {
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->markTestSkipped('Testing ancient versions would be more complicated.');
-
-            return;
-        }
         $parentAdmin = $this->prophesize('Sonata\AdminBundle\Admin\AdminInterface');
         $parentField = $this->prophesize('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
@@ -90,10 +85,6 @@ class AdminTypeTest extends TypeTestCase
 
     public function testDotFields()
     {
-        if (!method_exists('Symfony\Component\PropertyAccess\PropertyAccessor', 'isReadable')) {
-            return $this->markTestSkipped('Testing ancient versions would be more complicated.');
-        }
-
         $parentSubject = new \stdClass();
         $parentSubject->foo = 1;
 

--- a/Tests/Form/Type/ChoiceFieldMaskTypeTest.php
+++ b/Tests/Form/Type/ChoiceFieldMaskTypeTest.php
@@ -23,11 +23,7 @@ class ChoiceFieldMaskTypeTest extends TypeTestCase
 
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $type->setDefaultOptions($optionResolver);
-        } else {
-            $type->configureOptions($optionResolver);
-        }
+        $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve(
             [
@@ -49,9 +45,6 @@ class ChoiceFieldMaskTypeTest extends TypeTestCase
     public function testGetParent()
     {
         $type = new ChoiceFieldMaskType();
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        $this->assertSame(method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice', $type->getParent());
+        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\ChoiceType', $type->getParent());
     }
 }

--- a/Tests/Form/Type/Filter/DateTimeRangeTypeTest.php
+++ b/Tests/Form/Type/Filter/DateTimeRangeTypeTest.php
@@ -25,11 +25,7 @@ class DateTimeRangeTypeTest extends TypeTestCase
 
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $type->setDefaultOptions($optionResolver);
-        } else {
-            $type->configureOptions($optionResolver);
-        }
+        $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve();
 

--- a/Tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/Tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -34,11 +34,7 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->type->setDefaultOptions($optionResolver);
-        } else {
-            $this->type->configureOptions($optionResolver);
-        }
+        $this->type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve(['model_manager' => $modelManager, 'class' => 'Foo', 'property' => 'bar']);
 

--- a/Tests/Form/Type/ModelHiddenTypeTest.php
+++ b/Tests/Form/Type/ModelHiddenTypeTest.php
@@ -23,11 +23,7 @@ class ModelHiddenTypeTest extends TypeTestCase
         $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $type->setDefaultOptions($optionResolver);
-        } else {
-            $type->configureOptions($optionResolver);
-        }
+        $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve(['model_manager' => $modelManager, 'class' => '\Foo']);
 
@@ -45,9 +41,6 @@ class ModelHiddenTypeTest extends TypeTestCase
     public function testGetParent()
     {
         $type = new ModelHiddenType();
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        $this->assertSame(method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-            : 'hidden', $type->getParent());
+        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\HiddenType', $type->getParent());
     }
 }

--- a/Tests/Form/Type/ModelListTypeTest.php
+++ b/Tests/Form/Type/ModelListTypeTest.php
@@ -19,10 +19,6 @@ class ModelListTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->markTestSkipped('Testing ancient versions would be more complicated.');
-        }
-
         $this->modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         parent::setUp();

--- a/Tests/Form/Type/ModelReferenceTypeTest.php
+++ b/Tests/Form/Type/ModelReferenceTypeTest.php
@@ -21,10 +21,6 @@ class ModelReferenceTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->markTestSkipped('Testing ancient versions would be more complicated.');
-        }
-
         $this->modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         parent::setUp();

--- a/Tests/Form/Type/ModelTypeTest.php
+++ b/Tests/Form/Type/ModelTypeTest.php
@@ -33,11 +33,7 @@ class ModelTypeTest extends TypeTestCase
 
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->type->setDefaultOptions($optionResolver);
-        } else {
-            $this->type->configureOptions($optionResolver);
-        }
+        $this->type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve(['model_manager' => $modelManager, 'choices' => []]);
 
@@ -70,11 +66,7 @@ class ModelTypeTest extends TypeTestCase
         $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->type->setDefaultOptions($optionResolver);
-        } else {
-            $this->type->configureOptions($optionResolver);
-        }
+        $this->type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve(['model_manager' => $modelManager, 'choices' => [], 'multiple' => $multiple, 'expanded' => $expanded]);
 

--- a/Tests/Form/Widget/FilterChoiceWidgetTest.php
+++ b/Tests/Form/Widget/FilterChoiceWidgetTest.php
@@ -75,29 +75,13 @@ class FilterChoiceWidgetTest extends BaseWidgetTest
 
     protected function getChoiceClass()
     {
-        return
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice';
+        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
     }
 
-    /**
-     * For SF < 2.6, we use 'empty_data' to provide default empty value.
-     * For SF >= 2.6, we must use 'placeholder' to achieve the same.
-     */
     protected function getDefaultOption()
     {
-        if (method_exists(
-            'Symfony\Component\Form\Tests\AbstractLayoutTest',
-            'testSingleChoiceNonRequiredWithPlaceholder'
-        )) {
-            return [
-                'placeholder' => 'Choose an option',
-            ];
-        }
-
         return [
-                'empty_value' => 'Choose an option',
-            ];
+            'placeholder' => 'Choose an option',
+        ];
     }
 }

--- a/Tests/Form/Widget/FormChoiceWidgetTest.php
+++ b/Tests/Form/Widget/FormChoiceWidgetTest.php
@@ -99,29 +99,13 @@ class FormChoiceWidgetTest extends BaseWidgetTest
 
     protected function getChoiceClass()
     {
-        return
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice';
+        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
     }
 
-    /**
-     * For SF < 2.6, we use 'empty_data' to provide default empty value.
-     * For SF >= 2.6, we must use 'placeholder' to achieve the same.
-     */
     protected function getDefaultOption()
     {
-        if (method_exists(
-            'Symfony\Component\Form\Tests\AbstractLayoutTest',
-            'testSingleChoiceNonRequiredWithPlaceholder'
-        )) {
-            return [
-                'placeholder' => 'Choose an option',
-            ];
-        }
-
         return [
-                'empty_value' => 'Choose an option',
-            ];
+            'placeholder' => 'Choose an option',
+        ];
     }
 }

--- a/Tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
+++ b/Tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
@@ -52,20 +52,12 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
 
     protected function getParentClass()
     {
-        if (class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType')) {
-            return 'Sonata\AdminBundle\Form\Type\Filter\ChoiceType';
-        }
-
-        return 'sonata_type_filter_choice';
+        return 'Sonata\AdminBundle\Form\Type\Filter\ChoiceType';
     }
 
     protected function getChoiceClass()
     {
-        if (class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType')) {
-            return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
-        }
-
-        return 'choice';
+        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
     }
 
     protected function getExtensions()

--- a/Tests/Form/Widget/FormSonataNativeCollectionWidgetTest.php
+++ b/Tests/Form/Widget/FormSonataNativeCollectionWidgetTest.php
@@ -12,7 +12,6 @@
 namespace Sonata\AdminBundle\Tests\Form\Widget;
 
 use Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension;
-use Sonata\AdminBundle\Form\Type\CollectionType;
 use Symfony\Component\Form\Tests\Fixtures\TestExtension;
 
 class FormSonataNativeCollectionWidgetTest extends BaseWidgetTest
@@ -56,9 +55,6 @@ class FormSonataNativeCollectionWidgetTest extends BaseWidgetTest
         $extensions = parent::getExtensions();
         $guesser = $this->getMockForAbstractClass('Symfony\Component\Form\FormTypeGuesserInterface');
         $extension = new TestExtension($guesser);
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $extension->addType(new CollectionType());
-        }
 
         $extension->addTypeExtension(new FormTypeFieldExtension([], [
             'form_type' => 'vertical',
@@ -70,9 +66,6 @@ class FormSonataNativeCollectionWidgetTest extends BaseWidgetTest
 
     protected function getChoiceClass()
     {
-        return
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Sonata\AdminBundle\Form\Type\CollectionType' :
-            'sonata_type_native_collection';
+        return 'Sonata\AdminBundle\Form\Type\CollectionType';
     }
 }

--- a/Tests/Route/RouteCollectionTest.php
+++ b/Tests/Route/RouteCollectionTest.php
@@ -167,9 +167,7 @@ class RouteCollectionTest extends TestCase
         $this->assertArrayHasKey('debug', $route->getOptions());
         $this->assertSame($host, $route->getHost());
         $this->assertSame($methods, $route->getMethods());
-        if (method_exists($route, 'getCondition')) {
-            $this->assertSame($condition, $route->getCondition());
-        }
+        $this->assertSame($condition, $route->getCondition());
     }
 
     public function testRouteControllerService()

--- a/Tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/Tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -90,10 +90,6 @@ class SonataAdminExtensionTest extends TestCase
 
     public function setUp()
     {
-        // NEXT_MAJOR: remove this block when dropping symfony < 2.7 support
-        if (!class_exists('Symfony\Bridge\Twig\Extension\AssetExtension')) {
-            $this->markTestSkipped();
-        }
         date_default_timezone_set('Europe/London');
 
         $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');

--- a/Tests/Util/AdminObjectAclDataTest.php
+++ b/Tests/Util/AdminObjectAclDataTest.php
@@ -31,6 +31,32 @@ class AdminObjectAclDataTest extends TestCase
         $this->isInstanceOf('stdClass', $adminObjectAclData->getObject());
     }
 
+    /**
+     * @group legacy
+     */
+    public function testSetForm()
+    {
+        $form = $this->getMockBuilder('\Symfony\Component\Form\Form')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $adminObjectAclData = $this->createAdminObjectAclData();
+        $ret = $adminObjectAclData->setAclUsersForm($form);
+
+        $this->assertSame($adminObjectAclData, $ret);
+
+        return $adminObjectAclData;
+    }
+
+    /**
+     * @depends testSetForm
+     *
+     * @group legacy
+     */
+    public function testGetForm($adminObjectAclData)
+    {
+        $this->isInstanceOf('Symfony\Component\Form\Form', $adminObjectAclData->getAclUsersForm());
+    }
+
     public function testGetAclUsers()
     {
         $adminObjectAclData = $this->createAdminObjectAclData();
@@ -73,32 +99,6 @@ class AdminObjectAclDataTest extends TestCase
             $this->assertInternalType('string', $key);
             $this->assertInternalType('int', $mask);
         }
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testSetForm()
-    {
-        $form = $this->getMockBuilder('\Symfony\Component\Form\Form')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $adminObjectAclData = $this->createAdminObjectAclData();
-        $ret = $adminObjectAclData->setAclUsersForm($form);
-
-        $this->assertSame($adminObjectAclData, $ret);
-
-        return $adminObjectAclData;
-    }
-
-    /**
-     * @depends testSetForm
-     *
-     * @group legacy
-     */
-    public function testGetForm($adminObjectAclData)
-    {
-        $this->isInstanceOf('Symfony\Component\Form\Form', $adminObjectAclData->getAclUsersForm());
     }
 
     public function testSetAclUsersForm()

--- a/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -127,10 +127,6 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
             $admin->setSecurityHandler($this);
             $admin->setLabelTranslatorStrategy($this);
 
-            //            foreach ($admin->getChildren() as $child) {
-            //                $child->setTranslator($this);
-            //            }
-
             // call the different public method
             $methods = [
                 'getShow',

--- a/Twig/Extension/SonataAdminExtension.php
+++ b/Twig/Extension/SonataAdminExtension.php
@@ -30,7 +30,7 @@ class SonataAdminExtension extends \Twig_Extension
     protected $pool;
 
     /**
-     * @var LoggerInterface
+     * @var LoggerInterface|null
      */
     protected $logger;
 

--- a/Twig/GlobalVariables.php
+++ b/Twig/GlobalVariables.php
@@ -40,7 +40,7 @@ class GlobalVariables
         // NEXT_MAJOR : remove this block and set adminPool from parameter.
         if ($adminPool instanceof ContainerInterface) {
             @trigger_error(
-                'Using an instance of Symfony\Component\DependencyInjection\ContainerInterface is deprecated since 
+                'Using an instance of Symfony\Component\DependencyInjection\ContainerInterface is deprecated since
                 version 3.5 and will be removed in 4.0. Use Sonata\AdminBundle\Admin\Pool instead.',
                 E_USER_DEPRECATED
             );

--- a/Util/AdminObjectAclManipulator.php
+++ b/Util/AdminObjectAclManipulator.php
@@ -285,12 +285,7 @@ class AdminObjectAclManipulator
                 ];
             }
 
-            // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-            $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                'Sonata\AdminBundle\Form\Type\AclMatrixType' :
-                new AclMatrixType();
-
-            $formBuilder->add($key, $type, ['permissions' => $permissions, 'acl_value' => $aclValue]);
+            $formBuilder->add($key, AclMatrixType::class, ['permissions' => $permissions, 'acl_value' => $aclValue]);
         }
 
         return $formBuilder->getForm();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Keep removing code
- [ ] Fix travis

## Subject

<!-- Describe your Pull Request content here -->
Removing all code needed to be compatible with old versions of PHP and SF