### PR TITLE
Add support for `add` button in `sonata_type_model_autocomplete`

### DIFF
--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -63,39 +63,36 @@ class ModelAutocompleteType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['admin_code'] = $options['admin_code'];
-
-        $view->vars['placeholder'] = $options['placeholder'];
-        $view->vars['multiple'] = $options['multiple'];
-        $view->vars['minimum_input_length'] = $options['minimum_input_length'];
-        $view->vars['items_per_page'] = $options['items_per_page'];
-        $view->vars['width'] = $options['width'];
-
-        // ajax parameters
-        $view->vars['url'] = $options['url'];
-        $view->vars['route'] = $options['route'];
-        $view->vars['req_params'] = $options['req_params'];
-        $view->vars['req_param_name_search'] = $options['req_param_name_search'];
-        $view->vars['req_param_name_page_number'] = $options['req_param_name_page_number'];
-        $view->vars['req_param_name_items_per_page'] = $options['req_param_name_items_per_page'];
-        $view->vars['quiet_millis'] = $options['quiet_millis'];
-        $view->vars['cache'] = $options['cache'];
-
-        // CSS classes
-        $view->vars['container_css_class'] = $options['container_css_class'];
-        $view->vars['dropdown_css_class'] = $options['dropdown_css_class'];
-        $view->vars['dropdown_item_css_class'] = $options['dropdown_item_css_class'];
-
-        $view->vars['dropdown_auto_width'] = $options['dropdown_auto_width'];
-
-        // template
-        $view->vars['template'] = $options['template'];
-
-        $view->vars['context'] = $options['context'];
-
-        // add button
-        $view->vars['btn_add'] = $options['btn_add'];
-        $view->vars['btn_catalogue'] = $options['btn_catalogue'];
+        foreach ([
+            'admin_code',
+            'placeholder',
+            'multiple',
+            'minimum_input_length',
+            'items_per_page',
+            'width',
+            // ajax parameters
+            'url',
+            'route',
+            'req_params',
+            'req_param_name_search',
+            'req_param_name_page_number',
+            'req_param_name_items_per_page',
+            'quiet_millis',
+            'cache',
+            // CSS classes
+            'container_css_class',
+            'dropdown_css_class',
+            'dropdown_item_css_class',
+            'dropdown_auto_width',
+            // template
+            'template',
+            'context',
+            // add button
+            'btn_add',
+            'btn_catalogue',
+        ] as $passthroughOption) {
+            $view->vars[$passthroughOption] = $options[$passthroughOption];
+        }
     }
 
     /**

--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -92,6 +92,10 @@ class ModelAutocompleteType extends AbstractType
         $view->vars['template'] = $options['template'];
 
         $view->vars['context'] = $options['context'];
+
+        // add button
+        $view->vars['btn_add'] = $options['btn_add'];
+        $view->vars['btn_catalogue'] = $options['btn_catalogue'];
     }
 
     /**
@@ -131,6 +135,10 @@ class ModelAutocompleteType extends AbstractType
             'cache' => false,
 
             'to_string_callback' => null,
+
+            // add button
+            'btn_add' => 'link_add',
+            'btn_catalogue' => 'SonataAdminBundle',
 
             // ajax parameters
             'url' => '',

--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -134,7 +134,7 @@ class ModelAutocompleteType extends AbstractType
             'to_string_callback' => null,
 
             // add button
-            // NEXT_MAJOR: Set this value to true to display button by default
+            // NEXT_MAJOR: Set this value to 'link_add' to display button by default
             'btn_add' => false,
             'btn_catalogue' => 'SonataAdminBundle',
 

--- a/Form/Type/ModelAutocompleteType.php
+++ b/Form/Type/ModelAutocompleteType.php
@@ -134,7 +134,8 @@ class ModelAutocompleteType extends AbstractType
             'to_string_callback' => null,
 
             // add button
-            'btn_add' => 'link_add',
+            // NEXT_MAJOR: Set this value to true to display button by default
+            'btn_add' => false,
             'btn_catalogue' => 'SonataAdminBundle',
 
             // ajax parameters

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -312,6 +312,11 @@ template
   defaults to ``SonataAdminBundle:Form/Type:sonata_type_model_autocomplete.html.twig``.
   Use this option if you want to override the default template of this form type.
 
+btn_add and btn_catalogue:
+  The labels on the ``add`` button can be customized with these parameters.
+  Setting any of them to ``false`` will hide the corresponding button. You can also specify
+  a custom translation catalogue for these labels, which defaults to ``SonataAdminBundle``.
+
 .. code-block:: php
 
     <?php

--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -45,10 +45,10 @@ file that was distributed with this source code.
                       }}"
                 onclick="return start_field_dialog_form_add_{{ id }}(this);"
                 class="btn btn-success btn-sm sonata-ba-action"
-                title="{{ btn_add|trans({}, btn_catalogue) }}"
+                title="{{ 'link_add'|trans({}, btn_catalogue) }}"
                 >
                 <i class="fa fa-plus-circle"></i>
-                {{ btn_add|trans({}, btn_catalogue) }}
+                {{ 'link_add'|trans({}, btn_catalogue) }}
             </a>
         {% endif %}
         {% include 'SonataAdminBundle:CRUD/Association:edit_modal.html.twig' %}

--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -36,6 +36,22 @@ file that was distributed with this source code.
         {% endif -%}
     </div>
 
+    <div id="field_actions_{{ id }}" class="field-actions">
+        {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
+        {% if display_btn_add %}
+            <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
+                onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                class="btn btn-success btn-sm sonata-ba-action"
+                title="{{ btn_add|trans({}, btn_catalogue) }}"
+                >
+                <i class="fa fa-plus-circle"></i>
+                {{ btn_add|trans({}, btn_catalogue) }}
+            </a>
+        {% endif %}
+        {% include 'SonataAdminBundle:CRUD/Association:edit_modal.html.twig' %}
+        {% include 'SonataAdminBundle:CRUD/Association:edit_many_script.html.twig' %}
+    </div>
+
     <script>
         {% autoescape 'js' %}
         jQuery(function ($) {

--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -37,9 +37,12 @@ file that was distributed with this source code.
     </div>
 
     <div id="field_actions_{{ id }}" class="field-actions">
-        {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
+        {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') 
+                                 and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
         {% if display_btn_add %}
-            <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
+            <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create',
+                         sonata_admin.field_description.getOption('link_parameters', {})) 
+                      }}"
                 onclick="return start_field_dialog_form_add_{{ id }}(this);"
                 class="btn btn-success btn-sm sonata-ba-action"
                 title="{{ btn_add|trans({}, btn_catalogue) }}"

--- a/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -45,10 +45,10 @@ file that was distributed with this source code.
                       }}"
                 onclick="return start_field_dialog_form_add_{{ id }}(this);"
                 class="btn btn-success btn-sm sonata-ba-action"
-                title="{{ 'link_add'|trans({}, btn_catalogue) }}"
+                title="{{ btn_add|trans({}, btn_catalogue) }}"
                 >
                 <i class="fa fa-plus-circle"></i>
-                {{ 'link_add'|trans({}, btn_catalogue) }}
+                {{ btn_add|trans({}, btn_catalogue) }}
             </a>
         {% endif %}
         {% include 'SonataAdminBundle:CRUD/Association:edit_modal.html.twig' %}

--- a/Tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/Tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -75,7 +75,7 @@ class ModelAutocompleteTypeTest extends TypeTestCase
 
         $this->assertSame('', $options['context']);
 
-        // NEXT_MAJOR: Set this value to true
+        // NEXT_MAJOR: Set this value to 'link_add'
         $this->assertSame(false, $options['btn_add']);
         $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);
     }

--- a/Tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/Tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -74,6 +74,9 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $this->assertSame('SonataAdminBundle:Form/Type:sonata_type_model_autocomplete.html.twig', $options['template']);
 
         $this->assertSame('', $options['context']);
+
+        $this->assertSame('link_add', $options['btn_add']);
+        $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);
     }
 
     public function testGetBlockPrefix()

--- a/Tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/Tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -75,7 +75,8 @@ class ModelAutocompleteTypeTest extends TypeTestCase
 
         $this->assertSame('', $options['context']);
 
-        $this->assertSame('link_add', $options['btn_add']);
+        // NEXT_MAJOR: Set this value to true
+        $this->assertSame(false, $options['btn_add']);
         $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's the latest stable branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #2366 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
Adding the `add` functionnality to the **ModelAutocompleteType** through a `add` button which open a modal window just like **ModelType** field

This works the same way, by opening a modal window when you click on the `Add` button.
![image](https://user-images.githubusercontent.com/1230954/32608731-948736f6-c55d-11e7-98d3-4ef1c5b9790b.png)

```markdown
### Added
- Add support for `add` button in `sonata_type_model_autocomplete`
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [x] Update the documentation

## Subject

<!-- Describe your Pull Request content here -->
This pull request add the possibility to add a new record from an ModelAutocompleteType like the ModelEntityType does.

PHPUnit tests passed
Can't run PHP CS Fixer because of the [error below](https://github.com/Soullivaneuh/php-cs-fixer-styleci-bridge/issues/75)
```
PHP Fatal error:  Uncaught Error: Call to undefined method PhpCsFixer\Config::finder() in /opt/data/Eclipse/git/SonataAdminBundle/vendor/sllh/php-cs-fixer-styleci-bridge/src/ConfigBridge.php:136
```

Thanks to @npotier