### PR TITLE
FormRenderer does not have a method to set its environment

### DIFF
--- a/src/Controller/HelperController.php
+++ b/src/Controller/HelperController.php
@@ -567,9 +567,6 @@ class HelperController
             return $runtime;
         }
 
-        $runtime = $this->twig->getRuntime(FormRenderer::class);
-        $runtime->setEnvironment($this->twig);
-
-        return $runtime;
+        return $this->twig->getRuntime(FormRenderer::class);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4787 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Problem with FormRenderer not having environment causing that inline collection was unusable on SF 3.4
```

## Subject

<!-- Describe your Pull Request content here -->
FormRenderer does not have `setEnvironment` method.
Does this fix your issue @virtualize ? I would like to test it also, don't want to make more mistakes with this one