### PR TITLE
Do not override final Controller method render()

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated CRUDController::render()
+
+Call `CRUDController::renderWithExtraParams()` instead.
+
 UPGRADE FROM 3.23 to 3.24
 =========================
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -40,7 +40,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 
 // BC for Symfony < 3.3 where this trait does not exist
-// NEXT_MAJOR: Remove the polyfill and inherit from Controller again
+// NEXT_MAJOR: Remove the polyfill and inherit from \Symfony\Bundle\FrameworkBundle\Controller\Controller again
 require_once __DIR__.'/PolyfillControllerTrait.php';
 
 /**

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -48,7 +48,6 @@ require_once __DIR__.'/PolyfillControllerTrait.php';
  */
 class CRUDController implements ContainerAwareInterface
 {
-
     // NEXT_MAJOR: Don't use these traits anymore (inherit from Controller instead)
     use ControllerTrait, ContainerAwareTrait {
         ControllerTrait::render as originalRender;
@@ -60,6 +59,16 @@ class CRUDController implements ContainerAwareInterface
      * @var AdminInterface
      */
     protected $admin;
+
+    // BC for Symfony 3.3 where ControllerTrait exists but does not contain get() and has() methods.
+    public function __call($method, $arguments)
+    {
+        if (in_array($method, ['get', 'has'])) {
+            return call_user_func_array([$this->container, $method], $arguments);
+        }
+
+        throw new \LogicException('Call to undefined method '.__CLASS__.'::'.$method);
+    }
 
     /**
      * Sets the Container associated with this Controller.
@@ -73,30 +82,9 @@ class CRUDController implements ContainerAwareInterface
         $this->configure();
     }
 
-    // BC for Symfony 3.3 where ControllerTrait exists but does not contain get() and has() methods.
-    public function __call($method, $arguments)
-    {
-        if (in_array($method, ['get', 'has'])) {
-            return call_user_func_array([$this->container, $method], $arguments);
-        }
-
-        throw new \LogicException('Call to undefined method '.__CLASS__.'::'.$method);
-    }
-
-    /**
-     * Gets a container configuration parameter by its name.
-     *
-     * @param string $name The parameter name
-     *
-     * @return mixed
-     */
-    protected function getParameter($name)
-    {
-        return $this->container->getParameter($name);
-    }
-
     /**
      * NEXT_MAJOR: Remove this method.
+     *
      * @see renderWithExtraParams()
      *
      * @param string   $view       The view name
@@ -1028,6 +1016,18 @@ class CRUDController implements ContainerAwareInterface
         }
 
         return $this->container->get('request');
+    }
+
+    /**
+     * Gets a container configuration parameter by its name.
+     *
+     * @param string $name The parameter name
+     *
+     * @return mixed
+     */
+    protected function getParameter($name)
+    {
+        return $this->container->getParameter($name);
     }
 
     /**

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -101,9 +101,9 @@ class CRUDController implements ContainerAwareInterface
      */
     public function render($view, array $parameters = [], Response $response = null)
     {
-        @trigger_error('Method '.__CLASS__.'::render has been renamed to '.__CLASS__.'::renderWithExtraParams.'
-            .' If you need to render a template WITHOUT the additional parameters, call the templating component'
-            .' directly, such as: $this->container->get(\'twig\')->render(...);', E_USER_DEPRECATED
+        @trigger_error(
+            'Method '.__CLASS__.'::render has been renamed to '.__CLASS__.'::renderWithExtraParams.',
+            E_USER_DEPRECATED
         );
 
         return $this->renderWithExtraParams($view, $parameters, $response);

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -41,7 +41,9 @@ use Symfony\Component\Security\Csrf\CsrfToken;
 
 // BC for Symfony < 3.3 where this trait does not exist
 // NEXT_MAJOR: Remove the polyfill and inherit from \Symfony\Bundle\FrameworkBundle\Controller\Controller again
-require_once __DIR__.'/PolyfillControllerTrait.php';
+if (!trait_exists(ControllerTrait::class)) {
+    require_once __DIR__.'/PolyfillControllerTrait.php';
+}
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -67,6 +67,10 @@ class CRUDController implements ContainerAwareInterface
             return call_user_func_array([$this->container, $method], $arguments);
         }
 
+        if (method_exists($this, 'proxyToControllerClass')) {
+            return $this->proxyToControllerClass($method, $arguments);
+        }
+
         throw new \LogicException('Call to undefined method '.__CLASS__.'::'.$method);
     }
 

--- a/src/Controller/PolyfillControllerTrait.php
+++ b/src/Controller/PolyfillControllerTrait.php
@@ -1,0 +1,477 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Controller;
+
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Doctrine\Bundle\DoctrineBundle\Registry;
+
+
+/**
+ * Polyfills the FrameworkBundle's original ControllerTrait
+ *
+ * The methods in this trait are a copy of the Controller class
+ * in the FrameworkBundle of Symfony 3.2.
+ *
+ * NEXT_MAJOR: Remove this file.
+ *
+ * @author Christian Kraus <christian@kraus.work>
+ */
+trait PolyfillControllerTrait
+{
+
+    /**
+     * Generates a URL from the given parameters.
+     *
+     * @param string $route         The name of the route
+     * @param mixed  $parameters    An array of parameters
+     * @param int    $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
+     *
+     * @return string The generated URL
+     *
+     * @see UrlGeneratorInterface
+     */
+    protected function generateUrl($route, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    {
+        return $this->container->get('router')->generate($route, $parameters, $referenceType);
+    }
+
+
+    /**
+     * Forwards the request to another controller.
+     *
+     * @param string $controller The controller name (a string like BlogBundle:Post:index)
+     * @param array  $path       An array of path parameters
+     * @param array  $query      An array of query parameters
+     *
+     * @return Response A Response instance
+     */
+    protected function forward($controller, array $path = [], array $query = [])
+    {
+        $request             = $this->container->get('request_stack')->getCurrentRequest();
+        $path['_forwarded']  = $request->attributes;
+        $path['_controller'] = $controller;
+        $subRequest          = $request->duplicate($query, null, $path);
+
+        return $this->container->get('http_kernel')->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+    }
+
+
+    /**
+     * Returns a RedirectResponse to the given URL.
+     *
+     * @param string $url    The URL to redirect to
+     * @param int    $status The status code to use for the Response
+     *
+     * @return RedirectResponse
+     */
+    protected function redirect($url, $status = 302)
+    {
+        return new RedirectResponse($url, $status);
+    }
+
+
+    /**
+     * Returns a RedirectResponse to the given route with the given parameters.
+     *
+     * @param string $route      The name of the route
+     * @param array  $parameters An array of parameters
+     * @param int    $status     The status code to use for the Response
+     *
+     * @return RedirectResponse
+     */
+    protected function redirectToRoute($route, array $parameters = [], $status = 302)
+    {
+        return $this->redirect($this->generateUrl($route, $parameters), $status);
+    }
+
+
+    /**
+     * Returns a JsonResponse that uses the serializer component if enabled, or json_encode.
+     *
+     * @param mixed $data    The response data
+     * @param int   $status  The status code to use for the Response
+     * @param array $headers Array of extra headers to add
+     * @param array $context Context to pass to serializer when using serializer component
+     *
+     * @return JsonResponse
+     */
+    protected function json($data, $status = 200, $headers = [], $context = [])
+    {
+        if ($this->container->has('serializer')) {
+            $json = $this->container->get('serializer')->serialize(
+                $data,
+                'json',
+                array_merge(
+                    [
+                        'json_encode_options' => JsonResponse::DEFAULT_ENCODING_OPTIONS,
+                    ],
+                    $context
+                )
+            );
+
+            return new JsonResponse($json, $status, $headers, true);
+        }
+
+        return new JsonResponse($data, $status, $headers);
+    }
+
+
+    /**
+     * Returns a BinaryFileResponse object with original or customized file name and disposition header.
+     *
+     * @param \SplFileInfo|string $file        File object or path to file to be sent as response
+     * @param string|null         $fileName    File name to be sent to response or null (will use original file name)
+     * @param string              $disposition Disposition of response ("attachment" is default, other type is "inline")
+     *
+     * @return BinaryFileResponse
+     */
+    protected function file($file, $fileName = null, $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT)
+    {
+        $response = new BinaryFileResponse($file);
+        $response->setContentDisposition(
+            $disposition,
+            $fileName === null ? $response->getFile()->getFilename() : $fileName
+        );
+
+        return $response;
+    }
+
+
+    /**
+     * Adds a flash message to the current session for type.
+     *
+     * @param string $type    The type
+     * @param string $message The message
+     *
+     * @throws \LogicException
+     */
+    protected function addFlash($type, $message)
+    {
+        if (!$this->container->has('session')) {
+            throw new \LogicException('You can not use the addFlash method if sessions are disabled.');
+        }
+
+        $this->container->get('session')->getFlashBag()->add($type, $message);
+    }
+
+
+    /**
+     * Checks if the attributes are granted against the current authentication token and optionally supplied object.
+     *
+     * @param mixed $attributes The attributes
+     * @param mixed $object     The object
+     *
+     * @return bool
+     *
+     * @throws \LogicException
+     */
+    protected function isGranted($attributes, $object = null)
+    {
+        if (!$this->container->has('security.authorization_checker')) {
+            throw new \LogicException('The SecurityBundle is not registered in your application.');
+        }
+
+        return $this->container->get('security.authorization_checker')->isGranted($attributes, $object);
+    }
+
+
+    /**
+     * Throws an exception unless the attributes are granted against the current authentication token and optionally
+     * supplied object.
+     *
+     * @param mixed  $attributes The attributes
+     * @param mixed  $object     The object
+     * @param string $message    The message passed to the exception
+     *
+     * @throws AccessDeniedException
+     */
+    protected function denyAccessUnlessGranted($attributes, $object = null, $message = 'Access Denied.')
+    {
+        if (!$this->isGranted($attributes, $object)) {
+            $exception = $this->createAccessDeniedException($message);
+            $exception->setAttributes($attributes);
+            $exception->setSubject($object);
+
+            throw $exception;
+        }
+    }
+
+
+    /**
+     * Returns a rendered view.
+     *
+     * @param string $view       The view name
+     * @param array  $parameters An array of parameters to pass to the view
+     *
+     * @return string The rendered view
+     */
+    protected function renderView($view, array $parameters = [])
+    {
+        if ($this->container->has('templating')) {
+            return $this->container->get('templating')->render($view, $parameters);
+        }
+
+        if (!$this->container->has('twig')) {
+            throw new \LogicException(
+                'You can not use the "renderView" method if the Templating Component or the Twig Bundle are not available.'
+            );
+        }
+
+        return $this->container->get('twig')->render($view, $parameters);
+    }
+
+
+    /**
+     * Renders a view.
+     *
+     * @param string   $view       The view name
+     * @param array    $parameters An array of parameters to pass to the view
+     * @param Response $response   A response instance
+     *
+     * @return Response A Response instance
+     */
+    protected function render($view, array $parameters = [], Response $response = null)
+    {
+        if ($this->container->has('templating')) {
+            return $this->container->get('templating')->renderResponse($view, $parameters, $response);
+        }
+
+        if (!$this->container->has('twig')) {
+            throw new \LogicException(
+                'You can not use the "render" method if the Templating Component or the Twig Bundle are not available.'
+            );
+        }
+
+        if (null === $response) {
+            $response = new Response();
+        }
+
+        $response->setContent($this->container->get('twig')->render($view, $parameters));
+
+        return $response;
+    }
+
+
+    /**
+     * Streams a view.
+     *
+     * @param string           $view       The view name
+     * @param array            $parameters An array of parameters to pass to the view
+     * @param StreamedResponse $response   A response instance
+     *
+     * @return StreamedResponse A StreamedResponse instance
+     */
+    protected function stream($view, array $parameters = [], StreamedResponse $response = null)
+    {
+        if ($this->container->has('templating')) {
+            $templating = $this->container->get('templating');
+
+            $callback = function() use ($templating, $view, $parameters) {
+                $templating->stream($view, $parameters);
+            };
+        } elseif ($this->container->has('twig')) {
+            $twig = $this->container->get('twig');
+
+            $callback = function() use ($twig, $view, $parameters) {
+                $twig->display($view, $parameters);
+            };
+        } else {
+            throw new \LogicException(
+                'You can not use the "stream" method if the Templating Component or the Twig Bundle are not available.'
+            );
+        }
+
+        if (null === $response) {
+            return new StreamedResponse($callback);
+        }
+
+        $response->setCallback($callback);
+
+        return $response;
+    }
+
+
+    /**
+     * Returns a NotFoundHttpException.
+     *
+     * This will result in a 404 response code. Usage example:
+     *
+     *     throw $this->createNotFoundException('Page not found!');
+     *
+     * @param string          $message  A message
+     * @param \Exception|null $previous The previous exception
+     *
+     * @return NotFoundHttpException
+     */
+    protected function createNotFoundException($message = 'Not Found', \Exception $previous = null)
+    {
+        return new NotFoundHttpException($message, $previous);
+    }
+
+
+    /**
+     * Returns an AccessDeniedException.
+     *
+     * This will result in a 403 response code. Usage example:
+     *
+     *     throw $this->createAccessDeniedException('Unable to access this page!');
+     *
+     * @param string          $message  A message
+     * @param \Exception|null $previous The previous exception
+     *
+     * @return AccessDeniedException
+     */
+    protected function createAccessDeniedException($message = 'Access Denied.', \Exception $previous = null)
+    {
+        return new AccessDeniedException($message, $previous);
+    }
+
+
+    /**
+     * Creates and returns a Form instance from the type of the form.
+     *
+     * @param string $type    The fully qualified class name of the form type
+     * @param mixed  $data    The initial data for the form
+     * @param array  $options Options for the form
+     *
+     * @return Form
+     */
+    protected function createForm($type, $data = null, array $options = [])
+    {
+        return $this->container->get('form.factory')->create($type, $data, $options);
+    }
+
+
+    /**
+     * Creates and returns a form builder instance.
+     *
+     * @param mixed $data    The initial data for the form
+     * @param array $options Options for the form
+     *
+     * @return FormBuilder
+     */
+    protected function createFormBuilder($data = null, array $options = [])
+    {
+        return $this->container->get('form.factory')->createBuilder(FormType::class, $data, $options);
+    }
+
+
+    /**
+     * Shortcut to return the Doctrine Registry service.
+     *
+     * @return Registry
+     *
+     * @throws \LogicException If DoctrineBundle is not available
+     */
+    protected function getDoctrine()
+    {
+        if (!$this->container->has('doctrine')) {
+            throw new \LogicException('The DoctrineBundle is not registered in your application.');
+        }
+
+        return $this->container->get('doctrine');
+    }
+
+
+    /**
+     * Get a user from the Security Token Storage.
+     *
+     * @return mixed
+     *
+     * @throws \LogicException If SecurityBundle is not available
+     *
+     * @see TokenInterface::getUser()
+     */
+    protected function getUser()
+    {
+        if (!$this->container->has('security.token_storage')) {
+            throw new \LogicException('The SecurityBundle is not registered in your application.');
+        }
+
+        if (null === $token = $this->container->get('security.token_storage')->getToken()) {
+            return;
+        }
+
+        if (!is_object($user = $token->getUser())) {
+            // e.g. anonymous authentication
+            return;
+        }
+
+        return $user;
+    }
+
+
+    /**
+     * Returns true if the service id is defined.
+     *
+     * @param string $id The service id
+     *
+     * @return bool true if the service id is defined, false otherwise
+     */
+    protected function has($id)
+    {
+        return $this->container->has($id);
+    }
+
+
+    /**
+     * Gets a container service by its id.
+     *
+     * @param string $id The service id
+     *
+     * @return object The service
+     */
+    protected function get($id)
+    {
+        return $this->container->get($id);
+    }
+
+
+    /**
+     * Gets a container configuration parameter by its name.
+     *
+     * @param string $name The parameter name
+     *
+     * @return mixed
+     */
+    protected function getParameter($name)
+    {
+        return $this->container->getParameter($name);
+    }
+
+
+    /**
+     * Checks the validity of a CSRF token.
+     *
+     * @param string $id    The id used when generating the token
+     * @param string $token The actual token sent with the request that should be validated
+     *
+     * @return bool
+     */
+    protected function isCsrfTokenValid($id, $token)
+    {
+        if (!$this->container->has('security.csrf.token_manager')) {
+            throw new \LogicException('CSRF protection is not enabled in your application.');
+        }
+
+        return $this->container->get('security.csrf.token_manager')->isTokenValid(new CsrfToken($id, $token));
+    }
+}
+
+
+if (!trait_exists('\Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait')) {
+    class_alias(PolyfillControllerTrait::class, '\Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait');
+}

--- a/src/Controller/PolyfillControllerTrait.php
+++ b/src/Controller/PolyfillControllerTrait.php
@@ -59,7 +59,6 @@ class PolyfillProxyContainer extends Controller
         $this->setContainer($container);
     }
 
-
     public function proxyCall($method, $arguments)
     {
         return call_user_func_array([$this, $method], $arguments);

--- a/src/Controller/PolyfillControllerTrait.php
+++ b/src/Controller/PolyfillControllerTrait.php
@@ -9,29 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\FrameworkBundle\Controller;
+namespace Sonata\AdminBundle\Controller;
 
-use Doctrine\Bundle\DoctrineBundle\Registry;
-use Symfony\Component\Form\Extension\Core\Type\FormType;
-use Symfony\Component\Form\Form;
-use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
-use Symfony\Component\HttpFoundation\StreamedResponse;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Csrf\CsrfToken;
 
 /**
  * Polyfills the FrameworkBundle's original ControllerTrait.
- *
- * The methods in this trait are a copy of the Controller class
- * in the FrameworkBundle of Symfony 3.2.
  *
  * NEXT_MAJOR: Remove this file.
  *
@@ -39,424 +24,38 @@ use Symfony\Component\Security\Csrf\CsrfToken;
  */
 trait PolyfillControllerTrait
 {
-    /**
-     * Generates a URL from the given parameters.
-     *
-     * @param string $route         The name of the route
-     * @param mixed  $parameters    An array of parameters
-     * @param int    $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
-     *
-     * @return string The generated URL
-     *
-     * @see UrlGeneratorInterface
-     */
-    protected function generateUrl($route, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    protected $container;
+
+    public function __call($methodName, $arguments)
     {
-        return $this->container->get('router')->generate($route, $parameters, $referenceType);
+        $this->proxyToController($methodName, $arguments);
+    }
+
+    public function render($view, array $parameters = [], Response $response = null)
+    {
+        return $this->__call('render', [$view, $parameters, $response]);
     }
 
     /**
-     * Forwards the request to another controller.
-     *
-     * @param string $controller The controller name (a string like BlogBundle:Post:index)
-     * @param array  $path       An array of path parameters
-     * @param array  $query      An array of query parameters
-     *
-     * @return Response A Response instance
+     * @internal
      */
-    protected function forward($controller, array $path = [], array $query = [])
+    protected function proxyToControllerClass($methodName, $arguments)
     {
-        $request = $this->container->get('request_stack')->getCurrentRequest();
-        $path['_forwarded'] = $request->attributes;
-        $path['_controller'] = $controller;
-        $subRequest = $request->duplicate($query, null, $path);
+        $reflectionClass = new \ReflectionClass(Controller::class);
 
-        return $this->container->get('http_kernel')->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
-    }
-
-    /**
-     * Returns a RedirectResponse to the given URL.
-     *
-     * @param string $url    The URL to redirect to
-     * @param int    $status The status code to use for the Response
-     *
-     * @return RedirectResponse
-     */
-    protected function redirect($url, $status = 302)
-    {
-        return new RedirectResponse($url, $status);
-    }
-
-    /**
-     * Returns a RedirectResponse to the given route with the given parameters.
-     *
-     * @param string $route      The name of the route
-     * @param array  $parameters An array of parameters
-     * @param int    $status     The status code to use for the Response
-     *
-     * @return RedirectResponse
-     */
-    protected function redirectToRoute($route, array $parameters = [], $status = 302)
-    {
-        return $this->redirect($this->generateUrl($route, $parameters), $status);
-    }
-
-    /**
-     * Returns a JsonResponse that uses the serializer component if enabled, or json_encode.
-     *
-     * @param mixed $data    The response data
-     * @param int   $status  The status code to use for the Response
-     * @param array $headers Array of extra headers to add
-     * @param array $context Context to pass to serializer when using serializer component
-     *
-     * @return JsonResponse
-     */
-    protected function json($data, $status = 200, $headers = [], $context = [])
-    {
-        if ($this->container->has('serializer')) {
-            $json = $this->container->get('serializer')->serialize(
-                $data,
-                'json',
-                array_merge(
-                    [
-                        'json_encode_options' => JsonResponse::DEFAULT_ENCODING_OPTIONS,
-                    ],
-                    $context
-                )
-            );
-
-            return new JsonResponse($json, $status, $headers, true);
+        if (!$reflectionClass->hasMethod($methodName)) {
+            throw new \LogicException('Call to undefined method '.__CLASS__.'::'.$methodName);
         }
 
-        return new JsonResponse($data, $status, $headers);
-    }
+        $controller = $reflectionClass->newInstance();
+        $controller->setContainer($this->container);
+        $method = $reflectionClass->getMethod($methodName);
+        $method->setAccessible(true);
 
-    /**
-     * Returns a BinaryFileResponse object with original or customized file name and disposition header.
-     *
-     * @param \SplFileInfo|string $file        File object or path to file to be sent as response
-     * @param string|null         $fileName    File name to be sent to response or null (will use original file name)
-     * @param string              $disposition Disposition of response ("attachment" is default, other type is "inline")
-     *
-     * @return BinaryFileResponse
-     */
-    protected function file($file, $fileName = null, $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT)
-    {
-        $response = new BinaryFileResponse($file);
-        $response->setContentDisposition(
-            $disposition,
-            null === $fileName ? $response->getFile()->getFilename() : $fileName
-        );
-
-        return $response;
-    }
-
-    /**
-     * Adds a flash message to the current session for type.
-     *
-     * @param string $type    The type
-     * @param string $message The message
-     *
-     * @throws \LogicException
-     */
-    protected function addFlash($type, $message)
-    {
-        if (!$this->container->has('session')) {
-            throw new \LogicException('You can not use the addFlash method if sessions are disabled.');
-        }
-
-        $this->container->get('session')->getFlashBag()->add($type, $message);
-    }
-
-    /**
-     * Checks if the attributes are granted against the current authentication token and optionally supplied object.
-     *
-     * @param mixed $attributes The attributes
-     * @param mixed $object     The object
-     *
-     * @return bool
-     *
-     * @throws \LogicException
-     */
-    protected function isGranted($attributes, $object = null)
-    {
-        if (!$this->container->has('security.authorization_checker')) {
-            throw new \LogicException('The SecurityBundle is not registered in your application.');
-        }
-
-        return $this->container->get('security.authorization_checker')->isGranted($attributes, $object);
-    }
-
-    /**
-     * Throws an exception unless the attributes are granted against the current authentication token and optionally
-     * supplied object.
-     *
-     * @param mixed  $attributes The attributes
-     * @param mixed  $object     The object
-     * @param string $message    The message passed to the exception
-     *
-     * @throws AccessDeniedException
-     */
-    protected function denyAccessUnlessGranted($attributes, $object = null, $message = 'Access Denied.')
-    {
-        if (!$this->isGranted($attributes, $object)) {
-            $exception = $this->createAccessDeniedException($message);
-            $exception->setAttributes($attributes);
-            $exception->setSubject($object);
-
-            throw $exception;
-        }
-    }
-
-    /**
-     * Returns a rendered view.
-     *
-     * @param string $view       The view name
-     * @param array  $parameters An array of parameters to pass to the view
-     *
-     * @return string The rendered view
-     */
-    protected function renderView($view, array $parameters = [])
-    {
-        if ($this->container->has('templating')) {
-            return $this->container->get('templating')->render($view, $parameters);
-        }
-
-        if (!$this->container->has('twig')) {
-            throw new \LogicException(
-                'You can not use the "renderView" method if the Templating Component or the Twig Bundle are not available.'
-            );
-        }
-
-        return $this->container->get('twig')->render($view, $parameters);
-    }
-
-    /**
-     * Renders a view.
-     *
-     * @param string   $view       The view name
-     * @param array    $parameters An array of parameters to pass to the view
-     * @param Response $response   A response instance
-     *
-     * @return Response A Response instance
-     */
-    protected function render($view, array $parameters = [], Response $response = null)
-    {
-        if ($this->container->has('templating')) {
-            return $this->container->get('templating')->renderResponse($view, $parameters, $response);
-        }
-
-        if (!$this->container->has('twig')) {
-            throw new \LogicException(
-                'You can not use the "render" method if the Templating Component or the Twig Bundle are not available.'
-            );
-        }
-
-        if (null === $response) {
-            $response = new Response();
-        }
-
-        $response->setContent($this->container->get('twig')->render($view, $parameters));
-
-        return $response;
-    }
-
-    /**
-     * Streams a view.
-     *
-     * @param string           $view       The view name
-     * @param array            $parameters An array of parameters to pass to the view
-     * @param StreamedResponse $response   A response instance
-     *
-     * @return StreamedResponse A StreamedResponse instance
-     */
-    protected function stream($view, array $parameters = [], StreamedResponse $response = null)
-    {
-        if ($this->container->has('templating')) {
-            $templating = $this->container->get('templating');
-
-            $callback = function () use ($templating, $view, $parameters) {
-                $templating->stream($view, $parameters);
-            };
-        } elseif ($this->container->has('twig')) {
-            $twig = $this->container->get('twig');
-
-            $callback = function () use ($twig, $view, $parameters) {
-                $twig->display($view, $parameters);
-            };
-        } else {
-            throw new \LogicException(
-                'You can not use the "stream" method if the Templating Component or the Twig Bundle are not available.'
-            );
-        }
-
-        if (null === $response) {
-            return new StreamedResponse($callback);
-        }
-
-        $response->setCallback($callback);
-
-        return $response;
-    }
-
-    /**
-     * Returns a NotFoundHttpException.
-     *
-     * This will result in a 404 response code. Usage example:
-     *
-     *     throw $this->createNotFoundException('Page not found!');
-     *
-     * @param string          $message  A message
-     * @param \Exception|null $previous The previous exception
-     *
-     * @return NotFoundHttpException
-     */
-    protected function createNotFoundException($message = 'Not Found', \Exception $previous = null)
-    {
-        return new NotFoundHttpException($message, $previous);
-    }
-
-    /**
-     * Returns an AccessDeniedException.
-     *
-     * This will result in a 403 response code. Usage example:
-     *
-     *     throw $this->createAccessDeniedException('Unable to access this page!');
-     *
-     * @param string          $message  A message
-     * @param \Exception|null $previous The previous exception
-     *
-     * @return AccessDeniedException
-     */
-    protected function createAccessDeniedException($message = 'Access Denied.', \Exception $previous = null)
-    {
-        return new AccessDeniedException($message, $previous);
-    }
-
-    /**
-     * Creates and returns a Form instance from the type of the form.
-     *
-     * @param string $type    The fully qualified class name of the form type
-     * @param mixed  $data    The initial data for the form
-     * @param array  $options Options for the form
-     *
-     * @return Form
-     */
-    protected function createForm($type, $data = null, array $options = [])
-    {
-        return $this->container->get('form.factory')->create($type, $data, $options);
-    }
-
-    /**
-     * Creates and returns a form builder instance.
-     *
-     * @param mixed $data    The initial data for the form
-     * @param array $options Options for the form
-     *
-     * @return FormBuilder
-     */
-    protected function createFormBuilder($data = null, array $options = [])
-    {
-        return $this->container->get('form.factory')->createBuilder(FormType::class, $data, $options);
-    }
-
-    /**
-     * Shortcut to return the Doctrine Registry service.
-     *
-     * @return Registry
-     *
-     * @throws \LogicException If DoctrineBundle is not available
-     */
-    protected function getDoctrine()
-    {
-        if (!$this->container->has('doctrine')) {
-            throw new \LogicException('The DoctrineBundle is not registered in your application.');
-        }
-
-        return $this->container->get('doctrine');
-    }
-
-    /**
-     * Get a user from the Security Token Storage.
-     *
-     * @return mixed
-     *
-     * @throws \LogicException If SecurityBundle is not available
-     *
-     * @see TokenInterface::getUser()
-     */
-    protected function getUser()
-    {
-        if (!$this->container->has('security.token_storage')) {
-            throw new \LogicException('The SecurityBundle is not registered in your application.');
-        }
-
-        if (null === $token = $this->container->get('security.token_storage')->getToken()) {
-            return;
-        }
-
-        if (!is_object($user = $token->getUser())) {
-            // e.g. anonymous authentication
-            return;
-        }
-
-        return $user;
-    }
-
-    /**
-     * Returns true if the service id is defined.
-     *
-     * @param string $id The service id
-     *
-     * @return bool true if the service id is defined, false otherwise
-     */
-    protected function has($id)
-    {
-        return $this->container->has($id);
-    }
-
-    /**
-     * Gets a container service by its id.
-     *
-     * @param string $id The service id
-     *
-     * @return object The service
-     */
-    protected function get($id)
-    {
-        return $this->container->get($id);
-    }
-
-    /**
-     * Gets a container configuration parameter by its name.
-     *
-     * @param string $name The parameter name
-     *
-     * @return mixed
-     */
-    protected function getParameter($name)
-    {
-        return $this->container->getParameter($name);
-    }
-
-    /**
-     * Checks the validity of a CSRF token.
-     *
-     * @param string $id    The id used when generating the token
-     * @param string $token The actual token sent with the request that should be validated
-     *
-     * @return bool
-     */
-    protected function isCsrfTokenValid($id, $token)
-    {
-        if (!$this->container->has('security.csrf.token_manager')) {
-            throw new \LogicException('CSRF protection is not enabled in your application.');
-        }
-
-        return $this->container->get('security.csrf.token_manager')->isTokenValid(new CsrfToken($id, $token));
+        return $method->invokeArgs($controller, $arguments);
     }
 }
 
-if (!trait_exists('\Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait')) {
-    class_alias(PolyfillControllerTrait::class, '\Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait');
+if (!trait_exists(ControllerTrait::class)) {
+    class_alias(PolyfillControllerTrait::class, ControllerTrait::class);
 }

--- a/src/Controller/PolyfillControllerTrait.php
+++ b/src/Controller/PolyfillControllerTrait.php
@@ -25,8 +25,6 @@ use Symfony\Component\HttpFoundation\Response;
  */
 trait PolyfillControllerTrait
 {
-    protected $container;
-
     public function __call($methodName, $arguments)
     {
         $this->proxyToController($methodName, $arguments);

--- a/src/Controller/PolyfillControllerTrait.php
+++ b/src/Controller/PolyfillControllerTrait.php
@@ -38,7 +38,7 @@ trait PolyfillControllerTrait
     /**
      * @internal
      */
-    protected function proxyToControllerClass($methodName, $arguments)
+    final protected function proxyToControllerClass($methodName, $arguments)
     {
         if (!method_exists(Controller::class, $methodName)) {
             throw new \LogicException('Call to undefined method '.__CLASS__.'::'.$methodName);

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3724,8 +3724,11 @@ class CRUDControllerTest extends TestCase
 
     public function testItThrowsOnMissingRenderParameter()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectException(\ArgumentCountError::class);
+        if (class_exists(\ArgumentCountError::class)) {
+            $this->expectException(\ArgumentCountError::class);
+        } else {
+            $this->expectException(\LogicException::class);
+        }
         $this->controller->render();
     }
 

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -587,7 +587,7 @@ class CRUDControllerTest extends TestCase
         $this->parameters = [];
         $this->assertInstanceOf(
             'Symfony\Component\HttpFoundation\Response',
-            $this->controller->render('FooAdminBundle::foo.html.twig', [], null)
+            $this->controller->renderWithExtraParams('FooAdminBundle::foo.html.twig', [], null)
         );
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -600,7 +600,7 @@ class CRUDControllerTest extends TestCase
         $this->parameters = [];
         $response = $response = new Response();
         $response->headers->set('X-foo', 'bar');
-        $responseResult = $this->controller->render('FooAdminBundle::foo.html.twig', [], $response);
+        $responseResult = $this->controller->renderWithExtraParams('FooAdminBundle::foo.html.twig', [], $response);
 
         $this->assertSame($response, $responseResult);
         $this->assertSame('bar', $responseResult->headers->get('X-foo'));
@@ -615,7 +615,7 @@ class CRUDControllerTest extends TestCase
         $this->parameters = [];
         $this->assertInstanceOf(
             'Symfony\Component\HttpFoundation\Response',
-            $this->controller->render(
+            $this->controller->renderWithExtraParams(
                 'FooAdminBundle::foo.html.twig',
                 ['foo' => 'bar'],
                 null
@@ -634,7 +634,7 @@ class CRUDControllerTest extends TestCase
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
         $this->assertInstanceOf(
             'Symfony\Component\HttpFoundation\Response',
-            $this->controller->render(
+            $this->controller->renderWithExtraParams(
                 'FooAdminBundle::foo.html.twig',
                 ['foo' => 'bar'],
                 null

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3713,6 +3713,39 @@ class CRUDControllerTest extends TestCase
         $this->assertSame('bar', $this->request->request->get('foo'));
     }
 
+    public function testItThrowsWhenCallingAnUndefinedMethod()
+    {
+        $this->setExpectedException(
+            \LogicException::class,
+            'Call to undefined method Sonata\AdminBundle\Controller\CRUDController::doesNotExist'
+        );
+        $this->controller->doesNotExist();
+    }
+    public function testItThrowsOnMissingRenderParameter()
+    {
+        try {
+            $this->controller->render();
+        } catch (\Exception $exception) {
+            $this->assertInstanceOf(\LogicException::class, $exception);
+            $this->assertEquals(
+                'Sonata\AdminBundle\Controller\CRUDController::render requires at least one argument',
+                $exception->getMessage()
+            );
+        } catch (\ArgumentCountError $error) {
+            $this->assertStringStartsWith(
+                'Too few arguments to function Sonata\AdminBundle\Controller\CRUDController::render(), 0 passed',
+                $error->getMessage()
+            );
+        }
+    }
+    /**
+     * @expectedDeprecation
+     */
+    public function testRenderIsDeprecated()
+    {
+        $this->controller->render('toto.html.twig');
+    }
+
     public function getCsrfProvider()
     {
         return $this->csrfProvider;

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3723,7 +3723,7 @@ class CRUDControllerTest extends TestCase
     }
 
     /**
-     * @expectedDeprecation
+     * @expectedDeprecation Method Sonata\AdminBundle\Controller\CRUDController::render has been renamed to Sonata\AdminBundle\Controller\CRUDController::renderWithExtraParams
      */
     public function testRenderIsDeprecated()
     {

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -432,7 +432,13 @@ class CRUDControllerTest extends TestCase
             'addFlash',
         ];
         foreach ($testedMethods as $testedMethod) {
-            $method = new \ReflectionMethod('Sonata\\AdminBundle\\Controller\\CRUDController', $testedMethod);
+            // NEXT_MAJOR: Remove this check and only use CRUDController
+            if (method_exists('Sonata\\AdminBundle\\Controller\\CRUDController', $testedMethod)) {
+                $method = new \ReflectionMethod('Sonata\\AdminBundle\\Controller\\CRUDController', $testedMethod);
+            } else {
+                $method = new \ReflectionMethod('Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller', $testedMethod);
+            }
+
             $method->setAccessible(true);
             $this->protectedTestedMethods[$testedMethod] = $method;
         }
@@ -950,12 +956,6 @@ class CRUDControllerTest extends TestCase
             ['create', 'create', ['btn_create_and_create' => true], false],
             ['create?subclass=foo', 'create', ['btn_create_and_create' => true, 'subclass' => 'foo'], true],
         ];
-    }
-
-    public function testAddFlash()
-    {
-        $this->protectedTestedMethods['addFlash']->invoke($this->controller, 'foo', 'bar');
-        $this->assertSame(['bar'], $this->session->getFlashBag()->get('foo'));
     }
 
     public function testDeleteActionNotFoundException()

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3721,6 +3721,7 @@ class CRUDControllerTest extends TestCase
         );
         $this->controller->doesNotExist();
     }
+
     public function testItThrowsOnMissingRenderParameter()
     {
         try {
@@ -3738,6 +3739,7 @@ class CRUDControllerTest extends TestCase
             );
         }
     }
+
     /**
      * @expectedDeprecation
      */

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3722,16 +3722,6 @@ class CRUDControllerTest extends TestCase
         $this->controller->doesNotExist();
     }
 
-    public function testItThrowsOnMissingRenderParameter()
-    {
-        if (class_exists(\ArgumentCountError::class)) {
-            $this->expectException(\ArgumentCountError::class);
-        } else {
-            $this->expectException(\LogicException::class);
-        }
-        $this->controller->render();
-    }
-
     /**
      * @expectedDeprecation
      */

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3724,20 +3724,9 @@ class CRUDControllerTest extends TestCase
 
     public function testItThrowsOnMissingRenderParameter()
     {
-        try {
-            $this->controller->render();
-        } catch (\Exception $exception) {
-            $this->assertInstanceOf(\LogicException::class, $exception);
-            $this->assertEquals(
-                'Sonata\AdminBundle\Controller\CRUDController::render requires at least one argument',
-                $exception->getMessage()
-            );
-        } catch (\ArgumentCountError $error) {
-            $this->assertStringStartsWith(
-                'Too few arguments to function Sonata\AdminBundle\Controller\CRUDController::render(), 0 passed',
-                $error->getMessage()
-            );
-        }
+        $this->expectException(\LogicException::class);
+        $this->expectException(\ArgumentCountError::class);
+        $this->controller->render();
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this fixes a deprecation warning in Symfony 3.4 and a possible incompatibility with Symfony 4.0+.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4701 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `CRUDController::renderWithExtraParams` as a replacement for the `render` method

### Deprecated
- Deprecated `CRUDController::render`

### Fixed
- Deprecation warning for overriding `Controller::render` which is supposed to be final
```

## Subject

The basic solution has already been merged previously, in #4765.
It has then been reverted again in #4780 because it introduced a BC issue due to the now different behaviour of `CRUDController::render` (which was the inherited method from `Controller` that does not add required parameters.)

This PR re-implements the solution while avoiding the BC issues:

**Symfony 3.4 / 4.0+:** Instead of inheriting from `Controller`, we use the `ControllerTrait` (which contains all the helper methods) directly, aliasing the `render` method. No problem here.

**Symfony 3.3**: Same, but in 3.3 the `ControllerTrait` does not contain the methods `get()` and `has()`. I solve that issue by implementing `__call()` on `CRUDController` which handles those two methods specifically.

**Symfony 2.8 - 3.2:** These versions do not yet contain a `ControllerTrait`, so I polyfill it. That polyfill's methods are copied from 3.2's `Controller` class.