### PR TITLE
Fix content position only if needed

### DIFF
--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -661,9 +661,7 @@ var Admin = {
         });
     },
     handle_top_navbar_height: function() {
-        if (jQuery('body.fixed').length === 1) {
-            jQuery('.content-wrapper').css('padding-top', jQuery('.navbar-static-top').outerHeight());
-        }
+        jQuery('body.fixed .content-wrapper').css('padding-top', jQuery('.navbar-static-top').outerHeight());
     }
 };
 

--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -661,7 +661,9 @@ var Admin = {
         });
     },
     handle_top_navbar_height: function() {
-        jQuery('.content-wrapper').css('padding-top', jQuery('.navbar-static-top').outerHeight());
+        if (jQuery('body.fixed').length === 1) {
+            jQuery('.content-wrapper').css('padding-top', jQuery('.navbar-static-top').outerHeight());
+        }
     }
 };
 


### PR DESCRIPTION
I am targeting this branch, because this has no BC breaks in it.

The patch which was introduced by [this PR](https://github.com/sonata-project/SonataAdminBundle/pull/4678) is needed, if the `body` element uses the `fixed` class offered by AdminLTE for making the header fixed. However the above mentioned patch creates a big gap in the layout, if the header is not fixed. 

## Changelog
```markdown
### Fixed
- Checking for fixed class on body before adjusting the position of the content div
```

Fix content position only if needed.
