### PR TITLE
fix list filter parameters example in documentation

### DIFF
--- a/Resources/doc/cookbook/recipe_custom_action.rst
+++ b/Resources/doc/cookbook/recipe_custom_action.rst
@@ -117,7 +117,7 @@ to implement a ``clone`` action.
             return new RedirectResponse($this->admin->generateUrl('list'));
 
             // if you have a filtered list and want to keep your filters after the redirect
-            // return new RedirectResponse($this->admin->generateUrl('list', $this->admin->getFilterParameters()));
+            // return new RedirectResponse($this->admin->generateUrl('list', array('filter' => $this->admin->getFilterParameters())));
         }
     }
 


### PR DESCRIPTION

I am targeting this branch, to fix documentation.


## Changelog
```markdown
### Fixed
-  List filter parameters example in documentation
```
