### PR TITLE
Handle empty id list in CRUDController::batchAction

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -468,7 +468,16 @@ class CRUDController extends Controller
         if (count($idx) > 0) {
             $this->admin->getModelManager()->addIdentifiersToQuery($this->admin->getClass(), $query, $idx);
         } elseif (!$allElements) {
-            $query = null;
+            $this->addFlash(
+                'sonata_flash_info',
+                $this->trans('flash_batch_no_elements_processed', [], 'SonataAdminBundle')
+            );
+
+            return new RedirectResponse(
+                $this->admin->generateUrl('list', [
+                    'filter' => $this->admin->getFilterParameters(),
+                ])
+            );
         }
 
         return call_user_func([$this, $finalAction], $query, $request);

--- a/src/Resources/translations/SonataAdminBundle.en.xliff
+++ b/src/Resources/translations/SonataAdminBundle.en.xliff
@@ -174,6 +174,10 @@
                 <source>flash_batch_delete_success</source>
                 <target>Selected items have been successfully deleted.</target>
             </trans-unit>
+            <trans-unit id="flash_batch_no_elements_processed">
+                <source>flash_batch_no_elements_processed</source>
+                <target>No elements processed.</target>
+            </trans-unit>
             <trans-unit id="flash_batch_delete_error">
                 <source>flash_batch_delete_error</source>
                 <target>An Error has occurred during selected items deletion.</target>

--- a/src/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.fr.xliff
@@ -174,6 +174,10 @@
                 <source>flash_batch_delete_success</source>
                 <target>Les éléments séléctionnés ont été supprimés avec succès.</target>
             </trans-unit>
+            <trans-unit id="flash_batch_no_elements_processed">
+                <source>flash_batch_no_elements_processed</source>
+                <target>Aucun élément traité.</target>
+            </trans-unit>
             <trans-unit id="flash_batch_delete_error">
                 <source>flash_batch_delete_error</source>
                 <target>Une erreur est intervenue lors de la suppression des éléments séléctionnés.</target>

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3647,7 +3647,7 @@ class CRUDControllerTest extends TestCase
         $result = $controller->batchAction($this->request);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $result);
-        $this->assertSame('batchActionBar executed', $result->getContent());
+        $this->assertRegExp('/Redirecting to list/', $result->getContent());
     }
 
     /**


### PR DESCRIPTION
Refs #4736

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Changed
- Handle empty id list in `CRUDController::batchAction`
```

## Subject

Allow nullable query in batchActionDelete where using preBatchAction to remove elements from list of ids to be delete by the batchActionDelete.