### PR TITLE
Fix deprecations

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -55,7 +55,8 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                 $parentDefinition = null;
 
                 // NEXT_MAJOR: Remove check for DefinitionDecorator instance when dropping Symfony <3.3 support
-                if ($definition instanceof ChildDefinition || $definition instanceof DefinitionDecorator) {
+                if ($definition instanceof ChildDefinition ||
+                    (!class_exists(ChildDefinition::class) && $definition instanceof DefinitionDecorator)) {
                     $parentDefinition = $container->getDefinition($definition->getParent());
                 }
 

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -192,7 +192,7 @@ class CRUDControllerTest extends TestCase
                             return $twigRenderer;
                         }
 
-                        throw new \Twig_Error_Runtime('This runtime exists when Symony >= 3.2.');
+                        throw new \Twig_Error_Runtime('This runtime exists when Symfony >= 3.2.');
                 }
             }));
 

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -172,7 +172,12 @@ class CRUDControllerTest extends TestCase
 
         $twigRenderer = $this->createMock('Symfony\Bridge\Twig\Form\TwigRendererInterface');
 
-        $formExtension = new FormExtension($twigRenderer);
+        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+            $formExtension = new FormExtension();
+        } else {
+            // Remove this else clause when dropping sf < 3.2
+            $formExtension = new FormExtension($twigRenderer);
+        }
 
         $twig->expects($this->any())
             ->method('getExtension')

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -278,14 +278,13 @@ class HelperControllerTest extends TestCase
             $this->createMock('Symfony\Component\Translation\TranslatorInterface')
         );
 
-        $loader = $this->createMock('\Twig_LoaderInterface');
-
         // NEXT_MAJOR: Remove this check when dropping support for twig < 2
         if (method_exists('\Twig_LoaderInterface', 'getSourceContext')) {
-            $loader->method('getSourceContext')->will($this->returnValue(new \Twig_Source('<foo />', 'foo')));
+            $loader = $this->createMock('\Twig_LoaderInterface');
         } else {
-            $loader->method('getSource')->will($this->returnValue('<foo />'));
+            $loader = $this->createMock(['\Twig_LoaderInterface', 'Twig_SourceContextLoaderInterface']);
         }
+        $loader->method('getSourceContext')->will($this->returnValue(new \Twig_Source('<foo />', 'foo')));
 
         $twig = new \Twig_Environment($loader);
         $twig->addExtension($adminExtension);

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -339,9 +339,10 @@ class HelperControllerTest extends TestCase
             ->will($this->returnValue(new Response()));
 
         $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
-        $twig->addExtension(new FormExtension($mockRenderer));
 
+        // Remove the condition when dropping sf < 3.2
         if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+            $twig->addExtension(new FormExtension());
             $runtimeLoader = $this
                 ->getMockBuilder('Twig_RuntimeLoaderInterface')
                 ->getMock();
@@ -352,6 +353,8 @@ class HelperControllerTest extends TestCase
                 ->will($this->returnValue($mockRenderer));
 
             $twig->addRuntimeLoader($runtimeLoader);
+        } else {
+            $twig->addExtension(new FormExtension($mockRenderer));
         }
 
         $request = new Request([
@@ -453,8 +456,10 @@ class HelperControllerTest extends TestCase
             ->will($this->returnValue(new Response()));
 
         $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
-        $twig->addExtension(new FormExtension($mockRenderer));
+
+        // Remove the condition when dropping sf < 3.2
         if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+            $twig->addExtension(new FormExtension());
             $runtimeLoader = $this
                 ->getMockBuilder('Twig_RuntimeLoaderInterface')
                 ->getMock();
@@ -465,6 +470,8 @@ class HelperControllerTest extends TestCase
                 ->will($this->returnValue($mockRenderer));
 
             $twig->addRuntimeLoader($runtimeLoader);
+        } else {
+            $twig->addExtension(new FormExtension($mockRenderer));
         }
 
         $pool = new Pool($container, 'title', 'logo');

--- a/Tests/Fixtures/Admin/AbstractDummyGroupedMapper.php
+++ b/Tests/Fixtures/Admin/AbstractDummyGroupedMapper.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Admin;
+
+use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
+
+abstract class AbstractDummyGroupedMapper extends BaseGroupedMapper
+{
+    protected function getName()
+    {
+        return 'dummy';
+    }
+}

--- a/Tests/Mapper/BaseGroupedMapperTest.php
+++ b/Tests/Mapper/BaseGroupedMapperTest.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Tests\Mapper;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\AbstractDummyGroupedMapper;
 
 /**
  * Test for BaseGroupedMapper.
@@ -56,7 +57,10 @@ class BaseGroupedMapperTest extends TestCase
 
         $builder = $this->getMockForAbstractClass('Sonata\AdminBundle\Builder\BuilderInterface');
 
-        $this->baseGroupedMapper = $this->getMockForAbstractClass('Sonata\AdminBundle\Mapper\BaseGroupedMapper', [$builder, $admin]);
+        $this->baseGroupedMapper = $this->getMockForAbstractClass(
+            AbstractDummyGroupedMapper::class,
+            [$builder, $admin]
+        );
 
         // php 5.3 BC
         $object = $this;


### PR DESCRIPTION
I noticed we forgot a deprecation, so Travis should be red, and I hope this shows how useful this mode can be.

~~This is pedantic because it fixes deprecations while running tests.~~ The last commit fixes a deprecation in a non-test class, so patch

## Changelog

```markdown
### Fixed
- Deprecation about `Symfony\Component\DependencyInjection\DefinitionDecorator`
```