### PR TITLE
Refactor render to renderWithExtraParams

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -62,9 +62,9 @@ class CRUDController extends Controller
     }
 
     /**
-     * {@inheritdoc}
+     * Adds mandatory parameters before calling render().
      */
-    public function render($view, array $parameters = [], Response $response = null)
+    public function renderWithExtraParams($view, array $parameters = [], Response $response = null)
     {
         if (!$this->isXmlHttpRequest()) {
             $parameters['breadcrumbs_builder'] = $this->get('sonata.admin.breadcrumbs_builder');
@@ -79,7 +79,7 @@ class CRUDController extends Controller
 
         $parameters['admin_pool'] = $this->get('sonata.admin.pool');
 
-        return parent::render($view, $parameters, $response);
+        return $this->render($view, $parameters, $response);
     }
 
     /**
@@ -110,7 +110,7 @@ class CRUDController extends Controller
         // set the theme for the current Admin Form
         $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-        return $this->render($this->admin->getTemplate('list'), [
+        return $this->renderWithExtraParams($this->admin->getTemplate('list'), [
             'action' => 'list',
             'form' => $formView,
             'datagrid' => $datagrid,
@@ -224,7 +224,7 @@ class CRUDController extends Controller
             return $this->redirectTo($object);
         }
 
-        return $this->render($this->admin->getTemplate('delete'), [
+        return $this->renderWithExtraParams($this->admin->getTemplate('delete'), [
             'object' => $object,
             'action' => 'delete',
             'csrf_token' => $this->getCsrfToken('sonata.delete'),
@@ -339,7 +339,7 @@ class CRUDController extends Controller
         // set the theme for the current Admin Form
         $this->setFormTheme($formView, $this->admin->getFormTheme());
 
-        return $this->render($this->admin->getTemplate($templateKey), [
+        return $this->renderWithExtraParams($this->admin->getTemplate($templateKey), [
             'action' => 'edit',
             'form' => $formView,
             'object' => $existingObject,
@@ -443,7 +443,7 @@ class CRUDController extends Controller
             $formView = $datagrid->getForm()->createView();
             $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-            return $this->render($this->admin->getTemplate('batch_confirmation'), [
+            return $this->renderWithExtraParams($this->admin->getTemplate('batch_confirmation'), [
                 'action' => 'list',
                 'action_label' => $actionLabel,
                 'batch_translation_domain' => $batchTranslationDomain,
@@ -494,7 +494,7 @@ class CRUDController extends Controller
         $class = new \ReflectionClass($this->admin->hasActiveSubClass() ? $this->admin->getActiveSubClass() : $this->admin->getClass());
 
         if ($class->isAbstract()) {
-            return $this->render(
+            return $this->renderWithExtraParams(
                 'SonataAdminBundle:CRUD:select_subclass.html.twig',
                 [
                     'base_template' => $this->getBaseTemplate(),
@@ -584,7 +584,7 @@ class CRUDController extends Controller
         // set the theme for the current Admin Form
         $this->setFormTheme($formView, $this->admin->getFormTheme());
 
-        return $this->render($this->admin->getTemplate($templateKey), [
+        return $this->renderWithExtraParams($this->admin->getTemplate($templateKey), [
             'action' => 'create',
             'form' => $formView,
             'object' => $newObject,
@@ -622,7 +622,7 @@ class CRUDController extends Controller
 
         $this->admin->setSubject($object);
 
-        return $this->render($this->admin->getTemplate('show'), [
+        return $this->renderWithExtraParams($this->admin->getTemplate('show'), [
             'action' => 'show',
             'object' => $object,
             'elements' => $this->admin->getShow(),
@@ -667,7 +667,7 @@ class CRUDController extends Controller
 
         $revisions = $reader->findRevisions($this->admin->getClass(), $id);
 
-        return $this->render($this->admin->getTemplate('history'), [
+        return $this->renderWithExtraParams($this->admin->getTemplate('history'), [
             'action' => 'history',
             'object' => $object,
             'revisions' => $revisions,
@@ -728,7 +728,7 @@ class CRUDController extends Controller
 
         $this->admin->setSubject($object);
 
-        return $this->render($this->admin->getTemplate('show'), [
+        return $this->renderWithExtraParams($this->admin->getTemplate('show'), [
             'action' => 'show',
             'object' => $object,
             'elements' => $this->admin->getShow(),
@@ -802,7 +802,7 @@ class CRUDController extends Controller
 
         $this->admin->setSubject($base_object);
 
-        return $this->render($this->admin->getTemplate('show_compare'), [
+        return $this->renderWithExtraParams($this->admin->getTemplate('show_compare'), [
             'action' => 'show',
             'object' => $base_object,
             'object_compare' => $compare_object,
@@ -936,7 +936,7 @@ class CRUDController extends Controller
             }
         }
 
-        return $this->render($this->admin->getTemplate('acl'), [
+        return $this->renderWithExtraParams($this->admin->getTemplate('acl'), [
             'action' => 'acl',
             'permissions' => $adminObjectAclData->getUserPermissions(),
             'object' => $object,

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -501,8 +501,7 @@ class CRUDController extends Controller
                     'admin' => $this->admin,
                     'action' => 'create',
                 ],
-                null,
-                $request
+                null
             );
         }
 

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -587,7 +587,7 @@ class CRUDControllerTest extends TestCase
         $this->parameters = [];
         $this->assertInstanceOf(
             'Symfony\Component\HttpFoundation\Response',
-            $this->controller->render('FooAdminBundle::foo.html.twig', [], null, $this->request)
+            $this->controller->renderWithExtraParams('FooAdminBundle::foo.html.twig', [], null, $this->request)
         );
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -600,7 +600,7 @@ class CRUDControllerTest extends TestCase
         $this->parameters = [];
         $response = $response = new Response();
         $response->headers->set('X-foo', 'bar');
-        $responseResult = $this->controller->render('FooAdminBundle::foo.html.twig', [], $response, $this->request);
+        $responseResult = $this->controller->renderWithExtraParams('FooAdminBundle::foo.html.twig', [], $response, $this->request);
 
         $this->assertSame($response, $responseResult);
         $this->assertSame('bar', $responseResult->headers->get('X-foo'));
@@ -615,7 +615,7 @@ class CRUDControllerTest extends TestCase
         $this->parameters = [];
         $this->assertInstanceOf(
             'Symfony\Component\HttpFoundation\Response',
-            $this->controller->render('FooAdminBundle::foo.html.twig',
+            $this->controller->renderWithExtraParams('FooAdminBundle::foo.html.twig',
             ['foo' => 'bar'], null, $this->request)
         );
         $this->assertSame($this->admin, $this->parameters['admin']);
@@ -629,7 +629,15 @@ class CRUDControllerTest extends TestCase
     {
         $this->parameters = [];
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->render('FooAdminBundle::foo.html.twig', ['foo' => 'bar'], null, $this->request));
+        $this->assertInstanceOf(
+            'Symfony\Component\HttpFoundation\Response',
+            $this->controller->renderWithExtraParams(
+                'FooAdminBundle::foo.html.twig',
+                ['foo' => 'bar'],
+                null,
+                $this->request
+            )
+        );
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::ajax_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -587,7 +587,7 @@ class CRUDControllerTest extends TestCase
         $this->parameters = [];
         $this->assertInstanceOf(
             'Symfony\Component\HttpFoundation\Response',
-            $this->controller->renderWithExtraParams('FooAdminBundle::foo.html.twig', [], null, $this->request)
+            $this->controller->renderWithExtraParams('FooAdminBundle::foo.html.twig', [], null)
         );
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -600,7 +600,7 @@ class CRUDControllerTest extends TestCase
         $this->parameters = [];
         $response = $response = new Response();
         $response->headers->set('X-foo', 'bar');
-        $responseResult = $this->controller->renderWithExtraParams('FooAdminBundle::foo.html.twig', [], $response, $this->request);
+        $responseResult = $this->controller->renderWithExtraParams('FooAdminBundle::foo.html.twig', [], $response);
 
         $this->assertSame($response, $responseResult);
         $this->assertSame('bar', $responseResult->headers->get('X-foo'));
@@ -615,8 +615,11 @@ class CRUDControllerTest extends TestCase
         $this->parameters = [];
         $this->assertInstanceOf(
             'Symfony\Component\HttpFoundation\Response',
-            $this->controller->renderWithExtraParams('FooAdminBundle::foo.html.twig',
-            ['foo' => 'bar'], null, $this->request)
+            $this->controller->renderWithExtraParams(
+                'FooAdminBundle::foo.html.twig',
+                ['foo' => 'bar'],
+                null
+            )
         );
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -634,8 +637,7 @@ class CRUDControllerTest extends TestCase
             $this->controller->renderWithExtraParams(
                 'FooAdminBundle::foo.html.twig',
                 ['foo' => 'bar'],
-                null,
-                $this->request
+                null
             )
         );
         $this->assertSame($this->admin, $this->parameters['admin']);

--- a/tests/Controller/CoreControllerTest.php
+++ b/tests/Controller/CoreControllerTest.php
@@ -26,6 +26,7 @@ class CoreControllerTest extends TestCase
         $pool = new Pool($container, 'title', 'logo.png');
         $pool->setTemplates([
             'ajax' => 'ajax.html',
+            'dashboard' => 'dashboard.html',
         ]);
 
         $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
@@ -89,6 +90,7 @@ class CoreControllerTest extends TestCase
         $pool = new Pool($container, 'title', 'logo.png');
         $pool->setTemplates([
             'ajax' => 'ajax.html',
+            'dashboard' => 'dashboard.html',
         ]);
 
         $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');


### PR DESCRIPTION
`render()` is annotated with `@final` since 3.4, and its signature changes in 4.0. Since we do not need to override it, let's not do that. Fixes #4701

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

I am targeting this branch, because this is BC (removing a method that also exists in the parent is BC).


## Changelog
<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- deprecation about `Controller::render` being final
```
