### PR TITLE
Update docs about form types

### DIFF
--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -4,18 +4,17 @@ Form Types
 Admin related form types
 ------------------------
 
-When defining fields in your Admin classes you can use any of the standard
+When defining fields in your admin classes you can use any of the standard
 `Symfony field types`_ and configure them as you would normally. In addition
 there are some special Sonata field types which allow you to work with
 relationships between one entity class and another.
 
 .. _field-types-model:
 
-sonata_type_model
-^^^^^^^^^^^^^^^^^
+``Sonata\AdminBundle\Form\Type\ModelType``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Setting a field type of ``sonata_type_model`` will use an instance of
-``ModelType`` to render that field. This Type allows you to choose an existing
+This type allows you to choose an existing
 entity from the linked model class. In effect it shows a list of options from
 which you can choose a value (or values).
 
@@ -28,6 +27,10 @@ All we need to do now is add a reference for this field in our ``PageAdmin`` cla
     <?php
     // src/AppBundle/Admin/PageAdmin.php
 
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Form\Type\ModelType;
+
     class PageAdmin extends AbstractAdmin
     {
         protected function configureFormFields(FormMapper $formMapper)
@@ -35,7 +38,7 @@ All we need to do now is add a reference for this field in our ``PageAdmin`` cla
             $imageFieldOptions = array(); // see available options below
 
             $formMapper
-                ->add('image1', 'sonata_type_model', $imageFieldOptions)
+                ->add('image1', ModelType::class, $imageFieldOptions)
             ;
         }
     }
@@ -56,46 +59,46 @@ to display as choices in the selector.
 
 The available options are:
 
-property
-  defaults to null. You can set this to a `Symfony PropertyPath`_ compatible
+``property``
+  defaults to ``null``. You can set this to a `Symfony PropertyPath`_ compatible
   string to designate which field to use for the choice values.
 
-query
-  defaults to null. You can set this to a QueryBuilder instance in order to
+``query``
+  defaults to ``null``. You can set this to a QueryBuilder instance in order to
   define a custom query for retrieving the available options.
 
-template
+``template``
   defaults to 'choice' (not currently used?)
 
-multiple
-  defaults to false - see the `Symfony choice Field Type docs`_ for more info
+``multiple``
+  defaults to ``false`` - see the `Symfony choice Field Type docs`_ for more info
 
-expanded
-  defaults to false - see the `Symfony choice Field Type docs`_ for more info
+``expanded``
+  defaults to ``false`` - see the `Symfony choice Field Type docs`_ for more info
 
-choices
-  defaults to null - see the `Symfony choice Field Type docs`_ for more info
+``choices``
+  defaults to ``null`` - see the `Symfony choice Field Type docs`_ for more info
 
-preferred_choices
+``preferred_choices``
   defaults to array() - see the `Symfony choice Field Type docs`_ for more info
 
-choice_list
+``choice_list``
   **(deprecated in favor of choice_loader since Symfony 2.7)**
   defaults to a ``ModelChoiceList`` built from the other options
 
-choice_loader
+``choice_loader``
   defaults to a ``ModelChoiceLoader`` built from the other options
 
-model_manager
-  defaults to null, but is actually calculated from the linked Admin class.
+``model_manager``
+  defaults to ``null``, but is actually calculated from the linked admin class.
   You usually should not need to set this manually.
 
-class
-  The entity class managed by this field. Defaults to null, but is actually
-  calculated from the linked Admin class. You usually should not need to set
+``class``
+  The entity class managed by this field. Defaults to ``null``, but is actually
+  calculated from the linked admin class. You usually should not need to set
   this manually.
 
-btn_add, btn_list, btn_delete and btn_catalogue:
+``btn_add``, ``btn_list``, ``btn_delete`` and ``btn_catalogue``:
   The labels on the ``add``, ``list`` and ``delete`` buttons can be customized
   with these parameters. Setting any of them to ``false`` will hide the
   corresponding button. You can also specify a custom translation catalogue
@@ -107,25 +110,27 @@ btn_add, btn_list, btn_delete and btn_catalogue:
 
 .. note::
 
-    If you need to use a sortable ``sonata_type_model`` check the :doc:`../cookbook/recipe_sortable_sonata_type_model` page.
+    If you need to use a sortable ``Sonata\AdminBundle\Form\Type\ModelType`` check the :doc:`../cookbook/recipe_sortable_sonata_type_model` page.
 
 .. note::
 
-    When using ``sonata_type_model`` with ``btn_add``, a jQuery event will be
+    When using ``Sonata\AdminBundle\Form\Type\ModelType`` with ``btn_add``, a jQuery event will be
     triggered when a child form is added to the DOM
     (``sonata-admin-setup-list-modal`` by default and
     ``sonata-admin-append-form-element`` when using ``edit:inline``).
 
-sonata_type_model_hidden
-^^^^^^^^^^^^^^^^^^^^^^^^
-Setting a field type of ``sonata_type_model_hidden`` will use an instance of
-``ModelHiddenType`` to render hidden field. The value of hidden field is
-identifier of related entity.
+``Sonata\AdminBundle\Form\Type\ModelHiddenType``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The value of hidden field is identifier of related entity.
 
 .. code-block:: php
 
     <?php
     // src/AppBundle/Admin/PageAdmin.php
+
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Form\Type\ModelHiddenType;
 
     class PageAdmin extends AbstractAdmin
     {
@@ -133,31 +138,29 @@ identifier of related entity.
         {
             // generates hidden form field with id of related Category entity
             $formMapper
-                ->add('categoryId', 'sonata_type_model_hidden')
+                ->add('categoryId', ModelHiddenType::class)
             ;
         }
     }
 
 The available options are:
 
-model_manager
-  defaults to null, but is actually calculated from the linked Admin class.
+``model_manager``
+  defaults to ``null``, but is actually calculated from the linked admin class.
   You usually should not need to set this manually.
 
-class
-  The entity class managed by this field. Defaults to null, but is actually
-  calculated from the linked Admin class. You usually should not need to set
+``class``
+  The entity class managed by this field. Defaults to ``null``, but is actually
+  calculated from the linked admin class. You usually should not need to set
   this manually.
 
-sonata_type_model_autocomplete
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``Sonata\AdminBundle\Form\Type\ModelAutocompleteType``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Setting a field type of ``sonata_type_model_autocomplete`` will use an instance of
-``ModelAutocompleteType`` to render that field. This Type allows you to choose an existing
-entity from the linked model class. In effect it shows a list of options from
-which you can choose a value. The list of options is loaded dynamically
-with ajax after typing 3 chars (autocomplete). It is best for entities with many
-items.
+This type allows you to choose an existing entity from the linked model class.
+In effect it shows a list of options from which you can choose a value.
+The list of options is loaded dynamically with ajax after typing 3 chars (autocomplete).
+It is best for entities with many items.
 
 This field type works by default if the related entity has an admin instance and
 in the related entity datagrid is a string filter on the ``property`` field.
@@ -165,13 +168,17 @@ in the related entity datagrid is a string filter on the ``property`` field.
 For example, we have an entity class called ``Article`` (in the ``ArticleAdmin``)
 which has a field called ``category`` which maps a relationship to another entity
 class called ``Category``. All we need to do now is add a reference for this field
-in our ``ArticleAdmin`` class and make sure, that in the CategoryAdmin exists
+in our ``ArticleAdmin`` class and make sure, that in the ``CategoryAdmin`` exists
 datagrid filter for the property ``title``.
 
 .. code-block:: php
 
     <?php
     // src/AppBundle/Admin/ArticleAdmin.php
+
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 
     class ArticleAdmin extends AbstractAdmin
     {
@@ -180,7 +187,7 @@ datagrid filter for the property ``title``.
             // the dropdown autocomplete list will show only Category
             // entities that contain specified text in "title" attribute
             $formMapper
-                ->add('category', 'sonata_type_model_autocomplete', array(
+                ->add('category', ModelAutocompleteType::class, array(
                     'property' => 'title'
                 ))
             ;
@@ -191,6 +198,9 @@ datagrid filter for the property ``title``.
 
     <?php
     // src/AppBundle/Admin/CategoryAdmin.php
+
+    use Sonata\AdminBundle\Datagrid\DatagridMapper;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
 
     class CategoryAdmin extends AbstractAdmin
     {
@@ -205,22 +215,22 @@ datagrid filter for the property ``title``.
 
 The available options are:
 
-property
-  defaults to null. You have to set this to designate which field (or a list of fields) to use for the choice values.
+``property``
+  defaults to ``null``. You have to set this to designate which field (or a list of fields) to use for the choice values.
   This value can be string or array of strings.
 
-class
-  The entity class managed by this field. Defaults to null, but is actually
-  calculated from the linked Admin class. You usually should not need to set
+``class``
+  The entity class managed by this field. Defaults to ``null``, but is actually
+  calculated from the linked admin class. You usually should not need to set
   this manually.
 
-model_manager
-  defaults to null, but is actually calculated from the linked Admin class.
+``model_manager``
+  defaults to ``null``, but is actually calculated from the linked admin class.
   You usually should not need to set this manually.
 
-callback
-  defaults to null. Callable function that can be used to modify the query which is used to retrieve autocomplete items.
-  The callback should receive three parameters - the Admin instance, the property (or properties) defined as searchable and the
+``callback``
+  defaults to ``null``. Callable function that can be used to modify the query which is used to retrieve autocomplete items.
+  The callback should receive three parameters - the admin instance, the property (or properties) defined as searchable and the
   search value entered by the user.
 
   From the ``$admin`` parameter it is possible to get the ``Datagrid`` and the ``Request``:
@@ -228,7 +238,7 @@ callback
 .. code-block:: php
 
     $formMapper
-        ->add('category', 'sonata_type_model_autocomplete', array(
+        ->add('category', ModelAutocompleteType::class, array(
             'property' => 'title',
             'callback' => function ($admin, $property, $value) {
                 $datagrid = $admin->getDatagrid();
@@ -242,13 +252,13 @@ callback
         ))
     ;
 
-to_string_callback
-  defaults to null. Callable function that can be used to change the default toString behaviour of entity.
+``to_string_callback``
+  defaults to ``null``. Callable function that can be used to change the default toString behaviour of entity.
 
 .. code-block:: php
 
     $formMapper
-        ->add('category', 'sonata_type_model_autocomplete', array(
+        ->add('category', ModelAutocompleteType::class, array(
             'property' => 'title',
             'to_string_callback' => function($entity, $property) {
                 return $entity->getTitle();
@@ -256,63 +266,63 @@ to_string_callback
         ))
     ;
 
-multiple
-  defaults to false. Set to true, if your field is in a many-to-many relation.
+``multiple``
+  defaults to ``false``. Set to ``true``, if your field is in a many-to-many relation.
 
-placeholder
+``placeholder``
   defaults to "". Placeholder is shown when no item is selected.
 
-minimum_input_length
+``minimum_input_length``
   defaults to 3. Minimum number of chars that should be typed to load ajax data.
 
-items_per_page
+``items_per_page``
   defaults to 10. Number of items per one ajax request.
 
-quiet_millis
+``quiet_millis``
   defaults to 100. Number of milliseconds to wait for the user to stop typing before issuing the ajax request.
 
-cache
-  defaults to false. Set to true, if the requested pages should be cached by the browser.
+``cache``
+  defaults to ``false``. Set to ``true``, if the requested pages should be cached by the browser.
 
-url
+``url``
   defaults to "". Target external remote URL for ajax requests.
   You usually should not need to set this manually.
 
-route
+``route``
   The route ``name`` with ``parameters`` that is used as target URL for ajax
   requests.
 
-width
+``width``
   defaults to "". Controls the width style attribute of the Select2 container div.
 
-dropdown_auto_width
-  defaults to false. Set to true to enable the `dropdownAutoWidth` Select2 option,
+``dropdown_auto_width``
+  defaults to ``false``. Set to ``true`` to enable the `dropdownAutoWidth` Select2 option,
   which allows the drop downs to be wider than the parent input, sized according to their content.
 
-container_css_class
+``container_css_class``
   defaults to "". Css class that will be added to select2's container tag.
 
-dropdown_css_class
+``dropdown_css_class``
   defaults to "". CSS class of dropdown list.
 
-dropdown_item_css_class
+``dropdown_item_css_class``
   defaults to "". CSS class of dropdown item.
 
-req_param_name_search
+``req_param_name_search``
   defaults to "q". Ajax request parameter name which contains the searched text.
 
-req_param_name_page_number
+``req_param_name_page_number``
   defaults to "_page". Ajax request parameter name which contains the page number.
 
-req_param_name_items_per_page
+``req_param_name_items_per_page``
   defaults to "_per_page".  Ajax request parameter name which contains the limit of
   items per page.
 
-template
+``template``
   defaults to ``SonataAdminBundle:Form/Type:sonata_type_model_autocomplete.html.twig``.
   Use this option if you want to override the default template of this form type.
 
-btn_add and btn_catalogue:
+``btn_add`` and ``btn_catalogue``:
   The labels on the ``add`` button can be customized with these parameters.
   Setting any of them to ``false`` will hide the corresponding button. You can also specify
   a custom translation catalogue for these labels, which defaults to ``SonataAdminBundle``.
@@ -322,12 +332,16 @@ btn_add and btn_catalogue:
     <?php
     // src/AppBundle/Admin/ArticleAdmin.php
 
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
+
     class ArticleAdmin extends AbstractAdmin
     {
         protected function configureFormFields(FormMapper $formMapper)
         {
             $formMapper
-                ->add('category', 'sonata_type_model_autocomplete', array(
+                ->add('category', ModelAutocompleteType::class, array(
                     'property' => 'title',
                     'template' => 'AppBundle:Form/Type:sonata_type_model_autocomplete.html.twig',
                 ))
@@ -344,7 +358,7 @@ btn_add and btn_catalogue:
     {# change the default selection format #}
     {% block sonata_type_model_autocomplete_selection_format %}'<b>'+item.label+'</b>'{% endblock %}
 
-target_admin_access_action
+``target_admin_access_action``
   defaults to ``list``.
   By default, the user needs the ``LIST`` role (mapped to ``list`` access action)
   to get the autocomplete items from the target admin's datagrid.
@@ -360,6 +374,10 @@ target_admin_access_action
     <?php
     // src/AppBundle/Admin/ArticleAdmin.php
 
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
+
     class ArticleAdmin extends AbstractAdmin
     {
         protected function configureFormFields(FormMapper $formMapper)
@@ -367,7 +385,7 @@ target_admin_access_action
             // the dropdown autocomplete list will show only Category
             // entities that contain specified text in "title" attribute
             $formMapper
-                ->add('category', 'sonata_type_model_autocomplete', array(
+                ->add('category', ModelAutocompleteType::class, array(
                     'property' => 'title',
                     'target_admin_access_action' => 'autocomplete'
                 ))
@@ -379,6 +397,9 @@ target_admin_access_action
 
     <?php
     // src/AppBundle/Admin/CategoryAdmin.php
+
+    use Sonata\AdminBundle\Datagrid\DatagridMapper;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
 
     class CategoryAdmin extends AbstractAdmin
     {
@@ -396,11 +417,8 @@ target_admin_access_action
         }
     }
 
-sonata_choice_field_mask
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Setting a field type of ``sonata_choice_field_mask`` will use an instance of
-``ChoiceFieldMaskType`` to render choice field.
+``Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 According the choice made only associated fields are displayed. The others fields are hidden.
 
@@ -409,12 +427,17 @@ According the choice made only associated fields are displayed. The others field
     <?php
     // src/AppBundle/Admin/AppMenuAdmin.php
 
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType;
+    use Symfony\Component\Form\Extension\Core\Type\TextType;
+
     class AppMenuAdmin extends AbstractAdmin
     {
         protected function configureFormFields(FormMapper $formMapper)
         {
             $formMapper
-                ->add('linkType', 'sonata_type_choice_field_mask', array(
+                ->add('linkType', ChoiceFieldMaskType::class, array(
                     'choices' => array(
                         'uri' => 'uri',
                         'route' => 'route',
@@ -426,36 +449,36 @@ According the choice made only associated fields are displayed. The others field
                     'placeholder' => 'Choose an option',
                     'required' => false
                 ))
-                ->add('route', 'text')
-                ->add('uri', 'text')
+                ->add('route', TextType::class)
+                ->add('uri', TextType::class)
                 ->add('parameters')
             ;
         }
     }
 
-map
+``map``
   Associative array. Describes the fields that are displayed for each choice.
 
 
-sonata_type_admin
-^^^^^^^^^^^^^^^^^
+``Sonata\AdminBundle\Form\Type\AdminType``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Setting a field type of ``sonata_type_admin`` will embed another Admin class
-and use the embedded Admin's configuration when editing this field.
-``sonata_type_admin`` fields should only be used when editing a field which
+Setting a field type of ``Sonata\AdminBundle\Form\Type\AdminType`` will embed another admin class
+and use the embedded admin's configuration when editing this field.
+``Sonata\AdminBundle\Form\Type\AdminType`` fields should only be used when editing a field which
 represents a relationship between two model classes.
 
-This Type allows you to embed a complete form for the related element, which
+This type allows you to embed a complete form for the related element, which
 you can configure to allow the creation, editing and (optionally) deletion of
 related objects.
 
-For example, lets use a similar example to the one for ``sonata_type_model`` above.
+For example, lets use a similar example to the one for ``Sonata\AdminBundle\Form\Type\ModelType`` above.
 This time, when editing a ``Page`` using ``PageAdmin`` we want to enable the inline
 creation (and editing) of new Images instead of just selecting an existing Image
 from a list.
 
-First we need to create an ``ImageAdmin`` class and register it as an Admin class
-for managing ``Image`` objects. In our admin.yml we have an entry for ``ImageAdmin``
+First we need to create an ``ImageAdmin`` class and register it as an admin class
+for managing ``Image`` objects. In our ``admin.yml`` we have an entry for ``ImageAdmin``
 that looks like this:
 
 .. configuration-block::
@@ -479,7 +502,7 @@ that looks like this:
 
 .. note::
 
-    Refer to `Getting started documentation`_ to see how to define your admin.yml file.
+    Refer to `Getting started documentation`_ to see how to define your ``admin.yml`` file.
 
 To embed ``ImageAdmin`` within ``PageAdmin`` we just need to change the reference
 for the ``image1`` field to ``sonata_type_admin`` in our ``PageAdmin`` class:
@@ -489,37 +512,41 @@ for the ``image1`` field to ``sonata_type_admin`` in our ``PageAdmin`` class:
     <?php
     // src/AppBundle/Admin/PageAdmin.php
 
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Form\Type\AdminType;
+
     class PageAdmin extends AbstractAdmin
     {
         protected function configureFormFields(FormMapper $formMapper)
         {
             $formMapper
-                ->add('image1', 'sonata_type_admin')
+                ->add('image1', AdminType::class)
             ;
         }
     }
 
 We do not need to define any options since Sonata calculates that the linked class
-is of type ``Image`` and the service definition (in admin.yml) defines that ``Image``
+is of type ``Image`` and the service definition (in ``admin.yml``) defines that ``Image``
 objects are managed by the ``ImageAdmin`` class.
 
 The available options (which can be passed as a third parameter to ``FormMapper::add()``) are:
 
-delete
-  defaults to true and indicates that a 'delete' checkbox should be shown allowing
+``delete``
+  defaults to ``true`` and indicates that a 'delete' checkbox should be shown allowing
   the user to delete the linked object.
 
-btn_add, btn_list, btn_delete and btn_catalogue:
+``btn_add``, ``btn_list``, ``btn_delete`` and ``btn_catalogue``:
   The labels on the ``add``, ``list`` and ``delete`` buttons can be customized
   with these parameters. Setting any of them to ``false`` will hide the
   corresponding button. You can also specify a custom translation catalogue
   for these labels, which defaults to ``SonataAdminBundle``.
 
 
-sonata_type_collection
-^^^^^^^^^^^^^^^^^^^^^^
+``Sonata\CoreBundle\Form\Type\CollectionType``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``CollectionType`` is meant to handle creation and editing of model
+The ``Sonata\CoreBundle\Form\Type\CollectionType`` is meant to handle creation and editing of model
 collections. Rows can be added and deleted, and your model abstraction layer may
 allow you to edit fields inline. You can use ``type_options`` to pass values
 to the underlying forms.
@@ -528,6 +555,10 @@ to the underlying forms.
 
     <?php
     // src/AppBundle/Admin/ProductAdmin.php
+
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\CoreBundle\Form\Type\CollectionType;
 
     class ProductAdmin extends AbstractAdmin
     {
@@ -563,7 +594,7 @@ to the underlying forms.
 
 The available options (which can be passed as a third parameter to ``FormMapper::add()``) are:
 
-btn_add and btn_catalogue:
+``btn_add`` and ``btn_catalogue``:
   The label on the ``add`` button can be customized
   with this parameters. Setting it to ``false`` will hide the
   corresponding button. You can also specify a custom translation catalogue
@@ -572,16 +603,16 @@ btn_add and btn_catalogue:
 **TIP**: A jQuery event is fired after a row has been added (``sonata-admin-append-form-element``).
 You can listen to this event to trigger custom JavaScript (eg: add a calendar widget to a newly added date field)
 
-**TIP**: Setting the 'required' option to true does not cause a requirement of 'at least one' child entity.
-Setting the 'required' option to false causes all nested form fields to become not required as well.
+**TIP**: Setting the 'required' option to ``true`` does not cause a requirement of 'at least one' child entity.
+Setting the 'required' option to ``false`` causes all nested form fields to become not required as well.
 
 .. tip::
 
     You can check / uncheck a range of checkboxes by clicking a first one,
     then a second one with shift + click.
 
-sonata_type_native_collection (previously collection)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``Sonata\AdminBundle\Form\Type\CollectionType``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This bundle handle the native Symfony ``collection`` form type by adding:
 
@@ -607,14 +638,14 @@ FieldDescription options
 
 The fourth parameter to FormMapper::add() allows you to pass in ``FieldDescription``
 options as an array. The most useful of these is ``admin_code``, which allows you to
-specify which Admin to use for managing this relationship. It is most useful for inline
-editing in conjunction with the ``sonata_type_admin`` form type.
+specify which admin to use for managing this relationship. It is most useful for inline
+editing in conjunction with the ``Sonata\AdminBundle\Form\Type\AdminType`` form type.
 
 The value used should be the admin *service* name, not the class name. If you do
 not specify an ``admin_code`` in this way, the default admin class for the field's
 model type will  be used.
 
-For example, to specify the use of the Admin class which is registered as
+For example, to specify the use of the admin class which is registered as
 ``sonata.admin.imageSpecial`` for managing the ``image1`` field from our ``PageAdmin``
 example above:
 
@@ -623,12 +654,16 @@ example above:
     <?php
     // src/AppBundle/Admin/PageAdmin.php
 
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Form\Type\AdminType;
+
     class PageAdmin extends AbstractAdmin
     {
         protected function configureFormFields(FormMapper $formMapper)
         {
             $formMapper
-                ->add('image1', 'sonata_type_admin', array(), array(
+                ->add('image1', AdminType::class, array(), array(
                     'admin_code' => 'sonata.admin.imageSpecial'
                 ))
 
@@ -654,6 +689,12 @@ Given you have a ``PostType`` like this:
     <?php
     // src/AppBundle/Form/PostType.php
 
+    use Symfony\Component\Form\FormBuilderInterface;
+    use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+    use Symfony\Component\Form\Extension\Core\Type\TextType;
+    use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+    use Symfony\Component\Form\AbstractType;
+
     class PostType extends AbstractType
     {
         public function buildForm(FormBuilderInterface $builder, array $options)
@@ -674,6 +715,10 @@ you can reuse it like this:
 
     <?php
     // src/AppBundle/Admin/Post.php
+
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use AppBundle\Form\PostType;
 
     class Post extend AbstractAdmin
     {
@@ -707,6 +752,9 @@ General
     <?php
     // src/AppBundle/Admin/PageAdmin.php
 
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+
     class PageAdmin extends AbstractAdmin
     {
         protected function configureFormFields(FormMapper $formMapper)
@@ -723,8 +771,8 @@ General
         // ...
     }
 
-ChoiceType
-^^^^^^^^^^
+``Symfony\Component\Form\Extension\Core\Type\ChoiceType``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - ``sortable``: This option can be added for multiple choice widget to activate select2 sortable.
 
@@ -733,12 +781,16 @@ ChoiceType
     <?php
     // src/AppBundle/Admin/PageAdmin.php
 
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+
     class PageAdmin extends AbstractAdmin
     {
         protected function configureFormFields(FormMapper $formMapper)
         {
             $formMapper
-                ->add('multiChoices', 'choice', array(
+                ->add('multiChoices', ChoiceType::class, array(
                     'multiple' => true,
                     'sortable' => true,
                 ))


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am updating documentation about form types.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed documentation for Form Types.
```

## Subject

After finishing my last PR and updating these docs about form types I saw that all other types need an update, so here it goes, the only thing I am not sure about is the CollectionTypes as that part is a bit confusing because of the same class name but a different bundle.