### PR TITLE
Clean NEXT_MAJOR comments of #4542

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -225,17 +225,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     protected $parent = null;
 
     /**
-     * The base code route refer to the prefix used to generate the route name.
-     *
-     * NEXT_MAJOR: remove this attribute.
-     *
-     * @deprecated This attribute is deprecated since 3.x and will be removed in 4.0
-     *
-     * @var string
-     */
-    protected $baseCodeRoute = '';
-
-    /**
      * The related parent association, ie if OrderElement has a parent property named order,
      * then the $parentAssociationMapping must be a string named `order`.
      *
@@ -610,9 +599,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         if (!$this->classnameLabel) {
             $this->classnameLabel = substr($this->getClass(), strrpos($this->getClass(), '\\') + 1);
         }
-
-        // NEXT_MAJOR: Remove this line.
-        $this->baseCodeRoute = $this->getCode();
 
         $this->configure();
     }
@@ -2243,46 +2229,15 @@ EOT;
     }
 
     /**
-     * NEXT_MAJOR: Remove this function.
-     *
-     * @deprecated This method is deprecated since 3.x and will be removed in 4.0
-     *
-     * @param string $baseCodeRoute
-     */
-    public function setBaseCodeRoute($baseCodeRoute)
-    {
-        @trigger_error(
-            'The '.__METHOD__.' is deprecated since 3.x and will be removed in 4.0.',
-            E_USER_DEPRECATED
-        );
-
-        $this->baseCodeRoute = $baseCodeRoute;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getBaseCodeRoute()
     {
-        // NEXT_MAJOR: Uncomment the following lines.
-        // if ($this->isChild()) {
-        //     return $this->getParent()->getBaseCodeRoute().'|'.$this->getCode();
-        // }
-        //
-        // return $this->getCode();
-
-        // NEXT_MAJOR: Remove all the code below.
         if ($this->isChild()) {
-            $parentCode = $this->getParent()->getCode();
-
-            if ($this->getParent()->isChild()) {
-                $parentCode = $this->getParent()->getBaseCodeRoute();
-            }
-
-            return $parentCode.'|'.$this->getCode();
+            return $this->getParent()->getBaseCodeRoute().'|'.$this->getCode();
         }
 
-        return $this->baseCodeRoute;
+        return $this->getCode();
     }
 
     /**

--- a/Route/DefaultRouteGenerator.php
+++ b/Route/DefaultRouteGenerator.php
@@ -144,15 +144,7 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
             return $name;
         }
 
-        // NEXT_MAJOR: Uncomment the following line.
-        // $codePrefix = $admin->getBaseCodeRoute();
-
-        // NEXT_MAJOR: Remove next 5 lines.
-        $codePrefix = $admin->getCode();
-
-        if ($admin->isChild()) {
-            $codePrefix = $admin->getBaseCodeRoute();
-        }
+        $codePrefix = $admin->getBaseCodeRoute();
 
         // someone provide a code, so it is a child
         if (strpos($name, '.')) {

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -908,44 +908,28 @@ class AdminTest extends PHPUnit_Framework_TestCase
         $this->assertSame($modelManager, $admin->getModelManager());
     }
 
-    /**
-     * NEXT_MAJOR: remove this method.
-     *
-     * @group legacy
-     */
     public function testGetBaseCodeRoute()
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $postAdmin = new PostAdmin(
+            'sonata.post.admin.post',
+            'NewsBundle\Entity\Post',
+            'SonataNewsBundle:PostAdmin'
+        );
+        $commentAdmin = new CommentAdmin(
+            'sonata.post.admin.comment',
+            'Application\Sonata\NewsBundle\Entity\Comment',
+            'SonataNewsBundle:CommentAdmin'
+        );
 
-        $this->assertSame('', $admin->getBaseCodeRoute());
+        $this->assertSame($postAdmin->getCode(), $postAdmin->getBaseCodeRoute());
 
-        $admin->setBaseCodeRoute('foo');
-        $this->assertSame('foo', $admin->getBaseCodeRoute());
+        $postAdmin->addChild($commentAdmin);
+
+        $this->assertSame(
+            'sonata.post.admin.post|sonata.post.admin.comment',
+            $commentAdmin->getBaseCodeRoute()
+        );
     }
-
-    // NEXT_MAJOR: uncomment this method.
-    // public function testGetBaseCodeRoute()
-    // {
-    //     $postAdmin = new PostAdmin(
-    //         'sonata.post.admin.post',
-    //         'NewsBundle\Entity\Post',
-    //         'SonataNewsBundle:PostAdmin'
-    //     );
-    //     $commentAdmin = new CommentAdmin(
-    //         'sonata.post.admin.comment',
-    //         'Application\Sonata\NewsBundle\Entity\Comment',
-    //         'SonataNewsBundle:CommentAdmin'
-    //     );
-    //
-    //     $this->assertSame($postAdmin->getCode(), $postAdmin->getBaseCodeRoute());
-    //
-    //     $postAdmin->addChild($commentAdmin);
-    //
-    //     $this->assertSame(
-    //         'sonata.post.admin.post|sonata.post.admin.comment',
-    //         $commentAdmin->getBaseCodeRoute()
-    //     );
-    // }
 
     public function testGetRouteGenerator()
     {

--- a/Tests/Route/DefaultRouteGeneratorTest.php
+++ b/Tests/Route/DefaultRouteGeneratorTest.php
@@ -54,11 +54,10 @@ class DefaultRouteGeneratorTest extends PHPUnit_Framework_TestCase
 
         $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(false));
-        $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Foo'));
+        $admin->expects($this->any())->method('getBaseCodeRoute')->will($this->returnValue('base.Code.Foo'));
         $admin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(false));
         $admin->expects($this->once())->method('hasRequest')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
-        $admin->expects($this->any())->method('getCode')->will($this->returnValue('foo_code'));
         $admin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
@@ -103,7 +102,7 @@ class DefaultRouteGeneratorTest extends PHPUnit_Framework_TestCase
 
         $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(false));
-        $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Route'));
+        $admin->expects($this->any())->method('getBaseCodeRoute')->will($this->returnValue('base.Code.Route'));
         $admin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(false));
         $admin->expects($this->once())->method('hasRequest')->will($this->returnValue(true));
         $admin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array()));
@@ -132,13 +131,11 @@ class DefaultRouteGeneratorTest extends PHPUnit_Framework_TestCase
 
         $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(true));
-        $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Child'));
         $admin->expects($this->any())->method('getBaseCodeRoute')->will($this->returnValue('base.Code.Parent|base.Code.Child'));
         $admin->expects($this->any())->method('getIdParameter')->will($this->returnValue('id'));
         $admin->expects($this->any())->method('hasParentFieldDescription')->will($this->returnValue(false));
         $admin->expects($this->any())->method('hasRequest')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
-        $admin->expects($this->any())->method('getCode')->will($this->returnValue('foo_code'));
         $admin->expects($this->any())->method('getPersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($childCollection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
@@ -146,7 +143,7 @@ class DefaultRouteGeneratorTest extends PHPUnit_Framework_TestCase
         $parentAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $parentAdmin->expects($this->any())->method('getIdParameter')->will($this->returnValue('childId'));
         $parentAdmin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
-        $parentAdmin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Parent'));
+        $parentAdmin->expects($this->any())->method('getBaseCodeRoute')->will($this->returnValue('base.Code.Parent'));
         $parentAdmin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
 
         // no request attached in this test, so this will not be used
@@ -218,11 +215,11 @@ class DefaultRouteGeneratorTest extends PHPUnit_Framework_TestCase
         $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(false));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Parent'));
+        $admin->expects($this->any())->method('getBaseCodeRoute')->will($this->returnValue('base.Code.Parent'));
         // embeded admin (not nested ...)
         $admin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(true));
         $admin->expects($this->once())->method('hasRequest')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));
-        $admin->expects($this->any())->method('getCode')->will($this->returnValue('foo_code'));
         $admin->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(array('abc' => 'a123', 'efg' => 'e456')));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue(array()));
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
@@ -327,7 +324,7 @@ class DefaultRouteGeneratorTest extends PHPUnit_Framework_TestCase
 
         $standaloneAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
         $standaloneAdmin->expects($this->any())->method('isChild')->will($this->returnValue(false));
-        $standaloneAdmin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Child'));
+        $standaloneAdmin->expects($this->any())->method('getBaseCodeRoute')->will($this->returnValue('base.Code.Child'));
         $standaloneAdmin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(false));
         $standaloneAdmin->expects($this->once())->method('hasRequest')->will($this->returnValue(true));
         $standaloneAdmin->expects($this->any())->method('getUniqid')->will($this->returnValue('foo_uniqueid'));


### PR DESCRIPTION
I cherry picked the commit https://github.com/sonata-project/SonataAdminBundle/commit/26d69b89b3184d12653dffc2fdea65ea37125c6f and then cleaned NEXT_MAJOR comments.

I don't know if this should be closed or merged, but a discussion started here about it: https://github.com/sonata-project/SonataAdminBundle/pull/4542#discussion_r125561202


ping @greg0ire @OskarStark 