### PR TITLE
Fix sticky navbar when top navbar height changes

### DIFF
--- a/Resources/public/css/styles.css
+++ b/Resources/public/css/styles.css
@@ -28,6 +28,10 @@ body > .header .logo {
     font-family: 'Source Sans Pro', sans-serif;
 }
 
+.main-header {
+    height: 50px;
+}
+
 .logo img {
     display: inline;
     padding-bottom: 4px;


### PR DESCRIPTION
## Changelog

```markdown
### Fixed
- Fixed sticky navbar when top navbar height changes
```
## Subject

This PR fixes the navbar position when the top navbar height changes (when breadcrumbs are too long, for example).

To achieve this, on `document load` and `window resize`, I : 
- set the `content-wrapper` `padding-top` to the height of the `top navbar` (fixes content hidden behind it).
- update a dynamically inserted css class, by updating the `stuck navbar` top position (didn't find a better way).

I also removed the `debounce` function which seems not usefull anymore (we don't have to wait for any animation anymore, tell me if i'm wrong).

**Before**
![before](https://user-images.githubusercontent.com/663607/31027805-ea02e166-a54b-11e7-849b-1e28e866b6e8.jpg)

**After**
![after-top](https://user-images.githubusercontent.com/663607/31027804-ea013c44-a54b-11e7-87e2-aee47310bbe7.JPG)
![after-scroll](https://user-images.githubusercontent.com/663607/31027803-e9fc0e86-a54b-11e7-8ec1-e5fcaa57eba8.JPG)