### PR TITLE
Fix tests for SF >= 3.3.10

### DIFF
--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -143,26 +143,33 @@ class CRUDControllerTest extends PHPUnit_Framework_TestCase
             ->setConstructorArgs(array($this->container, array()))
             ->getMock();
 
+        $templatingRenderReturnCallback = $this->returnCallback(function (
+            $view,
+            array $parameters = array(),
+            Response $response = null
+        ) use (
+            &$params,
+            &$template
+        ) {
+            $template = $view;
+
+            if (null === $response) {
+                $response = new Response();
+            }
+
+            $params = $parameters;
+
+            return $response;
+        });
+
+        // SF < 3.3.10 BC
         $templating->expects($this->any())
             ->method('renderResponse')
-            ->will($this->returnCallback(function (
-                $view,
-                array $parameters = array(),
-                Response $response = null
-            ) use (
-                &$params,
-                &$template
-            ) {
-                $template = $view;
+            ->will($templatingRenderReturnCallback);
 
-                if (null === $response) {
-                    $response = new Response();
-                }
-
-                $params = $parameters;
-
-                return $response;
-            }));
+        $templating->expects($this->any())
+            ->method('render')
+            ->will($templatingRenderReturnCallback);
 
         $this->session = new Session(new MockArraySessionStorage());
 


### PR DESCRIPTION
Closes https://github.com/sonata-project/SonataAdminBundle/issues/4685

## Subject

The build is broken with SF >= 3.3.10.
Caused by https://github.com/symfony/symfony/pull/24431/files?diff=unified#diff-064e58dbe11951327d614e6922caaae5R234

