### PR TITLE
Fix class name for sonata.admin.route_id_handler

### DIFF
--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -27,7 +27,7 @@
         <service id="sonata.admin.breadcrumbs_builder" class="Sonata\AdminBundle\Admin\BreadcrumbsBuilder">
             <argument>%sonata.admin.configuration.breadcrumbs%</argument>
         </service>
-        <service id="sonata.admin.route_id_handler" class="Sonata\AdminBundle\Route\RouteIdHandler"/>
+        <service id="sonata.admin.route_id_handler" class="Sonata\AdminBundle\Route\Handler\RouteIdHandler"/>
         <service id="sonata.admin.default_route_id_handler" alias="sonata.admin.route_id_handler"/>
         <!-- Services used to format the label, default is sonata.admin.label.strategy.noop -->
         <service id="sonata.admin.label.strategy.bc" class="Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy"/>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Fixed wrong class name
```

## Subject
Errors after update:
```
PHP Fatal error: Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "RouteIdHandler" from namespace "Sonata\AdminBundle\Route"
```
