### PR TITLE
Restore backwards-compatibility for render calls

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated CRUDController::render()
+
+Call `CRUDController::renderWithExtraParams()` instead.
+
 UPGRADE FROM 3.23 to 3.24
 =========================
 

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "sensio/generator-bundle": "^3.1",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/intl-bundle": "^2.2.4",
-        "symfony/phpunit-bridge": "^3.3",
+        "symfony/phpunit-bridge": "^3.3.12",
         "symfony/yaml": "^2.8 || ^3.2"
     },
     "conflict": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,10 @@
         </testsuite>
     </testsuites>
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
     <filter>
         <whitelist>
             <directory suffix=".php">./src/</directory>

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -61,6 +61,29 @@ class CRUDController extends Controller
         $this->configure();
     }
 
+    public function __call($method, $arguments)
+    {
+        if ('render' === $method) {
+            if (count($arguments) < 1) {
+                throw new \LogicException(sprintf(
+                    '%s::%s requires at least one argument',
+                    __CLASS__,
+                    $method
+                ));
+            }
+            @trigger_error(sprintf(
+                'Calling "%s::render" is deprecated since 3.x and will no longer work as expected in 4.0.'.
+                ' Call "%s::renderWithExtraParams" instead.',
+                __CLASS__,
+                __CLASS__
+            ), E_USER_DEPRECATED);
+            $arguments += [null, [], null];
+            return $this->renderWithExtraParams($arguments[0], $arguments[1], $arguments[2]);
+        }
+
+        throw new \LogicException(sprintf('Call to undefined method %s::%s', __CLASS__, $method));
+    }
+
     /**
      * Adds mandatory parameters before calling render().
      */
@@ -456,7 +479,7 @@ class CRUDController extends Controller
 
         // execute the action, batchActionXxxxx
         $finalAction = sprintf('batchAction%s', $camelizedAction);
-        if (!is_callable([$this, $finalAction])) {
+        if (!method_exists($this, $finalAction)) {
             throw new \RuntimeException(sprintf('A `%s::%s` method must be callable', get_class($this), $finalAction));
         }
 

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3713,6 +3713,32 @@ class CRUDControllerTest extends TestCase
         $this->assertSame('bar', $this->request->request->get('foo'));
     }
 
+    public function testItThrowsWhenCallingAnUndefinedMethod()
+    {
+        $this->setExpectedException(
+            \LogicException::class,
+            'Call to undefined method Sonata\AdminBundle\Controller\CRUDController::doesNotExist'
+        );
+        $this->controller->doesNotExist();
+    }
+
+    public function testItThrowsOnMissingRenderParameter()
+    {
+        $this->setExpectedException(
+            \LogicException::class,
+            'Sonata\AdminBundle\Controller\CRUDController::render requires at least one argument'
+        );
+        $this->controller->render();
+    }
+
+    /**
+     * @expectedDeprecation Calling "Sonata\AdminBundle\Controller\CRUDController::render" is deprecated since 3.x and will no longer work as expected in 4.0. Call "Sonata\AdminBundle\Controller\CRUDController::renderWithExtraParams" instead.
+     */
+    public function testRenderIsDeprecated()
+    {
+        $this->controller->render('toto.html.twig');
+    }
+
     public function getCsrfProvider()
     {
         return $this->csrfProvider;

--- a/tests/Form/DataTransformer/ModelsToArrayTransformerLegacyTest.php
+++ b/tests/Form/DataTransformer/ModelsToArrayTransformerLegacyTest.php
@@ -19,7 +19,7 @@ use Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity;
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class LegacyModelsToArrayTransformerTest extends TestCase
+class ModelsToArrayTransformerLegacyTest extends TestCase
 {
     private $choiceList;
     private $modelManager;


### PR DESCRIPTION
I am targeting this branch, because this is BC.

Close https://github.com/sonata-project/SonataPageBundle/issues/910
## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Calling CRUDController::render

### Fixed
- BC-break in `render` behavior
```

## To do


- [x] test the deprecation
- [x] Add an upgrade note
