### PR TITLE
Add whitespace control in `standard_layout.html.twig` in order to avoid client side rendering issues

### DIFF
--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% set _preview = block('preview') is defined ? block('preview')|trim : null %}
+{%- set _preview = block('preview') is defined ? block('preview')|trim : null %}
 {% set _form = block('form') is defined ? block('form')|trim : null %}
 {% set _show = block('show') is defined ? block('show')|trim : null %}
 {% set _list_table = block('list_table') is defined ? block('list_table')|trim : null %}
@@ -20,7 +20,7 @@ file that was distributed with this source code.
 {% set _breadcrumb = block('breadcrumb') is defined ? block('breadcrumb')|trim : null %}
 {% set _actions = block('actions') is defined ? block('actions')|trim : null %}
 {% set _navbar_title = block('navbar_title') is defined ? block('navbar_title')|trim : null %}
-{% set _list_filters_actions = block('list_filters_actions') is defined ? block('list_filters_actions')|trim : null %}
+{% set _list_filters_actions = block('list_filters_actions') is defined ? block('list_filters_actions')|trim : null -%}
 
 <!DOCTYPE html>
 <html {% block html_attributes %}class="no-js"{% endblock %}>


### PR DESCRIPTION
I am targeting this branch, because this fix doesn't introduce any backward incompatible change.

## Changelog
```markdown
### Fixed
- Updated `src/Resources/views/standard_layout.html.twig` template in order to remove whitespace rendering before HTML DOCTYPE declaration.
```

## To do
~~- [ ] Add test~~

## Subject
Without this fix, there are 2 line breaks before the `<!DOCTYPE html>` declaration:

![image](https://user-images.githubusercontent.com/1231441/33272215-43c5fe32-d368-11e7-99bb-e6bcd21d3f9f.png)
Causing client to throw an `Uncaught SyntaxError`:

![image](https://user-images.githubusercontent.com/1231441/33272151-1a5b3238-d368-11e7-885b-c5a88f186183.png)

