### PR TITLE
Remove redundant backward compatibility

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -47,7 +47,6 @@ use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -355,7 +354,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     protected $securityHandler = null;
 
     /**
-     * @var ValidatorInterface|LegacyValidatorInterface
+     * @var ValidatorInterface
      */
     protected $validator = null;
 
@@ -2632,11 +2631,10 @@ EOT;
      */
     public function setValidator($validator)
     {
-        // TODO: Remove it when bumping requirements to SF 2.5+
-        if (!$validator instanceof ValidatorInterface && !$validator instanceof LegacyValidatorInterface) {
+        // NEXT_MAJOR: Move ValidatorInterface check to method signature
+        if (!$validator instanceof ValidatorInterface) {
             throw new \InvalidArgumentException(
                 'Argument 1 must be an instance of Symfony\Component\Validator\Validator\ValidatorInterface'
-                .' or Symfony\Component\Validator\ValidatorInterface'
             );
         }
 
@@ -3356,12 +3354,7 @@ EOT;
         $admin = $this;
 
         // add the custom inline validation option
-        // TODO: Remove conditional method when bumping requirements to SF 2.5+
-        if (method_exists($this->validator, 'getMetadataFor')) {
-            $metadata = $this->validator->getMetadataFor($this->getClass());
-        } else {
-            $metadata = $this->validator->getMetadataFactory()->getMetadataFor($this->getClass());
-        }
+        $metadata = $this->validator->getMetadataFor($this->getClass());
 
         $metadata->addConstraint(new InlineConstraint([
             'service' => $this,

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -18,9 +18,6 @@ use Sonata\AdminBundle\Util\FormBuilderIterator;
 use Sonata\AdminBundle\Util\FormViewIterator;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
-use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
-use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -273,7 +270,7 @@ class AdminHelper
             $currentPath .= empty($currentPath) ? $part : '_'.$part;
             $separator = empty($totalPath) ? '' : '.';
 
-            if ($this->pathExists($propertyAccessor, $entity, $totalPath.$separator.$currentPath)) {
+            if ($propertyAccessor->isReadable($entity, $totalPath.$separator.$currentPath)) {
                 $totalPath .= $separator.$currentPath;
                 $currentPath = '';
             }
@@ -305,34 +302,5 @@ class AdminHelper
         }
 
         return $this->getEntityClassName($associationAdmin, $elements);
-    }
-
-    /**
-     * Check if given path exists in $entity.
-     *
-     * @param PropertyAccessorInterface $propertyAccessor
-     * @param mixed                     $entity
-     * @param string                    $path
-     *
-     * @return bool
-     *
-     * @throws \RuntimeException
-     */
-    private function pathExists(PropertyAccessorInterface $propertyAccessor, $entity, $path)
-    {
-        // Symfony <= 2.3 did not have isReadable method for PropertyAccessor
-        if (method_exists($propertyAccessor, 'isReadable')) {
-            return $propertyAccessor->isReadable($entity, $path);
-        }
-
-        try {
-            $propertyAccessor->getValue($entity, $path);
-
-            return true;
-        } catch (NoSuchPropertyException $e) {
-            return false;
-        } catch (UnexpectedTypeException $e) {
-            return false;
-        }
     }
 }

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -26,7 +26,6 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -299,12 +298,12 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function id($entity);
 
     /**
-     * @param ValidatorInterface|LegacyValidatorInterface $validator
+     * @param ValidatorInterface $validator
      */
     public function setValidator($validator);
 
     /**
-     * @return ValidatorInterface|LegacyValidatorInterface
+     * @return ValidatorInterface
      */
     public function getValidator();
 

--- a/src/Admin/Extension/LockExtension.php
+++ b/src/Admin/Extension/LockExtension.php
@@ -59,10 +59,7 @@ class LockExtension extends AbstractAdminExtension
 
             $form->add(
                 $fieldName,
-                // NEXT_MAJOR: remove the check and add the FQCN
-                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-                    : 'hidden',
+                'Symfony\Component\Form\Extension\Core\Type\HiddenType',
                 [
                     'mapped' => false,
                     'data' => $lockVersion,

--- a/src/Block/AdminListBlockService.php
+++ b/src/Block/AdminListBlockService.php
@@ -78,13 +78,6 @@ class AdminListBlockService extends AbstractBlockService
             'groups' => false,
         ]);
 
-        // Symfony < 2.6 BC
-        if (method_exists($resolver, 'setNormalizer')) {
-            $resolver->setAllowedTypes('groups', ['bool', 'array']);
-        } else {
-            $resolver->setAllowedTypes([
-                'groups' => ['bool', 'array'],
-            ]);
-        }
+        $resolver->setAllowedTypes('groups', ['bool', 'array']);
     }
 }

--- a/src/Command/QuestionableCommand.php
+++ b/src/Command/QuestionableCommand.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\AdminBundle\Command;
 
-use Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper;
 use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -34,17 +33,6 @@ abstract class QuestionableCommand extends ContainerAwareCommand
     {
         $questionHelper = $this->getQuestionHelper();
 
-        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
-        if ($questionHelper instanceof DialogHelper) {
-            return $questionHelper->askAndValidate(
-                $output,
-                $questionHelper->getQuestion($questionText, $default),
-                $validator,
-                false,
-                $default
-            );
-        }
-
         $question = new Question($questionHelper->getQuestion($questionText, $default), $default);
 
         $question->setValidator($validator);
@@ -65,13 +53,6 @@ abstract class QuestionableCommand extends ContainerAwareCommand
     {
         $questionHelper = $this->getQuestionHelper();
 
-        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
-        if ($questionHelper instanceof DialogHelper) {
-            $question = $questionHelper->getQuestion($questionText, $default, $separator);
-
-            return $questionHelper->askConfirmation($output, $question, ('no' === $default ? false : true));
-        }
-
         $question = new ConfirmationQuestion($questionHelper->getQuestion(
             $questionText,
             $default,
@@ -82,25 +63,15 @@ abstract class QuestionableCommand extends ContainerAwareCommand
     }
 
     /**
-     * @return QuestionHelper|DialogHelper
+     * @return QuestionHelper
      */
     final protected function getQuestionHelper()
     {
-        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
-        if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
-            $questionHelper = $this->getHelper('dialog');
+        $questionHelper = $this->getHelper('question');
 
-            if (!$questionHelper instanceof DialogHelper) {
-                $questionHelper = new DialogHelper();
-                $this->getHelperSet()->set($questionHelper);
-            }
-        } else {
-            $questionHelper = $this->getHelper('question');
-
-            if (!$questionHelper instanceof QuestionHelper) {
-                $questionHelper = new QuestionHelper();
-                $this->getHelperSet()->set($questionHelper);
-            }
+        if (!$questionHelper instanceof QuestionHelper) {
+            $questionHelper = new QuestionHelper();
+            $this->getHelperSet()->set($questionHelper);
         }
 
         return $questionHelper;

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1012,11 +1012,7 @@ class CRUDController implements ContainerAwareInterface
      */
     public function getRequest()
     {
-        if ($this->container->has('request_stack')) {
-            return $this->container->get('request_stack')->getCurrentRequest();
-        }
-
-        return $this->container->get('request');
+        return $this->container->get('request_stack')->getCurrentRequest();
     }
 
     /**
@@ -1332,10 +1328,8 @@ class CRUDController implements ContainerAwareInterface
         $request = $this->getRequest();
         $token = $request->request->get('_sonata_csrf_token', false);
 
-        if ($this->container->has('security.csrf.token_manager')) { // SF3.0
+        if ($this->container->has('security.csrf.token_manager')) {
             $valid = $this->container->get('security.csrf.token_manager')->isTokenValid(new CsrfToken($intention, $token));
-        } elseif ($this->container->has('form.csrf_provider')) { // < SF3.0
-            $valid = $this->container->get('form.csrf_provider')->isCsrfTokenValid($intention, $token);
         } else {
             return;
         }
@@ -1368,11 +1362,6 @@ class CRUDController implements ContainerAwareInterface
     {
         if ($this->container->has('security.csrf.token_manager')) {
             return $this->container->get('security.csrf.token_manager')->getToken($intention)->getValue();
-        }
-
-        // TODO: Remove it when bumping requirements to SF 2.4+
-        if ($this->container->has('form.csrf_provider')) {
-            return $this->container->get('form.csrf_provider')->generateCsrfToken($intention);
         }
 
         return false;

--- a/src/Controller/CoreController.php
+++ b/src/Controller/CoreController.php
@@ -169,11 +169,6 @@ class CoreController extends Controller
      */
     private function getCurrentRequest()
     {
-        // NEXT_MAJOR: simplify this when dropping sf < 2.4
-        if ($this->container->has('request_stack')) {
-            return $this->container->get('request_stack')->getCurrentRequest();
-        }
-
-        return $this->container->get('request');
+        return $this->container->get('request_stack')->getCurrentRequest();
     }
 }

--- a/src/Controller/HelperController.php
+++ b/src/Controller/HelperController.php
@@ -27,7 +27,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -50,7 +49,7 @@ class HelperController
     protected $pool;
 
     /**
-     * @var ValidatorInterface|ValidatorInterface
+     * @var ValidatorInterface
      */
     protected $validator;
 
@@ -62,11 +61,11 @@ class HelperController
      */
     public function __construct(\Twig_Environment $twig, Pool $pool, AdminHelper $helper, $validator)
     {
-        if (!($validator instanceof ValidatorInterface) && !($validator instanceof LegacyValidatorInterface)) {
+        // NEXT_MAJOR: Move ValidatorInterface check to method signature
+        if (!($validator instanceof ValidatorInterface)) {
             throw new \InvalidArgumentException(
                 'Argument 4 is an instance of '.get_class($validator).', expecting an instance of'
-                .' \Symfony\Component\Validator\Validator\ValidatorInterface or'
-                .' \Symfony\Component\Validator\ValidatorInterface'
+                .' \Symfony\Component\Validator\Validator\ValidatorInterface'
             );
         }
 

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -124,10 +124,7 @@ class Datagrid implements DatagridInterface
             $this->formBuilder->add($filter->getFormName(), $type, $options);
         }
 
-        // NEXT_MAJOR: Remove BC trick when bumping Symfony requirement to 2.8+
-        $hiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-            : 'hidden';
+        $hiddenType = 'Symfony\Component\Form\Extension\Core\Type\HiddenType';
 
         $this->formBuilder->add('_sort_by', $hiddenType);
         $this->formBuilder->get('_sort_by')->addViewTransformer(new CallbackTransformer(

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -16,7 +16,6 @@ use Sonata\AdminBundle\Datagrid\Pager;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
@@ -256,11 +255,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $definition = $container->getDefinition($serviceId);
         $settings = $container->getParameter('sonata.admin.configuration.admin_services');
 
-        if (method_exists($definition, 'setShared')) { // Symfony 2.8+
-            $definition->setShared(false);
-        } else { // For Symfony <2.8 compatibility
-            $definition->setScope(ContainerInterface::SCOPE_PROTOTYPE);
-        }
+        $definition->setShared(false);
 
         $manager_type = $attributes['manager_type'];
 

--- a/src/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
@@ -13,7 +13,6 @@ namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -31,11 +30,7 @@ class AddFilterTypeCompilerPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('sonata.admin.filter.type') as $id => $attributes) {
             $serviceDefinition = $container->getDefinition($id);
 
-            if (method_exists($definition, 'setShared')) { // Symfony 2.8+
-                $serviceDefinition->setShared(false);
-            } else { // For Symfony <2.8 compatibility
-                $serviceDefinition->setScope(ContainerInterface::SCOPE_PROTOTYPE);
-            }
+            $serviceDefinition->setShared(false);
 
             $types[$serviceDefinition->getClass()] = $id;
 

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -71,15 +71,6 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
             );
         }
 
-        // TODO: Go back on xml configuration when bumping requirements to SF 2.6+
-        $sidebarMenu = $container->getDefinition('sonata.admin.sidebar_menu');
-        if (method_exists($sidebarMenu, 'setFactory')) {
-            $sidebarMenu->setFactory([new Reference('sonata.admin.menu_builder'), 'createSidebarMenu']);
-        } else {
-            $sidebarMenu->setFactoryService('sonata.admin.menu_builder');
-            $sidebarMenu->setFactoryMethod('createSidebarMenu');
-        }
-
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
@@ -179,32 +170,6 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $container->setParameter('sonata.admin.configuration.security.object_permissions', $config['security']['object_permissions']);
 
         $loader->load('security.xml');
-
-        // Set the SecurityContext for Symfony <2.6
-        // NEXT_MAJOR: Go back to simple xml configuration when bumping requirements to SF 2.6+
-        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
-            $tokenStorageReference = new Reference('security.token_storage');
-            $authorizationCheckerReference = new Reference('security.authorization_checker');
-        } else {
-            $tokenStorageReference = new Reference('security.context');
-            $authorizationCheckerReference = new Reference('security.context');
-        }
-
-        $container
-            ->getDefinition('sonata.admin.security.handler.role')
-            ->replaceArgument(0, $authorizationCheckerReference)
-        ;
-
-        $container
-            ->getDefinition('sonata.admin.security.handler.acl')
-            ->replaceArgument(0, $tokenStorageReference)
-            ->replaceArgument(1, $authorizationCheckerReference)
-        ;
-
-        $container
-            ->getDefinition('sonata.admin.menu.group_provider')
-            ->replaceArgument(2, $authorizationCheckerReference)
-        ;
 
         $container->setParameter('sonata.admin.extension.map', $config['extensions']);
 

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -93,12 +93,7 @@ abstract class Filter implements FilterInterface
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
-        // (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-            : 'text'
-        );
+        return $this->getOption('field_type', 'Symfony\Component\Form\Extension\Core\Type\TextType');
     }
 
     /**

--- a/src/Form/Extension/ChoiceTypeExtension.php
+++ b/src/Form/Extension/ChoiceTypeExtension.php
@@ -40,12 +40,7 @@ class ChoiceTypeExtension extends AbstractTypeExtension
     {
         $optionalOptions = ['sortable'];
 
-        if (method_exists($resolver, 'setDefined')) {
-            $resolver->setDefined($optionalOptions);
-        } else {
-            // To keep Symfony <2.6 support
-            $resolver->setOptional($optionalOptions);
-        }
+        $resolver->setDefined($optionalOptions);
     }
 
     /**

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -80,8 +80,7 @@ class FormMapper extends BaseGroupedMapper
         // change `collection` to `sonata_type_native_collection` form type to
         // avoid BC break problems
         if ('collection' === $type || 'Symfony\Component\Form\Extension\Core\Type\CollectionType' === $type) {
-            // the field name is used to preserve Symfony <2.8 compatibility, the FQCN should be used instead
-            $type = 'sonata_type_native_collection';
+            $type = 'Sonata\AdminBundle\Form\Type\CollectionType';
         }
 
         $label = $fieldName;

--- a/src/Form/Type/ChoiceFieldMaskType.php
+++ b/src/Form/Type/ChoiceFieldMaskType.php
@@ -62,12 +62,7 @@ class ChoiceFieldMaskType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        // NEXT_MAJOR: Remove conditional parent call when bumping requirements to SF 2.7+
-        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            parent::configureOptions($resolver);
-        } else {
-            parent::setDefaultOptions($resolver);
-        }
+        parent::configureOptions($resolver);
 
         $resolver->setDefaults([
             'map' => [],

--- a/src/Form/Type/CollectionType.php
+++ b/src/Form/Type/CollectionType.php
@@ -26,10 +26,7 @@ class CollectionType extends AbstractType
      */
     public function getParent()
     {
-        return
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\CollectionType' :
-            'collection';
+        return 'Symfony\Component\Form\Extension\Core\Type\CollectionType';
     }
 
     /**

--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -78,19 +78,11 @@ class ChoiceType extends AbstractType
 
         // NEXT_MAJOR: Remove first check (when requirement of Symfony is >= 2.8)
         if ('hidden' !== $options['operator_type'] && 'Symfony\Component\Form\Extension\Core\Type\HiddenType' !== $options['operator_type']) {
-            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
-            if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-                $choices = array_flip($choices);
-                foreach ($choices as $key => $value) {
-                    $choices[$key] = $this->translator->trans($value, [], 'SonataAdminBundle');
-                }
-            } else {
-                $operatorChoices['choice_translation_domain'] = 'SonataAdminBundle';
+            $operatorChoices['choice_translation_domain'] = 'SonataAdminBundle';
 
-                // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-                if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                    $operatorChoices['choices_as_values'] = true;
-                }
+            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                $operatorChoices['choices_as_values'] = true;
             }
 
             $operatorChoices['choices'] = $choices;

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -74,19 +74,11 @@ class DateRangeType extends AbstractType
             'required' => false,
         ];
 
-        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, [], 'SonataAdminBundle');
-            }
-        } else {
-            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
-            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $choiceOptions['choices_as_values'] = true;
-            }
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choiceOptions['choices_as_values'] = true;
         }
 
         $choiceOptions['choices'] = $choices;

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -74,19 +74,11 @@ class DateTimeRangeType extends AbstractType
             'required' => false,
         ];
 
-        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, [], 'SonataAdminBundle');
-            }
-        } else {
-            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
-            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $choiceOptions['choices_as_values'] = true;
-            }
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choiceOptions['choices_as_values'] = true;
         }
 
         $choiceOptions['choices'] = $choices;

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -90,19 +90,11 @@ class DateTimeType extends AbstractType
             'required' => false,
         ];
 
-        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, [], 'SonataAdminBundle');
-            }
-        } else {
-            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
-            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $choiceOptions['choices_as_values'] = true;
-            }
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choiceOptions['choices_as_values'] = true;
         }
 
         $choiceOptions['choices'] = $choices;

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Optionsresolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -90,19 +90,11 @@ class DateType extends AbstractType
             'required' => false,
         ];
 
-        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, [], 'SonataAdminBundle');
-            }
-        } else {
-            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
-            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $choiceOptions['choices_as_values'] = true;
-            }
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choiceOptions['choices_as_values'] = true;
         }
 
         $choiceOptions['choices'] = $choices;

--- a/src/Form/Type/Filter/NumberType.php
+++ b/src/Form/Type/Filter/NumberType.php
@@ -85,19 +85,11 @@ class NumberType extends AbstractType
             'required' => false,
         ];
 
-        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-            foreach ($choices as $key => $value) {
-                $choices[$key] = $this->translator->trans($value, [], 'SonataAdminBundle');
-            }
-        } else {
-            $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
+        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
-            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $choiceOptions['choices_as_values'] = true;
-            }
+        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choiceOptions['choices_as_values'] = true;
         }
 
         $choiceOptions['choices'] = $choices;

--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -171,6 +171,8 @@ class ModelAutocompleteType extends AbstractType
     }
 
     /**
+     * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
+     *
      * {@inheritdoc}
      */
     public function getName()

--- a/src/Form/Type/ModelType.php
+++ b/src/Form/Type/ModelType.php
@@ -11,9 +11,7 @@
 
 namespace Sonata\AdminBundle\Form\Type;
 
-use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
-use Sonata\AdminBundle\Form\DataTransformer\LegacyModelsToArrayTransformer;
 use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
 use Sonata\AdminBundle\Form\EventListener\MergeCollectionListener;
@@ -50,13 +48,10 @@ class ModelType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if ($options['multiple']) {
-            if (array_key_exists('choice_loader', $options) && null !== $options['choice_loader']) { // SF2.7+
-                $builder->addViewTransformer(new ModelsToArrayTransformer(
-                    $options['model_manager'],
-                    $options['class']), true);
-            } else {
-                $builder->addViewTransformer(new LegacyModelsToArrayTransformer($options['choice_list']), true);
-            }
+            $builder->addViewTransformer(
+                new ModelsToArrayTransformer($options['model_manager'], $options['class']),
+                true
+            );
 
             $builder
                 ->addEventSubscriber(new MergeCollectionListener($options['model_manager']))
@@ -96,40 +91,23 @@ class ModelType extends AbstractType
     {
         $options = [];
         $propertyAccessor = $this->propertyAccessor;
-        if (interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) { // SF2.7+
-            $options['choice_loader'] = function (Options $options, $previousValue) use ($propertyAccessor) {
-                if ($previousValue && count($choices = $previousValue->getChoices())) {
-                    return $choices;
-                }
-
-                return new ModelChoiceLoader(
-                    $options['model_manager'],
-                    $options['class'],
-                    $options['property'],
-                    $options['query'],
-                    $options['choices'],
-                    $propertyAccessor
-                );
-            };
-            // NEXT_MAJOR: Remove this when dropping support for SF 2.8
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $options['choices_as_values'] = true;
+        $options['choice_loader'] = function (Options $options, $previousValue) use ($propertyAccessor) {
+            if ($previousValue && count($choices = $previousValue->getChoices())) {
+                return $choices;
             }
-        } else {
-            $options['choice_list'] = function (Options $options, $previousValue) use ($propertyAccessor) {
-                if ($previousValue && count($choices = $previousValue->getChoices())) {
-                    return $choices;
-                }
 
-                return new ModelChoiceList(
-                    $options['model_manager'],
-                    $options['class'],
-                    $options['property'],
-                    $options['query'],
-                    $options['choices'],
-                    $propertyAccessor
-                );
-            };
+            return new ModelChoiceLoader(
+                $options['model_manager'],
+                $options['class'],
+                $options['property'],
+                $options['query'],
+                $options['choices'],
+                $propertyAccessor
+            );
+        };
+        // NEXT_MAJOR: Remove this when dropping support for SF 2.8
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $options['choices_as_values'] = true;
         }
 
         $resolver->setDefaults(array_merge($options, [

--- a/src/Menu/Provider/GroupMenuProvider.php
+++ b/src/Menu/Provider/GroupMenuProvider.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Menu\Provider;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * Menu provider based on group options.
@@ -33,20 +34,16 @@ class GroupMenuProvider implements MenuProviderInterface
     private $pool;
 
     /**
-     * NEXT_MAJOR: Use AuthorizationCheckerInterface when bumping requirements to >=Symfony 2.6.
-     *
-     * @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface|\Symfony\Component\Security\Core\SecurityContextInterface
+     * @var AuthorizationCheckerInterface
      */
     private $checker;
 
     /**
      * NEXT_MAJOR: Remove default value null of $checker.
-     * NEXT_MAJOR: Allow only injection of AuthorizationCheckerInterface when bumping requirements to >=Symfony 2.6.
      *
-     * @param FactoryInterface $menuFactory
-     * @param Pool             $pool
-     * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface|
-     *        \Symfony\Component\Security\Core\SecurityContextInterface|null  $checker
+     * @param FactoryInterface                   $menuFactory
+     * @param Pool                               $pool
+     * @param AuthorizationCheckerInterface|null $checker
      */
     public function __construct(FactoryInterface $menuFactory, Pool $pool, $checker = null)
     {
@@ -55,7 +52,7 @@ class GroupMenuProvider implements MenuProviderInterface
 
         /*
          * NEXT_MAJOR: Remove this if blocks.
-         * NEXT_MAJOR: Remove instance type checking when bumping requirements to >=Symfony 2.6.
+         * NEXT_MAJOR: Move AuthorizationCheckerInterface check to method signature.
          */
         if (null === $checker) {
             @trigger_error(
@@ -63,12 +60,9 @@ class GroupMenuProvider implements MenuProviderInterface
                 Pass Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface as 3rd argument.',
                 E_USER_DEPRECATED
             );
-        } elseif (!$checker instanceof \Symfony\Component\Security\Core\SecurityContextInterface
-            && !$checker instanceof \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface
-        ) {
+        } elseif (!$checker instanceof AuthorizationCheckerInterface) {
             throw new \InvalidArgumentException(
-                'Argument 3 must be an instance of either \Symfony\Component\Security\Core\SecurityContextInterface or
-                \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
+                'Argument 3 must be an instance of \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
             );
         }
 

--- a/src/Resources/config/menu.xml
+++ b/src/Resources/config/menu.xml
@@ -8,13 +8,13 @@
             <argument type="service" id="event_dispatcher"/>
         </service>
         <service id="sonata.admin.sidebar_menu" class="Knp\Menu\MenuItem" public="true">
+            <factory service="sonata.admin.menu_builder" method="createSidebarMenu"/>
             <tag name="knp_menu.menu" alias="sonata_admin_sidebar"/>
         </service>
-        <!--NEXT_MAJOR: Replace empty argument with security.authorization_checker service when bumping requirements to >=Symfony 2.6 -->
         <service id="sonata.admin.menu.group_provider" class="Sonata\AdminBundle\Menu\Provider\GroupMenuProvider" public="false">
             <argument type="service" id="knp_menu.factory"/>
             <argument type="service" id="sonata.admin.pool"/>
-            <argument/>
+            <argument type="service" id="security.authorization_checker"/>
             <tag name="knp_menu.provider"/>
         </service>
         <service id="sonata.admin.menu.matcher.voter.admin" class="Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter" public="true">

--- a/src/Resources/config/security.xml
+++ b/src/Resources/config/security.xml
@@ -11,17 +11,14 @@
     <services>
         <service id="sonata.admin.security.handler.noop" class="%sonata.admin.security.handler.noop.class%" public="false"/>
         <service id="sonata.admin.security.handler.role" class="%sonata.admin.security.handler.role.class%" public="false">
-            <argument/>
-            <!-- security.authorization_checker or security.context for Symfony <2.6 -->
+            <argument type="service" id="security.authorization_checker"/>
             <argument type="collection">
                 <argument>%sonata.admin.configuration.security.role_super_admin%</argument>
             </argument>
         </service>
         <service id="sonata.admin.security.handler.acl" class="%sonata.admin.security.handler.acl.class%" public="false">
-            <argument/>
-            <!-- security.token_storage or security.context for Symfony <2.6 -->
-            <argument/>
-            <!-- security.authorization_checker or security.context for Symfony <2.6 -->
+            <argument type="service" id="security.token_storage"/>
+            <argument type="service" id="security.authorization_checker"/>
             <argument type="service" id="security.acl.provider" on-invalid="null"/>
             <argument>%sonata.admin.security.mask.builder.class%</argument>
             <argument type="collection">

--- a/src/Security/Handler/AclSecurityHandler.php
+++ b/src/Security/Handler/AclSecurityHandler.php
@@ -23,7 +23,6 @@ use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -31,12 +30,12 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 class AclSecurityHandler implements AclSecurityHandlerInterface
 {
     /**
-     * @var TokenStorageInterface|SecurityContextInterface
+     * @var TokenStorageInterface
      */
     protected $tokenStorage;
 
     /**
-     * @var AuthorizationCheckerInterface|SecurityContextInterface
+     * @var AuthorizationCheckerInterface
      */
     protected $authorizationChecker;
 
@@ -66,21 +65,21 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
     protected $maskBuilderClass;
 
     /**
-     * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
-     *
-     * @param TokenStorageInterface|SecurityContextInterface $tokenStorage
-     * @param TokenStorageInterface|SecurityContextInterface $authorizationChecker
-     * @param MutableAclProviderInterface                    $aclProvider
-     * @param string                                         $maskBuilderClass
-     * @param array                                          $superAdminRoles
+     * @param TokenStorageInterface         $tokenStorage
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     * @param MutableAclProviderInterface   $aclProvider
+     * @param string                        $maskBuilderClass
+     * @param array                         $superAdminRoles
      */
     public function __construct($tokenStorage, $authorizationChecker, MutableAclProviderInterface $aclProvider, $maskBuilderClass, array $superAdminRoles)
     {
-        if (!$tokenStorage instanceof TokenStorageInterface && !$tokenStorage instanceof SecurityContextInterface) {
-            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        // NEXT_MAJOR: Move TokenStorageInterface check to method signature
+        if (!$tokenStorage instanceof TokenStorageInterface) {
+            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         }
-        if (!$authorizationChecker instanceof AuthorizationCheckerInterface && !$authorizationChecker instanceof SecurityContextInterface) {
-            throw new \InvalidArgumentException('Argument 2 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        // NEXT_MAJOR: Move AuthorizationCheckerInterface check to method signature
+        if (!$authorizationChecker instanceof AuthorizationCheckerInterface) {
+            throw new \InvalidArgumentException('Argument 2 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         }
 
         $this->tokenStorage = $tokenStorage;

--- a/src/Security/Handler/RoleSecurityHandler.php
+++ b/src/Security/Handler/RoleSecurityHandler.php
@@ -14,7 +14,6 @@ namespace Sonata\AdminBundle\Security\Handler;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -22,7 +21,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 class RoleSecurityHandler implements SecurityHandlerInterface
 {
     /**
-     * @var AuthorizationCheckerInterface|SecurityContextInterface
+     * @var AuthorizationCheckerInterface
      */
     protected $authorizationChecker;
 
@@ -32,15 +31,14 @@ class RoleSecurityHandler implements SecurityHandlerInterface
     protected $superAdminRoles;
 
     /**
-     * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
-     *
-     * @param AuthorizationCheckerInterface|SecurityContextInterface $authorizationChecker
-     * @param array                                                  $superAdminRoles
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     * @param array                         $superAdminRoles
      */
     public function __construct($authorizationChecker, array $superAdminRoles)
     {
-        if (!$authorizationChecker instanceof AuthorizationCheckerInterface && !$authorizationChecker instanceof SecurityContextInterface) {
-            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        // NEXT_MAJOR: Move AuthorizationCheckerInterface check to method signature
+        if (!$authorizationChecker instanceof AuthorizationCheckerInterface) {
+            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         }
 
         $this->authorizationChecker = $authorizationChecker;

--- a/src/Util/AdminObjectAclManipulator.php
+++ b/src/Util/AdminObjectAclManipulator.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\AdminBundle\Util;
 
-use Sonata\AdminBundle\Form\Type\AclMatrixType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -285,12 +284,11 @@ class AdminObjectAclManipulator
                 ];
             }
 
-            // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-            $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                'Sonata\AdminBundle\Form\Type\AclMatrixType' :
-                new AclMatrixType();
-
-            $formBuilder->add($key, $type, ['permissions' => $permissions, 'acl_value' => $aclValue]);
+            $formBuilder->add(
+                $key,
+                'Sonata\AdminBundle\Form\Type\AclMatrixType',
+                ['permissions' => $permissions, 'acl_value' => $aclValue]
+            );
         }
 
         return $formBuilder->getForm();

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -854,13 +854,7 @@ class AdminTest extends TestCase
 
         $this->assertNull($admin->getValidator());
 
-        $validatorClass = '\Symfony\Component\Validator\ValidatorInterface';
-
-        if (interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
-            $validatorClass = 'Symfony\Component\Validator\Validator\ValidatorInterface';
-        }
-
-        $validator = $this->getMockForAbstractClass($validatorClass);
+        $validator = $this->getMockForAbstractClass('Symfony\Component\Validator\Validator\ValidatorInterface');
 
         $admin->setValidator($validator);
         $this->assertSame($validator, $admin->getValidator());

--- a/tests/Admin/Extension/LockExtensionTest.php
+++ b/tests/Admin/Extension/LockExtensionTest.php
@@ -74,10 +74,7 @@ class LockExtensionTest extends TestCase
 
         $form->add(
             '_lock_version',
-            // NEXT_MAJOR: remove the check and add the FQCN
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-                : 'hidden',
+            'Symfony\Component\Form\Extension\Core\Type\HiddenType',
             ['mapped' => false, 'data' => 1]
         )->shouldBeCalled();
 

--- a/tests/Command/ExplainAdminCommandTest.php
+++ b/tests/Command/ExplainAdminCommandTest.php
@@ -131,25 +131,12 @@ class ExplainAdminCommandTest extends TestCase
                 return $adminParent;
             }));
 
-        if (interface_exists(
-            'Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface'
-        )) { // Prefer Symfony 2.5+ interfaces
-            $this->validatorFactory = $this->createMock(
-                'Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface'
-            );
+        $this->validatorFactory = $this->createMock('Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface');
 
-            $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
-            $validator->expects($this->any())->method('getMetadataFor')->will(
-                $this->returnValue($this->validatorFactory)
-            );
-        } else {
-            $this->validatorFactory = $this->createMock('Symfony\Component\Validator\MetadataFactoryInterface');
-
-            $validator = $this->createMock('Symfony\Component\Validator\ValidatorInterface');
-            $validator->expects($this->any())->method('getMetadataFactory')->will(
-                $this->returnValue($this->validatorFactory)
-            );
-        }
+        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validator->expects($this->any())->method('getMetadataFor')->will(
+            $this->returnValue($this->validatorFactory)
+        );
 
         // php 5.3 BC
         $admin = $this->admin;
@@ -187,27 +174,14 @@ class ExplainAdminCommandTest extends TestCase
 
     public function testExecute()
     {
-        // NEXT_MAJOR: Remove check, when bumping requirements to SF 2.5+
-        if (interface_exists('Symfony\Component\Validator\Mapping\MetadataInterface')) { //sf2.5+
-            $metadata = $this->createMock('Symfony\Component\Validator\Mapping\MetadataInterface');
-        } else {
-            $metadata = $this->createMock('Symfony\Component\Validator\MetadataInterface');
-        }
+        $metadata = $this->createMock('Symfony\Component\Validator\Mapping\MetadataInterface');
 
         $this->validatorFactory->expects($this->once())
             ->method('getMetadataFor')
             ->with($this->equalTo('Acme\Entity\Foo'))
             ->will($this->returnValue($metadata));
 
-        // NEXT_MAJOR: Remove check, when bumping requirements to SF 2.5+
-        if (class_exists('Symfony\Component\Validator\Mapping\GenericMetadata')) {
-            $class = 'GenericMetadata';
-        } else {
-            // Symfony <2.5 compatibility
-            $class = 'ElementMetadata';
-        }
-
-        $propertyMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\\'.$class);
+        $propertyMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\GenericMetadata');
         $propertyMetadata->constraints = [
             new NotNull(),
             new Length(['min' => 2, 'max' => 50, 'groups' => ['create', 'edit']]),
@@ -215,7 +189,7 @@ class ExplainAdminCommandTest extends TestCase
 
         $metadata->properties = ['firstName' => $propertyMetadata];
 
-        $getterMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\\'.$class);
+        $getterMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\GenericMetadata');
         $getterMetadata->constraints = [
             new NotNull(),
             new Email(['groups' => ['registration', 'edit']]),

--- a/tests/Command/GenerateAdminCommandTest.php
+++ b/tests/Command/GenerateAdminCommandTest.php
@@ -199,107 +199,50 @@ class GenerateAdminCommandTest extends TestCase
 
         $command = $this->application->find('sonata:admin:generate');
 
-        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
-        // DialogHelper does not exist in SensioGeneratorBundle 2.5+
-        if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
-            $dialog = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')
-                ->setMethods(['askConfirmation', 'askAndValidate'])
-                ->getMock();
+        $questionHelper = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper')
+            ->setMethods(['ask'])
+            ->getMock();
 
-            $dialog->expects($this->any())
-                ->method('askConfirmation')
-                ->will($this->returnCallback(function (OutputInterface $output, $question, $default) {
-                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
+        $questionHelper->expects($this->any())
+            ->method('ask')
+            ->will($this->returnCallback(function (InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity) {
+                $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>') - 6);
 
-                    switch ($questionClean) {
-                        case 'Do you want to generate a controller':
-                            return 'yes';
+                switch ($questionClean) {
+                    // confirmations
+                    case 'Do you want to generate a controller':
+                        return 'yes';
 
-                        case 'Do you want to update the services YAML configuration file':
-                            return 'yes';
-                    }
+                    case 'Do you want to update the services YAML configuration file':
+                        return 'yes';
 
-                    return $default;
-                }));
+                    // inputs
+                    case 'The fully qualified model class':
+                        return $modelEntity;
 
-            $dialog->expects($this->any())
-                ->method('askAndValidate')
-                ->will($this->returnCallback(function (OutputInterface $output, $question, $validator, $attempts = false, $default = null) use ($modelEntity) {
-                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
+                    case 'The bundle name':
+                        return 'AcmeDemoBundle';
 
-                    switch ($questionClean) {
-                        case 'The fully qualified model class':
-                            return $modelEntity;
+                    case 'The admin class basename':
+                        return 'FooAdmin';
 
-                        case 'The bundle name':
-                            return 'AcmeDemoBundle';
+                    case 'The controller class basename':
+                        return 'FooAdminController';
 
-                        case 'The admin class basename':
-                            return 'FooAdmin';
+                    case 'The services YAML configuration file':
+                        return 'admin.yml';
 
-                        case 'The controller class basename':
-                            return 'FooAdminController';
+                    case 'The admin service ID':
+                        return 'acme_demo_admin.admin.foo';
 
-                        case 'The services YAML configuration file':
-                            return 'admin.yml';
+                    case 'The manager type':
+                        return 'foo';
+                }
 
-                        case 'The admin service ID':
-                            return 'acme_demo_admin.admin.foo';
+                return false;
+            }));
 
-                        case 'The manager type':
-                            return 'foo';
-                    }
-
-                    return $default;
-                }));
-
-            $command->getHelperSet()->set($dialog, 'dialog');
-        } else {
-            $questionHelper = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper')
-                ->setMethods(['ask'])
-                ->getMock();
-
-            $questionHelper->expects($this->any())
-                ->method('ask')
-                ->will($this->returnCallback(function (InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity) {
-                    $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>') - 6);
-
-                    switch ($questionClean) {
-                        // confirmations
-                        case 'Do you want to generate a controller':
-                            return 'yes';
-
-                        case 'Do you want to update the services YAML configuration file':
-                            return 'yes';
-
-                        // inputs
-                        case 'The fully qualified model class':
-                            return $modelEntity;
-
-                        case 'The bundle name':
-                            return 'AcmeDemoBundle';
-
-                        case 'The admin class basename':
-                            return 'FooAdmin';
-
-                        case 'The controller class basename':
-                            return 'FooAdminController';
-
-                        case 'The services YAML configuration file':
-                            return 'admin.yml';
-
-                        case 'The admin service ID':
-                            return 'acme_demo_admin.admin.foo';
-
-                        case 'The manager type':
-                            return 'foo';
-                    }
-
-                    return false;
-                }));
-
-            $command->getHelperSet()->set($questionHelper, 'question');
-        }
+        $command->getHelperSet()->set($questionHelper, 'question');
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([
@@ -398,95 +341,38 @@ class GenerateAdminCommandTest extends TestCase
 
         $command = $this->application->find('sonata:admin:generate');
 
-        // NEXT_MAJOR: Remove this BC code for SensioGeneratorBundle 2.3/2.4 after dropping support for Symfony 2.3
-        // DialogHelper does not exist in SensioGeneratorBundle 2.5+
-        if (class_exists('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')) {
-            $dialog = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper')
-                ->setMethods(['askConfirmation', 'askAndValidate'])
-                ->getMock();
+        $questionHelper = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper')
+            ->setMethods(['ask'])
+            ->getMock();
 
-            $dialog->expects($this->any())
-                ->method('askConfirmation')
-                ->will($this->returnCallback(function (OutputInterface $output, $question, $default) {
-                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
+        $questionHelper->expects($this->any())
+            ->method('ask')
+            ->will($this->returnCallback(function (InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity) {
+                $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>') - 6);
 
-                    switch ($questionClean) {
-                        case 'Do you want to generate a controller':
-                            return false;
+                switch ($questionClean) {
+                    // confirmations
+                    case 'Do you want to generate a controller':
+                        return false;
 
-                        case 'Do you want to update the services YAML configuration file':
-                            return false;
-                    }
+                    case 'Do you want to update the services YAML configuration file':
+                        return false;
 
-                    return $default;
-                }));
+                    // inputs
+                    case 'The fully qualified model class':
+                        return $modelEntity;
 
-            $dialog->expects($this->any())
-                ->method('askAndValidate')
-                ->will($this->returnCallback(function (OutputInterface $output, $question, $validator, $attempts = false, $default = null) use ($modelEntity) {
-                    $questionClean = substr($question, 6, strpos($question, '</info>') - 6);
+                    case 'The bundle name':
+                        return 'AcmeDemoBundle';
 
-                    switch ($questionClean) {
-                        case 'The fully qualified model class':
-                            return $modelEntity;
+                    case 'The admin class basename':
+                        return 'FooAdmin';
+                }
 
-                        case 'The bundle name':
-                            return 'AcmeDemoBundle';
+                return false;
+            }));
 
-                        case 'The admin class basename':
-                            return 'FooAdmin';
-
-                        case 'The controller class basename':
-                            return 'FooAdminController';
-
-                        case 'The services YAML configuration file':
-                            return 'admin.yml';
-
-                        case 'The admin service ID':
-                            return 'acme_demo_admin.admin.foo';
-
-                        case 'The manager type':
-                            return 'foo';
-                    }
-
-                    return $default;
-                }));
-
-            $command->getHelperSet()->set($dialog, 'dialog');
-        } else {
-            $questionHelper = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper')
-                ->setMethods(['ask'])
-                ->getMock();
-
-            $questionHelper->expects($this->any())
-                ->method('ask')
-                ->will($this->returnCallback(function (InputInterface $input, OutputInterface $output, Question $question) use ($modelEntity) {
-                    $questionClean = substr($question->getQuestion(), 6, strpos($question->getQuestion(), '</info>') - 6);
-
-                    switch ($questionClean) {
-                        // confirmations
-                        case 'Do you want to generate a controller':
-                            return false;
-
-                        case 'Do you want to update the services YAML configuration file':
-                            return false;
-
-                        // inputs
-                        case 'The fully qualified model class':
-                            return $modelEntity;
-
-                        case 'The bundle name':
-                            return 'AcmeDemoBundle';
-
-                        case 'The admin class basename':
-                            return 'FooAdmin';
-                    }
-
-                    return false;
-                }));
-
-            $command->getHelperSet()->set($questionHelper, 'question');
-        }
+        $command->getHelperSet()->set($questionHelper, 'question');
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([

--- a/tests/Controller/CoreControllerTest.php
+++ b/tests/Controller/CoreControllerTest.php
@@ -31,11 +31,8 @@ class CoreControllerTest extends TestCase
         $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
         $request = new Request();
 
-        $requestStack = null;
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            $requestStack = new RequestStack();
-            $requestStack->push($request);
-        }
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
 
         $breadcrumbsBuilder = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface');
 
@@ -43,7 +40,6 @@ class CoreControllerTest extends TestCase
             'sonata.admin.breadcrumbs_builder' => $breadcrumbsBuilder,
             'sonata.admin.pool' => $pool,
             'templating' => $templating,
-            'request' => $request,
             'request_stack' => $requestStack,
         ];
 
@@ -95,16 +91,12 @@ class CoreControllerTest extends TestCase
         $request = new Request();
         $request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $requestStack = null;
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            $requestStack = new RequestStack();
-            $requestStack->push($request);
-        }
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
 
         $values = [
             'sonata.admin.pool' => $pool,
             'templating' => $templating,
-            'request' => $request,
             'request_stack' => $requestStack,
         ];
 

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -92,13 +92,7 @@ class HelperControllerTest extends TestCase
 
         $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
         $helper = new AdminHelper($pool);
-
-        // NEXT_MAJOR: Remove this when dropping support for SF < 2.8
-        if (interface_exists('Symfony\Component\Validator\ValidatorInterface')) {
-            $validator = $this->createMock('Symfony\Component\Validator\ValidatorInterface');
-        } else {
-            $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
-        }
+        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
         $this->controller = new HelperController($twig, $pool, $helper, $validator);
 
         // php 5.3 BC
@@ -116,9 +110,8 @@ class HelperControllerTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     * @dataProvider getValidatorInterfaces
      */
-    public function testgetShortObjectDescriptionActionInvalidAdmin($validatorInterface)
+    public function testgetShortObjectDescriptionActionInvalidAdmin()
     {
         $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
@@ -130,7 +123,7 @@ class HelperControllerTest extends TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(['sonata.post.admin']);
         $helper = new AdminHelper($pool);
-        $validator = $this->createMock($validatorInterface);
+        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
         $controller->getShortObjectDescriptionAction($request);
@@ -139,10 +132,8 @@ class HelperControllerTest extends TestCase
     /**
      * @expectedException \RuntimeException
      * @exceptionMessage Invalid format
-     *
-     * @dataProvider getValidatorInterfaces
      */
-    public function testgetShortObjectDescriptionActionObjectDoesNotExist($validatorInterface)
+    public function testgetShortObjectDescriptionActionObjectDoesNotExist()
     {
         $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('setUniqid');
@@ -163,16 +154,13 @@ class HelperControllerTest extends TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->createMock($validatorInterface);
+        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
         $controller->getShortObjectDescriptionAction($request);
     }
 
-    /**
-     * @dataProvider getValidatorInterfaces
-     */
-    public function testgetShortObjectDescriptionActionEmptyObjectId($validatorInterface)
+    public function testgetShortObjectDescriptionActionEmptyObjectId()
     {
         $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('setUniqid');
@@ -194,16 +182,13 @@ class HelperControllerTest extends TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->createMock($validatorInterface);
+        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
         $controller->getShortObjectDescriptionAction($request);
     }
 
-    /**
-     * @dataProvider getValidatorInterfaces
-     */
-    public function testgetShortObjectDescriptionActionObject($validatorInterface)
+    public function testgetShortObjectDescriptionActionObject()
     {
         $mockTemplate = 'AdminHelperTest:mock-short-object-description.html.twig';
 
@@ -243,7 +228,7 @@ class HelperControllerTest extends TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->createMock($validatorInterface);
+        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
 
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
@@ -253,10 +238,7 @@ class HelperControllerTest extends TestCase
         $this->assertSame($expected, $response->getContent());
     }
 
-    /**
-     * @dataProvider getValidatorInterfaces
-     */
-    public function testsetObjectFieldValueAction($validatorInterface)
+    public function testsetObjectFieldValueAction()
     {
         $object = new AdminControllerHelper_Foo();
 
@@ -301,7 +283,7 @@ class HelperControllerTest extends TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->createMock($validatorInterface);
+        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
 
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
@@ -310,10 +292,7 @@ class HelperControllerTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    /**
-     * @dataProvider getValidatorInterfaces
-     */
-    public function testappendFormFieldElementAction($validatorInterface)
+    public function testappendFormFieldElementAction()
     {
         $object = new AdminControllerHelper_Foo();
 
@@ -379,7 +358,7 @@ class HelperControllerTest extends TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(['sonata.post.admin']);
 
-        $validator = $this->createMock($validatorInterface);
+        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
 
         $mockView = $this->getMockBuilder('Symfony\Component\Form\FormView')
             ->disableOriginalConstructor()
@@ -408,10 +387,7 @@ class HelperControllerTest extends TestCase
         $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
     }
 
-    /**
-     * @dataProvider getValidatorInterfaces
-     */
-    public function testRetrieveFormFieldElementAction($validatorInterface)
+    public function testRetrieveFormFieldElementAction()
     {
         $object = new AdminControllerHelper_Foo();
 
@@ -496,7 +472,7 @@ class HelperControllerTest extends TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(['sonata.post.admin']);
 
-        $validator = $this->createMock($validatorInterface);
+        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
 
         $helper = $this->getMockBuilder('Sonata\AdminBundle\Admin\AdminHelper')
             ->setMethods(['getChildFormView'])
@@ -510,10 +486,7 @@ class HelperControllerTest extends TestCase
         $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
     }
 
-    /**
-     * @dataProvider getValidatorInterfaces
-     */
-    public function testSetObjectFieldValueActionWithViolations($validatorInterface)
+    public function testSetObjectFieldValueActionWithViolations()
     {
         $bar = new AdminControllerHelper_Bar();
 
@@ -550,7 +523,7 @@ class HelperControllerTest extends TestCase
             new ConstraintViolation('error2', null, [], null, 'enabled', null),
         ]);
 
-        $validator = $this->createMock($validatorInterface);
+        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
 
         $validator
             ->expects($this->once())
@@ -915,26 +888,5 @@ class HelperControllerTest extends TestCase
         $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
-    }
-
-    /**
-     * Symfony Validator has 2 API version (2.4 and 2.5)
-     * This data provider ensure tests pass on each one.
-     */
-    public function getValidatorInterfaces()
-    {
-        $data = [];
-
-        // For Symfony <= 2.8
-        if (interface_exists('Symfony\Component\Validator\ValidatorInterface')) {
-            $data['2.4'] = ['Symfony\Component\Validator\ValidatorInterface'];
-        }
-
-        // For Symfony >= 2.5
-        if (interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
-            $data['2.5'] = ['Symfony\Component\Validator\Validator\ValidatorInterface'];
-        }
-
-        return $data;
     }
 }

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -105,9 +105,7 @@ class DatagridMapperTest extends TestCase
         $this->assertInstanceOf('Sonata\AdminBundle\Filter\FilterInterface', $filter);
         $this->assertSame('foo.name', $filter->getName());
         $this->assertSame('foo__name', $filter->getFormName());
-        $this->assertSame(method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-            : 'text', $filter->getFieldType());
+        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\TextType', $filter->getFieldType());
         $this->assertSame('fooLabel', $filter->getLabel());
         $this->assertSame(['required' => false], $filter->getFieldOptions());
         $this->assertSame([

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -353,7 +353,7 @@ class ExtensionCompilerPassTest extends TestCase
             ->setClass('Symfony\Component\Form\FormFactoryInterface');
         $container
             ->register('validator')
-            ->setClass('Symfony\Component\Validator\ValidatorInterface');
+            ->setClass('Symfony\Component\Validator\Validator\ValidatorInterface');
         $container
             ->register('knp_menu.factory')
             ->setClass('Knp\Menu\FactoryInterface');

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -20,9 +20,7 @@ class FilterTest extends TestCase
     {
         $filter = new FooFilter();
 
-        $this->assertSame(method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-            : 'text', $filter->getFieldType());
+        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\TextType', $filter->getFieldType());
         $this->assertSame(['required' => false], $filter->getFieldOptions());
         $this->assertNull($filter->getLabel());
 

--- a/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
+++ b/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
@@ -21,10 +21,6 @@ class ModelChoiceLoaderTest extends TestCase
 
     public function setUp()
     {
-        if (false === interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
-            $this->markTestSkipped('Test only available for > SF2.7');
-        }
-
         $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
     }
 

--- a/tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -38,10 +38,7 @@ class ModelsToArrayTransformerTest extends TestCase
      */
     public function testLegacyConstructor()
     {
-        $choiceListClass = interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')
-            ? 'Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader'
-            : 'Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList'
-        ;
+        $choiceListClass = 'Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader';
 
         $choiceList = $this->prophesize($choiceListClass)->reveal();
 

--- a/tests/Form/Extension/ChoiceTypeExtensionTest.php
+++ b/tests/Form/Extension/ChoiceTypeExtensionTest.php
@@ -20,73 +20,52 @@ class ChoiceTypeExtensionTest extends TestCase
 {
     protected function setup()
     {
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
-            $container->expects($this->any())->method('has')->will($this->returnValue(true));
-            $container->expects($this->any())->method('get')
-                ->with($this->equalTo('sonata.admin.form.choice_extension'))
-                ->will($this->returnValue(new ChoiceTypeExtension()));
+        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->any())->method('has')->will($this->returnValue(true));
+        $container->expects($this->any())->method('get')
+            ->with($this->equalTo('sonata.admin.form.choice_extension'))
+            ->will($this->returnValue(new ChoiceTypeExtension()));
 
-            $typeServiceIds = [];
-            $typeExtensionServiceIds = [];
-            $guesserServiceIds = [];
-            $mappingTypes = [
-                'choice' => 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
-            ];
-            $extensionTypes = [
-                'choice' => [
-                    'sonata.admin.form.choice_extension',
-                ],
-            ];
+        $typeServiceIds = [];
+        $typeExtensionServiceIds = [];
+        $guesserServiceIds = [];
+        $mappingTypes = [
+            'choice' => 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+        ];
+        $extensionTypes = [
+            'choice' => [
+                'sonata.admin.form.choice_extension',
+            ],
+        ];
 
-            $dependency = new DependencyInjectionExtension(
-                $container,
-                $typeServiceIds,
-                $typeExtensionServiceIds,
-                $guesserServiceIds,
-                $mappingTypes,
-                $extensionTypes
-            );
+        $dependency = new DependencyInjectionExtension(
+            $container,
+            $typeServiceIds,
+            $typeExtensionServiceIds,
+            $guesserServiceIds,
+            $mappingTypes,
+            $extensionTypes
+        );
 
-            $this->factory = Forms::createFormFactoryBuilder()
-                ->addExtension($dependency)
-                ->getFormFactory();
-        } else {
-            $this->factory = Forms::createFormFactoryBuilder()
-                  ->addTypeExtension(new ChoiceTypeExtension())
-                  ->getFormFactory();
-        }
+        $this->factory = Forms::createFormFactoryBuilder()
+            ->addExtension($dependency)
+            ->getFormFactory();
     }
 
     public function testExtendedType()
     {
         $extension = new ChoiceTypeExtension();
 
-        /*
-         * NEXT_MAJOR: Remove when dropping Symfony <2.8 support. It should
-         * simply be:
-         *
-         * $this->assertSame(
-         *     'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
-         *     $extension->getExtendedType()
-         * );
-         */
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->assertSame(
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
-                $extension->getExtendedType()
-            );
-        } else {
-            $this->assertSame('choice', $extension->getExtendedType());
-        }
+        $this->assertSame(
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+            $extension->getExtendedType()
+        );
     }
 
     public function testDefaultOptionsWithSortable()
     {
-        $name = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice';
-
         $view = $this->factory
-            ->create($name, null, [
+            ->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, [
                 'sortable' => true,
             ])
             ->createView();
@@ -97,10 +76,8 @@ class ChoiceTypeExtensionTest extends TestCase
 
     public function testDefaultOptionsWithoutSortable()
     {
-        $name = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice';
-
         $view = $this->factory
-            ->create($name, null, [])
+            ->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, [])
             ->createView();
 
         $this->assertTrue(isset($view->vars['sortable']));

--- a/tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
+++ b/tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
@@ -24,12 +24,7 @@ class FormTypeFieldExtensionTest extends TestCase
     {
         $extension = new FormTypeFieldExtension([], []);
 
-        $this->assertSame(
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\FormType' :
-            'form',
-            $extension->getExtendedType()
-        );
+        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\FormType', $extension->getExtendedType());
     }
 
     public function testDefaultOptions()
@@ -37,11 +32,7 @@ class FormTypeFieldExtensionTest extends TestCase
         $extension = new FormTypeFieldExtension([], []);
 
         $resolver = new OptionsResolver();
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $extension->setDefaultOptions($resolver);
-        } else {
-            $extension->configureOptions($resolver);
-        }
+        $extension->configureOptions($resolver);
 
         $options = $resolver->resolve();
 

--- a/tests/Form/Type/AclMatrixTypeTest.php
+++ b/tests/Form/Type/AclMatrixTypeTest.php
@@ -36,11 +36,7 @@ class AclMatrixTypeTest extends TypeTestCase
 
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $type->setDefaultOptions($optionResolver);
-        } else {
-            $type->configureOptions($optionResolver);
-        }
+        $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve([
             'acl_value' => $user,

--- a/tests/Form/Type/AdminTypeTest.php
+++ b/tests/Form/Type/AdminTypeTest.php
@@ -26,11 +26,7 @@ class AdminTypeTest extends TypeTestCase
 
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $type->setDefaultOptions($optionResolver);
-        } else {
-            $type->configureOptions($optionResolver);
-        }
+        $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve();
 
@@ -44,11 +40,6 @@ class AdminTypeTest extends TypeTestCase
 
     public function testSubmitValidData()
     {
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->markTestSkipped('Testing ancient versions would be more complicated.');
-
-            return;
-        }
         $parentAdmin = $this->prophesize('Sonata\AdminBundle\Admin\AdminInterface');
         $parentField = $this->prophesize('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());

--- a/tests/Form/Type/ChoiceFieldMaskTypeTest.php
+++ b/tests/Form/Type/ChoiceFieldMaskTypeTest.php
@@ -23,11 +23,7 @@ class ChoiceFieldMaskTypeTest extends TypeTestCase
 
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $type->setDefaultOptions($optionResolver);
-        } else {
-            $type->configureOptions($optionResolver);
-        }
+        $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve(
             [
@@ -40,18 +36,15 @@ class ChoiceFieldMaskTypeTest extends TypeTestCase
         $this->assertSame(['foo' => ['field1', 'field2'], 'bar' => ['field3']], $options['map']);
     }
 
-    public function testGetName()
+    public function testGetBlockPrefix()
     {
         $type = new ChoiceFieldMaskType();
-        $this->assertSame('sonata_type_choice_field_mask', $type->getName());
+        $this->assertSame('sonata_type_choice_field_mask', $type->getBlockPrefix());
     }
 
     public function testGetParent()
     {
         $type = new ChoiceFieldMaskType();
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        $this->assertSame(method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice', $type->getParent());
+        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\ChoiceType', $type->getParent());
     }
 }

--- a/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
+++ b/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
@@ -25,11 +25,7 @@ class DateTimeRangeTypeTest extends TypeTestCase
 
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $type->setDefaultOptions($optionResolver);
-        } else {
-            $type->configureOptions($optionResolver);
-        }
+        $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve();
 

--- a/tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -34,11 +34,7 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->type->setDefaultOptions($optionResolver);
-        } else {
-            $this->type->configureOptions($optionResolver);
-        }
+        $this->type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve(['model_manager' => $modelManager, 'class' => 'Foo', 'property' => 'bar']);
 

--- a/tests/Form/Type/ModelHiddenTypeTest.php
+++ b/tests/Form/Type/ModelHiddenTypeTest.php
@@ -23,11 +23,7 @@ class ModelHiddenTypeTest extends TypeTestCase
         $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $type->setDefaultOptions($optionResolver);
-        } else {
-            $type->configureOptions($optionResolver);
-        }
+        $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve(['model_manager' => $modelManager, 'class' => '\Foo']);
 
@@ -36,18 +32,15 @@ class ModelHiddenTypeTest extends TypeTestCase
         $this->assertSame('\Foo', $options['class']);
     }
 
-    public function testGetName()
+    public function testGetBlockPrefix()
     {
         $type = new ModelHiddenType();
-        $this->assertSame('sonata_type_model_hidden', $type->getName());
+        $this->assertSame('sonata_type_model_hidden', $type->getBlockPrefix());
     }
 
     public function testGetParent()
     {
         $type = new ModelHiddenType();
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        $this->assertSame(method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-            : 'hidden', $type->getParent());
+        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\HiddenType', $type->getParent());
     }
 }

--- a/tests/Form/Type/ModelListTypeTest.php
+++ b/tests/Form/Type/ModelListTypeTest.php
@@ -19,10 +19,6 @@ class ModelListTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->markTestSkipped('Testing ancient versions would be more complicated.');
-        }
-
         $this->modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         parent::setUp();

--- a/tests/Form/Type/ModelReferenceTypeTest.php
+++ b/tests/Form/Type/ModelReferenceTypeTest.php
@@ -21,10 +21,6 @@ class ModelReferenceTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->markTestSkipped('Testing ancient versions would be more complicated.');
-        }
-
         $this->modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         parent::setUp();

--- a/tests/Form/Type/ModelTypeListTest.php
+++ b/tests/Form/Type/ModelTypeListTest.php
@@ -28,11 +28,7 @@ class ModelTypeListTest extends TypeTestCase
 
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $type->setDefaultOptions($optionResolver);
-        } else {
-            $type->configureOptions($optionResolver);
-        }
+        $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve();
 

--- a/tests/Form/Type/ModelTypeTest.php
+++ b/tests/Form/Type/ModelTypeTest.php
@@ -33,11 +33,7 @@ class ModelTypeTest extends TypeTestCase
 
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->type->setDefaultOptions($optionResolver);
-        } else {
-            $this->type->configureOptions($optionResolver);
-        }
+        $this->type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve(['model_manager' => $modelManager, 'choices' => []]);
 
@@ -55,11 +51,7 @@ class ModelTypeTest extends TypeTestCase
         $this->assertSame('link_list', $options['btn_list']);
         $this->assertSame('link_delete', $options['btn_delete']);
         $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);
-        if (interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) { // SF2.7+
-            $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader', $options['choice_loader']);
-        } else {
-            $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList', $options['choice_list']);
-        }
+        $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader', $options['choice_loader']);
     }
 
     /**
@@ -70,11 +62,7 @@ class ModelTypeTest extends TypeTestCase
         $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
         $optionResolver = new OptionsResolver();
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $this->type->setDefaultOptions($optionResolver);
-        } else {
-            $this->type->configureOptions($optionResolver);
-        }
+        $this->type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve(['model_manager' => $modelManager, 'choices' => [], 'multiple' => $multiple, 'expanded' => $expanded]);
 
@@ -92,12 +80,7 @@ class ModelTypeTest extends TypeTestCase
         $this->assertSame('link_list', $options['btn_list']);
         $this->assertSame('link_delete', $options['btn_delete']);
         $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);
-
-        if (interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) { // SF2.7+
-            $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader', $options['choice_loader']);
-        } else {
-            $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList', $options['choice_list']);
-        }
+        $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader', $options['choice_loader']);
     }
 
     public function getCompoundOptionTests()

--- a/tests/Form/Widget/FilterChoiceWidgetTest.php
+++ b/tests/Form/Widget/FilterChoiceWidgetTest.php
@@ -75,29 +75,13 @@ class FilterChoiceWidgetTest extends BaseWidgetTest
 
     protected function getChoiceClass()
     {
-        return
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice';
+        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
     }
 
-    /**
-     * For SF < 2.6, we use 'empty_data' to provide default empty value.
-     * For SF >= 2.6, we must use 'placeholder' to achieve the same.
-     */
     protected function getDefaultOption()
     {
-        if (method_exists(
-            'Symfony\Component\Form\Tests\AbstractLayoutTest',
-            'testSingleChoiceNonRequiredWithPlaceholder'
-        )) {
-            return [
-                'placeholder' => 'Choose an option',
-            ];
-        }
-
         return [
-                'empty_value' => 'Choose an option',
-            ];
+            'placeholder' => 'Choose an option',
+        ];
     }
 }

--- a/tests/Form/Widget/FormChoiceWidgetTest.php
+++ b/tests/Form/Widget/FormChoiceWidgetTest.php
@@ -99,29 +99,13 @@ class FormChoiceWidgetTest extends BaseWidgetTest
 
     protected function getChoiceClass()
     {
-        return
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice';
+        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
     }
 
-    /**
-     * For SF < 2.6, we use 'empty_data' to provide default empty value.
-     * For SF >= 2.6, we must use 'placeholder' to achieve the same.
-     */
     protected function getDefaultOption()
     {
-        if (method_exists(
-            'Symfony\Component\Form\Tests\AbstractLayoutTest',
-            'testSingleChoiceNonRequiredWithPlaceholder'
-        )) {
-            return [
-                'placeholder' => 'Choose an option',
-            ];
-        }
-
         return [
-                'empty_value' => 'Choose an option',
-            ];
+            'placeholder' => 'Choose an option',
+        ];
     }
 }

--- a/tests/Form/Widget/FormSonataNativeCollectionWidgetTest.php
+++ b/tests/Form/Widget/FormSonataNativeCollectionWidgetTest.php
@@ -12,7 +12,6 @@
 namespace Sonata\AdminBundle\Tests\Form\Widget;
 
 use Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension;
-use Sonata\AdminBundle\Form\Type\CollectionType;
 use Symfony\Component\Form\Tests\Fixtures\TestExtension;
 
 class FormSonataNativeCollectionWidgetTest extends BaseWidgetTest
@@ -56,9 +55,6 @@ class FormSonataNativeCollectionWidgetTest extends BaseWidgetTest
         $extensions = parent::getExtensions();
         $guesser = $this->getMockForAbstractClass('Symfony\Component\Form\FormTypeGuesserInterface');
         $extension = new TestExtension($guesser);
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $extension->addType(new CollectionType());
-        }
 
         $extension->addTypeExtension(new FormTypeFieldExtension([], [
             'form_type' => 'vertical',
@@ -70,9 +66,6 @@ class FormSonataNativeCollectionWidgetTest extends BaseWidgetTest
 
     protected function getChoiceClass()
     {
-        return
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Sonata\AdminBundle\Form\Type\CollectionType' :
-            'sonata_type_native_collection';
+        return 'Sonata\AdminBundle\Form\Type\CollectionType';
     }
 }

--- a/tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/tests/Menu/Provider/GroupMenuProviderTest.php
@@ -105,17 +105,6 @@ class GroupMenuProviderTest extends TestCase
     }
 
     /**
-     * NEXT_MAJOR: Remove this test when bumping requirements to >=Symfony 2.6.
-     *
-     * @group legacy
-     */
-    public function testGroupMenuProviderThrowsExceptionWithInvalidArgument()
-    {
-        $this->expectException('InvalidArgumentException');
-        new GroupMenuProvider($this->factory, $this->pool, 'foo');
-    }
-
-    /**
      * @param array $adminGroups
      *
      * @dataProvider getAdminGroups

--- a/tests/Security/Handler/AclSecurityHandlerTest.php
+++ b/tests/Security/Handler/AclSecurityHandlerTest.php
@@ -19,25 +19,12 @@ class AclSecurityHandlerTest extends TestCase
 {
     public function getTokenStorageMock()
     {
-        // Set the SecurityContext for Symfony <2.6
-        // TODO: Remove conditional return when bumping requirements to SF 2.6+
-        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
-            return $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
-            $this->authorizationChecker = $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
-        }
-
-        return $this->getMockForAbstractClass('Symfony\Component\Security\Core\SecurityContextInterface');
+        return $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
     }
 
     public function getAuthorizationCheckerMock()
     {
-        // Set the SecurityContext for Symfony <2.6
-        // TODO: Remove conditional return when bumping requirements to SF 2.6+
-        if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
-            return $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
-        }
-
-        return $this->getMockForAbstractClass('Symfony\Component\Security\Core\SecurityContextInterface');
+        return $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
     }
 
     public function testAcl()

--- a/tests/Security/Handler/RoleSecurityHandlerTest.php
+++ b/tests/Security/Handler/RoleSecurityHandlerTest.php
@@ -16,7 +16,6 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Security\Handler\RoleSecurityHandler;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
  * Test for RoleSecurityHandler.
@@ -31,19 +30,13 @@ class RoleSecurityHandlerTest extends TestCase
     private $admin;
 
     /**
-     * @var AuthorizationCheckerInterface|SecurityContextInterface
+     * @var AuthorizationCheckerInterface
      */
     private $authorizationChecker;
 
     public function setUp()
     {
-        // Set the SecurityContext for Symfony <2.6
-        if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
-            $this->authorizationChecker = $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
-        } else {
-            $this->authorizationChecker = $this->getMockForAbstractClass('Symfony\Component\Security\Core\SecurityContextInterface');
-        }
-
+        $this->authorizationChecker = $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I've discovered some redundant code.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Redundant code related to old Symfony versions has been removed
```


## Subject

<!-- Describe your Pull Request content here -->
Since minimal version of Symfony is 2.8 all checks for Symfony version less than 2.8 are redundant, let's remove them.