### PR TITLE
Fix "request" attribute deprecation on "knp_menu.voter"

### DIFF
--- a/src/Menu/Matcher/Voter/AdminVoter.php
+++ b/src/Menu/Matcher/Voter/AdminVoter.php
@@ -35,8 +35,6 @@ class AdminVoter implements VoterInterface
     private $request = null;
 
     /**
-     * AdminVoter constructor.
-     *
      * @param RequestStack $requestStack
      */
     public function __construct(RequestStack $requestStack = null)
@@ -53,7 +51,14 @@ class AdminVoter implements VoterInterface
      */
     public function setRequest($request)
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 3.x. Pass a RequestStack in the constructor instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated since version 3.x.
+                Pass a Symfony\Component\HttpFoundation\RequestStack
+                in the constructor instead.',
+            __METHOD__),
+            E_USER_DEPRECATED
+        );
 
         $this->request = $request;
 

--- a/src/Menu/Matcher/Voter/AdminVoter.php
+++ b/src/Menu/Matcher/Voter/AdminVoter.php
@@ -39,7 +39,7 @@ class AdminVoter implements VoterInterface
      *
      * @param RequestStack $requestStack
      */
-    public function __construct($requestStack = null)
+    public function __construct(RequestStack $requestStack = null)
     {
         $this->requestStack = $requestStack;
     }

--- a/src/Menu/Matcher/Voter/AdminVoter.php
+++ b/src/Menu/Matcher/Voter/AdminVoter.php
@@ -15,6 +15,7 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\VoterInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Admin menu voter based on extra `admin`.
@@ -33,13 +34,18 @@ class AdminVoter implements VoterInterface
      */
     private $request = null;
 
+    /**
+     * AdminVoter constructor.
+     *
+     * @param RequestStack $requestStack
+     */
     public function __construct($requestStack = null)
     {
         $this->requestStack = $requestStack;
     }
 
     /**
-     * @deprecated since version 3.29. Pass a RequestStack to the constructor instead.
+     * @deprecated since version 3.x. Pass a RequestStack to the constructor instead.
      *
      * @param Request $request
      *
@@ -47,7 +53,7 @@ class AdminVoter implements VoterInterface
      */
     public function setRequest($request)
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 3.29. Pass a RequestStack in the constructor instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 3.x. Pass a RequestStack in the constructor instead.', __METHOD__), E_USER_DEPRECATED);
 
         $this->request = $request;
 

--- a/src/Menu/Matcher/Voter/AdminVoter.php
+++ b/src/Menu/Matcher/Voter/AdminVoter.php
@@ -24,17 +24,31 @@ use Symfony\Component\HttpFoundation\Request;
 class AdminVoter implements VoterInterface
 {
     /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
      * @var Request
      */
     private $request = null;
 
+    public function __construct($requestStack = null)
+    {
+        $this->requestStack = $requestStack;
+    }
+
     /**
+     * @deprecated since version 3.29. Pass a RequestStack to the constructor instead.
+     *
      * @param Request $request
      *
      * @return $this
      */
     public function setRequest($request)
     {
+        @trigger_error(sprintf('The %s() method is deprecated since version 3.29. Pass a RequestStack in the constructor instead.', __METHOD__), E_USER_DEPRECATED);
+
         $this->request = $request;
 
         return $this;
@@ -47,11 +61,17 @@ class AdminVoter implements VoterInterface
     {
         $admin = $item->getExtra('admin');
 
+        if (null !== $this->requestStack) {
+            $request = $this->requestStack->getMasterRequest();
+        } else {
+            $request = $this->request;
+        }
+
         if ($admin instanceof AdminInterface
             && $admin->hasRoute('list') && $admin->hasAccess('list')
-            && $this->request
+            && $request
         ) {
-            $requestCode = $this->request->get('_sonata_admin');
+            $requestCode = $request->get('_sonata_admin');
 
             if ($admin->getCode() === $requestCode) {
                 return true;
@@ -65,7 +85,7 @@ class AdminVoter implements VoterInterface
         }
 
         $route = $item->getExtra('route');
-        if ($route && $this->request && $route == $this->request->get('_route')) {
+        if ($route && $request && $route == $request->get('_route')) {
             return true;
         }
 

--- a/src/Resources/config/menu.xml
+++ b/src/Resources/config/menu.xml
@@ -18,7 +18,8 @@
             <tag name="knp_menu.provider"/>
         </service>
         <service id="sonata.admin.menu.matcher.voter.admin" class="Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter" public="true">
-            <tag name="knp_menu.voter" request="true"/>
+            <argument type="service" id="request_stack" />
+            <tag name="knp_menu.voter"/>
         </service>
         <service id="sonata.admin.menu.matcher.voter.children" class="Sonata\AdminBundle\Menu\Matcher\Voter\ChildrenVoter" public="true">
             <argument type="service" id="knp_menu.matcher"/>

--- a/src/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ru.xliff
@@ -74,6 +74,10 @@
                 <source>link_add</source>
                 <target>Добавить новый</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Редактировать</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Список</target>
@@ -173,6 +177,10 @@
             <trans-unit id="flash_batch_delete_success">
                 <source>flash_batch_delete_success</source>
                 <target>Выбранные элементы были успешно удалены.</target>
+            </trans-unit>
+            <trans-unit id="flash_batch_no_elements_processed">
+                <source>flash_batch_no_elements_processed</source>
+                <target>Нет обработанных элементов.</target>
             </trans-unit>
             <trans-unit id="flash_batch_delete_error">
                 <source>flash_batch_delete_error</source>

--- a/tests/Menu/Matcher/Voter/AdminVoterTest.php
+++ b/tests/Menu/Matcher/Voter/AdminVoterTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Tests\Menu\Matcher\Voter;
 
 use Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Request;
 
 class AdminVoterTest extends AbstractVoterTest
@@ -40,6 +41,27 @@ class AdminVoterTest extends AbstractVoterTest
      * {@inheritdoc}
      */
     protected function createVoter($dataVoter, $route)
+    {
+        $request = new Request();
+        $request->request->set('_sonata_admin', $dataVoter);
+        $request->request->set('_route', $route);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $voter = new AdminVoter($requestStack);
+
+        return $voter;
+    }
+
+    /**
+     * @param mixed $dataVoter
+     * @param mixed $route
+     *
+     * @return VoterInterface
+     * @group legacy
+     */
+    protected function createVoterLegacy($dataVoter, $route)
     {
         $voter = new AdminVoter();
         $request = new Request();

--- a/tests/Menu/Matcher/Voter/AdminVoterTest.php
+++ b/tests/Menu/Matcher/Voter/AdminVoterTest.php
@@ -12,8 +12,8 @@
 namespace Sonata\AdminBundle\Tests\Menu\Matcher\Voter;
 
 use Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class AdminVoterTest extends AbstractVoterTest
 {


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Fixed
- `request` attribute deprecation on `knp_menu.voter`
```

## Subject

Using the "request" attribute of the "knp_menu.voter" tag is deprecated since KnpMenuBundle version 2.2. The RequestStack should be injected in the voter instead.