### PR TITLE
add btn_edit option to ModelListType

### DIFF
--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -119,6 +119,55 @@ The available options are:
     (``sonata-admin-setup-list-modal`` by default and
     ``sonata-admin-append-form-element`` when using ``edit:inline``).
 
+``Sonata\AdminBundle\Form\Type\ModelListType``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This type allows you to choose an existing entity,
+add a new one or edit the one that is already selected.
+
+For example, we have an entity class called ``Page`` which has a field called
+``image1`` which maps a relationship to another entity class called ``Image``.
+All we need to do now is add a reference for this field in our ``PageAdmin`` class:
+
+.. code-block:: php
+
+    <?php
+    // src/AppBundle/Admin/PageAdmin.php
+
+    use Sonata\AdminBundle\Form\Type\ModelListType;
+    use Sonata\AdminBundle\Form\FormMapper;
+
+    class PageAdmin extends AbstractAdmin
+    {
+        protected function configureFormFields(FormMapper $formMapper)
+        {
+            $formMapper
+                ->add('image1', ModelListType::class)
+            ;
+        }
+    }
+
+The available options are:
+
+``model_manager``
+  defaults to ``null``, but is actually calculated from the linked admin class.
+  You usually should not need to set this manually.
+
+``class``
+  The entity class managed by this field. Defaults to ``null``, but is actually
+  calculated from the linked admin class. You usually should not need to set
+  this manually.
+
+``btn_add``, ``btn_edit``, ``btn_list``, ``btn_delete`` and ``btn_catalogue``:
+  The labels on the ``add``, ``edit``, ``list`` and ``delete`` buttons can be customized
+  with these parameters. Setting any of them to ``false`` will hide the
+  corresponding button. You can also specify a custom translation catalogue
+  for these labels, which defaults to ``SonataAdminBundle``.
+
+.. note::
+
+    For more info, see the storage-engine-specific form field definitions: `ORM`_, `PHPCR`_, `MongoDB`_
+
 ``Sonata\AdminBundle\Form\Type\ModelHiddenType``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The value of hidden field is identifier of related entity.
@@ -806,3 +855,6 @@ General
 .. _`Symfony choice Field Type docs`: http://symfony.com/doc/current/reference/forms/types/choice.html
 .. _`Symfony PropertyPath`: http://api.symfony.com/2.0/Symfony/Component/Form/Util/PropertyPath.html
 .. _`Getting started documentation`: https://sonata-project.org/bundles/admin/master/doc/reference/getting_started.html#importing-it-in-the-main-config-yml
+.. _`ORM`: https://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/form_field_definition.html
+.. _`PHPCR`: https://sonata-project.org/bundles/doctrine-phpcr-admin/master/doc/reference/form_field_definition.html
+.. _`MongoDB`: https://sonata-project.org/bundles/mongo-admin/master/doc/reference/form_field_definition.html

--- a/src/Form/Type/ModelListType.php
+++ b/src/Form/Type/ModelListType.php
@@ -62,6 +62,7 @@ class ModelListType extends AbstractType
             $view->vars['sonata_admin']['edit'] = 'list';
         }
         $view->vars['btn_add'] = $options['btn_add'];
+        $view->vars['btn_edit'] = $options['btn_edit'];
         $view->vars['btn_list'] = $options['btn_list'];
         $view->vars['btn_delete'] = $options['btn_delete'];
         $view->vars['btn_catalogue'] = $options['btn_catalogue'];
@@ -86,6 +87,7 @@ class ModelListType extends AbstractType
             'model_manager' => null,
             'class' => null,
             'btn_add' => 'link_add',
+            'btn_edit' => 'link_edit',
             'btn_list' => 'link_list',
             'btn_delete' => 'link_delete',
             'btn_catalogue' => 'SonataAdminBundle',

--- a/src/Resources/translations/SonataAdminBundle.de.xliff
+++ b/src/Resources/translations/SonataAdminBundle.de.xliff
@@ -74,6 +74,10 @@
                 <source>link_add</source>
                 <target>Neu</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Bearbeiten</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Liste</target>

--- a/src/Resources/translations/SonataAdminBundle.en.xliff
+++ b/src/Resources/translations/SonataAdminBundle.en.xliff
@@ -74,6 +74,10 @@
                 <source>link_add</source>
                 <target>Add new</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Edit</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>List</target>

--- a/src/Resources/translations/SonataAdminBundle.es.xliff
+++ b/src/Resources/translations/SonataAdminBundle.es.xliff
@@ -74,6 +74,10 @@
                 <source>link_add</source>
                 <target>Agregar nuevo</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Editar</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Listar</target>

--- a/src/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.fr.xliff
@@ -74,6 +74,10 @@
                 <source>link_add</source>
                 <target>Ajouter</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Modifier</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Liste</target>

--- a/tests/Form/Type/ModelTypeListTest.php
+++ b/tests/Form/Type/ModelTypeListTest.php
@@ -39,6 +39,7 @@ class ModelTypeListTest extends TypeTestCase
         $this->assertNull($options['model_manager']);
         $this->assertNull($options['class']);
         $this->assertSame('link_add', $options['btn_add']);
+        $this->assertSame('link_edit', $options['btn_edit']);
         $this->assertSame('link_list', $options['btn_list']);
         $this->assertSame('link_delete', $options['btn_delete']);
         $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am adding `btn_edit` option to ModelListType that is needed for https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/708

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added edit button that opens in dialog instead of add if there is object already in sonata type model list
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [x] Update the documentation

## Subject

Currently we have only add button on ModelListType that replaces the object/value, this will add edit button that would open current object in a dialog and allow edit instead of replacing.
