### PR TITLE
Remove obsolete addFlash method

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -1244,25 +1244,6 @@ class CRUDController extends Controller
     }
 
     /**
-     * Adds a flash message for type.
-     *
-     * @param string $type
-     * @param string $message
-     *
-     * @TODO Remove this method when bumping requirements to Symfony >= 2.6
-     */
-    protected function addFlash($type, $message)
-    {
-        if (method_exists('Symfony\Bundle\FrameworkBundle\Controller\Controller', 'addFlash')) {
-            parent::addFlash($type, $message);
-        } else {
-            $this->get('session')
-                ->getFlashBag()
-                ->add($type, $message);
-        }
-    }
-
-    /**
      * Validate CSRF token for action without form.
      *
      * @param string $intention


### PR DESCRIPTION
I am targeting this branch because the `addFlash` method exists in FrameworkBundle since Sf 2.6 and the SonataAdminBundle branch 3.x require Sf 2.8^ || 3.0^.

Closes #4702 

## Changelog

```markdown
### Fixed
- Removed overridden method `CRUDController::addFlash` because it exists since Symfony 2.6 and it's final in 3.4.
```
