### PR TITLE
Add BC layer for SF < 3.4 and > 2.8

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -21,7 +21,9 @@ use Sonata\AdminBundle\Exception\ModelManagerException;
 use Sonata\AdminBundle\Util\AdminObjectAclData;
 use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
 use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
 use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\FormRenderer;
@@ -1401,6 +1403,14 @@ class CRUDController extends Controller
 
             return;
         }
+
+        // BC for Symfony < 3.4 where runtime should be TwigRenderer
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $twig->getRuntime(TwigRenderer::class)->setTheme($formView, $theme);
+
+            return;
+        }
+
         $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
     }
 }

--- a/src/Controller/HelperController.php
+++ b/src/Controller/HelperController.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Form\TwigRenderer;
 use Symfony\Component\Form\FormRenderer;
@@ -546,7 +547,7 @@ class HelperController
     }
 
     /**
-     * @return TwigRenderer
+     * @return FormRenderer|TwigRenderer
      */
     private function getFormRenderer()
     {
@@ -556,6 +557,14 @@ class HelperController
             $extension->initRuntime($this->twig);
 
             return $extension->renderer;
+        }
+
+        // BC for Symfony < 3.4 where runtime should be TwigRenderer
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $runtime = $this->twig->getRuntime(TwigRenderer::class);
+            $runtime->setEnvironment($this->twig);
+
+            return $runtime;
         }
 
         $runtime = $this->twig->getRuntime(FormRenderer::class);

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -24,6 +24,7 @@ use Sonata\AdminBundle\Tests\Fixtures\Controller\BatchAdminController;
 use Sonata\AdminBundle\Tests\Fixtures\Controller\PreCRUDController;
 use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
 use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
 use Symfony\Component\Form\FormRenderer;
@@ -171,30 +172,23 @@ class CRUDControllerTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $twigRenderer = $this->createMock('Symfony\Bridge\Twig\Form\TwigRendererInterface');
-
-        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-            $formExtension = new FormExtension();
-        } else {
-            // Remove this else clause when dropping sf < 3.2
-            $formExtension = new FormExtension($twigRenderer);
-        }
-
         $twig->expects($this->any())
             ->method('getExtension')
-            ->will($this->returnCallback(function ($name) use ($formExtension) {
+            ->will($this->returnCallback(function ($name) {
                 switch ($name) {
                     case FormExtension::class:
-                        return $formExtension;
+                        return new FormExtension($this->createMock(TwigRenderer::class));
                 }
             }));
 
         $twig->expects($this->any())
             ->method('getRuntime')
-            ->will($this->returnCallback(function ($name) use ($twigRenderer) {
+            ->will($this->returnCallback(function ($name) {
                 switch ($name) {
+                    case TwigRenderer::class:
+                        return $this->createMock(TwigRenderer::class);
                     case FormRenderer::class:
-                        return $twigRenderer;
+                        return $this->createMock(FormRenderer::class);
                 }
             }));
 

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -19,6 +19,8 @@ use Sonata\AdminBundle\Controller\HelperController;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\Command\DebugCommand;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -348,10 +350,18 @@ class HelperControllerTest extends TestCase
                 ->getMockBuilder('Twig_RuntimeLoaderInterface')
                 ->getMock();
 
-            $runtimeLoader->expects($this->once())
-                ->method('load')
-                ->with($this->equalTo(FormRenderer::class))
-                ->will($this->returnValue($mockRenderer));
+            // Remove the condition when dropping sf < 3.4
+            if (!class_exists(DebugCommand::class)) {
+                $runtimeLoader->expects($this->once())
+                    ->method('load')
+                    ->with($this->equalTo(TwigRenderer::class))
+                    ->will($this->returnValue($mockRenderer));
+            } else {
+                $runtimeLoader->expects($this->once())
+                    ->method('load')
+                    ->with($this->equalTo(FormRenderer::class))
+                    ->will($this->returnValue($mockRenderer));
+            }
 
             $twig->addRuntimeLoader($runtimeLoader);
         } else {
@@ -465,10 +475,18 @@ class HelperControllerTest extends TestCase
                 ->getMockBuilder('Twig_RuntimeLoaderInterface')
                 ->getMock();
 
-            $runtimeLoader->expects($this->once())
-                ->method('load')
-                ->with($this->equalTo(FormRenderer::class))
-                ->will($this->returnValue($mockRenderer));
+            // Remove the condition when dropping sf < 3.4
+            if (!class_exists(DebugCommand::class)) {
+                $runtimeLoader->expects($this->once())
+                    ->method('load')
+                    ->with($this->equalTo(TwigRenderer::class))
+                    ->will($this->returnValue($mockRenderer));
+            } else {
+                $runtimeLoader->expects($this->once())
+                    ->method('load')
+                    ->with($this->equalTo(FormRenderer::class))
+                    ->will($this->returnValue($mockRenderer));
+            }
 
             $twig->addRuntimeLoader($runtimeLoader);
         } else {


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4758

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix for getRuntime on Symfony older than 3.4
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

<!-- Describe your Pull Request content here -->
TwigRenderer is used as runtime until SF 3.4.
This code makes sure we retrieve the correct runtime for SF < 3.4

This should fix the issue, can you check it @0l1v3r5?
I don't know if this is the best way to do it @xabbuh or there is other work-around for this issue