### PR TITLE
getRuntime now receives a non deprecated runtime

### DIFF
--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -20,8 +20,11 @@ use Sonata\AdminBundle\Exception\LockException;
 use Sonata\AdminBundle\Exception\ModelManagerException;
 use Sonata\AdminBundle\Util\AdminObjectAclData;
 use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -1392,16 +1395,12 @@ class CRUDController extends Controller
     {
         $twig = $this->get('twig');
 
-        try {
-            $twig
-                ->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')
-                ->setTheme($formView, $theme);
-        } catch (\Twig_Error_Runtime $e) {
-            // BC for Symfony < 3.2 where this runtime not exists
-            $twig
-                ->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')
-                ->renderer
-                ->setTheme($formView, $theme);
+        // BC for Symfony < 3.2 where this runtime does not exists
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $twig->getExtension(FormExtension::class)->renderer->setTheme($formView, $theme);
+
+            return;
         }
+        $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
     }
 }

--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -15,7 +15,10 @@ use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Filter\FilterInterface;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -547,17 +550,17 @@ class HelperController
      */
     private function getFormRenderer()
     {
-        try {
-            $runtime = $this->twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer');
-            $runtime->setEnvironment($this->twig);
-
-            return $runtime;
-        } catch (\Twig_Error_Runtime $e) {
-            // BC for Symfony < 3.2 where this runtime not exists
-            $extension = $this->twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension');
+        // BC for Symfony < 3.2 where this runtime does not exists
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $extension = $this->twig->getExtension(FormExtension::class);
             $extension->initRuntime($this->twig);
 
             return $extension->renderer;
         }
+
+        $runtime = $this->twig->getRuntime(FormRenderer::class);
+        $runtime->setEnvironment($this->twig);
+
+        return $runtime;
     }
 }

--- a/Tests/Controller/CRUDControllerTest.php
+++ b/Tests/Controller/CRUDControllerTest.php
@@ -26,6 +26,7 @@ use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -183,7 +184,7 @@ class CRUDControllerTest extends TestCase
             ->method('getExtension')
             ->will($this->returnCallback(function ($name) use ($formExtension) {
                 switch ($name) {
-                    case 'Symfony\Bridge\Twig\Extension\FormExtension':
+                    case FormExtension::class:
                         return $formExtension;
                 }
             }));
@@ -192,12 +193,8 @@ class CRUDControllerTest extends TestCase
             ->method('getRuntime')
             ->will($this->returnCallback(function ($name) use ($twigRenderer) {
                 switch ($name) {
-                    case 'Symfony\Bridge\Twig\Form\TwigRenderer':
-                        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-                            return $twigRenderer;
-                        }
-
-                        throw new \Twig_Error_Runtime('This runtime exists when Symfony >= 3.2.');
+                    case FormRenderer::class:
+                        return $twigRenderer;
                 }
             }));
 

--- a/Tests/Controller/HelperControllerTest.php
+++ b/Tests/Controller/HelperControllerTest.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Controller\HelperController;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\ConstraintViolation;
@@ -349,7 +350,7 @@ class HelperControllerTest extends TestCase
 
             $runtimeLoader->expects($this->once())
                 ->method('load')
-                ->with($this->equalTo('Symfony\Bridge\Twig\Form\TwigRenderer'))
+                ->with($this->equalTo(FormRenderer::class))
                 ->will($this->returnValue($mockRenderer));
 
             $twig->addRuntimeLoader($runtimeLoader);
@@ -466,7 +467,7 @@ class HelperControllerTest extends TestCase
 
             $runtimeLoader->expects($this->once())
                 ->method('load')
-                ->with($this->equalTo('Symfony\Bridge\Twig\Form\TwigRenderer'))
+                ->with($this->equalTo(FormRenderer::class))
                 ->will($this->returnValue($mockRenderer));
 
             $twig->addRuntimeLoader($runtimeLoader);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- getRuntime now receives a non deprecated runtime
```

## Subject

<!-- Describe your Pull Request content here -->
Using Symfony 3.4 I found that this code does not work:

`$twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')`

I have been looking at Symfony docs and found the following:

`Symfony\Bridge\Twig\Form\TwigRenderer` is deprecated since 3.4
http://api.symfony.com/3.4/Symfony/Bridge/Twig/Form/TwigRenderer.html

And we should use `Symfony/Component/Form/FormRenderer` that is present since 2.8:
http://api.symfony.com/3.4/Symfony/Component/Form/FormRenderer.html

We probably never face an issue on this bundle because it is on a try/catch block but there are other bundles that use if/else: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/Controller/GalleryAdminController.php#L78

Also I did remove try/catch, not a good idea to rely on exceptions to make your code work.

## Stack trace

This stack trace is from SonataMediaBundle, because there we don't have the try/catch block:

```
Twig_Error_Runtime:
Unable to load the "Symfony\Bridge\Twig\Form\TwigRenderer" runtime.

  at /home/ubuntu/vendor/twig/twig/lib/Twig/Environment.php:663
  at Twig_Environment->getRuntime('Symfony\\Bridge\\Twig\\Form\\TwigRenderer')
     (/home/ubuntu/vendor/sonata-project/media-bundle/Controller/MediaAdminController.php:128)
  at Sonata\MediaBundle\Controller\MediaAdminController->setFormTheme(object(FormView), array('SonataDoctrineORMAdminBundle:Form:filter_admin_fields.html.twig'))
     (/home/ubuntu/vendor/sonata-project/media-bundle/Controller/MediaAdminController.php:100)
  at Sonata\MediaBundle\Controller\MediaAdminController->listAction(object(Request))
  at call_user_func_array(array(object(MediaAdminController), 'listAction'), array(object(Request)))
     (/home/ubuntu/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:153)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (/home/ubuntu/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:68)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (/home/ubuntu/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (web/app_dev.php:13)
```