### PR TITLE
Display title when it is set

### DIFF
--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -259,7 +259,11 @@ file that was distributed with this source code.
 
                         {% block sonata_page_content_header %}
                             {% block sonata_page_content_nav %}
-                                {% if _tab_menu is not empty or _actions is not empty or _list_filters_actions is not empty %}
+                                {% if _navbar_title is not empty
+                                  or _tab_menu is not empty
+                                  or _actions is not empty
+                                  or _list_filters_actions is not empty
+                                 %}
                                     <nav class="navbar navbar-default" role="navigation">
                                         <div class="container-fluid">
                                             {% block tab_menu_navbar_header %}


### PR DESCRIPTION
This is a patch that displays a title if there are no actions set

I am targeting this branch, because this is a bugfix.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- a condition to check if the navbar is to be displayed
### Fixed
- displaying a title when there are no specific actions
```

## Subject

The navbar does not show up when no action is set.
