### PR TITLE
3.x base_array_macro.html.twig updated as per latest twig

### DIFF
--- a/Resources/views/CRUD/base_array_macro.html.twig
+++ b/Resources/views/CRUD/base_array_macro.html.twig
@@ -9,15 +9,20 @@ file that was distributed with this source code.
 
 #}
 {% macro render_array(value, inline) %}
-    {% for key, val in value %}
-        {% if val is iterable %}
-            [{{ key }} => {{ _self.render_array(val, inline) }}]
-        {%  else %}
-            [{{ key }} => {{ val }}]
-        {%  endif %}
+    {% from _self import render_array %}
+    {% if value is iterable %}
+        {% for key, val in value %}
+            {% if val is iterable %}
+                [{{ key }} => {{ render_array(val, inline) }}]
+            {%  else %}
+                [{{ key }} => {{ val }}]
+            {%  endif %}
+            {% if not loop.last and not inline %}
+                <br>
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        {{ value }}
+    {% endif %}
 
-        {% if not loop.last and not inline %}
-            <br>
-        {% endif %}
-    {% endfor %}
 {% endmacro %}

--- a/Resources/views/CRUD/base_array_macro.html.twig
+++ b/Resources/views/CRUD/base_array_macro.html.twig
@@ -10,19 +10,14 @@ file that was distributed with this source code.
 #}
 {% macro render_array(value, inline) %}
     {% from _self import render_array %}
-    {% if value is iterable %}
-        {% for key, val in value %}
-            {% if val is iterable %}
-                [{{ key }} => {{ render_array(val, inline) }}]
-            {%  else %}
-                [{{ key }} => {{ val }}]
-            {%  endif %}
-            {% if not loop.last and not inline %}
-                <br>
-            {% endif %}
-        {% endfor %}
-    {% else %}
-        {{ value }}
-    {% endif %}
-
+    {% for key, val in value %}
+        {% if val is iterable %}
+            [{{ key }} => {{ render_array(val, inline) }}]
+        {%  else %}
+            [{{ key }} => {{ val }}]
+        {%  endif %}
+        {% if not loop.last and not inline %}
+            <br>
+        {% endif %}
+    {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
base_array_macro.html.twig updated as per latest twig

otherwise it show 
Twig Runtime Error: Impossible to invoke a method (“render_array”) on a string variable


