### PR TITLE
Allow disabling block translation

### DIFF
--- a/Block/AdminStatsBlockService.php
+++ b/Block/AdminStatsBlockService.php
@@ -87,6 +87,7 @@ class AdminStatsBlockService extends AbstractBlockService
         $resolver->setDefaults([
             'icon' => 'fa-line-chart',
             'text' => 'Statistics',
+            'translation_domain' => null,
             'color' => 'bg-aqua',
             'code' => false,
             'filters' => [],

--- a/Resources/views/Block/block_stats.html.twig
+++ b/Resources/views/Block/block_stats.html.twig
@@ -11,13 +11,20 @@ file that was distributed with this source code.
 
 {% extends sonata_block.templates.block_base %}
 
+{% set translation_domain = settings.translation_domain ?? admin.translationDomain %}
+
 {% block block %}
     <!-- small box -->
     <div class="small-box {{ settings.color }}">
         <div class="inner">
             <h3>{{ pager.count() }}</h3>
-
-            <p>{{ settings.text|trans({}, admin.translationDomain) }}</p>
+            <p>
+                {% if translation_domain %}
+                    {{ settings.text|trans({}, translation_domain) }}
+                {% else %}
+                    {{ settings.text }}
+                {% endif %}
+            </p>
         </div>
         <div class="icon">
             <i class="fa {{ settings.icon }}"></i>

--- a/Tests/Block/AdminStatsBlockServiceTest.php
+++ b/Tests/Block/AdminStatsBlockServiceTest.php
@@ -40,6 +40,7 @@ class AdminStatsBlockServiceTest extends AbstractBlockServiceTestCase
         $this->assertSettings([
             'icon' => 'fa-line-chart',
             'text' => 'Statistics',
+            'translation_domain' => null,
             'color' => 'bg-aqua',
             'code' => false,
             'filters' => [],


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `translation_domain` key to `AdminStatsBlockService` to change or disable translation

```

## Subject

All block texts were translation by default, which isn't unseful if you don't use translation keys.
