### PR TITLE
Fix check current field sorting

### DIFF
--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -68,7 +68,7 @@ file that was distributed with this source code.
                                             {% if field_description.options.sortable is defined and field_description.options.sortable %}
                                                 {% set sortable             = true %}
                                                 {% set sort_parameters      = admin.modelmanager.sortparameters(field_description, admin.datagrid) %}
-                                                {% set current              = admin.datagrid.values._sort_by == field_description or admin.datagrid.values._sort_by.fieldName == sort_parameters.filter._sort_by %}
+                                                {% set current              = admin.datagrid.values._sort_by == field_description or admin.datagrid.values._sort_by.name == sort_parameters.filter._sort_by %}
                                                 {% set sort_active_class    = current ? 'sonata-ba-list-field-order-active' : '' %}
                                                 {% set sort_by              = current ? admin.datagrid.values._sort_order : field_description.options._sort_order %}
                                             {% endif %}


### PR DESCRIPTION
I am targeting this branch, because this is a bugfix.

## Changelog

```markdown
### Fixed 
- check if the field is used to sort the list
```

## Subject

In configure field list we can set path to sort
```php
->add('size', null, [
    'sortable' => 'recentVersion.size',              
])
```

But this field is not mark as current sorting field. 

before:
![before screenshot](https://screenshots.firefoxusercontent.com/images/a22570bb-1a4e-4b58-ad2b-3dcb94b7e8f9.png)

after:
![after screenshot](https://screenshots.firefoxusercontent.com/images/0a8670ec-8e22-484a-835c-f036b4701cae.png)
