### PR TITLE
Don't translate empty placeholder

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -213,19 +213,23 @@ file that was distributed with this source code.
         <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %} >
             {% if empty_value is defined and empty_value is not none %}
                 <option value=""{% if required and value is empty %} selected="selected"{% endif %}>
-                    {% if not sonata_admin.admin %}
-                        {{- empty_value|trans({}, translation_domain) -}}
-                    {% else %}
-                        {{- empty_value|trans({}, sonata_admin.field_description.translationDomain) -}}
-                    {% endif%}
+                    {% if empty_value != '' %}
+                        {% if not sonata_admin.admin %}
+                            {{- empty_value|trans({}, translation_domain) -}}
+                        {% else %}
+                            {{- empty_value|trans({}, sonata_admin.field_description.translationDomain) -}}
+                        {% endif %}
+                    {% endif %}
                 </option>
             {% elseif placeholder is defined and placeholder is not none %}
                 <option value=""{% if required and value is empty %} selected="selected"{% endif %}>
-                    {% if not sonata_admin.admin %}
-                        {{- placeholder|trans({}, translation_domain) -}}
-                    {% else %}
-                        {{- placeholder|trans({}, sonata_admin.field_description.translationDomain) -}}
-                    {% endif%}
+                    {% if placeholder != '' %}
+                        {% if not sonata_admin.admin %}
+                            {{- placeholder|trans({}, translation_domain) -}}
+                        {% else %}
+                            {{- placeholder|trans({}, sonata_admin.field_description.translationDomain) -}}
+                        {% endif %}
+                    {% endif %}
                 </option>
             {% endif %}
             {% if preferred_choices|length > 0 %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I got missing translate for empty string on form render.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Don't translate empty placeholder on form render
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
