### PR TITLE
AbstractAdmin::hasSubject is now populating AbstractAdmin::$subject property

### DIFF
--- a/Admin/AbstractAdmin.php
+++ b/Admin/AbstractAdmin.php
@@ -1705,7 +1705,7 @@ EOT;
      */
     public function hasSubject()
     {
-        return null != $this->subject;
+        return (bool) $this->getSubject();
     }
 
     /**

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Route\DefaultRouteGenerator;
 use Sonata\AdminBundle\Route\RoutesCache;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentAdmin;
@@ -62,10 +63,12 @@ class AdminTest extends TestCase
 
     public function testGetClass()
     {
-        $class = 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post';
+        $class = Post::class;
         $baseControllerName = 'SonataNewsBundle:PostAdmin';
 
         $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
+
+        $admin->setModelManager($this->getMockForAbstractClass(ModelManagerInterface::class));
 
         $admin->setSubject(new \Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\BlogPost());
         $this->assertSame(
@@ -686,7 +689,7 @@ class AdminTest extends TestCase
     {
         $admin = new PostAdmin(
             'sonata.post.admin.post',
-            'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post',
+            Post::class,
             'SonataNewsBundle:PostAdmin'
         );
         $this->assertFalse($admin->hasSubClass('test'));
@@ -695,7 +698,7 @@ class AdminTest extends TestCase
         $this->assertNull($admin->getActiveSubClass());
         $this->assertNull($admin->getActiveSubclassCode());
         $this->assertSame(
-            'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post',
+            Post::class,
             $admin->getClass()
         );
 
@@ -745,6 +748,8 @@ class AdminTest extends TestCase
     public function testNonExistantSubclass()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin->setModelManager($this->getMockForAbstractClass(ModelManagerInterface::class));
+
         $admin->setRequest(new \Symfony\Component\HttpFoundation\Request(['subclass' => 'inject']));
 
         $admin->setSubClasses(['extended1' => 'NewsBundle\Entity\PostExtended1', 'extended2' => 'NewsBundle\Entity\PostExtended2']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4569

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `AbstractAdmin::hasSubject` is now populating `AbstractAdmin::$subject` property
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

AbstractAdmin::hasSubject is now populating AbstractAdmin::$subject property.