### PR TITLE
Don't get result twice if it is empty

### DIFF
--- a/Datagrid/Datagrid.php
+++ b/Datagrid/Datagrid.php
@@ -102,7 +102,7 @@ class Datagrid implements DatagridInterface
     {
         $this->buildPager();
 
-        if (!$this->results) {
+        if (null === $this->results) {
             $this->results = $this->pager->getResults();
         }
 

--- a/Tests/Datagrid/DatagridTest.php
+++ b/Tests/Datagrid/DatagridTest.php
@@ -313,6 +313,16 @@ class DatagridTest extends PHPUnit_Framework_TestCase
         $this->assertSame(['foo', 'bar'], $this->datagrid->getResults());
     }
 
+    public function testEmptyResults()
+    {
+        $this->pager->expects($this->once())
+            ->method('getResults')
+            ->will($this->returnValue([]));
+
+        $this->assertSame([], $this->datagrid->getResults());
+        $this->assertSame([], $this->datagrid->getResults());
+    }
+
     public function testBuildPager()
     {
         $filter1 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because Datagrid generates several the same queries to get results.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix duplicate DB queries on empty results.
```
