### PR TITLE
Add missing space when merging label classes

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -110,7 +110,7 @@ file that was distributed with this source code.
     {% set label_class = label_class|default('') ~ ' control-label' %}
 
     {% if label is not same as(false) %}
-        {% set label_attr = label_attr|merge({'class': label_attr.class|default('') ~ label_class }) %}
+        {% set label_attr = label_attr|merge({'class': label_attr.class|default('') ~ ' ' ~ label_class }) %}
 
         {% if not compound %}
             {% set label_attr = label_attr|merge({'for': id}) %}


### PR DESCRIPTION
## Changelog

```markdown
### Fixed
- Fixed missing space when form class is defined in label_attr
```
## Subject

Small PR to fix missing space in form label class attribute.
