### PR TITLE
Use class for ancestors and remove set parent as current

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,11 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated ChildrenVoter and service
+
+The feature provided by this class was replaced with something much more simple, and you should not rely on it anymore,
+as well as on the `sonata.admin.menu.matcher.voter.children` service.
+
 UPGRADE FROM 3.26 to 3.27
 =========================
 

--- a/src/Menu/Matcher/Voter/ChildrenVoter.php
+++ b/src/Menu/Matcher/Voter/ChildrenVoter.php
@@ -15,10 +15,17 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\MatcherInterface;
 use Knp\Menu\Matcher\Voter\VoterInterface;
 
+@trigger_error(sprintf(
+    '"%s" is deprecated since 3.x, will be removed in 4.0.',
+    ChildrenVoter::class
+));
+
 /**
  * Children menu voter based on children items.
  *
  * @author Samusev Andrey <andrey.simfi@ya.ru>
+ *
+ * @deprecated since 3.x, will be removed in 4.0.
  */
 class ChildrenVoter implements VoterInterface
 {

--- a/src/Resources/config/menu.xml
+++ b/src/Resources/config/menu.xml
@@ -21,8 +21,8 @@
             <tag name="knp_menu.voter" request="true"/>
         </service>
         <service id="sonata.admin.menu.matcher.voter.children" class="Sonata\AdminBundle\Menu\Matcher\Voter\ChildrenVoter" public="true">
+            <deprecated>The "%service_id%" service is deprecated since 3.x and will be removed in 4.0.</deprecated>
             <argument type="service" id="knp_menu.matcher"/>
-            <tag name="knp_menu.voter"/>
         </service>
         <service id="sonata.admin.menu.matcher.voter.active" class="Sonata\AdminBundle\Menu\Matcher\Voter\ActiveVoter" public="true">
             <tag name="knp_menu.voter"/>

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -16,7 +16,7 @@
     {%- endif %}
 
     {%- if item.displayed and display|default %}
-        {% set options = options|merge({branch_class: 'treeview', currentClass: "active"}) %}
+        {% set options = options|merge({branch_class: 'treeview', currentClass: "active", ancestorClass: "active"}) %}
         {%- do item.setChildrenAttribute('class', (item.childrenAttribute('class')~' active')|trim) %}
         {%- do item.setChildrenAttribute('class', (item.childrenAttribute('class')~' treeview-menu')|trim) %}
         {{ parent() }}

--- a/tests/Menu/Matcher/Voter/ChildrenVoterTest.php
+++ b/tests/Menu/Matcher/Voter/ChildrenVoterTest.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Menu\Matcher\Voter\ChildrenVoter;
 
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
+ * @group legacy
  */
 class ChildrenVoterTest extends AbstractVoterTest
 {


### PR DESCRIPTION
I am targeting this branch, because this is BC.

Closes #4639 
Fixes #4805

## Changelog
```markdown
### Fixed
- interference with other bundles

### Deprecated
- using the `ChildrenVoter` class
- using the `sonata.admin.menu.matcher.voter.children` service
```

## Subject

This is a carry of #4639
