### PR TITLE
Fix autocomplete form type in filter (issue #4771)

### DIFF
--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -37,24 +37,26 @@ file that was distributed with this source code.
         {% endif -%}
     </div>
 
-    <div id="field_actions_{{ id }}" class="field-actions">
-        {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') 
-                                 and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
-        {% if display_btn_add %}
-            <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create',
-                         sonata_admin.field_description.getOption('link_parameters', {})) 
-                      }}"
-                onclick="return start_field_dialog_form_add_{{ id }}(this);"
-                class="btn btn-success btn-sm sonata-ba-action"
-                title="{{ btn_add|trans({}, btn_catalogue) }}"
-                >
-                <i class="fa fa-plus-circle"></i>
-                {{ btn_add|trans({}, btn_catalogue) }}
-            </a>
-        {% endif %}
-        {% include 'SonataAdminBundle:CRUD/Association:edit_modal.html.twig' %}
-        {% include 'SonataAdminBundle:CRUD/Association:edit_many_script.html.twig' %}
-    </div>
+    {% if sonata_admin.field_description.associationadmin is defined %}
+        <div id="field_actions_{{ id }}" class="field-actions">
+            {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') 
+                                     and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
+            {% if display_btn_add %}
+                <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create',
+                             sonata_admin.field_description.getOption('link_parameters', {})) 
+                          }}"
+                    onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                    class="btn btn-success btn-sm sonata-ba-action"
+                    title="{{ btn_add|trans({}, btn_catalogue) }}"
+                    >
+                    <i class="fa fa-plus-circle"></i>
+                    {{ btn_add|trans({}, btn_catalogue) }}
+                </a>
+            {% endif %}
+            {% include 'SonataAdminBundle:CRUD/Association:edit_modal.html.twig' %}
+            {% include 'SonataAdminBundle:CRUD/Association:edit_many_script.html.twig' %}
+        </div>
+    {% endif %}
 
     <script>
         {% autoescape 'js' %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's the one with the bug.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

This PR fixes the #4771 issue.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Add a check for existing var associationadmin which is null for filter

