### PR TITLE
Temporary fix for SF4 DI changes until we can support service locators

### DIFF
--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -53,6 +53,9 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                 $definition = $container->getDefinition($id);
                 $parentDefinition = null;
 
+                // Temporary fix until we can support service locators
+                $definition->setPublic(true);
+
                 // NEXT_MAJOR: Remove check for DefinitionDecorator instance when dropping Symfony <3.3 support
                 if ($definition instanceof ChildDefinition ||
                     (!class_exists(ChildDefinition::class) && $definition instanceof DefinitionDecorator)) {

--- a/src/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
@@ -31,6 +31,7 @@ class AddFilterTypeCompilerPass implements CompilerPassInterface
             $serviceDefinition = $container->getDefinition($id);
 
             $serviceDefinition->setShared(false);
+            $serviceDefinition->setPublic(true); // Temporary fix until we can support service locators
 
             $types[$serviceDefinition->getClass()] = $id;
 


### PR DESCRIPTION
I am targeting this branch, because this is backward-compatible bug fix.

## Changelog

```markdown
### Changed
- Services tagged with `sonata.admin` and `sonata.admin.filter.type` are now public
```

## Subject

Prevents the following messages:

> User Deprecated: The "sonata.admin.orm.filter.type.number"  service is private, getting it from the container is deprecated since  Symfony 3.2 and will fail in 4.0. You should either make the service  public, or stop using the container directly and use dependency  injection instead.

Also should fix SF4 compatibility