### PR TITLE
Replace deprecated boolean flag in route generator

### DIFF
--- a/src/Admin/UrlGeneratorInterface.php
+++ b/src/Admin/UrlGeneratorInterface.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Admin;
 
 use Sonata\AdminBundle\Route\RouteGeneratorInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface as RoutingUrlGeneratorInterface;
 
 /**
  * Contains url generation logic related to an admin.
@@ -45,33 +46,33 @@ interface UrlGeneratorInterface
      * @param string $name
      * @param mixed  $object
      * @param array  $parameters
-     * @param bool   $absolute
+     * @param int    $absolute
      *
      * @return string return a complete url
      */
-    public function generateObjectUrl($name, $object, array $parameters = [], $absolute = false);
+    public function generateObjectUrl($name, $object, array $parameters = [], $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH);
 
     /**
      * Generates a url for the given parameters.
      *
      * @param string $name
      * @param array  $parameters
-     * @param bool   $absolute
+     * @param int    $absolute
      *
      * @return string return a complete url
      */
-    public function generateUrl($name, array $parameters = [], $absolute = false);
+    public function generateUrl($name, array $parameters = [], $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH);
 
     /**
      * Generates a url for the given parameters.
      *
      * @param string $name
      * @param array  $parameters
-     * @param bool   $absolute
+     * @param int    $absolute
      *
      * @return array return url parts: 'route', 'routeParameters', 'routeAbsolute'
      */
-    public function generateMenuUrl($name, array $parameters = [], $absolute = false);
+    public function generateMenuUrl($name, array $parameters = [], $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH);
 
     /**
      * @param mixed $entity

--- a/src/Twig/GlobalVariables.php
+++ b/src/Twig/GlobalVariables.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Twig;
 
 use Sonata\AdminBundle\Admin\Pool;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -67,11 +68,11 @@ class GlobalVariables
      * @param string $code
      * @param string $action
      * @param array  $parameters
-     * @param mixed  $absolute
+     * @param int    $absolute
      *
      * @return string
      */
-    public function url($code, $action, $parameters = [], $absolute = false)
+    public function url($code, $action, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
         list($action, $code) = $this->getCodeAction($code, $action);
 
@@ -83,11 +84,11 @@ class GlobalVariables
      * @param string $action
      * @param mixed  $object
      * @param array  $parameters
-     * @param mixed  $absolute
+     * @param int    $absolute
      *
      * @return string
      */
-    public function objectUrl($code, $action, $object, $parameters = [], $absolute = false)
+    public function objectUrl($code, $action, $object, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
         list($action, $code) = $this->getCodeAction($code, $action);
 

--- a/tests/Twig/GlobalVariablesTest.php
+++ b/tests/Twig/GlobalVariablesTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Twig;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Twig\GlobalVariables;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
@@ -36,7 +37,7 @@ class GlobalVariablesTest extends TestCase
     {
         $this->admin->expects($this->once())
             ->method('generateUrl')
-            ->with('sonata.page.admin.page|sonata.page.admin.snapshot.list', ['foo'], false)
+            ->with('sonata.page.admin.page|sonata.page.admin.snapshot.list', ['foo'], UrlGeneratorInterface::ABSOLUTE_PATH)
             ->willReturn(true);
 
         $this->pool->expects($this->once())
@@ -53,7 +54,7 @@ class GlobalVariablesTest extends TestCase
     {
         $this->admin->expects($this->once())
             ->method('generateObjectUrl')
-            ->with('sonata.page.admin.page|sonata.page.admin.snapshot.list', 'foo', ['bar'], false)
+            ->with('sonata.page.admin.page|sonata.page.admin.snapshot.list', 'foo', ['bar'], UrlGeneratorInterface::ABSOLUTE_PATH)
             ->willReturn(true);
 
         $this->pool->expects($this->once())
@@ -74,7 +75,7 @@ class GlobalVariablesTest extends TestCase
     {
         $this->admin->expects($this->once())
             ->method('generateUrl')
-            ->with('sonata.page.admin.page|sonata.page.admin.snapshot.list', ['foo'], false)
+            ->with('sonata.page.admin.page|sonata.page.admin.snapshot.list', ['foo'], UrlGeneratorInterface::ABSOLUTE_PATH)
             ->willReturn(true);
 
         $this->pool->expects($this->once())


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed calling route generator with boolean value
```


## Subject

This will reduce some deprecation warnings.
