### PR TITLE
Fixed choice_translation_domain for expanded choices

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -187,7 +187,11 @@ file that was distributed with this source code.
     <ul {{ block('widget_container_attributes') }}>
     {% for child in form %}
         <li>
-            {{ form_widget(child, {'horizontal': false, 'horizontal_input_wrapper_class': ''}) }} {# {'horizontal': false, 'horizontal_input_wrapper_class': ''} needed to avoid MopaBootstrapBundle messing with the DOM #}
+            {{ form_widget(child, {
+                'horizontal': false,
+                'horizontal_input_wrapper_class': '',
+                'translation_domain': choice_translation_domain
+            }) }} {# 'horizontal' values are needed to avoid MopaBootstrapBundle messing with the DOM #}
         </li>
     {% endfor %}
     </ul>

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -170,7 +170,11 @@ file that was distributed with this source code.
             {{- widget|raw -}}
             {%- if label is not same as(false) -%}
                 <span class="control-label__text">
-                    {{- label|trans({}, translation_domain) -}}
+                    {% if translation_domain is same as(false) %}
+                        {{- label -}}
+                    {% else %}
+                        {{- label|trans({}, translation_domain) -}}
+                    {%- endif -%}
                 </span>
             {%- endif -%}
         </label>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it fixed the translation domain for expanded choices in admin.

imo that was a bug which is fixed by this backwards compatible thing

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- fixed choice_translation_domain for expanded choices in admin
- make false translation_domain working for the label if no translation is needed
```
<!-- Describe your Pull Request content here -->

because i broke #4667