### PR TITLE
Fixed PHPDoc

### DIFF
--- a/Filter/FilterInterface.php
+++ b/Filter/FilterInterface.php
@@ -28,7 +28,7 @@ interface FilterInterface
      * @param ProxyQueryInterface $queryBuilder
      * @param string              $alias
      * @param string              $field
-     * @param string              $value
+     * @param mixed[]             $value
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is pedantic.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

According to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/Filter/Filter.php#L31-L34, the 4th parameter is an array and no string.
