### PR TITLE
Replace FQCN strings with ::class constants

### DIFF
--- a/src/Admin/Extension/LockExtension.php
+++ b/src/Admin/Extension/LockExtension.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Model\LockInterface;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
@@ -59,7 +60,7 @@ class LockExtension extends AbstractAdminExtension
 
             $form->add(
                 $fieldName,
-                'Symfony\Component\Form\Extension\Core\Type\HiddenType',
+                HiddenType::class,
                 [
                     'mapped' => false,
                     'data' => $lockVersion,

--- a/src/Command/GenerateAdminCommand.php
+++ b/src/Command/GenerateAdminCommand.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Command;
 
+use Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle;
 use Sonata\AdminBundle\Generator\AdminGenerator;
 use Sonata\AdminBundle\Generator\ControllerGenerator;
 use Sonata\AdminBundle\Manipulator\ServicesManipulator;
@@ -58,7 +59,7 @@ class GenerateAdminCommand extends QuestionableCommand
      */
     public function isEnabled()
     {
-        return class_exists('Sensio\\Bundle\\GeneratorBundle\\SensioGeneratorBundle');
+        return class_exists(SensioGeneratorBundle::class);
     }
 
     /**

--- a/src/Controller/HelperController.php
+++ b/src/Controller/HelperController.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Filter\FilterInterface;
+use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Bridge\Twig\Command\DebugCommand;
 use Symfony\Bridge\Twig\Extension\FormExtension;
@@ -341,7 +342,7 @@ class HelperController
 
         // render the widget
         // todo : fix this, the twig environment variable is not set inside the extension ...
-        $extension = $this->twig->getExtension('Sonata\AdminBundle\Twig\Extension\SonataAdminExtension');
+        $extension = $this->twig->getExtension(SonataAdminExtension::class);
 
         $content = $extension->renderListElement($this->twig, $rootObject, $fieldDescription);
 

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 
@@ -124,7 +125,7 @@ class Datagrid implements DatagridInterface
             $this->formBuilder->add($filter->getFormName(), $type, $options);
         }
 
-        $hiddenType = 'Symfony\Component\Form\Extension\Core\Type\HiddenType';
+        $hiddenType = HiddenType::class;
 
         $this->formBuilder->add('_sort_by', $hiddenType);
         $this->formBuilder->get('_sort_by')->addViewTransformer(new CallbackTransformer(
@@ -152,7 +153,7 @@ class Datagrid implements DatagridInterface
 
         if (isset($this->values['_sort_by'])) {
             if (!$this->values['_sort_by'] instanceof FieldDescriptionInterface) {
-                throw new UnexpectedTypeException($this->values['_sort_by'], 'FieldDescriptionInterface');
+                throw new UnexpectedTypeException($this->values['_sort_by'], FieldDescriptionInterface::class);
             }
 
             if ($this->values['_sort_by']->isSortable()) {

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -11,11 +11,97 @@
 
 namespace Sonata\AdminBundle\DependencyInjection;
 
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AbstractAdminExtension;
+use Sonata\AdminBundle\Admin\AdminExtensionInterface;
+use Sonata\AdminBundle\Admin\AdminHelper;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\BaseFieldDescription;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Block\AdminListBlockService;
+use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
+use Sonata\AdminBundle\Builder\FormContractorInterface;
+use Sonata\AdminBundle\Builder\ListBuilderInterface;
+use Sonata\AdminBundle\Builder\RouteBuilderInterface;
+use Sonata\AdminBundle\Builder\ShowBuilderInterface;
+use Sonata\AdminBundle\Datagrid\Datagrid;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Datagrid\Pager;
+use Sonata\AdminBundle\Datagrid\PagerInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Exception\ModelManagerException;
+use Sonata\AdminBundle\Exception\NoValueException;
+use Sonata\AdminBundle\Filter\Filter;
+use Sonata\AdminBundle\Filter\FilterFactory;
+use Sonata\AdminBundle\Filter\FilterFactoryInterface;
+use Sonata\AdminBundle\Filter\FilterInterface;
+use Sonata\AdminBundle\Form\DataTransformer\ArrayToModelTransformer;
+use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
+use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
+use Sonata\AdminBundle\Form\EventListener\MergeCollectionListener;
+use Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\AdminType;
+use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
+use Sonata\AdminBundle\Form\Type\Filter\DateRangeType;
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeType;
+use Sonata\AdminBundle\Form\Type\Filter\DateType;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\AdminBundle\Form\Type\Filter\NumberType;
+use Sonata\AdminBundle\Form\Type\ModelListType;
+use Sonata\AdminBundle\Form\Type\ModelReferenceType;
+use Sonata\AdminBundle\Form\Type\ModelType;
+use Sonata\AdminBundle\Guesser\TypeGuesserChain;
+use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
+use Sonata\AdminBundle\Model\AuditManager;
+use Sonata\AdminBundle\Model\AuditManagerInterface;
+use Sonata\AdminBundle\Model\AuditReaderInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Route\AdminPoolLoader;
+use Sonata\AdminBundle\Route\DefaultRouteGenerator;
+use Sonata\AdminBundle\Route\PathInfoBuilder;
+use Sonata\AdminBundle\Route\QueryStringBuilder;
+use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\AdminBundle\Route\RouteGeneratorInterface;
+use Sonata\AdminBundle\Security\Acl\Permission\AdminPermissionMap;
+use Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder;
+use Sonata\AdminBundle\Security\Handler\AclSecurityHandler;
+use Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface;
+use Sonata\AdminBundle\Security\Handler\NoopSecurityHandler;
+use Sonata\AdminBundle\Security\Handler\RoleSecurityHandler;
+use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
+use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy;
+use Sonata\AdminBundle\Translator\FormLabelTranslatorStrategy;
+use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
+use Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy;
+use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
+use Sonata\AdminBundle\Translator\UnderscoreLabelTranslatorStrategy;
+use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension as TwigSonataAdminExtension;
+use Sonata\AdminBundle\Util\AdminAclManipulator;
+use Sonata\AdminBundle\Util\AdminAclManipulatorInterface;
+use Sonata\AdminBundle\Util\FormBuilderIterator;
+use Sonata\AdminBundle\Util\FormViewIterator;
+use Sonata\AdminBundle\Util\ObjectAclManipulator;
+use Sonata\AdminBundle\Util\ObjectAclManipulatorInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType as SymfonyChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType as SymfonyDateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType as SymfonyDateType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType as SymfonyEmailType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType as SymfonyIntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType as SymfonyTextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType as SymfonyTextType;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -65,7 +151,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         }
 
         // NEXT_MAJOR : remove this block
-        if (method_exists('Symfony\Component\DependencyInjection\Definition', 'setDeprecated')) {
+        if (method_exists(Definition::class, 'setDeprecated')) {
             $container->getDefinition('sonata.admin.exporter')->setDeprecated(
                 'The service "%service_id%" is deprecated in favor of the "sonata.exporter.exporter" service'
             );
@@ -186,13 +272,13 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
             'date' => 'sonata-medium-date',
 
             // SF3+
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' => '',
-            'Symfony\Component\Form\Extension\Core\Type\DateType' => 'sonata-medium-date',
-            'Symfony\Component\Form\Extension\Core\Type\DateTimeType' => 'sonata-medium-date',
-            'Symfony\Component\Form\Extension\Core\Type\EmailType' => '',
-            'Symfony\Component\Form\Extension\Core\Type\IntegerType' => '',
-            'Symfony\Component\Form\Extension\Core\Type\TextareaType' => '',
-            'Symfony\Component\Form\Extension\Core\Type\TextType' => '',
+            SymfonyChoiceType::class => '',
+            SymfonyDateType::class => 'sonata-medium-date',
+            SymfonyDateTimeType::class => 'sonata-medium-date',
+            SymfonyEmailType::class => '',
+            SymfonyIntegerType::class => '',
+            SymfonyTextareaType::class => '',
+            SymfonyTextType::class => '',
         ];
 
         $container->getDefinition('sonata.admin.form.extension.field')
@@ -288,84 +374,84 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
     public function configureClassesToCompile()
     {
         $this->addClassesToCompile([
-            'Sonata\\AdminBundle\\Admin\\AbstractAdmin',
-            'Sonata\\AdminBundle\\Admin\\AbstractAdminExtension',
-            'Sonata\\AdminBundle\\Admin\\AdminExtensionInterface',
-            'Sonata\\AdminBundle\\Admin\\AdminHelper',
-            'Sonata\\AdminBundle\\Admin\\AdminInterface',
-            'Sonata\\AdminBundle\\Admin\\BaseFieldDescription',
-            'Sonata\\AdminBundle\\Admin\\FieldDescriptionCollection',
-            'Sonata\\AdminBundle\\Admin\\FieldDescriptionInterface',
-            'Sonata\\AdminBundle\\Admin\\Pool',
-            'Sonata\\AdminBundle\\Block\\AdminListBlockService',
-            'Sonata\\AdminBundle\\Builder\\DatagridBuilderInterface',
-            'Sonata\\AdminBundle\\Builder\\FormContractorInterface',
-            'Sonata\\AdminBundle\\Builder\\ListBuilderInterface',
-            'Sonata\\AdminBundle\\Builder\\RouteBuilderInterface',
-            'Sonata\\AdminBundle\\Builder\\ShowBuilderInterface',
-            'Sonata\\AdminBundle\\Datagrid\\Datagrid',
-            'Sonata\\AdminBundle\\Datagrid\\DatagridInterface',
-            'Sonata\\AdminBundle\\Datagrid\\DatagridMapper',
-            'Sonata\\AdminBundle\\Datagrid\\ListMapper',
-            'Sonata\\AdminBundle\\Datagrid\\Pager',
-            'Sonata\\AdminBundle\\Datagrid\\PagerInterface',
-            'Sonata\\AdminBundle\\Datagrid\\ProxyQueryInterface',
-            'Sonata\\AdminBundle\\Exception\\ModelManagerException',
-            'Sonata\\AdminBundle\\Exception\\NoValueException',
-            'Sonata\\AdminBundle\\Filter\\Filter',
-            'Sonata\\AdminBundle\\Filter\\FilterFactory',
-            'Sonata\\AdminBundle\\Filter\\FilterFactoryInterface',
-            'Sonata\\AdminBundle\\Filter\\FilterInterface',
-            'Sonata\\AdminBundle\\Form\\DataTransformer\\ArrayToModelTransformer',
-            'Sonata\\AdminBundle\\Form\\DataTransformer\\ModelsToArrayTransformer',
-            'Sonata\\AdminBundle\\Form\\DataTransformer\\ModelToIdTransformer',
-            'Sonata\\AdminBundle\\Form\\EventListener\\MergeCollectionListener',
-            'Sonata\\AdminBundle\\Form\\Extension\\Field\\Type\\FormTypeFieldExtension',
-            'Sonata\\AdminBundle\\Form\\FormMapper',
-            'Sonata\\AdminBundle\\Form\\Type\\AdminType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\ChoiceType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DateRangeType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DateTimeRangeType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DateTimeType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DateType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\DefaultType',
-            'Sonata\\AdminBundle\\Form\\Type\\Filter\\NumberType',
-            'Sonata\\AdminBundle\\Form\\Type\\ModelReferenceType',
-            'Sonata\\AdminBundle\\Form\\Type\\ModelType',
-            'Sonata\\AdminBundle\\Form\\Type\\ModelListType',
-            'Sonata\\AdminBundle\\Guesser\\TypeGuesserChain',
-            'Sonata\\AdminBundle\\Guesser\\TypeGuesserInterface',
-            'Sonata\\AdminBundle\\Model\\AuditManager',
-            'Sonata\\AdminBundle\\Model\\AuditManagerInterface',
-            'Sonata\\AdminBundle\\Model\\AuditReaderInterface',
-            'Sonata\\AdminBundle\\Model\\ModelManagerInterface',
-            'Sonata\\AdminBundle\\Route\\AdminPoolLoader',
-            'Sonata\\AdminBundle\\Route\\DefaultRouteGenerator',
-            'Sonata\\AdminBundle\\Route\\PathInfoBuilder',
-            'Sonata\\AdminBundle\\Route\\QueryStringBuilder',
-            'Sonata\\AdminBundle\\Route\\RouteCollection',
-            'Sonata\\AdminBundle\\Route\\RouteGeneratorInterface',
-            'Sonata\\AdminBundle\\Security\\Acl\\Permission\\AdminPermissionMap',
-            'Sonata\\AdminBundle\\Security\\Acl\\Permission\\MaskBuilder',
-            'Sonata\\AdminBundle\\Security\\Handler\\AclSecurityHandler',
-            'Sonata\\AdminBundle\\Security\\Handler\\AclSecurityHandlerInterface',
-            'Sonata\\AdminBundle\\Security\\Handler\\NoopSecurityHandler',
-            'Sonata\\AdminBundle\\Security\\Handler\\RoleSecurityHandler',
-            'Sonata\\AdminBundle\\Security\\Handler\\SecurityHandlerInterface',
-            'Sonata\\AdminBundle\\Show\\ShowMapper',
-            'Sonata\\AdminBundle\\Translator\\BCLabelTranslatorStrategy',
-            'Sonata\\AdminBundle\\Translator\\FormLabelTranslatorStrategy',
-            'Sonata\\AdminBundle\\Translator\\LabelTranslatorStrategyInterface',
-            'Sonata\\AdminBundle\\Translator\\NativeLabelTranslatorStrategy',
-            'Sonata\\AdminBundle\\Translator\\NoopLabelTranslatorStrategy',
-            'Sonata\\AdminBundle\\Translator\\UnderscoreLabelTranslatorStrategy',
-            'Sonata\\AdminBundle\\Twig\\Extension\\SonataAdminExtension',
-            'Sonata\\AdminBundle\\Util\\AdminAclManipulator',
-            'Sonata\\AdminBundle\\Util\\AdminAclManipulatorInterface',
-            'Sonata\\AdminBundle\\Util\\FormBuilderIterator',
-            'Sonata\\AdminBundle\\Util\\FormViewIterator',
-            'Sonata\\AdminBundle\\Util\\ObjectAclManipulator',
-            'Sonata\\AdminBundle\\Util\\ObjectAclManipulatorInterface',
+            AbstractAdmin::class,
+            AbstractAdminExtension::class,
+            AdminExtensionInterface::class,
+            AdminHelper::class,
+            AdminInterface::class,
+            BaseFieldDescription::class,
+            FieldDescriptionCollection::class,
+            FieldDescriptionInterface::class,
+            Pool::class,
+            AdminListBlockService::class,
+            DatagridBuilderInterface::class,
+            FormContractorInterface::class,
+            ListBuilderInterface::class,
+            RouteBuilderInterface::class,
+            ShowBuilderInterface::class,
+            Datagrid::class,
+            DatagridInterface::class,
+            DatagridMapper::class,
+            ListMapper::class,
+            Pager::class,
+            PagerInterface::class,
+            ProxyQueryInterface::class,
+            ModelManagerException::class,
+            NoValueException::class,
+            Filter::class,
+            FilterFactory::class,
+            FilterFactoryInterface::class,
+            FilterInterface::class,
+            ArrayToModelTransformer::class,
+            ModelsToArrayTransformer::class,
+            ModelToIdTransformer::class,
+            MergeCollectionListener::class,
+            FormTypeFieldExtension::class,
+            FormMapper::class,
+            AdminType::class,
+            ChoiceType::class,
+            DateRangeType::class,
+            DateTimeRangeType::class,
+            DateTimeType::class,
+            DateType::class,
+            DefaultType::class,
+            NumberType::class,
+            ModelReferenceType::class,
+            ModelType::class,
+            ModelListType::class,
+            TypeGuesserChain::class,
+            TypeGuesserInterface::class,
+            AuditManager::class,
+            AuditManagerInterface::class,
+            AuditReaderInterface::class,
+            ModelManagerInterface::class,
+            AdminPoolLoader::class,
+            DefaultRouteGenerator::class,
+            PathInfoBuilder::class,
+            QueryStringBuilder::class,
+            RouteCollection::class,
+            RouteGeneratorInterface::class,
+            AdminPermissionMap::class,
+            MaskBuilder::class,
+            AclSecurityHandler::class,
+            AclSecurityHandlerInterface::class,
+            NoopSecurityHandler::class,
+            RoleSecurityHandler::class,
+            SecurityHandlerInterface::class,
+            ShowMapper::class,
+            BCLabelTranslatorStrategy::class,
+            FormLabelTranslatorStrategy::class,
+            LabelTranslatorStrategyInterface::class,
+            NativeLabelTranslatorStrategy::class,
+            NoopLabelTranslatorStrategy::class,
+            UnderscoreLabelTranslatorStrategy::class,
+            TwigSonataAdminExtension::class,
+            AdminAclManipulator::class,
+            AdminAclManipulatorInterface::class,
+            FormBuilderIterator::class,
+            FormViewIterator::class,
+            ObjectAclManipulator::class,
+            ObjectAclManipulatorInterface::class,
         ]);
     }
 

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\AdminBundle\Filter;
 
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
@@ -93,7 +95,7 @@ abstract class Filter implements FilterInterface
      */
     public function getFieldType()
     {
-        return $this->getOption('field_type', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        return $this->getOption('field_type', TextType::class);
     }
 
     /**

--- a/src/Form/DataTransformer/LegacyModelsToArrayTransformer.php
+++ b/src/Form/DataTransformer/LegacyModelsToArrayTransformer.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Form\DataTransformer;
 
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
@@ -35,7 +36,7 @@ class LegacyModelsToArrayTransformer implements DataTransformerInterface
      */
     public function __construct(ModelChoiceList $choiceList)
     {
-        if (interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
+        if (interface_exists(ChoiceLoaderInterface::class)) {
             @trigger_error(
                 'The '.__CLASS__.' class is deprecated since 3.11, to be removed in 4.0. '.
                 'Use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer instead.',
@@ -84,7 +85,7 @@ class LegacyModelsToArrayTransformer implements DataTransformerInterface
         );
 
         if (!$collection instanceof \ArrayAccess) {
-            throw new UnexpectedTypeException($collection, '\ArrayAccess');
+            throw new UnexpectedTypeException($collection, \ArrayAccess::class);
         }
 
         if ('' === $keys || null === $keys) {

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -13,7 +13,9 @@ namespace Sonata\AdminBundle\Form;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
+use Sonata\AdminBundle\Form\Type\CollectionType;
 use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType as SymfonyCollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -79,8 +81,8 @@ class FormMapper extends BaseGroupedMapper
 
         // change `collection` to `sonata_type_native_collection` form type to
         // avoid BC break problems
-        if ('collection' === $type || 'Symfony\Component\Form\Extension\Core\Type\CollectionType' === $type) {
-            $type = 'Sonata\AdminBundle\Form\Type\CollectionType';
+        if ('collection' === $type || SymfonyCollectionType::class === $type) {
+            $type = CollectionType::class;
         }
 
         $label = $fieldName;

--- a/src/Form/Type/AclMatrixType.php
+++ b/src/Form/Type/AclMatrixType.php
@@ -66,11 +66,11 @@ class AclMatrixType extends AbstractType
 
         if (method_exists($resolver, 'setDefined')) {
             $resolver->setAllowedTypes('permissions', 'array');
-            $resolver->setAllowedTypes('acl_value', ['string', '\Symfony\Component\Security\Core\User\UserInterface']);
+            $resolver->setAllowedTypes('acl_value', ['string', UserInterface::class]);
         } else {
             $resolver->setAllowedTypes([
                 'permissions' => 'array',
-                'acl_value' => ['string', '\Symfony\Component\Security\Core\User\UserInterface'],
+                'acl_value' => ['string', UserInterface::class],
             ]);
         }
     }

--- a/src/Form/Type/CollectionType.php
+++ b/src/Form/Type/CollectionType.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType as SymfonyCollectionType;
 
 /**
  * This type wrap native `collection` form type and render `add` and `delete`
@@ -26,7 +27,7 @@ class CollectionType extends AbstractType
      */
     public function getParent()
     {
-        return 'Symfony\Component\Form\Extension\Core\Type\CollectionType';
+        return SymfonyCollectionType::class;
     }
 
     /**

--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -13,7 +13,9 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -77,11 +79,11 @@ class ChoiceType extends AbstractType
         $operatorChoices = [];
 
         // NEXT_MAJOR: Remove first check (when requirement of Symfony is >= 2.8)
-        if ('hidden' !== $options['operator_type'] && 'Symfony\Component\Form\Extension\Core\Type\HiddenType' !== $options['operator_type']) {
+        if ('hidden' !== $options['operator_type'] && HiddenType::class !== $options['operator_type']) {
             $operatorChoices['choice_translation_domain'] = 'SonataAdminBundle';
 
             // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
                 $operatorChoices['choices_as_values'] = true;
             }
 

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -77,7 +78,7 @@ class DateRangeType extends AbstractType
         $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
         // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
             $choiceOptions['choices_as_values'] = true;
         }
 

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -77,7 +78,7 @@ class DateTimeRangeType extends AbstractType
         $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
         // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
             $choiceOptions['choices_as_values'] = true;
         }
 

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -93,7 +94,7 @@ class DateTimeType extends AbstractType
         $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
         // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
             $choiceOptions['choices_as_values'] = true;
         }
 

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -93,7 +94,7 @@ class DateType extends AbstractType
         $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
         // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
             $choiceOptions['choices_as_values'] = true;
         }
 

--- a/src/Form/Type/Filter/NumberType.php
+++ b/src/Form/Type/Filter/NumberType.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -88,7 +89,7 @@ class NumberType extends AbstractType
         $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
 
         // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
             $choiceOptions['choices_as_values'] = true;
         }
 

--- a/src/Form/Type/ModelType.php
+++ b/src/Form/Type/ModelType.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -106,7 +107,7 @@ class ModelType extends AbstractType
             );
         };
         // NEXT_MAJOR: Remove this when dropping support for SF 2.8
-        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
             $options['choices_as_values'] = true;
         }
 

--- a/src/Guesser/TypeGuesserChain.php
+++ b/src/Guesser/TypeGuesserChain.php
@@ -35,7 +35,7 @@ class TypeGuesserChain implements TypeGuesserInterface
     {
         foreach ($guessers as $guesser) {
             if (!$guesser instanceof TypeGuesserInterface) {
-                throw new UnexpectedTypeException($guesser, 'Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+                throw new UnexpectedTypeException($guesser, TypeGuesserInterface::class);
             }
 
             if ($guesser instanceof self) {

--- a/src/SonataAdminBundle.php
+++ b/src/SonataAdminBundle.php
@@ -11,10 +11,26 @@
 
 namespace Sonata\AdminBundle;
 
+use Mopa\Bundle\BootstrapBundle\Form\Type\TabType;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
+use Sonata\AdminBundle\Form\Type\AdminType;
+use Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType;
+use Sonata\AdminBundle\Form\Type\CollectionType;
+use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
+use Sonata\AdminBundle\Form\Type\Filter\DateRangeType;
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeType;
+use Sonata\AdminBundle\Form\Type\Filter\DateType;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\AdminBundle\Form\Type\Filter\NumberType;
+use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
+use Sonata\AdminBundle\Form\Type\ModelHiddenType;
+use Sonata\AdminBundle\Form\Type\ModelListType;
+use Sonata\AdminBundle\Form\Type\ModelReferenceType;
+use Sonata\AdminBundle\Form\Type\ModelType;
 use Sonata\CoreBundle\Form\FormHelper;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -48,22 +64,22 @@ class SonataAdminBundle extends Bundle
     public function registerFormMapping()
     {
         FormHelper::registerFormTypeMapping([
-            'sonata_type_admin' => 'Sonata\AdminBundle\Form\Type\AdminType',
-            'sonata_type_model' => 'Sonata\AdminBundle\Form\Type\ModelType',
-            'sonata_type_model_list' => 'Sonata\AdminBundle\Form\Type\ModelListType',
-            'sonata_type_model_reference' => 'Sonata\AdminBundle\Form\Type\ModelReferenceType',
-            'sonata_type_model_hidden' => 'Sonata\AdminBundle\Form\Type\ModelHiddenType',
-            'sonata_type_model_autocomplete' => 'Sonata\AdminBundle\Form\Type\ModelAutocompleteType',
-            'sonata_type_native_collection' => 'Sonata\AdminBundle\Form\Type\CollectionType',
-            'sonata_type_choice_field_mask' => 'Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType',
-            'sonata_type_filter_number' => 'Sonata\AdminBundle\Form\Type\Filter\NumberType',
-            'sonata_type_filter_choice' => 'Sonata\AdminBundle\Form\Type\Filter\ChoiceType',
-            'sonata_type_filter_default' => 'Sonata\AdminBundle\Form\Type\Filter\DefaultType',
-            'sonata_type_filter_date' => 'Sonata\AdminBundle\Form\Type\Filter\DateType',
-            'sonata_type_filter_date_range' => 'Sonata\AdminBundle\Form\Type\Filter\DateRangeType',
-            'sonata_type_filter_datetime' => 'Sonata\AdminBundle\Form\Type\Filter\DateTimeType',
-            'sonata_type_filter_datetime_range' => 'Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType',
-            'tab' => 'Mopa\Bundle\BootstrapBundle\Form\Type\TabType',
+            'sonata_type_admin' => AdminType::class,
+            'sonata_type_model' => ModelType::class,
+            'sonata_type_model_list' => ModelListType::class,
+            'sonata_type_model_reference' => ModelReferenceType::class,
+            'sonata_type_model_hidden' => ModelHiddenType::class,
+            'sonata_type_model_autocomplete' => ModelAutocompleteType::class,
+            'sonata_type_native_collection' => CollectionType::class,
+            'sonata_type_choice_field_mask' => ChoiceFieldMaskType::class,
+            'sonata_type_filter_number' => NumberType::class,
+            'sonata_type_filter_choice' => ChoiceType::class,
+            'sonata_type_filter_default' => DefaultType::class,
+            'sonata_type_filter_date' => DateType::class,
+            'sonata_type_filter_date_range' => DateRangeType::class,
+            'sonata_type_filter_datetime' => DateTimeType::class,
+            'sonata_type_filter_datetime_range' => DateTimeRangeType::class,
+            'tab' => TabType::class,
         ]);
 
         FormHelper::registerFormExtensionMapping('form', [

--- a/src/Util/AdminObjectAclManipulator.php
+++ b/src/Util/AdminObjectAclManipulator.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Util;
 
+use Sonata\AdminBundle\Form\Type\AclMatrixType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -286,7 +287,7 @@ class AdminObjectAclManipulator
 
             $formBuilder->add(
                 $key,
-                'Sonata\AdminBundle\Form\Type\AclMatrixType',
+                AclMatrixType::class,
                 ['permissions' => $permissions, 'acl_value' => $aclValue]
             );
         }

--- a/tests/Admin/AdminHelperTest.php
+++ b/tests/Admin/AdminHelperTest.php
@@ -13,8 +13,14 @@ namespace Sonata\AdminBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminHelper;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormView;
 
 class AdminHelperTest extends TestCase
@@ -26,7 +32,7 @@ class AdminHelperTest extends TestCase
 
     public function setUp()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
 
         $pool = new Pool($container, 'title', 'logo.png');
         $this->helper = new AdminHelper($pool);
@@ -34,8 +40,8 @@ class AdminHelperTest extends TestCase
 
     public function testGetChildFormBuilder()
     {
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
-        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $formBuilder = new FormBuilder('test', 'stdClass', $eventDispatcher, $formFactory);
 
@@ -43,7 +49,7 @@ class AdminHelperTest extends TestCase
         $formBuilder->add($childFormBuilder);
 
         $this->assertNull($this->helper->getChildFormBuilder($formBuilder, 'foo'));
-        $this->isInstanceOf('Symfony\Component\Form\FormBuilder', $this->helper->getChildFormBuilder($formBuilder, 'test_elementId'));
+        $this->isInstanceOf(FormBuilder::class, $this->helper->getChildFormBuilder($formBuilder, 'test_elementId'));
     }
 
     public function testGetChildFormView()
@@ -54,15 +60,15 @@ class AdminHelperTest extends TestCase
         $child->vars['id'] = 'test_elementId';
 
         $this->assertNull($this->helper->getChildFormView($formView, 'foo'));
-        $this->isInstanceOf('Symfony\Component\Form\FormView', $this->helper->getChildFormView($formView, 'test_elementId'));
+        $this->isInstanceOf(FormView::class, $this->helper->getChildFormView($formView, 'test_elementId'));
     }
 
     public function testAddNewInstance()
     {
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->once())->method('getNewInstance')->will($this->returnValue(new \stdClass()));
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getAssociationAdmin')->will($this->returnValue($admin));
         $fieldDescription->expects($this->once())->method('getAssociationMapping')->will($this->returnValue(['fieldName' => 'fooBar']));
 
@@ -76,10 +82,10 @@ class AdminHelperTest extends TestCase
 
     public function testAddNewInstancePlural()
     {
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->once())->method('getNewInstance')->will($this->returnValue(new \stdClass()));
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getAssociationAdmin')->will($this->returnValue($admin));
         $fieldDescription->expects($this->once())->method('getAssociationMapping')->will($this->returnValue(['fieldName' => 'fooBars']));
 
@@ -93,10 +99,10 @@ class AdminHelperTest extends TestCase
 
     public function testAddNewInstanceInflector()
     {
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->once())->method('getNewInstance')->will($this->returnValue(new \stdClass()));
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getAssociationAdmin')->will($this->returnValue($admin));
         $fieldDescription->expects($this->once())->method('getAssociationMapping')->will($this->returnValue(['fieldName' => 'entries']));
 
@@ -142,14 +148,14 @@ class AdminHelperTest extends TestCase
         $object->expects($this->atLeastOnce())->method('getPathToObject')->will($this->returnValue([$subObject]));
         $subObject->expects($this->atLeastOnce())->method('getMore')->will($this->returnValue('Value'));
 
-        $this->expectException('Exception', 'Could not get element id from '.$path.' Failing part: calls');
+        $this->expectException(\Exception::class, 'Could not get element id from '.$path.' Failing part: calls');
 
         $this->helper->getElementAccessPath($path, $object);
     }
 
     public function testAppendFormFieldElementNested()
     {
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $object = $this->getMockBuilder('stdClass')
             ->setMethods(['getSubObject'])
             ->getMock();
@@ -165,9 +171,9 @@ class AdminHelperTest extends TestCase
         $sub3Object = $this->getMockBuilder('stdClass')
             ->setMethods(['getFinalData'])
             ->getMock();
-        $dataMapper = $this->createMock('Symfony\Component\Form\DataMapperInterface');
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
-        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dataMapper = $this->createMock(DataMapperInterface::class);
+        $formFactory = $this->createMock(FormFactoryInterface::class);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $formBuilder = new FormBuilder('test', get_class($simpleObject), $eventDispatcher, $formFactory);
         $childFormBuilder = new FormBuilder('subObject', get_class($subObject), $eventDispatcher, $formFactory);
 
@@ -183,7 +189,7 @@ class AdminHelperTest extends TestCase
         $admin->expects($this->once())->method('getFormBuilder')->will($this->returnValue($formBuilder));
         $admin->expects($this->once())->method('getSubject')->will($this->returnValue($object));
 
-        $this->expectException('Exception', 'unknown collection class');
+        $this->expectException(\Exception::class, 'unknown collection class');
 
         $this->helper->appendFormFieldElement($admin, $simpleObject, 'uniquePartOfId_sub_object_0_and_more_0_final_data');
     }

--- a/tests/Admin/BaseAdminModelManagerTest.php
+++ b/tests/Admin/BaseAdminModelManagerTest.php
@@ -13,6 +13,8 @@ namespace Sonata\AdminBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 
 class BaseAdminModelManager_Admin extends AbstractAdmin
 {
@@ -22,9 +24,9 @@ class BaseAdminModelManagerTest extends TestCase
 {
     public function testHook()
     {
-        $securityHandler = $this->getMockForAbstractClass('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
+        $securityHandler = $this->getMockForAbstractClass(SecurityHandlerInterface::class);
 
-        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
         $modelManager->expects($this->once())->method('create');
         $modelManager->expects($this->once())->method('update');
         $modelManager->expects($this->once())->method('delete');
@@ -42,7 +44,7 @@ class BaseAdminModelManagerTest extends TestCase
 
     public function testObject()
     {
-        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
         $modelManager->expects($this->once())->method('find')->will($this->returnCallback(function ($class, $id) {
             if ('class' != $class) {
                 throw new \RuntimeException('Invalid class argument');
@@ -60,7 +62,7 @@ class BaseAdminModelManagerTest extends TestCase
 
     public function testCreateQuery()
     {
-        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
         $modelManager->expects($this->once())->method('createQuery')->will($this->returnCallback(function ($class) {
             if ('class' != $class) {
                 throw new \RuntimeException('Invalid class argument');
@@ -74,7 +76,7 @@ class BaseAdminModelManagerTest extends TestCase
 
     public function testId()
     {
-        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
         $modelManager->expects($this->exactly(2))->method('getNormalizedIdentifier');
 
         $admin = new BaseAdminModelManager_Admin('code', 'class', 'controller');

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -12,7 +12,9 @@
 namespace Sonata\AdminBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
+use Sonata\AdminBundle\Exception\NoValueException;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\FieldDescription;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooBoolean;
@@ -81,21 +83,21 @@ class BaseFieldDescriptionTest extends TestCase
     {
         $description = new FieldDescription();
 
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $description->setAdmin($admin);
-        $this->isInstanceOf('Sonata\AdminBundle\Admin\AdminInterface', $description->getAdmin());
+        $this->isInstanceOf(AdminInterface::class, $description->getAdmin());
 
-        $associationAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $associationAdmin = $this->getMockForAbstractClass(AdminInterface::class);
         $associationAdmin->expects($this->once())->method('setParentFieldDescription');
 
         $this->assertFalse($description->hasAssociationAdmin());
         $description->setAssociationAdmin($associationAdmin);
         $this->assertTrue($description->hasAssociationAdmin());
-        $this->isInstanceOf('Sonata\AdminBundle\Admin\AdminInterface', $description->getAssociationAdmin());
+        $this->isInstanceOf(AdminInterface::class, $description->getAssociationAdmin());
 
-        $parent = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $parent = $this->getMockForAbstractClass(AdminInterface::class);
         $description->setParent($parent);
-        $this->isInstanceOf('Sonata\AdminBundle\Admin\AdminInterface', $description->getParent());
+        $this->isInstanceOf(AdminInterface::class, $description->getParent());
     }
 
     public function testGetValue()
@@ -195,7 +197,7 @@ class BaseFieldDescriptionTest extends TestCase
     {
         $description = new FieldDescription();
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $description->setAdmin($admin);
 
         $admin->expects($this->once())
@@ -236,7 +238,7 @@ class BaseFieldDescriptionTest extends TestCase
         $this->assertSame(true, $description->getFieldValue($foo, 'bar'));
         $this->assertSame(false, $description->getFieldValue($foo, 'baz'));
 
-        $this->expectException('Sonata\AdminBundle\Exception\NoValueException');
+        $this->expectException(NoValueException::class);
         $description->getFieldValue($foo, 'inexistantMethod');
     }
 
@@ -251,7 +253,7 @@ class BaseFieldDescriptionTest extends TestCase
         $this->assertSame('Baz', $description->getFieldValue($foo, 'inexistantMethod'));
 
         $description->setOption('code', 'inexistantMethod');
-        $this->expectException('Sonata\AdminBundle\Exception\NoValueException');
+        $this->expectException(NoValueException::class);
         $description->getFieldValue($foo, 'inexistantMethod');
     }
 

--- a/tests/Admin/Extension/LockExtensionTest.php
+++ b/tests/Admin/Extension/LockExtensionTest.php
@@ -12,12 +12,19 @@
 namespace Sonata\AdminBundle\Tests\Admin\Extension;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\Extension\LockExtension;
+use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Model\LockInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class LockExtensionTest extends TestCase
@@ -54,8 +61,8 @@ class LockExtensionTest extends TestCase
 
     protected function setUp()
     {
-        $this->modelManager = $this->prophesize('Sonata\AdminBundle\Model\LockInterface');
-        $this->admin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $this->modelManager = $this->prophesize(LockInterface::class);
+        $this->admin = $this->prophesize(AbstractAdmin::class);
 
         $this->eventDispatcher = new EventDispatcher();
         $this->request = new Request();
@@ -74,7 +81,7 @@ class LockExtensionTest extends TestCase
 
         $form->add(
             '_lock_version',
-            'Symfony\Component\Form\Extension\Core\Type\HiddenType',
+            HiddenType::class,
             ['mapped' => false, 'data' => 1]
         )->shouldBeCalled();
 
@@ -84,7 +91,7 @@ class LockExtensionTest extends TestCase
 
     public function testConfigureFormFieldsWhenModelManagerIsNotImplementingLockerInterface()
     {
-        $modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->prophesize(ModelManagerInterface::class);
         $formMapper = $this->configureFormMapper();
         $form = $this->configureForm();
         $this->configureAdmin(null, null, $modelManager->reveal());
@@ -163,7 +170,7 @@ class LockExtensionTest extends TestCase
 
     public function testPreUpdateIfModelManagerIsNotImplementingLockerInterface()
     {
-        $modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->prophesize(ModelManagerInterface::class);
         $uniqid = 'admin123';
         $this->configureAdmin($uniqid, $this->request, $modelManager->reveal());
 
@@ -184,7 +191,7 @@ class LockExtensionTest extends TestCase
 
     private function configureForm()
     {
-        $form = $this->prophesize('Symfony\Component\Form\FormInterface');
+        $form = $this->prophesize(FormInterface::class);
 
         $form->getData()->willReturn($this->object);
         $form->getParent()->willReturn(null);
@@ -194,8 +201,8 @@ class LockExtensionTest extends TestCase
 
     private function configureFormMapper()
     {
-        $contractor = $this->prophesize('Sonata\AdminBundle\Builder\FormContractorInterface');
-        $formFactory = $this->prophesize('Symfony\Component\Form\FormFactoryInterface');
+        $contractor = $this->prophesize(FormContractorInterface::class);
+        $formFactory = $this->prophesize(FormFactoryInterface::class);
         $formBuilder = new FormBuilder('form', null, $this->eventDispatcher, $formFactory->reveal());
 
         return new FormMapper($contractor->reveal(), $formBuilder, $this->admin->reveal());

--- a/tests/Admin/FieldDescriptionCollectionTest.php
+++ b/tests/Admin/FieldDescriptionCollectionTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 
 class FieldDescriptionCollectionTest extends TestCase
 {
@@ -20,11 +21,11 @@ class FieldDescriptionCollectionTest extends TestCase
     {
         $collection = new FieldDescriptionCollection();
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('title'));
         $collection->add($fieldDescription);
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('position'));
         $collection->add($fieldDescription);
 
@@ -36,8 +37,8 @@ class FieldDescriptionCollectionTest extends TestCase
         $this->assertCount(2, $collection->getElements());
         $this->assertCount(2, $collection);
 
-        $this->isInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $collection['title']);
-        $this->isInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $collection->get('title'));
+        $this->isInstanceOf(FieldDescriptionInterface::class, $collection['title']);
+        $this->isInstanceOf(FieldDescriptionInterface::class, $collection->get('title'));
 
         $collection->remove('title');
         $this->assertFalse($collection->has('title'));
@@ -73,11 +74,11 @@ class FieldDescriptionCollectionTest extends TestCase
     {
         $collection = new FieldDescriptionCollection();
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('title'));
         $collection->add($fieldDescription);
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('position'));
         $collection->add($fieldDescription);
 
@@ -92,15 +93,15 @@ class FieldDescriptionCollectionTest extends TestCase
     {
         $collection = new FieldDescriptionCollection();
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('title'));
         $collection->add($fieldDescription);
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('position'));
         $collection->add($fieldDescription);
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('batch'));
         $collection->add($fieldDescription);
 

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -12,7 +12,9 @@
 namespace Sonata\AdminBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class PoolTest extends TestCase
 {
@@ -55,16 +57,16 @@ class PoolTest extends TestCase
 
     public function testGetDashboardGroups()
     {
-        $admin_group1 = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin_group1 = $this->createMock(AdminInterface::class);
         $admin_group1->expects($this->once())->method('showIn')->will($this->returnValue(true));
 
-        $admin_group2 = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin_group2 = $this->createMock(AdminInterface::class);
         $admin_group2->expects($this->once())->method('showIn')->will($this->returnValue(false));
 
-        $admin_group3 = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin_group3 = $this->createMock(AdminInterface::class);
         $admin_group3->expects($this->once())->method('showIn')->will($this->returnValue(false));
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
 
         $container->expects($this->any())->method('get')->will($this->onConsecutiveCalls(
             $admin_group1, $admin_group2, $admin_group3
@@ -194,7 +196,7 @@ class PoolTest extends TestCase
 
     public function testGetAdminByAdminCodeForChildClass()
     {
-        $adminMock = $this->getMockBuilder('Sonata\AdminBundle\Admin\AdminInterface')
+        $adminMock = $this->getMockBuilder(AdminInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $adminMock->expects($this->any())
@@ -205,7 +207,7 @@ class PoolTest extends TestCase
             ->with($this->equalTo('sonata.news.admin.comment'))
             ->will($this->returnValue('commentAdminClass'));
 
-        $containerMock = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $containerMock = $this->createMock(ContainerInterface::class);
         $containerMock->expects($this->any())
             ->method('get')
             ->will($this->returnValue($adminMock));
@@ -218,14 +220,14 @@ class PoolTest extends TestCase
 
     public function testGetAdminByAdminCodeForChildInvalidClass()
     {
-        $adminMock = $this->getMockBuilder('Sonata\AdminBundle\Admin\AdminInterface')
+        $adminMock = $this->getMockBuilder(AdminInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $adminMock->expects($this->any())
             ->method('hasChild')
             ->will($this->returnValue(false));
 
-        $containerMock = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $containerMock = $this->createMock(ContainerInterface::class);
         $containerMock->expects($this->any())
             ->method('get')
             ->will($this->returnValue($adminMock));
@@ -256,7 +258,7 @@ class PoolTest extends TestCase
 
     public function testGetContainer()
     {
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\ContainerInterface', $this->pool->getContainer());
+        $this->assertInstanceOf(ContainerInterface::class, $this->pool->getContainer());
     }
 
     public function testTemplates()
@@ -296,7 +298,7 @@ class PoolTest extends TestCase
      */
     private function getContainer()
     {
-        $containerMock = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $containerMock = $this->createMock(ContainerInterface::class);
         $containerMock->expects($this->any())
             ->method('get')
             ->will($this->returnCallback(function ($serviceId) {

--- a/tests/Block/AdminListBlockServiceTest.php
+++ b/tests/Block/AdminListBlockServiceTest.php
@@ -30,7 +30,7 @@ class AdminListBlockServiceTest extends AbstractBlockServiceTestCase
     {
         parent::setUp();
 
-        $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
+        $this->pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
     }
 
     public function testDefaultSettings()

--- a/tests/Block/AdminSearchBlockServiceTest.php
+++ b/tests/Block/AdminSearchBlockServiceTest.php
@@ -35,8 +35,8 @@ class AdminSearchBlockServiceTest extends AbstractBlockServiceTestCase
     {
         parent::setUp();
 
-        $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
-        $this->searchHandler = $this->getMockBuilder('Sonata\AdminBundle\Search\SearchHandler')->disableOriginalConstructor()->getMock();
+        $this->pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $this->searchHandler = $this->getMockBuilder(SearchHandler::class)->disableOriginalConstructor()->getMock();
     }
 
     public function testDefaultSettings()

--- a/tests/Block/AdminStatsBlockServiceTest.php
+++ b/tests/Block/AdminStatsBlockServiceTest.php
@@ -29,7 +29,7 @@ class AdminStatsBlockServiceTest extends AbstractBlockServiceTestCase
     {
         parent::setUp();
 
-        $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
+        $this->pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
     }
 
     public function testDefaultSettings()

--- a/tests/Bridge/Exporter/AdminExporterTest.php
+++ b/tests/Bridge/Exporter/AdminExporterTest.php
@@ -12,7 +12,9 @@
 namespace Sonata\AdminBundle\Tests\Bridge\Exporter;
 
 use Exporter\Exporter;
+use Exporter\Writer\TypedWriterInterface;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Bridge\Exporter\AdminExporter;
 
 class AdminExporterTest extends TestCase
@@ -32,7 +34,7 @@ class AdminExporterTest extends TestCase
     {
         $writers = [];
         foreach ($globalFormats as $exportFormat) {
-            $writer = $this->createMock('Exporter\Writer\TypedWriterInterface');
+            $writer = $this->createMock(TypedWriterInterface::class);
             $writer->expects($this->once())
                 ->method('getFormat')
                 ->will($this->returnValue($exportFormat));
@@ -40,7 +42,7 @@ class AdminExporterTest extends TestCase
         }
 
         $exporter = new Exporter($writers);
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->once())
             ->method('getExportFormats')
             ->will($this->returnValue($adminFormats));
@@ -50,7 +52,7 @@ class AdminExporterTest extends TestCase
 
     public function testGetExportFilename()
     {
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->once())
             ->method('getClass')
             ->will($this->returnValue('MyProject\AppBundle\Model\MyClass'));

--- a/tests/Command/CreateClassCacheCommandTest.php
+++ b/tests/Command/CreateClassCacheCommandTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Command\CreateClassCacheCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -48,8 +50,8 @@ class CreateClassCacheCommandTest extends TestCase
         $this->application = new Application();
         $command = new CreateClassCacheCommand();
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $kernel = $this->createMock('Symfony\Component\HttpKernel\KernelInterface');
+        $container = $this->createMock(ContainerInterface::class);
+        $kernel = $this->createMock(KernelInterface::class);
 
         $kernel->expects($this->any())
             ->method('getCacheDir')

--- a/tests/Command/ExplainAdminCommandTest.php
+++ b/tests/Command/ExplainAdminCommandTest.php
@@ -12,14 +12,25 @@
 namespace Sonata\AdminBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
+use Sonata\AdminBundle\Builder\ListBuilderInterface;
 use Sonata\AdminBundle\Command\ExplainAdminCommand;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
+use Symfony\Component\Validator\Mapping\GenericMetadata;
+use Symfony\Component\Validator\Mapping\MetadataInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -37,7 +48,7 @@ class ExplainAdminCommandTest extends TestCase
     private $admin;
 
     /**
-     * @var Symfony\Component\Validator\MetadataFactoryInterface
+     * @var MetadataFactoryInterface
      */
     private $validatorFactory;
 
@@ -46,9 +57,9 @@ class ExplainAdminCommandTest extends TestCase
         $this->application = new Application();
         $command = new ExplainAdminCommand();
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
 
-        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->createMock(AdminInterface::class);
 
         $this->admin->expects($this->any())
             ->method('getCode')
@@ -70,7 +81,7 @@ class ExplainAdminCommandTest extends TestCase
             ->method('getRoutes')
             ->will($this->returnValue($routeCollection));
 
-        $fieldDescription1 = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription1 = $this->createMock(FieldDescriptionInterface::class);
 
         $fieldDescription1->expects($this->any())
             ->method('getType')
@@ -80,7 +91,7 @@ class ExplainAdminCommandTest extends TestCase
             ->method('getTemplate')
             ->will($this->returnValue('SonataAdminBundle:CRUD:foo_text.html.twig'));
 
-        $fieldDescription2 = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription2 = $this->createMock(FieldDescriptionInterface::class);
 
         $fieldDescription2->expects($this->any())
             ->method('getType')
@@ -120,7 +131,7 @@ class ExplainAdminCommandTest extends TestCase
             ->will($this->returnValue(true));
 
         // php 5.3 BC
-        $adminParent = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $adminParent = $this->createMock(AdminInterface::class);
         $adminParent->expects($this->any())
             ->method('getCode')
             ->will($this->returnValue('foo_child'));
@@ -131,9 +142,9 @@ class ExplainAdminCommandTest extends TestCase
                 return $adminParent;
             }));
 
-        $this->validatorFactory = $this->createMock('Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface');
+        $this->validatorFactory = $this->createMock(MetadataFactoryInterface::class);
 
-        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validator = $this->createMock(ValidatorInterface::class);
         $validator->expects($this->any())->method('getMetadataFor')->will(
             $this->returnValue($this->validatorFactory)
         );
@@ -174,14 +185,14 @@ class ExplainAdminCommandTest extends TestCase
 
     public function testExecute()
     {
-        $metadata = $this->createMock('Symfony\Component\Validator\Mapping\MetadataInterface');
+        $metadata = $this->createMock(MetadataInterface::class);
 
         $this->validatorFactory->expects($this->once())
             ->method('getMetadataFor')
             ->with($this->equalTo('Acme\Entity\Foo'))
             ->will($this->returnValue($metadata));
 
-        $propertyMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\GenericMetadata');
+        $propertyMetadata = $this->getMockForAbstractClass(GenericMetadata::class);
         $propertyMetadata->constraints = [
             new NotNull(),
             new Length(['min' => 2, 'max' => 50, 'groups' => ['create', 'edit']]),
@@ -189,7 +200,7 @@ class ExplainAdminCommandTest extends TestCase
 
         $metadata->properties = ['firstName' => $propertyMetadata];
 
-        $getterMetadata = $this->getMockForAbstractClass('Symfony\Component\Validator\Mapping\GenericMetadata');
+        $getterMetadata = $this->getMockForAbstractClass(GenericMetadata::class);
         $getterMetadata->constraints = [
             new NotNull(),
             new Email(['groups' => ['registration', 'edit']]),
@@ -197,25 +208,25 @@ class ExplainAdminCommandTest extends TestCase
 
         $metadata->getters = ['email' => $getterMetadata];
 
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
 
         $this->admin->expects($this->any())
             ->method('getModelManager')
             ->will($this->returnValue($modelManager));
 
-        $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
+        $formBuilder = $this->createMock(FormBuilderInterface::class);
 
         $this->admin->expects($this->any())
              ->method('getFormBuilder')
              ->will($this->returnValue($formBuilder));
 
-        $datagridBuilder = $this->createMock('\Sonata\AdminBundle\Builder\DatagridBuilderInterface');
+        $datagridBuilder = $this->createMock(DatagridBuilderInterface::class);
 
         $this->admin->expects($this->any())
             ->method('getDatagridBuilder')
             ->will($this->returnValue($datagridBuilder));
 
-        $listBuilder = $this->createMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
+        $listBuilder = $this->createMock(ListBuilderInterface::class);
 
         $this->admin->expects($this->any())
             ->method('getListBuilder')
@@ -237,10 +248,10 @@ class ExplainAdminCommandTest extends TestCase
 
     public function testExecuteEmptyValidator()
     {
-        if (interface_exists('Symfony\Component\Validator\Mapping\MetadataInterface')) { //sf2.5+
-            $metadata = $this->createMock('Symfony\Component\Validator\Mapping\MetadataInterface');
+        if (interface_exists(MetadataInterface::class)) { //sf2.5+
+            $metadata = $this->createMock(MetadataInterface::class);
         } else {
-            $metadata = $this->createMock('Symfony\Component\Validator\MetadataInterface');
+            $metadata = $this->createMock(MetadataInterface::class);
         }
 
         $this->validatorFactory->expects($this->once())
@@ -251,25 +262,25 @@ class ExplainAdminCommandTest extends TestCase
         $metadata->properties = [];
         $metadata->getters = [];
 
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
 
         $this->admin->expects($this->any())
             ->method('getModelManager')
             ->will($this->returnValue($modelManager));
 
-        $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
+        $formBuilder = $this->createMock(FormBuilderInterface::class);
 
         $this->admin->expects($this->any())
              ->method('getFormBuilder')
              ->will($this->returnValue($formBuilder));
 
-        $datagridBuilder = $this->createMock('\Sonata\AdminBundle\Builder\DatagridBuilderInterface');
+        $datagridBuilder = $this->createMock(DatagridBuilderInterface::class);
 
         $this->admin->expects($this->any())
             ->method('getDatagridBuilder')
             ->will($this->returnValue($datagridBuilder));
 
-        $listBuilder = $this->createMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
+        $listBuilder = $this->createMock(ListBuilderInterface::class);
 
         $this->admin->expects($this->any())
             ->method('getListBuilder')

--- a/tests/Command/GenerateAdminCommandTest.php
+++ b/tests/Command/GenerateAdminCommandTest.php
@@ -12,7 +12,9 @@
 namespace Sonata\AdminBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 use Sonata\AdminBundle\Command\GenerateAdminCommand;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\DemoAdminBundle;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,6 +23,7 @@ use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -60,7 +63,7 @@ class GenerateAdminCommandTest extends TestCase
         $bundle = new DemoAdminBundle();
         $bundle->setPath($this->tempDirectory);
 
-        $kernel = $this->createMock('Symfony\Component\HttpKernel\KernelInterface');
+        $kernel = $this->createMock(KernelInterface::class);
         $kernel->expects($this->any())
             ->method('getBundles')
             ->will($this->returnValue([$bundle]));
@@ -123,13 +126,13 @@ class GenerateAdminCommandTest extends TestCase
     public function testExecute()
     {
         $this->command->setContainer($this->container);
-        $this->container->set('sonata.admin.manager.foo', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.foo', $this->createMock(ModelManagerInterface::class));
 
         $command = $this->application->find('sonata:admin:generate');
         $commandTester = new CommandTester($command);
         $commandTester->execute([
             'command' => $command->getName(),
-            'model' => 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo',
+            'model' => \Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo::class,
             '--bundle' => 'AcmeDemoBundle',
             '--admin' => 'FooAdmin',
             '--controller' => 'FooAdminController',
@@ -171,7 +174,7 @@ class GenerateAdminCommandTest extends TestCase
 
     public function testExecuteWithExceptionNoModelManagers()
     {
-        $this->expectException('RuntimeException', 'There are no model managers registered.');
+        $this->expectException(\RuntimeException::class, 'There are no model managers registered.');
 
         $this->command->setContainer($this->container);
 
@@ -179,7 +182,7 @@ class GenerateAdminCommandTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute([
             'command' => $command->getName(),
-            'model' => 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo',
+            'model' => \Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo::class,
             '--bundle' => 'AcmeDemoBundle',
             '--admin' => 'FooAdmin',
             '--controller' => 'FooAdminController',
@@ -194,12 +197,12 @@ class GenerateAdminCommandTest extends TestCase
     public function testExecuteInteractive($modelEntity)
     {
         $this->command->setContainer($this->container);
-        $this->container->set('sonata.admin.manager.foo', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
-        $this->container->set('sonata.admin.manager.bar', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.foo', $this->createMock(ModelManagerInterface::class));
+        $this->container->set('sonata.admin.manager.bar', $this->createMock(ModelManagerInterface::class));
 
         $command = $this->application->find('sonata:admin:generate');
 
-        $questionHelper = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper')
+        $questionHelper = $this->getMockBuilder(QuestionHelper::class)
             ->setMethods(['ask'])
             ->getMock();
 
@@ -285,8 +288,8 @@ class GenerateAdminCommandTest extends TestCase
     public function getExecuteInteractiveTests()
     {
         return [
-            ['Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo'],
-            ['Sonata\AdminBundle\Tests\Fixtures\Entity\Foo'],
+            [\Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo::class],
+            [\Sonata\AdminBundle\Tests\Fixtures\Entity\Foo::class],
         ];
     }
 
@@ -296,8 +299,8 @@ class GenerateAdminCommandTest extends TestCase
     public function testValidateManagerType($expected, $managerType)
     {
         $this->command->setContainer($this->container);
-        $this->container->set('sonata.admin.manager.foo', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
-        $this->container->set('sonata.admin.manager.bar', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.foo', $this->createMock(ModelManagerInterface::class));
+        $this->container->set('sonata.admin.manager.bar', $this->createMock(ModelManagerInterface::class));
 
         $this->assertSame($expected, $this->command->validateManagerType($managerType));
     }
@@ -313,35 +316,35 @@ class GenerateAdminCommandTest extends TestCase
     public function testValidateManagerTypeWithException1()
     {
         $this->command->setContainer($this->container);
-        $this->setExpectedException('InvalidArgumentException', 'Invalid manager type "foo". Available manager types are "".');
+        $this->setExpectedException(\InvalidArgumentException::class, 'Invalid manager type "foo". Available manager types are "".');
         $this->command->validateManagerType('foo');
     }
 
     public function testValidateManagerTypeWithException2()
     {
         $this->command->setContainer($this->container);
-        $this->container->set('sonata.admin.manager.foo', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
-        $this->container->set('sonata.admin.manager.bar', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.foo', $this->createMock(ModelManagerInterface::class));
+        $this->container->set('sonata.admin.manager.bar', $this->createMock(ModelManagerInterface::class));
 
-        $this->expectException('InvalidArgumentException', 'Invalid manager type "baz". Available manager types are "foo", "bar".');
+        $this->expectException(\InvalidArgumentException::class, 'Invalid manager type "baz". Available manager types are "foo", "bar".');
         $this->command->validateManagerType('baz');
     }
 
     public function testValidateManagerTypeWithException3()
     {
-        $this->expectException('InvalidArgumentException', 'Invalid manager type "baz". Available manager types are "".');
+        $this->expectException(\InvalidArgumentException::class, 'Invalid manager type "baz". Available manager types are "".');
         $this->command->validateManagerType('baz');
     }
 
     public function testAnswerUpdateServicesWithNo()
     {
-        $this->container->set('sonata.admin.manager.foo', $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface'));
+        $this->container->set('sonata.admin.manager.foo', $this->createMock(ModelManagerInterface::class));
 
-        $modelEntity = 'Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo';
+        $modelEntity = \Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo::class;
 
         $command = $this->application->find('sonata:admin:generate');
 
-        $questionHelper = $this->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper')
+        $questionHelper = $this->getMockBuilder(QuestionHelper::class)
             ->setMethods(['ask'])
             ->getMock();
 

--- a/tests/Command/ListAdminCommandTest.php
+++ b/tests/Command/ListAdminCommandTest.php
@@ -12,10 +12,12 @@
 namespace Sonata\AdminBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Command\ListAdminCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -27,14 +29,14 @@ class ListAdminCommandTest extends TestCase
         $application = new Application();
         $command = new ListAdminCommand();
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
 
-        $admin1 = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin1 = $this->createMock(AdminInterface::class);
         $admin1->expects($this->any())
             ->method('getClass')
             ->will($this->returnValue('Acme\Entity\Foo'));
 
-        $admin2 = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin2 = $this->createMock(AdminInterface::class);
         $admin2->expects($this->any())
             ->method('getClass')
             ->will($this->returnValue('Acme\Entity\Bar'));

--- a/tests/Command/SetupAclCommandTest.php
+++ b/tests/Command/SetupAclCommandTest.php
@@ -12,11 +12,13 @@
 namespace Sonata\AdminBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Command\SetupAclCommand;
 use Sonata\AdminBundle\Util\AdminAclManipulatorInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -28,9 +30,9 @@ class SetupAclCommandTest extends TestCase
         $application = new Application();
         $command = new SetupAclCommand();
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $aclManipulator = $this->createMock('Sonata\AdminBundle\Util\AdminAclManipulatorInterface');
+        $container = $this->createMock(ContainerInterface::class);
+        $admin = $this->createMock(AdminInterface::class);
+        $aclManipulator = $this->createMock(AdminAclManipulatorInterface::class);
 
         $container->expects($this->any())
             ->method('get')
@@ -68,7 +70,7 @@ class SetupAclCommandTest extends TestCase
         $application = new Application();
         $command = new SetupAclCommand();
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
 
         $container->expects($this->any())
             ->method('get')
@@ -99,8 +101,8 @@ class SetupAclCommandTest extends TestCase
         $application = new Application();
         $command = new SetupAclCommand();
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $container = $this->createMock(ContainerInterface::class);
+        $admin = $this->createMock(AdminInterface::class);
 
         $container->expects($this->any())
             ->method('get')

--- a/tests/Command/ValidatorsTest.php
+++ b/tests/Command/ValidatorsTest.php
@@ -40,7 +40,7 @@ class ValidatorsTest extends TestCase
      */
     public function testValidateUsernameWithException($value)
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->setExpectedException(\InvalidArgumentException::class);
 
         Validators::validateUsername($value);
     }
@@ -74,7 +74,7 @@ class ValidatorsTest extends TestCase
      */
     public function testValidateEntityNameWithException($value)
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->setExpectedException(\InvalidArgumentException::class);
 
         Validators::validateEntityName($value);
     }
@@ -113,7 +113,7 @@ class ValidatorsTest extends TestCase
      */
     public function testValidateClassWithException($value)
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->setExpectedException(\InvalidArgumentException::class);
 
         Validators::validateClass($value);
     }
@@ -149,7 +149,7 @@ class ValidatorsTest extends TestCase
      */
     public function testValidateAdminClassBasenameWithException($value)
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->setExpectedException(\InvalidArgumentException::class);
 
         Validators::validateAdminClassBasename($value);
     }
@@ -185,7 +185,7 @@ class ValidatorsTest extends TestCase
      */
     public function testValidateControllerClassBasenameWithException($value)
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->setExpectedException(\InvalidArgumentException::class);
 
         Validators::validateControllerClassBasename($value);
     }
@@ -259,7 +259,7 @@ class ValidatorsTest extends TestCase
      */
     public function testValidateServiceIdWithException($value)
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->setExpectedException(\InvalidArgumentException::class);
 
         Validators::validateServiceId($value);
     }

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -12,21 +12,37 @@
 namespace Sonata\AdminBundle\Tests\Controller;
 
 use Exporter\Exporter;
+use Exporter\Source\SourceIteratorInterface;
 use Exporter\Writer\JsonWriter;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Controller\CRUDController;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Exception\LockException;
 use Sonata\AdminBundle\Exception\ModelManagerException;
+use Sonata\AdminBundle\Export\Exporter as SonataExporter;
+use Sonata\AdminBundle\Model\AuditManager;
+use Sonata\AdminBundle\Model\AuditReaderInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Security\Acl\Permission\AdminPermissionMap;
+use Sonata\AdminBundle\Security\Handler\AclSecurityHandler;
 use Sonata\AdminBundle\Tests\Fixtures\Controller\BatchAdminController;
 use Sonata\AdminBundle\Tests\Fixtures\Controller\PreCRUDController;
+use Sonata\AdminBundle\Util\AdminObjectAclData;
 use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormRenderer;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -34,6 +50,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Csrf\CsrfToken;
@@ -80,7 +97,7 @@ class CRUDControllerTest extends TestCase
     private $session;
 
     /**
-     * @var \Sonata\AdminBundle\Model\AuditManager
+     * @var AuditManager
      */
     private $auditManager;
 
@@ -124,20 +141,20 @@ class CRUDControllerTest extends TestCase
      */
     protected function setUp()
     {
-        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->createMock(ContainerInterface::class);
 
         $this->request = new Request();
         $this->pool = new Pool($this->container, 'title', 'logo.png');
         $this->pool->setAdminServiceIds(['foo.admin']);
         $this->request->attributes->set('_sonata_admin', 'foo.admin');
-        $this->admin = $this->getMockBuilder('Sonata\AdminBundle\Admin\AbstractAdmin')
+        $this->admin = $this->getMockBuilder(AbstractAdmin::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $this->translator = $this->createMock(TranslatorInterface::class);
         $this->parameters = [];
         $this->template = '';
 
-        $templating = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine')
+        $templating = $this->getMockBuilder(DelegatingEngine::class)
             ->setConstructorArgs([$this->container, []])
             ->getMock();
 
@@ -168,7 +185,7 @@ class CRUDControllerTest extends TestCase
 
         $this->session = new Session(new MockArraySessionStorage());
 
-        $twig = $this->getMockBuilder('Twig_Environment')
+        $twig = $this->getMockBuilder(\Twig_Environment::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -193,25 +210,25 @@ class CRUDControllerTest extends TestCase
             }));
 
         // NEXT_MAJOR : require sonata/exporter ^1.7 and remove conditional
-        if (class_exists('Exporter\Exporter')) {
+        if (class_exists(Exporter::class)) {
             $exporter = new Exporter([new JsonWriter('/tmp/sonataadmin/export.json')]);
         } else {
-            $exporter = $this->createMock('Sonata\AdminBundle\Export\Exporter');
+            $exporter = $this->createMock(SonataExporter::class);
 
             $exporter->expects($this->any())
                 ->method('getResponse')
                 ->will($this->returnValue(new StreamedResponse()));
         }
 
-        $this->auditManager = $this->getMockBuilder('Sonata\AdminBundle\Model\AuditManager')
+        $this->auditManager = $this->getMockBuilder(AuditManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->adminObjectAclManipulator = $this->getMockBuilder('Sonata\AdminBundle\Util\AdminObjectAclManipulator')
+        $this->adminObjectAclManipulator = $this->getMockBuilder(AdminObjectAclManipulator::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->csrfProvider = $this->getMockBuilder('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface')
+        $this->csrfProvider = $this->getMockBuilder(CsrfTokenManagerInterface::class)
             ->getMock();
 
         $this->csrfProvider->expects($this->any())
@@ -230,12 +247,12 @@ class CRUDControllerTest extends TestCase
                 return false;
             }));
 
-        $this->logger = $this->createMock('Psr\Log\LoggerInterface');
+        $this->logger = $this->createMock(LoggerInterface::class);
 
         $requestStack = new RequestStack();
         $requestStack->push($this->request);
 
-        $this->kernel = $this->createMock('Symfony\Component\HttpKernel\KernelInterface');
+        $this->kernel = $this->createMock(KernelInterface::class);
 
         $this->container->expects($this->any())
             ->method('get')
@@ -397,10 +414,10 @@ class CRUDControllerTest extends TestCase
         ];
         foreach ($testedMethods as $testedMethod) {
             // NEXT_MAJOR: Remove this check and only use CRUDController
-            if (method_exists('Sonata\\AdminBundle\\Controller\\CRUDController', $testedMethod)) {
-                $method = new \ReflectionMethod('Sonata\\AdminBundle\\Controller\\CRUDController', $testedMethod);
+            if (method_exists(CRUDController::class, $testedMethod)) {
+                $method = new \ReflectionMethod(CRUDController::class, $testedMethod);
             } else {
-                $method = new \ReflectionMethod('Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller', $testedMethod);
+                $method = new \ReflectionMethod(Controller::class, $testedMethod);
             }
 
             $method->setAccessible(true);
@@ -488,7 +505,7 @@ class CRUDControllerTest extends TestCase
             ->method('isChild')
             ->will($this->returnValue(true));
 
-        $adminParent = $this->getMockBuilder('Sonata\AdminBundle\Admin\AbstractAdmin')
+        $adminParent = $this->getMockBuilder(AbstractAdmin::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->admin->expects($this->once())
@@ -505,7 +522,7 @@ class CRUDControllerTest extends TestCase
     public function testConfigureWithException()
     {
         $this->expectException(
-            'RuntimeException',
+            \RuntimeException::class,
             'There is no `_sonata_admin` defined for the controller `Sonata\AdminBundle\Controller\CRUDController`'
         );
 
@@ -516,7 +533,7 @@ class CRUDControllerTest extends TestCase
     public function testConfigureWithException2()
     {
         $this->expectException(
-            'RuntimeException',
+            \RuntimeException::class,
             'Unable to find the admin class related to the current controller '.
             '(Sonata\AdminBundle\Controller\CRUDController)'
         );
@@ -556,7 +573,7 @@ class CRUDControllerTest extends TestCase
     {
         $this->parameters = [];
         $this->assertInstanceOf(
-            'Symfony\Component\HttpFoundation\Response',
+            Response::class,
             $this->controller->renderWithExtraParams('FooAdminBundle::foo.html.twig', [], null)
         );
         $this->assertSame($this->admin, $this->parameters['admin']);
@@ -584,7 +601,7 @@ class CRUDControllerTest extends TestCase
     {
         $this->parameters = [];
         $this->assertInstanceOf(
-            'Symfony\Component\HttpFoundation\Response',
+            Response::class,
             $this->controller->renderWithExtraParams(
                 'FooAdminBundle::foo.html.twig',
                 ['foo' => 'bar'],
@@ -603,7 +620,7 @@ class CRUDControllerTest extends TestCase
         $this->parameters = [];
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
         $this->assertInstanceOf(
-            'Symfony\Component\HttpFoundation\Response',
+            Response::class,
             $this->controller->renderWithExtraParams(
                 'FooAdminBundle::foo.html.twig',
                 ['foo' => 'bar'],
@@ -619,7 +636,7 @@ class CRUDControllerTest extends TestCase
 
     public function testListActionAccessDenied()
     {
-        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException(AccessDeniedException::class);
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -645,13 +662,13 @@ class CRUDControllerTest extends TestCase
         $controller->setContainer($this->container);
 
         $response = $controller->listAction($this->request);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('preList called', $response->getContent());
     }
 
     public function testListAction()
     {
-        $datagrid = $this->createMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock(DatagridInterface::class);
 
         $this->admin->expects($this->any())
             ->method('hasRoute')
@@ -663,13 +680,13 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('list'))
             ->will($this->returnValue(true));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $form->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock(FormView::class)));
 
         $this->admin->expects($this->once())
             ->method('getDatagrid')
@@ -680,15 +697,15 @@ class CRUDControllerTest extends TestCase
             ->will($this->returnValue($form));
 
         $this->parameters = [];
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->listAction($this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->listAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('list', $this->parameters['action']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
-        $this->assertInstanceOf('Sonata\AdminBundle\Datagrid\DatagridInterface', $this->parameters['datagrid']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
+        $this->assertInstanceOf(DatagridInterface::class, $this->parameters['datagrid']);
         $this->assertSame('csrf-token-123_sonata.batch', $this->parameters['csrf_token']);
         $this->assertSame([], $this->session->getFlashBag()->all());
         $this->assertSame('SonataAdminBundle:CRUD:list.html.twig', $this->template);
@@ -696,19 +713,19 @@ class CRUDControllerTest extends TestCase
 
     public function testBatchActionDeleteAccessDenied()
     {
-        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException(AccessDeniedException::class);
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
             ->with($this->equalTo('batchDelete'))
             ->will($this->throwException(new AccessDeniedException()));
 
-        $this->controller->batchActionDelete($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        $this->controller->batchActionDelete($this->createMock(ProxyQueryInterface::class));
     }
 
     public function testBatchActionDelete()
     {
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -725,16 +742,16 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_batch_delete_success', [], 'SonataAdminBundle');
 
-        $result = $this->controller->batchActionDelete($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        $result = $this->controller->batchActionDelete($this->createMock(ProxyQueryInterface::class));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
+        $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
         $this->assertSame('list?filter%5Bfoo%5D=bar', $result->getTargetUrl());
     }
 
     public function testBatchActionDeleteWithModelManagerException()
     {
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
         $this->assertLoggerLogsModelManagerException($modelManager, 'batchDelete');
 
         $this->admin->expects($this->once())
@@ -747,17 +764,17 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_batch_delete_error', [], 'SonataAdminBundle');
 
-        $result = $this->controller->batchActionDelete($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        $result = $this->controller->batchActionDelete($this->createMock(ProxyQueryInterface::class));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
+        $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_delete_error'], $this->session->getFlashBag()->get('sonata_flash_error'));
         $this->assertSame('list?filter%5Bfoo%5D=bar', $result->getTargetUrl());
     }
 
     public function testBatchActionDeleteWithModelManagerExceptionInDebugMode()
     {
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
-        $this->expectException('Sonata\AdminBundle\Exception\ModelManagerException');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
+        $this->expectException(ModelManagerException::class);
 
         $modelManager->expects($this->once())
             ->method('batchDelete')
@@ -773,12 +790,12 @@ class CRUDControllerTest extends TestCase
             ->method('isDebug')
             ->will($this->returnValue(true));
 
-        $this->controller->batchActionDelete($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        $this->controller->batchActionDelete($this->createMock(ProxyQueryInterface::class));
     }
 
     public function testShowActionNotFoundException()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -789,7 +806,7 @@ class CRUDControllerTest extends TestCase
 
     public function testShowActionAccessDenied()
     {
-        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException(AccessDeniedException::class);
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -821,7 +838,7 @@ class CRUDControllerTest extends TestCase
         $controller->setContainer($this->container);
 
         $response = $controller->showAction(null, $this->request);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('preShow called: 123456', $response->getContent());
     }
 
@@ -838,20 +855,20 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('show'))
             ->will($this->returnValue(true));
 
-        $show = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionCollection');
+        $show = $this->createMock(FieldDescriptionCollection::class);
 
         $this->admin->expects($this->once())
             ->method('getShow')
             ->will($this->returnValue($show));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->showAction(null, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->showAction(null, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('show', $this->parameters['action']);
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionCollection', $this->parameters['elements']);
+        $this->assertInstanceOf(FieldDescriptionCollection::class, $this->parameters['elements']);
         $this->assertSame($object, $this->parameters['object']);
 
         $this->assertSame([], $this->session->getFlashBag()->all());
@@ -884,7 +901,7 @@ class CRUDControllerTest extends TestCase
             ->will($this->returnValue(true));
 
         $response = $this->protectedTestedMethods['redirectTo']->invoke($this->controller, $object, $this->request);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame($expected, $response->getTargetUrl());
     }
 
@@ -907,7 +924,7 @@ class CRUDControllerTest extends TestCase
             ->will($this->returnValue(false));
 
         $response = $this->protectedTestedMethods['redirectTo']->invoke($this->controller, $object, $this->request);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame('list', $response->getTargetUrl());
     }
 
@@ -924,7 +941,7 @@ class CRUDControllerTest extends TestCase
 
     public function testDeleteActionNotFoundException()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -935,7 +952,7 @@ class CRUDControllerTest extends TestCase
 
     public function testDeleteActionAccessDenied()
     {
-        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException(AccessDeniedException::class);
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -967,7 +984,7 @@ class CRUDControllerTest extends TestCase
         $controller->setContainer($this->container);
 
         $response = $controller->deleteAction(null, $this->request);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('preDelete called: 123456', $response->getContent());
     }
 
@@ -984,7 +1001,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('delete'))
             ->will($this->returnValue(true));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->deleteAction(1, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->deleteAction(1, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -1013,7 +1030,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('delete'))
             ->will($this->returnValue(true));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->deleteAction(1, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->deleteAction(1, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -1047,7 +1064,7 @@ class CRUDControllerTest extends TestCase
 
         $response = $this->controller->deleteAction(1, $this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(json_encode(['result' => 'ok']), $response->getContent());
         $this->assertSame([], $this->session->getFlashBag()->all());
     }
@@ -1073,7 +1090,7 @@ class CRUDControllerTest extends TestCase
 
         $response = $this->controller->deleteAction(1, $this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(json_encode(['result' => 'ok']), $response->getContent());
         $this->assertSame([], $this->session->getFlashBag()->all());
     }
@@ -1104,14 +1121,14 @@ class CRUDControllerTest extends TestCase
 
         $response = $this->controller->deleteAction(1, $this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(json_encode(['result' => 'error']), $response->getContent());
         $this->assertSame([], $this->session->getFlashBag()->all());
     }
 
     public function testDeleteActionWithModelManagerExceptionInDebugMode()
     {
-        $this->expectException('Sonata\AdminBundle\Exception\ModelManagerException');
+        $this->expectException(ModelManagerException::class);
 
         $object = new \stdClass();
 
@@ -1169,7 +1186,7 @@ class CRUDControllerTest extends TestCase
 
         $response = $this->controller->deleteAction(1, $this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(['flash_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
         $this->assertSame('list', $response->getTargetUrl());
     }
@@ -1204,7 +1221,7 @@ class CRUDControllerTest extends TestCase
 
         $response = $this->controller->deleteAction(1, $this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(['flash_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
         $this->assertSame('list', $response->getTargetUrl());
     }
@@ -1239,7 +1256,7 @@ class CRUDControllerTest extends TestCase
 
         $response = $this->controller->deleteAction(1, $this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(['flash_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
         $this->assertSame('list', $response->getTargetUrl());
     }
@@ -1260,7 +1277,7 @@ class CRUDControllerTest extends TestCase
         //without POST request parameter "_method" should not be used as real REST method
         $this->request->query->set('_method', 'DELETE');
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->deleteAction(1, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->deleteAction(1, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -1304,7 +1321,7 @@ class CRUDControllerTest extends TestCase
 
         $response = $this->controller->deleteAction(1, $this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(['flash_delete_error'], $this->session->getFlashBag()->get('sonata_flash_error'));
         $this->assertSame('list', $response->getTargetUrl());
     }
@@ -1336,7 +1353,7 @@ class CRUDControllerTest extends TestCase
 
     public function testEditActionNotFoundException()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -1347,7 +1364,7 @@ class CRUDControllerTest extends TestCase
 
     public function testEditActionAccessDenied()
     {
-        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException(AccessDeniedException::class);
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -1379,7 +1396,7 @@ class CRUDControllerTest extends TestCase
         $controller->setContainer($this->container);
 
         $response = $controller->editAction(null, $this->request);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('preEdit called: 123456', $response->getContent());
     }
 
@@ -1396,7 +1413,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('edit'))
             ->will($this->returnValue(true));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1404,20 +1421,20 @@ class CRUDControllerTest extends TestCase
             ->method('getForm')
             ->will($this->returnValue($form));
 
-        $formView = $this->createMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock(FormView::class);
 
         $form->expects($this->any())
             ->method('createView')
             ->will($this->returnValue($formView));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction(null, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->editAction(null, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('edit', $this->parameters['action']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
         $this->assertSame($object, $this->parameters['object']);
         $this->assertSame([], $this->session->getFlashBag()->all());
         $this->assertSame('SonataAdminBundle:CRUD:edit.html.twig', $this->template);
@@ -1452,7 +1469,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('edit'))
             ->will($this->returnValue(true));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1483,7 +1500,7 @@ class CRUDControllerTest extends TestCase
 
         $response = $this->controller->editAction(null, $this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(['flash_edit_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
         $this->assertSame('stdClass_edit', $response->getTargetUrl());
     }
@@ -1504,7 +1521,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('edit'))
             ->will($this->returnValue(true));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1529,20 +1546,20 @@ class CRUDControllerTest extends TestCase
 
         $this->request->setMethod('POST');
 
-        $formView = $this->createMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock(FormView::class);
 
         $form->expects($this->any())
             ->method('createView')
             ->will($this->returnValue($formView));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction(null, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->editAction(null, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('edit', $this->parameters['action']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
         $this->assertSame($object, $this->parameters['object']);
 
         $this->assertSame(['sonata_flash_error' => ['flash_edit_error']], $this->session->getFlashBag()->all());
@@ -1566,7 +1583,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('edit'))
             ->will($this->returnValue(true));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1600,7 +1617,7 @@ class CRUDControllerTest extends TestCase
 
         $response = $this->controller->editAction(null, $this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(json_encode(['result' => 'ok', 'objectId' => 'foo_normalized', 'objectName' => 'foo']), $response->getContent());
         $this->assertSame([], $this->session->getFlashBag()->all());
     }
@@ -1618,7 +1635,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('edit'))
             ->will($this->returnValue(true));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1637,20 +1654,20 @@ class CRUDControllerTest extends TestCase
         $this->request->setMethod('POST');
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $formView = $this->createMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock(FormView::class);
 
         $form->expects($this->any())
             ->method('createView')
             ->will($this->returnValue($formView));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction(null, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->editAction(null, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::ajax_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('edit', $this->parameters['action']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
         $this->assertSame($object, $this->parameters['object']);
 
         $this->assertSame([], $this->session->getFlashBag()->all());
@@ -1677,7 +1694,7 @@ class CRUDControllerTest extends TestCase
             ->method('getClass')
             ->will($this->returnValue('stdClass'));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1705,21 +1722,21 @@ class CRUDControllerTest extends TestCase
             ->will($this->returnValue(true));
         $this->request->setMethod('POST');
 
-        $formView = $this->createMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock(FormView::class);
 
         $form->expects($this->any())
             ->method('createView')
             ->will($this->returnValue($formView));
 
         $this->assertLoggerLogsModelManagerException($this->admin, 'update');
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction(null, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->editAction(null, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('edit', $this->parameters['action']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
         $this->assertSame($object, $this->parameters['object']);
 
         $this->assertSame(['sonata_flash_error' => ['flash_edit_error']], $this->session->getFlashBag()->all());
@@ -1739,7 +1756,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('edit'))
             ->will($this->returnValue(true));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1751,7 +1768,7 @@ class CRUDControllerTest extends TestCase
             ->method('supportsPreviewMode')
             ->will($this->returnValue(true));
 
-        $formView = $this->createMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock(FormView::class);
 
         $form->expects($this->any())
             ->method('createView')
@@ -1768,14 +1785,14 @@ class CRUDControllerTest extends TestCase
         $this->request->setMethod('POST');
         $this->request->request->set('btn_preview', 'Preview');
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction(null, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->editAction(null, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('edit', $this->parameters['action']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
         $this->assertSame($object, $this->parameters['object']);
 
         $this->assertSame([], $this->session->getFlashBag()->all());
@@ -1800,7 +1817,7 @@ class CRUDControllerTest extends TestCase
             ->method('getClass')
             ->will($this->returnValue($class));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1830,7 +1847,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo($object))
             ->will($this->returnValue($class));
 
-        $formView = $this->createMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock(FormView::class);
 
         $form->expects($this->any())
             ->method('createView')
@@ -1842,12 +1859,12 @@ class CRUDControllerTest extends TestCase
             '%link_end%' => '</a>',
         ], 'SonataAdminBundle');
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->editAction(null, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->editAction(null, $this->request));
     }
 
     public function testCreateActionAccessDenied()
     {
-        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException(AccessDeniedException::class);
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -1879,7 +1896,7 @@ class CRUDControllerTest extends TestCase
         $controller->setContainer($this->container);
 
         $response = $controller->createAction($this->request);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('preCreate called: 123456', $response->getContent());
     }
 
@@ -1900,7 +1917,7 @@ class CRUDControllerTest extends TestCase
             ->method('getNewInstance')
             ->will($this->returnValue($object));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1908,20 +1925,20 @@ class CRUDControllerTest extends TestCase
             ->method('getForm')
             ->will($this->returnValue($form));
 
-        $formView = $this->createMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock(FormView::class);
 
         $form->expects($this->any())
             ->method('createView')
             ->will($this->returnValue($formView));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction($this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->createAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('create', $this->parameters['action']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
         $this->assertSame($object, $this->parameters['object']);
 
         $this->assertSame([], $this->session->getFlashBag()->all());
@@ -1971,7 +1988,7 @@ class CRUDControllerTest extends TestCase
             ->method('create')
             ->will($this->returnArgument(0));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2006,14 +2023,14 @@ class CRUDControllerTest extends TestCase
 
         $response = $this->controller->createAction($this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(['flash_create_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
         $this->assertSame('stdClass_edit', $response->getTargetUrl());
     }
 
     public function testCreateActionAccessDenied2()
     {
-        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException(AccessDeniedException::class);
 
         $object = new \stdClass();
 
@@ -2034,7 +2051,7 @@ class CRUDControllerTest extends TestCase
             ->method('getNewInstance')
             ->will($this->returnValue($object));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2083,7 +2100,7 @@ class CRUDControllerTest extends TestCase
             ->method('getNewInstance')
             ->will($this->returnValue($object));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2108,20 +2125,20 @@ class CRUDControllerTest extends TestCase
 
         $this->request->setMethod('POST');
 
-        $formView = $this->createMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock(FormView::class);
 
         $form->expects($this->any())
             ->method('createView')
             ->will($this->returnValue($formView));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction($this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->createAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('create', $this->parameters['action']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
         $this->assertSame($object, $this->parameters['object']);
 
         $this->assertSame(['sonata_flash_error' => ['flash_create_error']], $this->session->getFlashBag()->all());
@@ -2148,7 +2165,7 @@ class CRUDControllerTest extends TestCase
             ->method('getNewInstance')
             ->will($this->returnValue($object));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2177,7 +2194,7 @@ class CRUDControllerTest extends TestCase
 
         $this->request->setMethod('POST');
 
-        $formView = $this->createMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock(FormView::class);
 
         $form->expects($this->any())
             ->method('createView')
@@ -2185,14 +2202,14 @@ class CRUDControllerTest extends TestCase
 
         $this->assertLoggerLogsModelManagerException($this->admin, 'create');
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction($this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->createAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('create', $this->parameters['action']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
         $this->assertSame($object, $this->parameters['object']);
 
         $this->assertSame(['sonata_flash_error' => ['flash_create_error']], $this->session->getFlashBag()->all());
@@ -2225,7 +2242,7 @@ class CRUDControllerTest extends TestCase
             ->method('create')
             ->will($this->returnArgument(0));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2259,7 +2276,7 @@ class CRUDControllerTest extends TestCase
 
         $response = $this->controller->createAction($this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(json_encode(['result' => 'ok', 'objectId' => 'foo_normalized']), $response->getContent());
         $this->assertSame([], $this->session->getFlashBag()->all());
     }
@@ -2277,7 +2294,7 @@ class CRUDControllerTest extends TestCase
             ->method('getNewInstance')
             ->will($this->returnValue($object));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2300,20 +2317,20 @@ class CRUDControllerTest extends TestCase
         $this->request->setMethod('POST');
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $formView = $this->createMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock(FormView::class);
 
         $form->expects($this->any())
             ->method('createView')
             ->will($this->returnValue($formView));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction($this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->createAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::ajax_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('create', $this->parameters['action']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
         $this->assertSame($object, $this->parameters['object']);
 
         $this->assertSame([], $this->session->getFlashBag()->all());
@@ -2333,7 +2350,7 @@ class CRUDControllerTest extends TestCase
             ->method('getNewInstance')
             ->will($this->returnValue($object));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2349,7 +2366,7 @@ class CRUDControllerTest extends TestCase
             ->method('supportsPreviewMode')
             ->will($this->returnValue(true));
 
-        $formView = $this->createMock('Symfony\Component\Form\FormView');
+        $formView = $this->createMock(FormView::class);
 
         $form->expects($this->any())
             ->method('createView')
@@ -2366,14 +2383,14 @@ class CRUDControllerTest extends TestCase
         $this->request->setMethod('POST');
         $this->request->request->set('btn_preview', 'Preview');
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->createAction($this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->createAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('create', $this->parameters['action']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
         $this->assertSame($object, $this->parameters['object']);
 
         $this->assertSame([], $this->session->getFlashBag()->all());
@@ -2382,7 +2399,7 @@ class CRUDControllerTest extends TestCase
 
     public function testExportActionAccessDenied()
     {
-        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException(AccessDeniedException::class);
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -2394,7 +2411,7 @@ class CRUDControllerTest extends TestCase
 
     public function testExportActionWrongFormat()
     {
-        $this->expectException('RuntimeException', 'Export in format `csv` is not allowed for class: `Foo`. Allowed formats are: `json`');
+        $this->expectException(\RuntimeException::class, 'Export in format `csv` is not allowed for class: `Foo`. Allowed formats are: `json`');
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -2425,7 +2442,7 @@ class CRUDControllerTest extends TestCase
             ->method('getExportFormats')
             ->will($this->returnValue(['json']));
 
-        $dataSourceIterator = $this->createMock('Exporter\Source\SourceIteratorInterface');
+        $dataSourceIterator = $this->createMock(SourceIteratorInterface::class);
 
         $this->admin->expects($this->once())
             ->method('getDataSourceIterator')
@@ -2434,14 +2451,14 @@ class CRUDControllerTest extends TestCase
         $this->request->query->set('format', 'json');
 
         $response = $this->controller->exportAction($this->request);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\StreamedResponse', $response);
+        $this->assertInstanceOf(StreamedResponse::class, $response);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame([], $this->session->getFlashBag()->all());
     }
 
     public function testHistoryActionAccessDenied()
     {
-        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException(AccessDeniedException::class);
 
         $this->admin->expects($this->any())
             ->method('getObject')
@@ -2457,7 +2474,7 @@ class CRUDControllerTest extends TestCase
 
     public function testHistoryActionNotFoundException()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
         $this->admin->expects($this->once())
             ->method('getObject')
@@ -2468,7 +2485,7 @@ class CRUDControllerTest extends TestCase
 
     public function testHistoryActionNoReader()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the audit reader for class : Foo');
+        $this->expectException(NotFoundHttpException::class, 'unable to find the audit reader for class : Foo');
 
         $this->request->query->set('id', 123);
 
@@ -2519,7 +2536,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(true));
 
-        $reader = $this->createMock('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $reader = $this->createMock(AuditReaderInterface::class);
 
         $this->auditManager->expects($this->once())
             ->method('getReader')
@@ -2531,7 +2548,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'), $this->equalTo(123))
             ->will($this->returnValue([]));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->historyAction(null, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->historyAction(null, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -2547,14 +2564,14 @@ class CRUDControllerTest extends TestCase
 
     public function testAclActionAclNotEnabled()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'ACL are not enabled for this admin');
+        $this->expectException(NotFoundHttpException::class, 'ACL are not enabled for this admin');
 
         $this->controller->aclAction(null, $this->request);
     }
 
     public function testAclActionNotFoundException()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
         $this->admin->expects($this->once())
             ->method('isAclEnabled')
@@ -2569,7 +2586,7 @@ class CRUDControllerTest extends TestCase
 
     public function testAclActionAccessDenied()
     {
-        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException(AccessDeniedException::class);
 
         $this->admin->expects($this->once())
             ->method('isAclEnabled')
@@ -2613,35 +2630,35 @@ class CRUDControllerTest extends TestCase
 
         $this->adminObjectAclManipulator->expects($this->once())
             ->method('getMaskBuilderClass')
-            ->will($this->returnValue('\Sonata\AdminBundle\Security\Acl\Permission\AdminPermissionMap'));
+            ->will($this->returnValue(AdminPermissionMap::class));
 
-        $aclUsersForm = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $aclUsersForm = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $aclUsersForm->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock(FormView::class)));
 
-        $aclRolesForm = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $aclRolesForm = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $aclRolesForm->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock(FormView::class)));
 
         $this->adminObjectAclManipulator->expects($this->once())
             ->method('createAclUsersForm')
-            ->with($this->isInstanceOf('Sonata\AdminBundle\Util\AdminObjectAclData'))
+            ->with($this->isInstanceOf(AdminObjectAclData::class))
             ->will($this->returnValue($aclUsersForm));
 
         $this->adminObjectAclManipulator->expects($this->once())
             ->method('createAclRolesForm')
-            ->with($this->isInstanceOf('Sonata\AdminBundle\Util\AdminObjectAclData'))
+            ->with($this->isInstanceOf(AdminObjectAclData::class))
             ->will($this->returnValue($aclRolesForm));
 
-        $aclSecurityHandler = $this->getMockBuilder('Sonata\AdminBundle\Security\Handler\AclSecurityHandler')
+        $aclSecurityHandler = $this->getMockBuilder(AclSecurityHandler::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2653,7 +2670,7 @@ class CRUDControllerTest extends TestCase
             ->method('getSecurityHandler')
             ->will($this->returnValue($aclSecurityHandler));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->aclAction(null, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->aclAction(null, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -2662,10 +2679,10 @@ class CRUDControllerTest extends TestCase
         $this->assertSame('acl', $this->parameters['action']);
         $this->assertSame([], $this->parameters['permissions']);
         $this->assertSame($object, $this->parameters['object']);
-        $this->assertInstanceOf('\ArrayIterator', $this->parameters['users']);
-        $this->assertInstanceOf('\ArrayIterator', $this->parameters['roles']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['aclUsersForm']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['aclRolesForm']);
+        $this->assertInstanceOf(\ArrayIterator::class, $this->parameters['users']);
+        $this->assertInstanceOf(\ArrayIterator::class, $this->parameters['roles']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['aclUsersForm']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['aclRolesForm']);
 
         $this->assertSame([], $this->session->getFlashBag()->all());
         $this->assertSame('SonataAdminBundle:CRUD:acl.html.twig', $this->template);
@@ -2696,9 +2713,9 @@ class CRUDControllerTest extends TestCase
 
         $this->adminObjectAclManipulator->expects($this->once())
             ->method('getMaskBuilderClass')
-            ->will($this->returnValue('\Sonata\AdminBundle\Security\Acl\Permission\AdminPermissionMap'));
+            ->will($this->returnValue(AdminPermissionMap::class));
 
-        $aclUsersForm = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $aclUsersForm = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2708,27 +2725,27 @@ class CRUDControllerTest extends TestCase
 
         $aclUsersForm->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock(FormView::class)));
 
-        $aclRolesForm = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $aclRolesForm = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $aclRolesForm->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock(FormView::class)));
 
         $this->adminObjectAclManipulator->expects($this->once())
             ->method('createAclUsersForm')
-            ->with($this->isInstanceOf('Sonata\AdminBundle\Util\AdminObjectAclData'))
+            ->with($this->isInstanceOf(AdminObjectAclData::class))
             ->will($this->returnValue($aclUsersForm));
 
         $this->adminObjectAclManipulator->expects($this->once())
             ->method('createAclRolesForm')
-            ->with($this->isInstanceOf('Sonata\AdminBundle\Util\AdminObjectAclData'))
+            ->with($this->isInstanceOf(AdminObjectAclData::class))
             ->will($this->returnValue($aclRolesForm));
 
-        $aclSecurityHandler = $this->getMockBuilder('Sonata\AdminBundle\Security\Handler\AclSecurityHandler')
+        $aclSecurityHandler = $this->getMockBuilder(AclSecurityHandler::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2742,7 +2759,7 @@ class CRUDControllerTest extends TestCase
 
         $this->request->setMethod('POST');
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->aclAction(null, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->aclAction(null, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -2751,10 +2768,10 @@ class CRUDControllerTest extends TestCase
         $this->assertSame('acl', $this->parameters['action']);
         $this->assertSame([], $this->parameters['permissions']);
         $this->assertSame($object, $this->parameters['object']);
-        $this->assertInstanceOf('\ArrayIterator', $this->parameters['users']);
-        $this->assertInstanceOf('\ArrayIterator', $this->parameters['roles']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['aclUsersForm']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['aclRolesForm']);
+        $this->assertInstanceOf(\ArrayIterator::class, $this->parameters['users']);
+        $this->assertInstanceOf(\ArrayIterator::class, $this->parameters['roles']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['aclUsersForm']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['aclRolesForm']);
 
         $this->assertSame([], $this->session->getFlashBag()->all());
         $this->assertSame('SonataAdminBundle:CRUD:acl.html.twig', $this->template);
@@ -2785,23 +2802,23 @@ class CRUDControllerTest extends TestCase
 
         $this->adminObjectAclManipulator->expects($this->once())
             ->method('getMaskBuilderClass')
-            ->will($this->returnValue('\Sonata\AdminBundle\Security\Acl\Permission\AdminPermissionMap'));
+            ->will($this->returnValue(AdminPermissionMap::class));
 
-        $aclUsersForm = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $aclUsersForm = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $aclUsersForm->expects($this->any())
             ->method('createView')
-            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock(FormView::class)));
 
-        $aclRolesForm = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $aclRolesForm = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $aclRolesForm->expects($this->any())
             ->method('createView')
-            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock(FormView::class)));
 
         $aclRolesForm->expects($this->once())
             ->method('isValid')
@@ -2809,15 +2826,15 @@ class CRUDControllerTest extends TestCase
 
         $this->adminObjectAclManipulator->expects($this->once())
             ->method('createAclUsersForm')
-            ->with($this->isInstanceOf('Sonata\AdminBundle\Util\AdminObjectAclData'))
+            ->with($this->isInstanceOf(AdminObjectAclData::class))
             ->will($this->returnValue($aclUsersForm));
 
         $this->adminObjectAclManipulator->expects($this->once())
             ->method('createAclRolesForm')
-            ->with($this->isInstanceOf('Sonata\AdminBundle\Util\AdminObjectAclData'))
+            ->with($this->isInstanceOf(AdminObjectAclData::class))
             ->will($this->returnValue($aclRolesForm));
 
-        $aclSecurityHandler = $this->getMockBuilder('Sonata\AdminBundle\Security\Handler\AclSecurityHandler')
+        $aclSecurityHandler = $this->getMockBuilder(AclSecurityHandler::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2835,7 +2852,7 @@ class CRUDControllerTest extends TestCase
 
         $response = $this->controller->aclAction(null, $this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
 
         $this->assertSame(['flash_acl_edit_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
         $this->assertSame('stdClass_acl', $response->getTargetUrl());
@@ -2843,7 +2860,7 @@ class CRUDControllerTest extends TestCase
 
     public function testHistoryViewRevisionActionAccessDenied()
     {
-        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException(AccessDeniedException::class);
 
         $this->admin->expects($this->any())
             ->method('getObject')
@@ -2859,7 +2876,7 @@ class CRUDControllerTest extends TestCase
 
     public function testHistoryViewRevisionActionNotFoundException()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the object with id: 123');
+        $this->expectException(NotFoundHttpException::class, 'unable to find the object with id: 123');
 
         $this->request->query->set('id', 123);
 
@@ -2872,7 +2889,7 @@ class CRUDControllerTest extends TestCase
 
     public function testHistoryViewRevisionActionNoReader()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the audit reader for class : Foo');
+        $this->expectException(NotFoundHttpException::class, 'unable to find the audit reader for class : Foo');
 
         $this->request->query->set('id', 123);
 
@@ -2901,7 +2918,7 @@ class CRUDControllerTest extends TestCase
 
     public function testHistoryViewRevisionActionNotFoundRevision()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the targeted object `123` from the revision `456` with classname : `Foo`');
+        $this->expectException(NotFoundHttpException::class, 'unable to find the targeted object `123` from the revision `456` with classname : `Foo`');
 
         $this->request->query->set('id', 123);
 
@@ -2925,7 +2942,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(true));
 
-        $reader = $this->createMock('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $reader = $this->createMock(AuditReaderInterface::class);
 
         $this->auditManager->expects($this->once())
             ->method('getReader')
@@ -2964,7 +2981,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(true));
 
-        $reader = $this->createMock('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $reader = $this->createMock(AuditReaderInterface::class);
 
         $this->auditManager->expects($this->once())
             ->method('getReader')
@@ -2989,7 +3006,7 @@ class CRUDControllerTest extends TestCase
             ->method('getShow')
             ->will($this->returnValue($fieldDescriptionCollection));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->historyViewRevisionAction(123, 456, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->historyViewRevisionAction(123, 456, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -3005,7 +3022,7 @@ class CRUDControllerTest extends TestCase
 
     public function testHistoryCompareRevisionsActionAccessDenied()
     {
-        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+        $this->expectException(AccessDeniedException::class);
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -3017,7 +3034,7 @@ class CRUDControllerTest extends TestCase
 
     public function testHistoryCompareRevisionsActionNotFoundException()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the object with id: 123');
+        $this->expectException(NotFoundHttpException::class, 'unable to find the object with id: 123');
 
         $this->request->query->set('id', 123);
 
@@ -3035,7 +3052,7 @@ class CRUDControllerTest extends TestCase
 
     public function testHistoryCompareRevisionsActionNoReader()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the audit reader for class : Foo');
+        $this->expectException(NotFoundHttpException::class, 'unable to find the audit reader for class : Foo');
 
         $this->request->query->set('id', 123);
 
@@ -3064,7 +3081,7 @@ class CRUDControllerTest extends TestCase
 
     public function testHistoryCompareRevisionsActionNotFoundBaseRevision()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the targeted object `123` from the revision `456` with classname : `Foo`');
+        $this->expectException(NotFoundHttpException::class, 'unable to find the targeted object `123` from the revision `456` with classname : `Foo`');
 
         $this->request->query->set('id', 123);
 
@@ -3088,7 +3105,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(true));
 
-        $reader = $this->createMock('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $reader = $this->createMock(AuditReaderInterface::class);
 
         $this->auditManager->expects($this->once())
             ->method('getReader')
@@ -3106,7 +3123,7 @@ class CRUDControllerTest extends TestCase
 
     public function testHistoryCompareRevisionsActionNotFoundCompareRevision()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'unable to find the targeted object `123` from the revision `789` with classname : `Foo`');
+        $this->expectException(NotFoundHttpException::class, 'unable to find the targeted object `123` from the revision `789` with classname : `Foo`');
 
         $this->request->query->set('id', 123);
 
@@ -3130,7 +3147,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(true));
 
-        $reader = $this->createMock('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $reader = $this->createMock(AuditReaderInterface::class);
 
         $this->auditManager->expects($this->once())
             ->method('getReader')
@@ -3178,7 +3195,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'))
             ->will($this->returnValue(true));
 
-        $reader = $this->createMock('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $reader = $this->createMock(AuditReaderInterface::class);
 
         $this->auditManager->expects($this->once())
             ->method('getReader')
@@ -3211,7 +3228,7 @@ class CRUDControllerTest extends TestCase
             ->method('getShow')
             ->will($this->returnValue($fieldDescriptionCollection));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->historyCompareRevisionsAction(123, 456, 789, $this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->historyCompareRevisionsAction(123, 456, 789, $this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -3228,7 +3245,7 @@ class CRUDControllerTest extends TestCase
 
     public function testBatchActionWrongMethod()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Invalid request type "GET", POST expected');
+        $this->expectException(NotFoundHttpException::class, 'Invalid request type "GET", POST expected');
 
         $this->controller->batchAction($this->request);
     }
@@ -3240,7 +3257,7 @@ class CRUDControllerTest extends TestCase
      */
     public function testBatchActionActionNotDefined()
     {
-        $this->expectException('RuntimeException', 'The `foo` batch action is not defined');
+        $this->expectException(\RuntimeException::class, 'The `foo` batch action is not defined');
 
         $batchActions = [];
 
@@ -3276,7 +3293,7 @@ class CRUDControllerTest extends TestCase
      */
     public function testBatchActionMethodNotExist()
     {
-        $this->expectException('RuntimeException', 'A `Sonata\AdminBundle\Controller\CRUDController::batchActionFoo` method must be callable');
+        $this->expectException(\RuntimeException::class, 'A `Sonata\AdminBundle\Controller\CRUDController::batchActionFoo` method must be callable');
 
         $batchActions = ['foo' => ['label' => 'Foo Bar', 'ask_confirmation' => false]];
 
@@ -3284,7 +3301,7 @@ class CRUDControllerTest extends TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock(DatagridInterface::class);
         $this->admin->expects($this->once())
             ->method('getDatagrid')
             ->will($this->returnValue($datagrid));
@@ -3309,9 +3326,9 @@ class CRUDControllerTest extends TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock(DatagridInterface::class);
 
-        $query = $this->createMock('\Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock(ProxyQueryInterface::class);
         $datagrid->expects($this->once())
             ->method('getQuery')
             ->will($this->returnValue($query));
@@ -3320,7 +3337,7 @@ class CRUDControllerTest extends TestCase
             ->method('getDatagrid')
             ->will($this->returnValue($datagrid));
 
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -3348,7 +3365,7 @@ class CRUDControllerTest extends TestCase
 
         $result = $this->controller->batchAction($this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
+        $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
         $this->assertSame('list', $result->getTargetUrl());
     }
@@ -3366,9 +3383,9 @@ class CRUDControllerTest extends TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock(DatagridInterface::class);
 
-        $query = $this->createMock('\Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock(ProxyQueryInterface::class);
         $datagrid->expects($this->once())
             ->method('getQuery')
             ->will($this->returnValue($query));
@@ -3377,7 +3394,7 @@ class CRUDControllerTest extends TestCase
             ->method('getDatagrid')
             ->will($this->returnValue($datagrid));
 
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -3406,7 +3423,7 @@ class CRUDControllerTest extends TestCase
 
         $result = $this->controller->batchAction($this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
+        $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
         $this->assertSame('list', $result->getTargetUrl());
     }
@@ -3430,25 +3447,25 @@ class CRUDControllerTest extends TestCase
         $this->request->request->set('data', json_encode($data));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock(DatagridInterface::class);
 
         $this->admin->expects($this->once())
             ->method('getDatagrid')
             ->will($this->returnValue($datagrid));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $form->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($this->createMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue($this->createMock(FormView::class)));
 
         $datagrid->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->controller->batchAction($this->request));
+        $this->assertInstanceOf(Response::class, $this->controller->batchAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('SonataAdminBundle::standard_layout.html.twig', $this->parameters['base_template']);
@@ -3456,7 +3473,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame('list', $this->parameters['action']);
         $this->assertSame($datagrid, $this->parameters['datagrid']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $this->parameters['form']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
         $this->assertSame($data, $this->parameters['data']);
         $this->assertSame('csrf-token-123_sonata.batch', $this->parameters['csrf_token']);
         $this->assertSame('Foo Bar', $this->parameters['action_label']);
@@ -3481,7 +3498,7 @@ class CRUDControllerTest extends TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock(DatagridInterface::class);
 
         $this->admin->expects($this->once())
             ->method('getDatagrid')
@@ -3496,7 +3513,7 @@ class CRUDControllerTest extends TestCase
 
         $result = $controller->batchAction($this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
+        $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_empty'], $this->session->getFlashBag()->get('sonata_flash_info'));
         $this->assertSame('list', $result->getTargetUrl());
     }
@@ -3517,7 +3534,7 @@ class CRUDControllerTest extends TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock(DatagridInterface::class);
 
         $this->admin->expects($this->once())
             ->method('getDatagrid')
@@ -3532,7 +3549,7 @@ class CRUDControllerTest extends TestCase
 
         $result = $controller->batchAction($this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
+        $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_foo_error'], $this->session->getFlashBag()->get('sonata_flash_info'));
         $this->assertSame('list', $result->getTargetUrl());
     }
@@ -3550,7 +3567,7 @@ class CRUDControllerTest extends TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock(DatagridInterface::class);
 
         $this->admin->expects($this->once())
             ->method('getDatagrid')
@@ -3565,7 +3582,7 @@ class CRUDControllerTest extends TestCase
 
         $result = $this->controller->batchAction($this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
+        $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_empty'], $this->session->getFlashBag()->get('sonata_flash_info'));
         $this->assertSame('list', $result->getTargetUrl());
     }
@@ -3586,9 +3603,9 @@ class CRUDControllerTest extends TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock(DatagridInterface::class);
 
-        $query = $this->createMock('\Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock(ProxyQueryInterface::class);
         $datagrid->expects($this->once())
             ->method('getQuery')
             ->will($this->returnValue($query));
@@ -3597,7 +3614,7 @@ class CRUDControllerTest extends TestCase
             ->method('getDatagrid')
             ->will($this->returnValue($datagrid));
 
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
 
         $this->admin->expects($this->any())
             ->method('getModelManager')
@@ -3615,7 +3632,7 @@ class CRUDControllerTest extends TestCase
         $this->expectTranslate('flash_batch_no_elements_processed', [], 'SonataAdminBundle');
         $result = $controller->batchAction($this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $result);
+        $this->assertInstanceOf(Response::class, $result);
         $this->assertRegExp('/Redirecting to list/', $result->getContent());
     }
 
@@ -3632,9 +3649,9 @@ class CRUDControllerTest extends TestCase
             ->method('getBatchActions')
             ->will($this->returnValue($batchActions));
 
-        $datagrid = $this->createMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock(DatagridInterface::class);
 
-        $query = $this->createMock('\Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock(ProxyQueryInterface::class);
         $datagrid->expects($this->once())
             ->method('getQuery')
             ->will($this->returnValue($query));
@@ -3643,7 +3660,7 @@ class CRUDControllerTest extends TestCase
             ->method('getDatagrid')
             ->will($this->returnValue($datagrid));
 
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
 
         $this->admin->expects($this->once())
             ->method('checkAccess')
@@ -3672,7 +3689,7 @@ class CRUDControllerTest extends TestCase
 
         $result = $this->controller->batchAction($this->request);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $result);
+        $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
         $this->assertSame('list', $result->getTargetUrl());
         $this->assertSame('bar', $this->request->request->get('foo'));

--- a/tests/Controller/CoreControllerTest.php
+++ b/tests/Controller/CoreControllerTest.php
@@ -12,16 +12,20 @@
 namespace Sonata\AdminBundle\Tests\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Controller\CoreController;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
 
 class CoreControllerTest extends TestCase
 {
     public function testdashboardActionStandardRequest()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
 
         $pool = new Pool($container, 'title', 'logo.png');
         $pool->setTemplates([
@@ -29,13 +33,13 @@ class CoreControllerTest extends TestCase
             'dashboard' => 'dashboard.html',
         ]);
 
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating = $this->createMock(EngineInterface::class);
         $request = new Request();
 
         $requestStack = new RequestStack();
         $requestStack->push($request);
 
-        $breadcrumbsBuilder = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface');
+        $breadcrumbsBuilder = $this->getMockForAbstractClass(BreadcrumbsBuilderInterface::class);
 
         $values = [
             'sonata.admin.breadcrumbs_builder' => $breadcrumbsBuilder,
@@ -76,12 +80,12 @@ class CoreControllerTest extends TestCase
 
         $response = $controller->dashboardAction($request);
 
-        $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->isInstanceOf(Response::class, $response);
     }
 
     public function testdashboardActionAjaxLayout()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
 
         $pool = new Pool($container, 'title', 'logo.png');
         $pool->setTemplates([
@@ -89,7 +93,7 @@ class CoreControllerTest extends TestCase
             'dashboard' => 'dashboard.html',
         ]);
 
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating = $this->createMock(EngineInterface::class);
         $request = new Request();
         $request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
@@ -134,6 +138,6 @@ class CoreControllerTest extends TestCase
 
         $response = $controller->dashboardAction($request);
 
-        $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->isInstanceOf(Response::class, $response);
     }
 }

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -12,20 +12,36 @@
 namespace Sonata\AdminBundle\Tests\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Controller\HelperController;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\AdminBundle\Datagrid\Pager;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
+use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Bridge\Twig\Form\TwigRendererInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\Command\DebugCommand;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormConfigInterface;
 use Symfony\Component\Form\FormRenderer;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class AdminControllerHelper_Foo
 {
@@ -84,15 +100,15 @@ class HelperControllerTest extends TestCase
      */
     protected function setUp()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
         $pool = new Pool($container, 'title', 'logo.png');
         $pool->setAdminServiceIds(['foo.admin']);
 
-        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $this->admin = $this->createMock(AbstractAdmin::class);
 
-        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
+        $twig = new \Twig_Environment($this->createMock(\Twig_LoaderInterface::class));
         $helper = new AdminHelper($pool);
-        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validator = $this->createMock(ValidatorInterface::class);
         $this->controller = new HelperController($twig, $pool, $helper, $validator);
 
         // php 5.3 BC
@@ -113,8 +129,8 @@ class HelperControllerTest extends TestCase
      */
     public function testgetShortObjectDescriptionActionInvalidAdmin()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
+        $container = $this->createMock(ContainerInterface::class);
+        $twig = new \Twig_Environment($this->createMock(\Twig_LoaderInterface::class));
         $request = new Request([
             'code' => 'sonata.post.admin',
             'objectId' => 42,
@@ -123,7 +139,7 @@ class HelperControllerTest extends TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(['sonata.post.admin']);
         $helper = new AdminHelper($pool);
-        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validator = $this->createMock(ValidatorInterface::class);
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
         $controller->getShortObjectDescriptionAction($request);
@@ -135,14 +151,14 @@ class HelperControllerTest extends TestCase
      */
     public function testgetShortObjectDescriptionActionObjectDoesNotExist()
     {
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->once())->method('setUniqid');
         $admin->expects($this->once())->method('getObject')->will($this->returnValue(false));
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
-        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
+        $twig = new \Twig_Environment($this->createMock(\Twig_LoaderInterface::class));
         $request = new Request([
             'code' => 'sonata.post.admin',
             'objectId' => 42,
@@ -154,7 +170,7 @@ class HelperControllerTest extends TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validator = $this->createMock(ValidatorInterface::class);
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
         $controller->getShortObjectDescriptionAction($request);
@@ -162,14 +178,14 @@ class HelperControllerTest extends TestCase
 
     public function testgetShortObjectDescriptionActionEmptyObjectId()
     {
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->once())->method('setUniqid');
         $admin->expects($this->once())->method('getObject')->with($this->identicalTo(null))->will($this->returnValue(false));
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
-        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
+        $twig = new \Twig_Environment($this->createMock(\Twig_LoaderInterface::class));
         $request = new Request([
             'code' => 'sonata.post.admin',
             'objectId' => '',
@@ -182,7 +198,7 @@ class HelperControllerTest extends TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validator = $this->createMock(ValidatorInterface::class);
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
         $controller->getShortObjectDescriptionAction($request);
@@ -192,7 +208,7 @@ class HelperControllerTest extends TestCase
     {
         $mockTemplate = 'AdminHelperTest:mock-short-object-description.html.twig';
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->once())->method('setUniqid');
         $admin->expects($this->once())->method('getTemplate')->will($this->returnValue($mockTemplate));
         $admin->expects($this->once())->method('getObject')->will($this->returnValue(new AdminControllerHelper_Foo()));
@@ -205,10 +221,10 @@ class HelperControllerTest extends TestCase
             return '/ok/url';
         }));
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
-        $twig = $this->getMockBuilder('\Twig_Environment')->disableOriginalConstructor()->getMock();
+        $twig = $this->getMockBuilder(\Twig_Environment::class)->disableOriginalConstructor()->getMock();
 
         $twig->expects($this->once())->method('render')
             ->with($mockTemplate)
@@ -228,7 +244,7 @@ class HelperControllerTest extends TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validator = $this->createMock(ValidatorInterface::class);
 
         $controller = new HelperController($twig, $pool, $helper, $validator);
 
@@ -242,16 +258,16 @@ class HelperControllerTest extends TestCase
     {
         $object = new AdminControllerHelper_Foo();
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getOption')->will($this->returnValue(true));
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $admin = $this->createMock(AbstractAdmin::class);
         $admin->expects($this->once())->method('getObject')->will($this->returnValue($object));
         $admin->expects($this->once())->method('hasAccess')->will($this->returnValue(true));
         $admin->expects($this->once())->method('getListFieldDescription')->will($this->returnValue($fieldDescription));
         $fieldDescription->expects($this->exactly(2))->method('getAdmin')->will($this->returnValue($admin));
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
         $pool = new Pool($container, 'title', 'logo');
@@ -259,15 +275,15 @@ class HelperControllerTest extends TestCase
 
         $adminExtension = new SonataAdminExtension(
             $pool,
-            $this->createMock('Psr\Log\LoggerInterface'),
-            $this->createMock('Symfony\Component\Translation\TranslatorInterface')
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(TranslatorInterface::class)
         );
 
         // NEXT_MAJOR: Remove this check when dropping support for twig < 2
-        if (method_exists('\Twig_LoaderInterface', 'getSourceContext')) {
-            $loader = $this->createMock('\Twig_LoaderInterface');
+        if (method_exists(\Twig_LoaderInterface::class, 'getSourceContext')) {
+            $loader = $this->createMock(\Twig_LoaderInterface::class);
         } else {
-            $loader = $this->createMock(['\Twig_LoaderInterface', 'Twig_SourceContextLoaderInterface']);
+            $loader = $this->createMock([\Twig_LoaderInterface::class, \Twig_SourceContextLoaderInterface::class]);
         }
         $loader->method('getSourceContext')->will($this->returnValue(new \Twig_Source('<foo />', 'foo')));
 
@@ -283,7 +299,7 @@ class HelperControllerTest extends TestCase
 
         $helper = new AdminHelper($pool);
 
-        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validator = $this->createMock(ValidatorInterface::class);
 
         $validator
             ->expects($this->once())
@@ -303,23 +319,23 @@ class HelperControllerTest extends TestCase
     {
         $object = new AdminControllerHelper_Foo();
 
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelManager->expects($this->once())->method('find')->will($this->returnValue($object));
 
-        $mockTheme = $this->getMockBuilder('Symfony\Component\Form\FormView')
+        $mockTheme = $this->getMockBuilder(FormView::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->once())->method('getModelManager')->will($this->returnValue($modelManager));
         $admin->expects($this->once())->method('setRequest');
         $admin->expects($this->once())->method('setSubject');
         $admin->expects($this->once())->method('getFormTheme')->will($this->returnValue($mockTheme));
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
-        $mockRenderer = $this->getMockBuilder('Symfony\Bridge\Twig\Form\TwigRendererInterface')
+        $mockRenderer = $this->getMockBuilder(TwigRendererInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -327,13 +343,13 @@ class HelperControllerTest extends TestCase
             ->method('searchAndRenderBlock')
             ->will($this->returnValue(new Response()));
 
-        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
+        $twig = new \Twig_Environment($this->createMock(\Twig_LoaderInterface::class));
 
         // Remove the condition when dropping sf < 3.2
-        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+        if (method_exists(AppVariable::class, 'getToken')) {
             $twig->addExtension(new FormExtension());
             $runtimeLoader = $this
-                ->getMockBuilder('Twig_RuntimeLoaderInterface')
+                ->getMockBuilder(\Twig_RuntimeLoaderInterface::class)
                 ->getMock();
 
             // Remove the condition when dropping sf < 3.4
@@ -365,25 +381,25 @@ class HelperControllerTest extends TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(['sonata.post.admin']);
 
-        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validator = $this->createMock(ValidatorInterface::class);
 
-        $mockView = $this->getMockBuilder('Symfony\Component\Form\FormView')
+        $mockView = $this->getMockBuilder(FormView::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockForm = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $mockForm = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mockForm->expects($this->once())
             ->method('createView')
             ->will($this->returnValue($mockView));
 
-        $helper = $this->getMockBuilder('Sonata\AdminBundle\Admin\AdminHelper')
+        $helper = $this->getMockBuilder(AdminHelper::class)
             ->setMethods(['appendFormFieldElement', 'getChildFormView'])
             ->setConstructorArgs([$pool])
             ->getMock();
         $helper->expects($this->once())->method('appendFormFieldElement')->will($this->returnValue([
-            $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface'),
+            $this->createMock(FieldDescriptionInterface::class),
             $mockForm,
         ]));
         $helper->expects($this->once())->method('getChildFormView')->will($this->returnValue($mockView));
@@ -391,7 +407,7 @@ class HelperControllerTest extends TestCase
         $controller = new HelperController($twig, $pool, $helper, $validator);
         $response = $controller->appendFormFieldElementAction($request);
 
-        $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->isInstanceOf(Response::class, $response);
     }
 
     public function testRetrieveFormFieldElementAction()
@@ -406,14 +422,14 @@ class HelperControllerTest extends TestCase
             'context' => 'list',
         ], [], [], [], [], ['REQUEST_METHOD' => 'POST']);
 
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelManager->expects($this->once())->method('find')->will($this->returnValue($object));
 
-        $mockView = $this->getMockBuilder('Symfony\Component\Form\FormView')
+        $mockView = $this->getMockBuilder(FormView::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockForm = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $mockForm = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -429,19 +445,19 @@ class HelperControllerTest extends TestCase
             ->method('createView')
             ->will($this->returnValue($mockView));
 
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)
             ->disableOriginalConstructor()
             ->getMock();
         $formBuilder->expects($this->once())->method('getForm')->will($this->returnValue($mockForm));
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->once())->method('getModelManager')->will($this->returnValue($modelManager));
         $admin->expects($this->once())->method('getFormBuilder')->will($this->returnValue($formBuilder));
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
-        $mockRenderer = $this->getMockBuilder('Symfony\Bridge\Twig\Form\TwigRendererInterface')
+        $mockRenderer = $this->getMockBuilder(TwigRendererInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -449,13 +465,13 @@ class HelperControllerTest extends TestCase
             ->method('searchAndRenderBlock')
             ->will($this->returnValue(new Response()));
 
-        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
+        $twig = new \Twig_Environment($this->createMock(\Twig_LoaderInterface::class));
 
         // Remove the condition when dropping sf < 3.2
-        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+        if (method_exists(AppVariable::class, 'getToken')) {
             $twig->addExtension(new FormExtension());
             $runtimeLoader = $this
-                ->getMockBuilder('Twig_RuntimeLoaderInterface')
+                ->getMockBuilder(\Twig_RuntimeLoaderInterface::class)
                 ->getMock();
 
             // Remove the condition when dropping sf < 3.4
@@ -479,9 +495,9 @@ class HelperControllerTest extends TestCase
         $pool = new Pool($container, 'title', 'logo');
         $pool->setAdminServiceIds(['sonata.post.admin']);
 
-        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validator = $this->createMock(ValidatorInterface::class);
 
-        $helper = $this->getMockBuilder('Sonata\AdminBundle\Admin\AdminHelper')
+        $helper = $this->getMockBuilder(AdminHelper::class)
             ->setMethods(['getChildFormView'])
             ->setConstructorArgs([$pool])
             ->getMock();
@@ -490,7 +506,7 @@ class HelperControllerTest extends TestCase
         $controller = new HelperController($twig, $pool, $helper, $validator);
         $response = $controller->retrieveFormFieldElementAction($request);
 
-        $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->isInstanceOf(Response::class, $response);
     }
 
     public function testSetObjectFieldValueActionWithViolations()
@@ -500,18 +516,18 @@ class HelperControllerTest extends TestCase
         $object = new AdminControllerHelper_Foo();
         $object->setBar($bar);
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getOption')->will($this->returnValue(true));
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $admin = $this->createMock(AbstractAdmin::class);
         $admin->expects($this->once())->method('getObject')->will($this->returnValue($object));
         $admin->expects($this->once())->method('hasAccess')->will($this->returnValue(true));
         $admin->expects($this->once())->method('getListFieldDescription')->will($this->returnValue($fieldDescription));
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->any())->method('get')->will($this->returnValue($admin));
 
-        $twig = new \Twig_Environment($this->createMock('\Twig_LoaderInterface'));
+        $twig = new \Twig_Environment($this->createMock(\Twig_LoaderInterface::class));
         $request = new Request([
             'code' => 'sonata.post.admin',
             'objectId' => 42,
@@ -530,7 +546,7 @@ class HelperControllerTest extends TestCase
             new ConstraintViolation('error2', null, [], null, 'enabled', null),
         ]);
 
-        $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validator = $this->createMock(ValidatorInterface::class);
 
         $validator
             ->expects($this->once())
@@ -581,11 +597,11 @@ class HelperControllerTest extends TestCase
             ->with('create')
             ->will($this->returnValue(true));
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
 
         $fieldDescription->expects($this->once())
             ->method('getTargetEntity')
-            ->will($this->returnValue('Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo'));
+            ->will($this->returnValue(Foo::class));
 
         $fieldDescription->expects($this->once())
             ->method('getName')
@@ -600,7 +616,7 @@ class HelperControllerTest extends TestCase
             ->with('barField')
             ->will($this->returnValue($fieldDescription));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -608,7 +624,7 @@ class HelperControllerTest extends TestCase
             ->method('getForm')
             ->will($this->returnValue($form));
 
-        $formType = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $formType = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -617,7 +633,7 @@ class HelperControllerTest extends TestCase
             ->with('barField')
             ->will($this->returnValue($formType));
 
-        $formConfig = $this->getMockBuilder('Symfony\Component\Form\FormConfigInterface')
+        $formConfig = $this->getMockBuilder(FormConfigInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -645,17 +661,17 @@ class HelperControllerTest extends TestCase
             ->with('create')
             ->will($this->returnValue(true));
 
-        $targetAdmin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $targetAdmin = $this->createMock(AbstractAdmin::class);
         $targetAdmin->expects($this->once())
             ->method('checkAccess')
             ->with('list')
             ->will($this->returnValue(null));
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
 
         $fieldDescription->expects($this->once())
             ->method('getTargetEntity')
-            ->will($this->returnValue('Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo'));
+            ->will($this->returnValue(Foo::class));
 
         $fieldDescription->expects($this->once())
             ->method('getName')
@@ -674,7 +690,7 @@ class HelperControllerTest extends TestCase
             ->with('barField')
             ->will($this->returnValue($fieldDescription));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -682,7 +698,7 @@ class HelperControllerTest extends TestCase
             ->method('getForm')
             ->will($this->returnValue($form));
 
-        $formType = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $formType = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -691,7 +707,7 @@ class HelperControllerTest extends TestCase
             ->with('barField')
             ->will($this->returnValue($formType));
 
-        $formConfig = $this->getMockBuilder('Symfony\Component\Form\FormConfigInterface')
+        $formConfig = $this->getMockBuilder(FormConfigInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -731,7 +747,7 @@ class HelperControllerTest extends TestCase
         ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $response = $this->controller->retrieveAutocompleteItemsAction($request);
-        $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->isInstanceOf(Response::class, $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertSame('{"status":"KO","message":"Too short search string."}', $response->getContent());
     }
@@ -749,7 +765,7 @@ class HelperControllerTest extends TestCase
             ->with($entity)
             ->will($this->returnValue(123));
 
-        $targetAdmin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $targetAdmin = $this->createMock(AbstractAdmin::class);
         $targetAdmin->expects($this->once())
             ->method('checkAccess')
             ->with('list')
@@ -760,13 +776,13 @@ class HelperControllerTest extends TestCase
             ->with(false)
             ->will($this->returnValue(null));
 
-        $datagrid = $this->createMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock(DatagridInterface::class);
         $targetAdmin->expects($this->once())
             ->method('getDatagrid')
             ->with()
             ->will($this->returnValue($datagrid));
 
-        $metadata = $this->createMock('Sonata\CoreBundle\Model\Metadata');
+        $metadata = $this->createMock(Metadata::class);
         $metadata->expects($this->once())
             ->method('getTitle')
             ->with()
@@ -796,7 +812,7 @@ class HelperControllerTest extends TestCase
             ->with()
             ->will($this->returnValue(null));
 
-        $pager = $this->createMock('Sonata\AdminBundle\Datagrid\Pager');
+        $pager = $this->createMock(Pager::class);
         $datagrid->expects($this->once())
             ->method('getPager')
             ->with()
@@ -812,11 +828,11 @@ class HelperControllerTest extends TestCase
             ->with()
             ->will($this->returnValue(true));
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
 
         $fieldDescription->expects($this->once())
             ->method('getTargetEntity')
-            ->will($this->returnValue('Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo'));
+            ->will($this->returnValue(Foo::class));
 
         $fieldDescription->expects($this->once())
             ->method('getName')
@@ -835,7 +851,7 @@ class HelperControllerTest extends TestCase
             ->with('barField')
             ->will($this->returnValue($fieldDescription));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -843,7 +859,7 @@ class HelperControllerTest extends TestCase
             ->method('getForm')
             ->will($this->returnValue($form));
 
-        $formType = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $formType = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -852,7 +868,7 @@ class HelperControllerTest extends TestCase
             ->with('barField')
             ->will($this->returnValue($formType));
 
-        $formConfig = $this->getMockBuilder('Symfony\Component\Form\FormConfigInterface')
+        $formConfig = $this->getMockBuilder(FormConfigInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -892,7 +908,7 @@ class HelperControllerTest extends TestCase
         ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $response = $this->controller->retrieveAutocompleteItemsAction($request);
-        $this->isInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->isInstanceOf(Response::class, $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
     }

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -12,8 +12,19 @@
 namespace Sonata\AdminBundle\Tests\Datagrid;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\BaseFieldDescription;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
 use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\PagerInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Filter\Filter;
+use Sonata\AdminBundle\Filter\FilterInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilder;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -32,21 +43,21 @@ class DatagridMapperTest extends TestCase
 
     public function setUp()
     {
-        $datagridBuilder = $this->createMock('Sonata\AdminBundle\Builder\DatagridBuilderInterface');
+        $datagridBuilder = $this->createMock(DatagridBuilderInterface::class);
 
-        $proxyQuery = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
-        $pager = $this->createMock('Sonata\AdminBundle\Datagrid\PagerInterface');
-        $fieldDescriptionCollection = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionCollection');
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')
+        $proxyQuery = $this->createMock(ProxyQueryInterface::class);
+        $pager = $this->createMock(PagerInterface::class);
+        $fieldDescriptionCollection = $this->createMock(FieldDescriptionCollection::class);
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)
                      ->disableOriginalConstructor()
                      ->getMock();
 
         $this->datagrid = new Datagrid($proxyQuery, $fieldDescriptionCollection, $pager, $formBuilder, []);
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
 
         // php 5.3 BC
-        $filter = $this->getMockForAbstractClass('Sonata\AdminBundle\Filter\Filter');
+        $filter = $this->getMockForAbstractClass(Filter::class);
 
         $filter->expects($this->any())
             ->method('getDefaultOptions')
@@ -62,7 +73,7 @@ class DatagridMapperTest extends TestCase
                 $datagrid->addFilter($filterClone);
             }));
 
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
 
         // php 5.3 BC
         $fieldDescription = $this->getFieldDescriptionMock();
@@ -102,10 +113,10 @@ class DatagridMapperTest extends TestCase
         $this->datagridMapper->add($fieldDescription, null, ['field_name' => 'fooFilterName']);
 
         $filter = $this->datagridMapper->get('foo.name');
-        $this->assertInstanceOf('Sonata\AdminBundle\Filter\FilterInterface', $filter);
+        $this->assertInstanceOf(FilterInterface::class, $filter);
         $this->assertSame('foo.name', $filter->getName());
         $this->assertSame('foo__name', $filter->getFormName());
-        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\TextType', $filter->getFieldType());
+        $this->assertSame(TextType::class, $filter->getFieldType());
         $this->assertSame('fooLabel', $filter->getLabel());
         $this->assertSame(['required' => false], $filter->getFieldOptions());
         $this->assertSame([
@@ -128,7 +139,7 @@ class DatagridMapperTest extends TestCase
         $this->datagridMapper->add($fieldDescription, 'foo_type', ['field_name' => 'fooFilterName', 'foo_filter_option' => 'foo_filter_option_value', 'foo_default_option' => 'bar_custom'], 'foo_field_type', ['foo_field_option' => 'baz']);
 
         $filter = $this->datagridMapper->get('fooName');
-        $this->assertInstanceOf('Sonata\AdminBundle\Filter\FilterInterface', $filter);
+        $this->assertInstanceOf(FilterInterface::class, $filter);
         $this->assertSame('fooName', $filter->getName());
         $this->assertSame('fooName', $filter->getFormName());
         $this->assertSame('foo_field_type', $filter->getFieldType());
@@ -156,7 +167,7 @@ class DatagridMapperTest extends TestCase
 
         $fieldDescription = $this->datagridMapper->get('fooName');
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Filter\FilterInterface', $fieldDescription);
+        $this->assertInstanceOf(FilterInterface::class, $fieldDescription);
         $this->assertSame('fooName', $fieldDescription->getName());
     }
 
@@ -168,7 +179,7 @@ class DatagridMapperTest extends TestCase
 
         $fieldDescription = $this->datagridMapper->get('foo.bar');
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Filter\FilterInterface', $fieldDescription);
+        $this->assertInstanceOf(FilterInterface::class, $fieldDescription);
         $this->assertSame('foo.bar', $fieldDescription->getName());
         $this->assertSame('bar', $fieldDescription->getOption('field_name'));
     }
@@ -189,7 +200,7 @@ class DatagridMapperTest extends TestCase
 
     public function testAddException()
     {
-        $this->expectException('\RuntimeException', 'Unknown field name in datagrid mapper. Field name should be either of FieldDescriptionInterface interface or string');
+        $this->expectException(\RuntimeException::class, 'Unknown field name in datagrid mapper. Field name should be either of FieldDescriptionInterface interface or string');
 
         $this->datagridMapper->add(12345);
     }
@@ -209,7 +220,7 @@ class DatagridMapperTest extends TestCase
                 return false;
             }));
 
-        $this->expectException('RuntimeException', 'Duplicate field name "fooName" in datagrid mapper. Names should be unique.');
+        $this->expectException(\RuntimeException::class, 'Duplicate field name "fooName" in datagrid mapper. Names should be unique.');
 
         $this->datagridMapper->add('fooName');
         $this->datagridMapper->add('fooName');
@@ -257,7 +268,7 @@ class DatagridMapperTest extends TestCase
 
     private function getFieldDescriptionMock($name = null, $label = null)
     {
-        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\BaseFieldDescription');
+        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class);
 
         if (null !== $name) {
             $fieldDescription->setName($name);

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -13,10 +13,16 @@ namespace Sonata\AdminBundle\Tests\Datagrid;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Filter\FilterInterface;
+use Sonata\AdminBundle\Tests\Fixtures\Entity\Form\TestEntity;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormFactoryInterface;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -39,6 +45,11 @@ class DatagridTest extends TestCase
     private $query;
 
     /**
+     * @var FieldDescriptionCollection
+     */
+    private $columns;
+
+    /**
      * @var FormBuilder
      */
     private $formBuilder;
@@ -50,16 +61,16 @@ class DatagridTest extends TestCase
 
     public function setUp()
     {
-        $this->query = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $this->query = $this->createMock(ProxyQueryInterface::class);
         $this->columns = new FieldDescriptionCollection();
-        $this->pager = $this->createMock('Sonata\AdminBundle\Datagrid\PagerInterface');
+        $this->pager = $this->createMock(PagerInterface::class);
 
         $this->formTypes = [];
 
         // php 5.3 BC
         $formTypes = &$this->formTypes;
 
-        $this->formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')
+        $this->formBuilder = $this->getMockBuilder(FormBuilder::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -74,19 +85,19 @@ class DatagridTest extends TestCase
             }));
 
         // php 5.3 BC
-        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $formFactory = $this->createMock(FormFactoryInterface::class);
 
         $this->formBuilder->expects($this->any())
             ->method('add')
             ->will($this->returnCallback(function ($name, $type, $options) use (&$formTypes, $eventDispatcher, $formFactory) {
-                $formTypes[$name] = new FormBuilder($name, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Form\TestEntity', $eventDispatcher, $formFactory, $options);
+                $formTypes[$name] = new FormBuilder($name, TestEntity::class, $eventDispatcher, $formFactory, $options);
 
                 return;
             }));
 
         // php 5.3 BC
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -111,7 +122,7 @@ class DatagridTest extends TestCase
         $this->assertFalse($this->datagrid->hasFilter('foo'));
         $this->assertNull($this->datagrid->getFilter('foo'));
 
-        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock(FilterInterface::class);
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -131,17 +142,17 @@ class DatagridTest extends TestCase
     {
         $this->assertSame([], $this->datagrid->getFilters());
 
-        $filter1 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter1 = $this->createMock(FilterInterface::class);
         $filter1->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
 
-        $filter2 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter2 = $this->createMock(FilterInterface::class);
         $filter2->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
 
-        $filter3 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter3 = $this->createMock(FilterInterface::class);
         $filter3->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('baz'));
@@ -161,17 +172,17 @@ class DatagridTest extends TestCase
     {
         $this->assertSame([], $this->datagrid->getFilters());
 
-        $filter1 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter1 = $this->createMock(FilterInterface::class);
         $filter1->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
 
-        $filter2 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter2 = $this->createMock(FilterInterface::class);
         $filter2->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
 
-        $filter3 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter3 = $this->createMock(FilterInterface::class);
         $filter3->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('baz'));
@@ -212,7 +223,7 @@ class DatagridTest extends TestCase
     {
         $this->assertFalse($this->datagrid->hasActiveFilters());
 
-        $filter1 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter1 = $this->createMock(FilterInterface::class);
         $filter1->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -224,7 +235,7 @@ class DatagridTest extends TestCase
 
         $this->assertFalse($this->datagrid->hasActiveFilters());
 
-        $filter2 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter2 = $this->createMock(FilterInterface::class);
         $filter2->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
@@ -244,7 +255,7 @@ class DatagridTest extends TestCase
 
     public function testHasDisplayableFiltersNotActive()
     {
-        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock(FilterInterface::class);
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -262,7 +273,7 @@ class DatagridTest extends TestCase
 
     public function testHasDisplayableFiltersActive()
     {
-        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock(FilterInterface::class);
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
@@ -280,7 +291,7 @@ class DatagridTest extends TestCase
 
     public function testHasDisplayableFiltersAlwaysShow()
     {
-        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock(FilterInterface::class);
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
@@ -299,7 +310,7 @@ class DatagridTest extends TestCase
 
     public function testGetForm()
     {
-        $this->assertInstanceOf('Symfony\Component\Form\Form', $this->datagrid->getForm());
+        $this->assertInstanceOf(Form::class, $this->datagrid->getForm());
     }
 
     public function testGetResults()
@@ -325,7 +336,7 @@ class DatagridTest extends TestCase
 
     public function testBuildPager()
     {
-        $filter1 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter1 = $this->createMock(FilterInterface::class);
         $filter1->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -341,7 +352,7 @@ class DatagridTest extends TestCase
 
         $this->datagrid->addFilter($filter1);
 
-        $filter2 = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter2 = $this->createMock(FilterInterface::class);
         $filter2->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
@@ -360,23 +371,23 @@ class DatagridTest extends TestCase
         $this->datagrid->buildPager();
 
         $this->assertSame(['foo' => null, 'bar' => null], $this->datagrid->getValues());
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('fooFormName'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('fooFormName'));
         $this->assertSame(['bar1' => 'baz1'], $this->formBuilder->get('fooFormName')->getOptions());
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('barFormName'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('barFormName'));
         $this->assertSame(['bar2' => 'baz2'], $this->formBuilder->get('barFormName')->getOptions());
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_by'));
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_order'));
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_page'));
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_per_page'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_by'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_order'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_page'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_per_page'));
     }
 
     /**
      * @expectedException        \Symfony\Component\Form\Exception\UnexpectedTypeException
-     * @expectedExceptionMessage Expected argument of type "FieldDescriptionInterface", "array" given
+     * @expectedExceptionMessage Expected argument of type "Sonata\AdminBundle\Admin\FieldDescriptionInterface", "array" given
      */
     public function testBuildPagerWithException()
     {
-        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock(FilterInterface::class);
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -396,7 +407,7 @@ class DatagridTest extends TestCase
 
     public function testBuildPagerWithSortBy()
     {
-        $sortBy = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $sortBy = $this->createMock(FieldDescriptionInterface::class);
         $sortBy->expects($this->once())
             ->method('isSortable')
             ->will($this->returnValue(true));
@@ -413,7 +424,7 @@ class DatagridTest extends TestCase
 
         $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, ['_sort_by' => $sortBy]);
 
-        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock(FilterInterface::class);
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -432,12 +443,12 @@ class DatagridTest extends TestCase
         $this->datagrid->buildPager();
 
         $this->assertSame(['_sort_by' => $sortBy, 'foo' => null], $this->datagrid->getValues());
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('fooFormName'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('fooFormName'));
         $this->assertSame(['bar' => 'baz'], $this->formBuilder->get('fooFormName')->getOptions());
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_by'));
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_order'));
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_page'));
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_per_page'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_by'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_order'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_page'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_per_page'));
     }
 
     /**
@@ -445,7 +456,7 @@ class DatagridTest extends TestCase
      */
     public function testBuildPagerWithPage($page, $perPage)
     {
-        $sortBy = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $sortBy = $this->createMock(FieldDescriptionInterface::class);
         $sortBy->expects($this->once())
             ->method('isSortable')
             ->will($this->returnValue(true));
@@ -462,7 +473,7 @@ class DatagridTest extends TestCase
 
         $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, ['_sort_by' => $sortBy, '_page' => $page, '_per_page' => $perPage]);
 
-        $filter = $this->createMock('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->createMock(FilterInterface::class);
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -486,12 +497,12 @@ class DatagridTest extends TestCase
             '_per_page' => $perPage,
             'foo' => null,
         ], $this->datagrid->getValues());
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('fooFormName'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('fooFormName'));
         $this->assertSame(['bar' => 'baz'], $this->formBuilder->get('fooFormName')->getOptions());
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_by'));
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_order'));
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_page'));
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_per_page'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_by'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_order'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_page'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_per_page'));
     }
 
     public function getBuildPagerWithPageTests()
@@ -530,10 +541,10 @@ class DatagridTest extends TestCase
             '_per_page' => ['type' => null, 'value' => $perPage],
             '_page' => ['type' => null, 'value' => $page],
         ], $this->datagrid->getValues());
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_by'));
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_sort_order'));
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_page'));
-        $this->assertInstanceOf('Symfony\Component\Form\FormBuilder', $this->formBuilder->get('_per_page'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_by'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_order'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_page'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_per_page'));
     }
 
     public function getBuildPagerWithPage2Tests()

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -12,10 +12,14 @@
 namespace Sonata\AdminBundle\Tests\Datagrid;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Builder\ListBuilderInterface;
 use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
 
 /**
@@ -40,9 +44,9 @@ class ListMapperTest extends TestCase
 
     public function setUp()
     {
-        $listBuilder = $this->createMock('Sonata\AdminBundle\Builder\ListBuilderInterface');
+        $listBuilder = $this->createMock(ListBuilderInterface::class);
         $this->fieldDescriptionCollection = new FieldDescriptionCollection();
-        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $this->admin = $this->createMock(AbstractAdmin::class);
 
         $listBuilder->expects($this->any())
             ->method('addField')
@@ -50,7 +54,7 @@ class ListMapperTest extends TestCase
                 $list->add($fieldDescription);
             }));
 
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
 
         // php 5.3 BC
         $fieldDescription = $this->getFieldDescriptionMock();
@@ -119,7 +123,7 @@ class ListMapperTest extends TestCase
         $fieldLabelBar = $this->listMapper->get('fooNameLabelBar');
         $fieldLabelFalse = $this->listMapper->get('fooNameLabelFalse');
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $fieldDescription);
         $this->assertSame('fooName', $fieldDescription->getName());
         $this->assertSame('fooName', $fieldDescription->getOption('label'));
         $this->assertSame('Foo Bar', $fieldLabelBar->getOption('label'));
@@ -138,7 +142,7 @@ class ListMapperTest extends TestCase
 
         $fieldDescription = $this->listMapper->get('_action');
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $fieldDescription);
         $this->assertSame('_action', $fieldDescription->getName());
         $this->assertCount(1, $fieldDescription->getOption('actions'));
         $this->assertSame(['show' => []], $fieldDescription->getOption('actions'));
@@ -153,7 +157,7 @@ class ListMapperTest extends TestCase
 
         $fieldDescription = $this->listMapper->get('_action');
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $fieldDescription);
         $this->assertSame('_action', $fieldDescription->getName());
         $this->assertCount(1, $fieldDescription->getOption('actions'));
         $this->assertSame(['show' => []], $fieldDescription->getOption('actions'));
@@ -186,7 +190,7 @@ class ListMapperTest extends TestCase
                 return false;
             }));
 
-        $this->expectException('RuntimeException', 'Duplicate field name "fooName" in list mapper. Names should be unique.');
+        $this->expectException(\RuntimeException::class, 'Duplicate field name "fooName" in list mapper. Names should be unique.');
 
         $this->listMapper->add('fooName');
         $this->listMapper->add('fooName');
@@ -194,7 +198,7 @@ class ListMapperTest extends TestCase
 
     public function testAddWrongTypeException()
     {
-        $this->expectException('RuntimeException', 'Unknown field name in list mapper. Field name should be either of FieldDescriptionInterface interface or string.');
+        $this->expectException(\RuntimeException::class, 'Unknown field name in list mapper. Field name should be either of FieldDescriptionInterface interface or string.');
 
         $this->listMapper->add(12345);
     }
@@ -253,7 +257,7 @@ class ListMapperTest extends TestCase
 
     private function getFieldDescriptionMock($name = null, $label = null)
     {
-        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\BaseFieldDescription');
+        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class);
 
         if (null !== $name) {
             $fieldDescription->setName($name);

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Datagrid;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Datagrid\Pager;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -26,7 +27,7 @@ class PagerTest extends TestCase
 
     protected function setUp()
     {
-        $this->pager = $this->getMockForAbstractClass('Sonata\AdminBundle\Datagrid\Pager');
+        $this->pager = $this->getMockForAbstractClass(Pager::class);
     }
 
     /**
@@ -138,7 +139,7 @@ class PagerTest extends TestCase
 
     public function testGetQuery()
     {
-        $query = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock(ProxyQueryInterface::class);
 
         $this->pager->setQuery($query);
         $this->assertSame($query, $this->pager->getQuery());
@@ -364,7 +365,7 @@ class PagerTest extends TestCase
 
         $this->callMethod($this->pager, 'setNbResults', [3]);
 
-        $query = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock(ProxyQueryInterface::class);
 
         $query->expects($this->any())
             ->method('setFirstResult')
@@ -492,7 +493,7 @@ class PagerTest extends TestCase
 
         $this->callMethod($this->pager, 'setNbResults', [3]);
 
-        $query = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock(ProxyQueryInterface::class);
 
         $query->expects($this->any())
             ->method('setFirstResult')
@@ -550,7 +551,7 @@ class PagerTest extends TestCase
 
         $this->callMethod($this->pager, 'setNbResults', [3]);
 
-        $query = $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $query = $this->createMock(ProxyQueryInterface::class);
 
         $query->expects($this->any())
             ->method('setFirstResult')

--- a/tests/Datagrid/SimplePagerTest.php
+++ b/tests/Datagrid/SimplePagerTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Datagrid;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Datagrid\SimplePager;
 
 /**
@@ -26,7 +27,7 @@ class SimplePagerTest extends TestCase
     public function setUp()
     {
         $this->pager = new SimplePager(10, 2);
-        $this->proxyQuery = $this->getMockBuilder('Sonata\AdminBundle\Datagrid\ProxyQueryInterface')
+        $this->proxyQuery = $this->getMockBuilder(ProxyQueryInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -116,7 +117,7 @@ class SimplePagerTest extends TestCase
 
     public function testInitNoQuery()
     {
-        $this->setExpectedException('RuntimeException');
+        $this->setExpectedException(\RuntimeException::class);
         $this->pager->init();
     }
 }

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -11,14 +11,27 @@
 
 namespace Sonata\AdminBundle\Tests\DependencyInjection;
 
+use Knp\Menu\Matcher\MatcherInterface;
+use Knp\Menu\Provider\MenuProviderInterface;
+use Knp\Menu\Silex\RouterAwareFactory;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
+use Sonata\AdminBundle\Route\RoutesCache;
 use Sonata\DoctrinePHPCRAdminBundle\Route\PathInfoBuilderSlashes;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Bundle\FrameworkBundle\Translation\Translator;
+use Symfony\Bundle\FrameworkBundle\Translation\TranslatorInterface;
+use Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory;
+use Symfony\Bundle\FrameworkBundle\Validator\Validator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @author Tiago Garcia
@@ -42,12 +55,12 @@ class AddDependencyCallsCompilerPassTest extends TestCase
     public function testTranslatorDisabled()
     {
         $this->expectException(
-          'RuntimeException', 'The "translator" service is not yet enabled.
+            \RuntimeException::class, 'The "translator" service is not yet enabled.
                 It\'s required by SonataAdmin to display all labels properly.
 
                 To learn how to enable the translator service please visit:
                 http://symfony.com/doc/current/translation.html#configuration
-             '
+            '
         );
 
         $container = $this->getContainer();
@@ -174,12 +187,12 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $this->assertArrayHasKey('sonata_group_five', $adminGroups);
         $this->assertTrue($adminGroups['sonata_group_five']['keep_open']);
 
-        $this->assertArrayHasKey('Sonata\AdminBundle\Tests\DependencyInjection\Post', $adminClasses);
-        $this->assertContains('sonata_post_admin', $adminClasses['Sonata\AdminBundle\Tests\DependencyInjection\Post']);
-        $this->assertArrayHasKey('Sonata\AdminBundle\Tests\DependencyInjection\Article', $adminClasses);
-        $this->assertContains('sonata_article_admin', $adminClasses['Sonata\AdminBundle\Tests\DependencyInjection\Article']);
-        $this->assertArrayHasKey('Sonata\AdminBundle\Tests\DependencyInjection\News', $adminClasses);
-        $this->assertContains('sonata_news_admin', $adminClasses['Sonata\AdminBundle\Tests\DependencyInjection\News']);
+        $this->assertArrayHasKey(Post::class, $adminClasses);
+        $this->assertContains('sonata_post_admin', $adminClasses[Post::class]);
+        $this->assertArrayHasKey(Article::class, $adminClasses);
+        $this->assertContains('sonata_article_admin', $adminClasses[Article::class]);
+        $this->assertArrayHasKey(News::class, $adminClasses);
+        $this->assertContains('sonata_news_admin', $adminClasses[News::class]);
         $newsRouteBuilderMethodCall = current(array_filter(
             $container->getDefinition('sonata_news_admin')->getMethodCalls(),
             function ($element) {
@@ -365,7 +378,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
 
         $compilerPass = new AddDependencyCallsCompilerPass();
 
-        $this->expectException('\RuntimeException', 'You can\'t use "on_top" option with multiple same name groups.');
+        $this->expectException(\RuntimeException::class, 'You can\'t use "on_top" option with multiple same name groups.');
 
         $compilerPass->process($container);
     }
@@ -401,7 +414,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
 
         $compilerPass = new AddDependencyCallsCompilerPass();
 
-        $this->expectException('\RuntimeException', 'You can\'t use "on_top" option with multiple same name groups.');
+        $this->expectException(\RuntimeException::class, 'You can\'t use "on_top" option with multiple same name groups.');
 
         $compilerPass->process($container);
     }
@@ -418,11 +431,11 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $compilerPass = new AddDependencyCallsCompilerPass();
         $container
             ->register('sonata_report_one_admin')
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\ReportOne', 'SonataAdminBundle:CRUD'])
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', ReportOne::class, 'SonataAdminBundle:CRUD'])
             ->addTag('sonata.admin', ['group' => 'sonata_report_group', 'manager_type' => 'orm', 'on_top' => true]);
 
-        $this->expectException('\RuntimeException', 'You can\'t use "on_top" option with multiple same name groups.');
+        $this->expectException(\RuntimeException::class, 'You can\'t use "on_top" option with multiple same name groups.');
 
         $compilerPass->process($container);
     }
@@ -439,11 +452,11 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $compilerPass = new AddDependencyCallsCompilerPass();
         $container
             ->register('sonata_report_two_admin')
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\ReportOne', 'SonataAdminBundle:CRUD'])
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', ReportOne::class, 'SonataAdminBundle:CRUD'])
             ->addTag('sonata.admin', ['group' => 'sonata_report_group', 'manager_type' => 'orm', 'on_top' => false]);
 
-        $this->expectException('\RuntimeException', 'You can\'t use "on_top" option with multiple same name groups.');
+        $this->expectException(\RuntimeException::class, 'You can\'t use "on_top" option with multiple same name groups.');
 
         $compilerPass->process($container);
     }
@@ -460,13 +473,13 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $compilerPass = new AddDependencyCallsCompilerPass();
         $container
             ->register('sonata_document_one_admin')
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\ReportOne', 'SonataAdminBundle:CRUD'])
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', ReportOne::class, 'SonataAdminBundle:CRUD'])
             ->addTag('sonata.admin', ['group' => 'sonata_document_group', 'manager_type' => 'orm', 'on_top' => false]);
         $container
             ->register('sonata_document_two_admin')
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\ReportOne', 'SonataAdminBundle:CRUD'])
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', ReportOne::class, 'SonataAdminBundle:CRUD'])
             ->addTag('sonata.admin', ['group' => 'sonata_document_group', 'manager_type' => 'orm', 'on_top' => false]);
 
         try {
@@ -488,7 +501,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $compilerPass = new AddDependencyCallsCompilerPass();
         $container
             ->register('sonata_abstract_post_admin')
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\Post', ''])
+            ->setArguments(['', Post::class, ''])
             ->setAbstract(true);
 
         // NEXT_MAJOR: Simplify this when dropping sf < 3.3
@@ -497,7 +510,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
             new DefinitionDecorator('sonata_abstract_post_admin');
         $adminDefinition
             ->setPublic(true)
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAbstractServiceAdmin')
+            ->setClass(MockAbstractServiceAdmin::class)
             ->setArguments([0 => 'extra_argument_1'])
             ->addTag('sonata.admin', ['group' => 'sonata_post_one_group', 'manager_type' => 'orm']);
 
@@ -507,7 +520,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
             new DefinitionDecorator('sonata_abstract_post_admin');
         $adminTwoDefinition
             ->setPublic(true)
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAbstractServiceAdmin')
+            ->setClass(MockAbstractServiceAdmin::class)
             ->setArguments([0 => 'extra_argument_2', 'index_0' => 'should_not_override'])
             ->addTag('sonata.admin', ['group' => 'sonata_post_two_group', 'manager_type' => 'orm']);
 
@@ -530,13 +543,13 @@ class AddDependencyCallsCompilerPassTest extends TestCase
 
         $definition = $container->getDefinition('sonata_post_one_admin');
         $this->assertSame('sonata_post_one_admin', $definition->getArgument(0));
-        $this->assertSame('Sonata\AdminBundle\Tests\DependencyInjection\Post', $definition->getArgument(1));
+        $this->assertSame(Post::class, $definition->getArgument(1));
         $this->assertSame('SonataAdminBundle:CRUD', $definition->getArgument(2));
         $this->assertSame('extra_argument_1', $definition->getArgument(3));
 
         $definition = $container->getDefinition('sonata_post_two_admin');
         $this->assertSame('sonata_post_two_admin', $definition->getArgument(0));
-        $this->assertSame('Sonata\AdminBundle\Tests\DependencyInjection\Post', $definition->getArgument(1));
+        $this->assertSame(Post::class, $definition->getArgument(1));
         $this->assertSame('SonataAdminBundle:CRUD', $definition->getArgument(2));
         $this->assertSame('extra_argument_2', $definition->getArgument(3));
     }
@@ -620,28 +633,28 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         // Add dependencies for SonataAdminBundle (these services will never get called so dummy classes will do)
         $container
             ->register('twig')
-            ->setClass('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+            ->setClass(EngineInterface::class);
         $container
             ->register('templating')
-            ->setClass('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+            ->setClass(EngineInterface::class);
         $container
             ->register('translator')
-            ->setClass('Symfony\Bundle\FrameworkBundle\Translation\TranslatorInterface');
+            ->setClass(TranslatorInterface::class);
         $container
             ->register('validator')
-            ->setClass('Symfony\Bundle\FrameworkBundle\Validator\Validator');
+            ->setClass(Validator::class);
         $container
             ->register('validator.validator_factory')
-            ->setClass('Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory');
+            ->setClass(ConstraintValidatorFactory::class);
         $container
             ->register('router')
-            ->setClass('Symfony\Component\Routing\RouterInterface');
+            ->setClass(RouterInterface::class);
         $container
             ->register('property_accessor')
-            ->setClass('Symfony\Component\PropertyAccess\PropertyAccessor');
+            ->setClass(PropertyAccessor::class);
         $container
             ->register('form.factory')
-            ->setClass('Symfony\Component\Form\FormFactoryInterface');
+            ->setClass(FormFactoryInterface::class);
         foreach ([
             'doctrine_phpcr' => 'PHPCR',
             'orm' => 'ORM', ] as $key => $bundleSubstring) {
@@ -678,63 +691,63 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         }
         $container
             ->register('sonata.admin.route.path_info_slashes')
-            ->setClass('Sonata\DoctrinePHPCRAdminBundle\Route\PathInfoBuilderSlashes');
+            ->setClass(PathInfoBuilderSlashes::class);
         $container
             ->register('sonata.admin.route.cache')
-            ->setClass('Sonata\AdminBundle\Route\RoutesCache');
+            ->setClass(RoutesCache::class);
         $container
             ->register('knp_menu.factory')
-            ->setClass('Knp\Menu\Silex\RouterAwareFactory');
+            ->setClass(RouterAwareFactory::class);
         $container
             ->register('knp_menu.menu_provider')
-            ->setClass('Knp\Menu\Provider\MenuProviderInterface');
+            ->setClass(MenuProviderInterface::class);
         $container
             ->register('knp_menu.matcher')
-            ->setClass('Knp\Menu\Matcher\MatcherInterface');
+            ->setClass(MatcherInterface::class);
         $container
             ->register('event_dispatcher')
-            ->setClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+            ->setClass(EventDispatcherInterface::class);
 
         // Add admin definition's
         $container
             ->register('sonata_news_admin')
             ->setPublic(true)
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\News', 'SonataAdminBundle:CRUD'])
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', News::class, 'SonataAdminBundle:CRUD'])
             ->addTag('sonata.admin', ['group' => 'sonata_group_two', 'label' => '5 Entry', 'manager_type' => 'orm']);
         $container
             ->register('sonata_post_admin')
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
+            ->setClass(MockAdmin::class)
             ->setPublic(true)
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\Post', 'SonataAdminBundle:CRUD'])
+            ->setArguments(['', Post::class, 'SonataAdminBundle:CRUD'])
             ->addTag('sonata.admin', ['group' => 'sonata_group_one', 'manager_type' => 'orm']);
         $container
             ->register('sonata_article_admin')
             ->setPublic(true)
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\Article', 'SonataAdminBundle:CRUD'])
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', Article::class, 'SonataAdminBundle:CRUD'])
             ->addTag('sonata.admin', ['group' => 'sonata_group_one', 'label' => '1 Entry', 'manager_type' => 'doctrine_phpcr']);
         $container
             ->register('sonata_report_admin')
             ->setPublic(true)
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\Report', 'SonataAdminBundle:CRUD'])
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', Report::class, 'SonataAdminBundle:CRUD'])
             ->addTag('sonata.admin', ['group' => 'sonata_report_group', 'manager_type' => 'orm', 'on_top' => true]);
         $container
             ->register('sonata_report_one_admin')
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\ReportOne', 'SonataAdminBundle:CRUD'])
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', ReportOne::class, 'SonataAdminBundle:CRUD'])
             ->addTag('sonata.admin', ['group' => 'sonata_report_one_group', 'manager_type' => 'orm', 'show_mosaic_button' => false]);
         $container
             ->register('sonata_report_two_admin')
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\ReportTwo', 'SonataAdminBundle:CRUD'])
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', ReportTwo::class, 'SonataAdminBundle:CRUD'])
             ->addTag('sonata.admin', ['group' => 'sonata_report_two_group', 'manager_type' => 'orm', 'show_mosaic_button' => true]);
 
         // translator
         $container
             ->register('translator.default')
-            ->setClass('Symfony\Bundle\FrameworkBundle\Translation\Translator');
+            ->setClass(Translator::class);
         $container->setAlias('translator', 'translator.default');
 
         return $container;

--- a/tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
@@ -13,6 +13,8 @@ namespace Sonata\AdminBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 
 class AddFilterTypeCompilerPassTest extends TestCase
 {
@@ -24,14 +26,14 @@ class AddFilterTypeCompilerPassTest extends TestCase
 
     public function setUp()
     {
-        $this->filterFactory = $this->createMock('Symfony\Component\DependencyInjection\Definition');
-        $this->fooFilter = $this->createMock('Symfony\Component\DependencyInjection\Definition');
-        $this->barFilter = $this->createMock('Symfony\Component\DependencyInjection\Definition');
+        $this->filterFactory = $this->createMock(Definition::class);
+        $this->fooFilter = $this->createMock(Definition::class);
+        $this->barFilter = $this->createMock(Definition::class);
     }
 
     public function testProcess()
     {
-        $containerBuilderMock = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $containerBuilderMock = $this->createMock(ContainerBuilder::class);
 
         $containerBuilderMock->expects($this->any())
             ->method('getDefinition')

--- a/tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Tests\DependencyInjection;
 use JMS\DiExtraBundle\Metadata\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Annotation\Admin;
+use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
 
 class AnnotationCompilerPassTest extends TestCase
 {
@@ -24,14 +25,14 @@ class AnnotationCompilerPassTest extends TestCase
          */
 
         $this->expectException(
-            'LogicException',
+            \LogicException::class,
             'Unable to generate admin group and label for class Sonata\AdminBundle\Tests\Fixtures\Foo.'
         );
 
         $annotation = new Admin();
-        $annotation->class = 'Sonata\AdminBundle\Tests\Fixtures\Foo';
+        $annotation->class = \Sonata\AdminBundle\Tests\Fixtures\Foo::class;
 
-        $meta = new ClassMetadata('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo');
+        $meta = new ClassMetadata(\Sonata\AdminBundle\Tests\Fixtures\Entity\Foo::class);
 
         $annotation->processMetadata($meta);
     }
@@ -45,10 +46,10 @@ class AnnotationCompilerPassTest extends TestCase
          * )
          */
         $annotation = new Admin();
-        $annotation->class = 'Sonata\Admin\Entity\Tests\Fixtures\Foo';
+        $annotation->class = \Sonata\Admin\Entity\Tests\Fixtures\Foo::class;
         $annotation->showInDashboard = false;
 
-        $meta = new ClassMetadata('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo');
+        $meta = new ClassMetadata(\Sonata\AdminBundle\Tests\Fixtures\Entity\Foo::class);
 
         $annotation->processMetadata($meta);
 
@@ -71,9 +72,9 @@ class AnnotationCompilerPassTest extends TestCase
          * @Admin(class="Sonata\AdminBundle\Entity\Foo")
          */
         $annotation = new Admin();
-        $annotation->class = 'Sonata\AdminBundle\Entity\Foo';
+        $annotation->class = \Sonata\AdminBundle\Entity\Foo::class;
 
-        $meta = new ClassMetadata('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo');
+        $meta = new ClassMetadata(\Sonata\AdminBundle\Tests\Fixtures\Entity\Foo::class);
 
         $annotation->processMetadata($meta);
 
@@ -96,10 +97,10 @@ class AnnotationCompilerPassTest extends TestCase
          * @Admin(class="Sonata\AdminBundle\Entity\Foo", id="my.id")
          */
         $annotation = new Admin();
-        $annotation->class = 'Sonata\AdminBundle\Entity\Foo';
+        $annotation->class = \Sonata\AdminBundle\Entity\Foo::class;
         $annotation->id = 'my.id';
 
-        $meta = new ClassMetadata('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo');
+        $meta = new ClassMetadata(\Sonata\AdminBundle\Tests\Fixtures\Entity\Foo::class);
 
         $annotation->processMetadata($meta);
 
@@ -120,7 +121,7 @@ class AnnotationCompilerPassTest extends TestCase
          * )
          */
         $annotation = new Admin();
-        $annotation->class = 'Sonata\AdminBundle\Entity\Foo';
+        $annotation->class = \Sonata\AdminBundle\Entity\Foo::class;
         $annotation->managerType = 'doctrine_mongodb';
         $annotation->group = 'myGroup';
         $annotation->label = 'myLabel';
@@ -129,7 +130,7 @@ class AnnotationCompilerPassTest extends TestCase
         $annotation->keepOpen = true;
         $annotation->onTop = true;
 
-        $meta = new ClassMetadata('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo');
+        $meta = new ClassMetadata(\Sonata\AdminBundle\Tests\Fixtures\Entity\Foo::class);
 
         $annotation->processMetadata($meta);
 

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -11,11 +11,25 @@
 
 namespace Sonata\AdminBundle\Tests\DependencyInjection;
 
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\Matcher\MatcherInterface;
+use Knp\Menu\Provider\MenuProviderInterface;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminExtensionInterface;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
+use Sonata\AdminBundle\Tests\Fixtures\DependencyInjection\TimestampableTrait;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Bundle\FrameworkBundle\Translation\TranslatorInterface;
+use Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class ExtensionCompilerPassTest extends TestCase
 {
@@ -69,7 +83,7 @@ class ExtensionCompilerPassTest extends TestCase
         $extensionMap = $container->getParameter($this->root.'.extension.map');
 
         $method = new \ReflectionMethod(
-            'Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass', 'flattenExtensionConfiguration'
+            ExtensionCompilerPass::class, 'flattenExtensionConfiguration'
         );
 
         $method->setAccessible(true);
@@ -100,7 +114,7 @@ class ExtensionCompilerPassTest extends TestCase
         $extensionMap = $container->getParameter($this->root.'.extension.map');
 
         $method = new \ReflectionMethod(
-            'Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass', 'flattenExtensionConfiguration'
+            ExtensionCompilerPass::class, 'flattenExtensionConfiguration'
         );
 
         $method->setAccessible(true);
@@ -129,38 +143,38 @@ class ExtensionCompilerPassTest extends TestCase
         $this->assertArrayHasKey('implements', $extensionMap);
         $this->assertCount(1, $extensionMap['implements']);
 
-        $this->assertArrayHasKey('Sonata\AdminBundle\Tests\DependencyInjection\Publishable', $extensionMap['implements']);
-        $this->assertCount(2, $extensionMap['implements']['Sonata\AdminBundle\Tests\DependencyInjection\Publishable']);
-        $this->assertArrayHasKey('sonata_extension_publish', $extensionMap['implements']['Sonata\AdminBundle\Tests\DependencyInjection\Publishable']);
-        $this->assertArrayHasKey('sonata_extension_order', $extensionMap['implements']['Sonata\AdminBundle\Tests\DependencyInjection\Publishable']);
+        $this->assertArrayHasKey(Publishable::class, $extensionMap['implements']);
+        $this->assertCount(2, $extensionMap['implements'][Publishable::class]);
+        $this->assertArrayHasKey('sonata_extension_publish', $extensionMap['implements'][Publishable::class]);
+        $this->assertArrayHasKey('sonata_extension_order', $extensionMap['implements'][Publishable::class]);
 
         // Extends
         $this->assertArrayHasKey('extends', $extensionMap);
         $this->assertCount(1, $extensionMap['extends']);
 
-        $this->assertArrayHasKey('Sonata\AdminBundle\Tests\DependencyInjection\Post', $extensionMap['extends']);
-        $this->assertCount(1, $extensionMap['extends']['Sonata\AdminBundle\Tests\DependencyInjection\Post']);
-        $this->assertArrayHasKey('sonata_extension_order', $extensionMap['extends']['Sonata\AdminBundle\Tests\DependencyInjection\Post']);
+        $this->assertArrayHasKey(Post::class, $extensionMap['extends']);
+        $this->assertCount(1, $extensionMap['extends'][Post::class]);
+        $this->assertArrayHasKey('sonata_extension_order', $extensionMap['extends'][Post::class]);
 
         // Instanceof
         $this->assertArrayHasKey('instanceof', $extensionMap);
         $this->assertCount(1, $extensionMap['instanceof']);
 
-        $this->assertArrayHasKey('Sonata\AdminBundle\Tests\DependencyInjection\Post', $extensionMap['instanceof']);
-        $this->assertCount(1, $extensionMap['instanceof']['Sonata\AdminBundle\Tests\DependencyInjection\Post']);
-        $this->assertArrayHasKey('sonata_extension_history', $extensionMap['instanceof']['Sonata\AdminBundle\Tests\DependencyInjection\Post']);
+        $this->assertArrayHasKey(Post::class, $extensionMap['instanceof']);
+        $this->assertCount(1, $extensionMap['instanceof'][Post::class]);
+        $this->assertArrayHasKey('sonata_extension_history', $extensionMap['instanceof'][Post::class]);
 
         // Uses
         $this->assertArrayHasKey('uses', $extensionMap);
 
         if ($this->hasTraits) {
             $this->assertCount(1, $extensionMap['uses']);
-            $this->assertArrayHasKey('Sonata\AdminBundle\Tests\Fixtures\DependencyInjection\TimestampableTrait', $extensionMap['uses']);
-            $this->assertCount(1, $extensionMap['uses']['Sonata\AdminBundle\Tests\Fixtures\DependencyInjection\TimestampableTrait']);
-            $this->assertArrayHasKey('sonata_extension_post', $extensionMap['uses']['Sonata\AdminBundle\Tests\Fixtures\DependencyInjection\TimestampableTrait']);
+            $this->assertArrayHasKey(TimestampableTrait::class, $extensionMap['uses']);
+            $this->assertCount(1, $extensionMap['uses'][TimestampableTrait::class]);
+            $this->assertArrayHasKey('sonata_extension_post', $extensionMap['uses'][TimestampableTrait::class]);
         } else {
             $this->assertCount(0, $extensionMap['uses']);
-            $this->assertArrayNotHasKey('Sonata\AdminBundle\Tests\Fixtures\DependencyInjection\TimestampableTrait', $extensionMap['uses']);
+            $this->assertArrayNotHasKey(TimestampableTrait::class, $extensionMap['uses']);
         }
     }
 
@@ -174,7 +188,7 @@ class ExtensionCompilerPassTest extends TestCase
             'extensions' => [
                 'sonata_extension_unknown' => [
                     'excludes' => ['sonata_article_admin'],
-                    'instanceof' => ['Sonata\AdminBundle\Tests\DependencyInjection\Post'],
+                    'instanceof' => [Post::class],
                 ],
             ],
         ];
@@ -196,7 +210,7 @@ class ExtensionCompilerPassTest extends TestCase
             'extensions' => [
                 'sonata_extension_publish' => [
                     'admins' => ['sonata_unknown_admin'],
-                    'implements' => ['Sonata\AdminBundle\Tests\DependencyInjection\Publishable'],
+                    'implements' => [Publishable::class],
                 ],
             ],
         ];
@@ -268,13 +282,13 @@ class ExtensionCompilerPassTest extends TestCase
     public function testProcessThrowsExceptionIfTraitsAreNotAvailable()
     {
         if (!$this->hasTraits) {
-            $this->expectException('\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException', 'PHP >= 5.4.0 is required to use traits.');
+            $this->expectException(InvalidConfigurationException::class, 'PHP >= 5.4.0 is required to use traits.');
         }
 
         $config = [
             'extensions' => [
                 'sonata_extension_post' => [
-                    'uses' => ['Sonata\AdminBundle\Tests\Fixtures\DependencyInjection\TimestampableTrait'],
+                    'uses' => [TimestampableTrait::class],
                 ],
             ],
         ];
@@ -296,24 +310,24 @@ class ExtensionCompilerPassTest extends TestCase
             'extensions' => [
                 'sonata_extension_publish' => [
                     'admins' => ['sonata_post_admin'],
-                    'implements' => ['Sonata\AdminBundle\Tests\DependencyInjection\Publishable'],
+                    'implements' => [Publishable::class],
                 ],
                 'sonata_extension_history' => [
                     'excludes' => ['sonata_article_admin'],
-                    'instanceof' => ['Sonata\AdminBundle\Tests\DependencyInjection\Post'],
+                    'instanceof' => [Post::class],
                     'priority' => 255,
                 ],
                 'sonata_extension_order' => [
                     'excludes' => ['sonata_post_admin'],
-                    'extends' => ['Sonata\AdminBundle\Tests\DependencyInjection\Post'],
-                    'implements' => ['Sonata\AdminBundle\Tests\DependencyInjection\Publishable'],
+                    'extends' => [Post::class],
+                    'implements' => [Publishable::class],
                     'priority' => -128,
                 ],
             ],
         ];
 
         if ($this->hasTraits) {
-            $config['extensions']['sonata_extension_post']['uses'] = ['Sonata\AdminBundle\Tests\Fixtures\DependencyInjection\TimestampableTrait'];
+            $config['extensions']['sonata_extension_post']['uses'] = [TimestampableTrait::class];
         }
 
         return $config;
@@ -332,63 +346,63 @@ class ExtensionCompilerPassTest extends TestCase
         // Add dependencies for SonataAdminBundle (these services will never get called so dummy classes will do)
         $container
             ->register('twig')
-            ->setClass('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+            ->setClass(EngineInterface::class);
         $container
             ->register('templating')
-            ->setClass('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+            ->setClass(EngineInterface::class);
         $container
             ->register('translator')
-            ->setClass('Symfony\Bundle\FrameworkBundle\Translation\TranslatorInterface');
+            ->setClass(TranslatorInterface::class);
         $container
             ->register('validator.validator_factory')
-            ->setClass('Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory');
+            ->setClass(ConstraintValidatorFactory::class);
         $container
             ->register('router')
-            ->setClass('Symfony\Component\Routing\RouterInterface');
+            ->setClass(RouterInterface::class);
         $container
             ->register('property_accessor')
-            ->setClass('Symfony\Component\PropertyAccess\PropertyAccessor');
+            ->setClass(PropertyAccessor::class);
         $container
             ->register('form.factory')
-            ->setClass('Symfony\Component\Form\FormFactoryInterface');
+            ->setClass(FormFactoryInterface::class);
         $container
             ->register('validator')
-            ->setClass('Symfony\Component\Validator\Validator\ValidatorInterface');
+            ->setClass(ValidatorInterface::class);
         $container
             ->register('knp_menu.factory')
-            ->setClass('Knp\Menu\FactoryInterface');
+            ->setClass(FactoryInterface::class);
         $container
             ->register('knp_menu.matcher')
-            ->setClass('Knp\Menu\Matcher\MatcherInterface');
+            ->setClass(MatcherInterface::class);
         $container
             ->register('knp_menu.menu_provider')
-            ->setClass('Knp\Menu\Provider\MenuProviderInterface');
+            ->setClass(MenuProviderInterface::class);
 
         // Add admin definition's
         $container
             ->register('sonata_post_admin')
             ->setPublic(true)
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\Post', 'SonataAdminBundle:CRUD'])
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', Post::class, 'SonataAdminBundle:CRUD'])
             ->addTag('sonata.admin');
         $container
             ->register('sonata_news_admin')
             ->setPublic(true)
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\News', 'SonataAdminBundle:CRUD'])
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', News::class, 'SonataAdminBundle:CRUD'])
             ->addTag('sonata.admin');
         $container
             ->register('sonata_article_admin')
             ->setPublic(true)
-            ->setClass('Sonata\AdminBundle\Tests\DependencyInjection\MockAdmin')
-            ->setArguments(['', 'Sonata\AdminBundle\Tests\DependencyInjection\Article', 'SonataAdminBundle:CRUD'])
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', Article::class, 'SonataAdminBundle:CRUD'])
             ->addTag('sonata.admin');
         $container
             ->register('event_dispatcher')
-            ->setClass('Symfony\Component\EventDispatcher\EventDispatcher');
+            ->setClass(EventDispatcher::class);
 
         // Add admin extension definition's
-        $extensionClass = get_class($this->createMock('Sonata\AdminBundle\Admin\AdminExtensionInterface'));
+        $extensionClass = get_class($this->createMock(AdminExtensionInterface::class));
 
         $container
             ->register('sonata_extension_publish')

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
 use Symfony\Component\Config\Definition\Processor;
 
 class ConfigurationTest extends TestCase
@@ -36,7 +37,7 @@ class ConfigurationTest extends TestCase
 
     public function testOptionsWithInvalidFormat()
     {
-        $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidTypeException');
+        $this->expectException(InvalidTypeException::class);
 
         $config = $this->process([[
             'options' => [
@@ -189,7 +190,7 @@ class ConfigurationTest extends TestCase
 
     public function testDashboardGroupsWithBadItemsParams()
     {
-        $this->expectException('\InvalidArgumentException', 'Expected either parameters "route" and "label" for array items');
+        $this->expectException(\InvalidArgumentException::class, 'Expected either parameters "route" and "label" for array items');
 
         $config = $this->process([[
             'dashboard' => [

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\AdminBundle\Bridge\Exporter\AdminExporter;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
 
 class SonataAdminExtensionTest extends AbstractExtensionTestCase
@@ -36,7 +37,7 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $this->load();
         $this->assertContainerBuilderHasService(
             'sonata.admin.admin_exporter',
-            'Sonata\AdminBundle\Bridge\Exporter\AdminExporter'
+            AdminExporter::class
         );
     }
 

--- a/tests/Event/AdminEventExtensionTest.php
+++ b/tests/Event/AdminEventExtensionTest.php
@@ -12,9 +12,16 @@
 namespace Sonata\AdminBundle\Tests\Event;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Event\AdminEventExtension;
 use Sonata\AdminBundle\Event\ConfigureEvent;
 use Sonata\AdminBundle\Event\PersistenceEvent;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Show\ShowMapper;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class AdminEventExtensionTest extends TestCase
 {
@@ -23,7 +30,7 @@ class AdminEventExtensionTest extends TestCase
      */
     public function getExtension($args)
     {
-        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $stub = $eventDispatcher->expects($this->once())->method('dispatch');
         call_user_func_array([$stub, 'with'], $args);
 
@@ -33,7 +40,7 @@ class AdminEventExtensionTest extends TestCase
     public function getMapper($class)
     {
         $mapper = $this->getMockBuilder($class)->disableOriginalConstructor()->getMock();
-        $mapper->expects($this->once())->method('getAdmin')->will($this->returnValue($this->createMock('Sonata\AdminBundle\Admin\AdminInterface')));
+        $mapper->expects($this->once())->method('getAdmin')->will($this->returnValue($this->createMock(AdminInterface::class)));
 
         return $mapper;
     }
@@ -85,7 +92,7 @@ class AdminEventExtensionTest extends TestCase
                 $this->equalTo('sonata.admin.event.configure.form'),
                 $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_FORM)),
             ])
-            ->configureFormFields($this->getMapper('Sonata\AdminBundle\Form\FormMapper'));
+            ->configureFormFields($this->getMapper(FormMapper::class));
     }
 
     public function testConfigureListFields()
@@ -95,7 +102,7 @@ class AdminEventExtensionTest extends TestCase
                 $this->equalTo('sonata.admin.event.configure.list'),
                 $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_LIST)),
             ])
-            ->configureListFields($this->getMapper('Sonata\AdminBundle\Datagrid\ListMapper'));
+            ->configureListFields($this->getMapper(ListMapper::class));
     }
 
     public function testConfigureDatagridFields()
@@ -105,7 +112,7 @@ class AdminEventExtensionTest extends TestCase
                 $this->equalTo('sonata.admin.event.configure.datagrid'),
                 $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_DATAGRID)),
             ])
-            ->configureDatagridFilters($this->getMapper('Sonata\AdminBundle\Datagrid\DatagridMapper'));
+            ->configureDatagridFilters($this->getMapper(DatagridMapper::class));
     }
 
     public function testConfigureShowFields()
@@ -115,7 +122,7 @@ class AdminEventExtensionTest extends TestCase
                 $this->equalTo('sonata.admin.event.configure.show'),
                 $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_SHOW)),
             ])
-            ->configureShowFields($this->getMapper('Sonata\AdminBundle\Show\ShowMapper'));
+            ->configureShowFields($this->getMapper(ShowMapper::class));
     }
 
     public function testPreUpdate()
@@ -123,14 +130,14 @@ class AdminEventExtensionTest extends TestCase
         $this->getExtension([
             $this->equalTo('sonata.admin.event.persistence.pre_update'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_UPDATE)),
-        ])->preUpdate($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
+        ])->preUpdate($this->createMock(AdminInterface::class), new \stdClass());
     }
 
     public function testConfigureQuery()
     {
         $this->getExtension([
             $this->equalTo('sonata.admin.event.configure.query'),
-        ])->configureQuery($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), $this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        ])->configureQuery($this->createMock(AdminInterface::class), $this->createMock(ProxyQueryInterface::class));
     }
 
     public function testPostUpdate()
@@ -138,7 +145,7 @@ class AdminEventExtensionTest extends TestCase
         $this->getExtension([
             $this->equalTo('sonata.admin.event.persistence.post_update'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_UPDATE)),
-        ])->postUpdate($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
+        ])->postUpdate($this->createMock(AdminInterface::class), new \stdClass());
     }
 
     public function testPrePersist()
@@ -146,7 +153,7 @@ class AdminEventExtensionTest extends TestCase
         $this->getExtension([
             $this->equalTo('sonata.admin.event.persistence.pre_persist'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_PERSIST)),
-        ])->prePersist($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
+        ])->prePersist($this->createMock(AdminInterface::class), new \stdClass());
     }
 
     public function testPostPersist()
@@ -154,7 +161,7 @@ class AdminEventExtensionTest extends TestCase
         $this->getExtension([
             $this->equalTo('sonata.admin.event.persistence.post_persist'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_PERSIST)),
-        ])->postPersist($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
+        ])->postPersist($this->createMock(AdminInterface::class), new \stdClass());
     }
 
     public function testPreRemove()
@@ -162,7 +169,7 @@ class AdminEventExtensionTest extends TestCase
         $this->getExtension([
             $this->equalTo('sonata.admin.event.persistence.pre_remove'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_REMOVE)),
-        ])->preRemove($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
+        ])->preRemove($this->createMock(AdminInterface::class), new \stdClass());
     }
 
     public function testPostRemove()
@@ -170,6 +177,6 @@ class AdminEventExtensionTest extends TestCase
         $this->getExtension([
             $this->equalTo('sonata.admin.event.persistence.post_remove'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_REMOVE)),
-        ])->postRemove($this->createMock('Sonata\AdminBundle\Admin\AdminInterface'), new \stdClass());
+        ])->postRemove($this->createMock(AdminInterface::class), new \stdClass());
     }
 }

--- a/tests/Event/ConfigureEventTest.php
+++ b/tests/Event/ConfigureEventTest.php
@@ -35,8 +35,8 @@ class ConfigureEventTest extends TestCase
 
     protected function setUp()
     {
-        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $this->mapper = $this->getMockBuilder('Sonata\AdminBundle\Mapper\BaseMapper')
+        $this->admin = $this->createMock(AdminInterface::class);
+        $this->mapper = $this->getMockBuilder(BaseMapper::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -52,7 +52,7 @@ class ConfigureEventTest extends TestCase
     {
         $result = $this->event->getAdmin();
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\AdminInterface', $result);
+        $this->assertInstanceOf(AdminInterface::class, $result);
         $this->assertSame($this->admin, $result);
     }
 
@@ -60,7 +60,7 @@ class ConfigureEventTest extends TestCase
     {
         $result = $this->event->getMapper();
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Mapper\BaseMapper', $result);
+        $this->assertInstanceOf(BaseMapper::class, $result);
         $this->assertSame($this->mapper, $result);
     }
 }

--- a/tests/Event/ConfigureQueryEventTest.php
+++ b/tests/Event/ConfigureQueryEventTest.php
@@ -35,8 +35,8 @@ class ConfigureQueryEventTest extends TestCase
 
     protected function setUp()
     {
-        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
-        $this->proxyQuery = $this->getMockForAbstractClass('Sonata\AdminBundle\Datagrid\ProxyQueryInterface');
+        $this->admin = $this->getMockForAbstractClass(AdminInterface::class);
+        $this->proxyQuery = $this->getMockForAbstractClass(ProxyQueryInterface::class);
 
         $this->event = new ConfigureQueryEvent($this->admin, $this->proxyQuery, 'Foo');
     }
@@ -50,7 +50,7 @@ class ConfigureQueryEventTest extends TestCase
     {
         $result = $this->event->getAdmin();
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\AdminInterface', $result);
+        $this->assertInstanceOf(AdminInterface::class, $result);
         $this->assertSame($this->admin, $result);
     }
 
@@ -58,7 +58,7 @@ class ConfigureQueryEventTest extends TestCase
     {
         $result = $this->event->getProxyQuery();
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Datagrid\ProxyQueryInterface', $result);
+        $this->assertInstanceOf(ProxyQueryInterface::class, $result);
         $this->assertSame($this->proxyQuery, $result);
     }
 }

--- a/tests/Event/PersistenceEventTest.php
+++ b/tests/Event/PersistenceEventTest.php
@@ -34,7 +34,7 @@ class PersistenceEventTest extends TestCase
 
     protected function setUp()
     {
-        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->getMockForAbstractClass(AdminInterface::class);
         $this->object = new \stdClass();
 
         $this->event = new PersistenceEvent($this->admin, $this->object, 'Foo');
@@ -49,7 +49,7 @@ class PersistenceEventTest extends TestCase
     {
         $result = $this->event->getAdmin();
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\AdminInterface', $result);
+        $this->assertInstanceOf(AdminInterface::class, $result);
         $this->assertSame($this->admin, $result);
     }
 

--- a/tests/Export/ExporterTest.php
+++ b/tests/Export/ExporterTest.php
@@ -12,8 +12,10 @@
 namespace Sonata\AdminBundle\Tests\Filter;
 
 use Exporter\Source\ArraySourceIterator;
+use Exporter\Source\SourceIteratorInterface;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Export\Exporter;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * NEXT_MAJOR: remove this class.
@@ -27,7 +29,7 @@ class ExporterTest extends TestCase
      */
     public function testFilter()
     {
-        $source = $this->createMock('Exporter\Source\SourceIteratorInterface');
+        $source = $this->createMock(SourceIteratorInterface::class);
 
         $exporter = new Exporter();
         $exporter->getResponse('foo', 'foo', $source);
@@ -45,7 +47,7 @@ class ExporterTest extends TestCase
         $exporter = new Exporter();
         $response = $exporter->getResponse($format, $filename, $source);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame($contentType, $response->headers->get('Content-Type'));
         // Quotes does not appear on some sonata versions.
         $this->assertRegExp('/attachment; filename="?'.$filename.'"?/', $response->headers->get('Content-Disposition'));

--- a/tests/Filter/FilterFactoryTest.php
+++ b/tests/Filter/FilterFactoryTest.php
@@ -13,14 +13,17 @@ namespace Sonata\AdminBundle\Tests\Filter;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Filter\FilterFactory;
+use Sonata\AdminBundle\Filter\FilterInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class FilterFactoryTest extends TestCase
 {
     public function testEmptyType()
     {
-        $this->expectException('\RuntimeException', 'The type must be defined');
+        $this->expectException(\RuntimeException::class, 'The type must be defined');
 
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
 
         $filter = new FilterFactory($container, []);
         $filter->create('test', null);
@@ -28,9 +31,9 @@ class FilterFactoryTest extends TestCase
 
     public function testUnknownType()
     {
-        $this->expectException('\RuntimeException', 'No attached service to type named `mytype`');
+        $this->expectException(\RuntimeException::class, 'No attached service to type named `mytype`');
 
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
 
         $filter = new FilterFactory($container, []);
         $filter->create('test', 'mytype');
@@ -38,9 +41,9 @@ class FilterFactoryTest extends TestCase
 
     public function testUnknownClassType()
     {
-        $this->expectException('\RuntimeException', 'No attached service to type named `Sonata\AdminBundle\Form\Type\Filter\FooType`');
+        $this->expectException(\RuntimeException::class, 'No attached service to type named `Sonata\AdminBundle\Form\Type\Filter\FooType`');
 
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
 
         $filter = new FilterFactory($container, []);
         $filter->create('test', 'Sonata\AdminBundle\Form\Type\Filter\FooType');
@@ -48,19 +51,19 @@ class FilterFactoryTest extends TestCase
 
     public function testClassType()
     {
-        $this->expectException('\RuntimeException', 'The service `Sonata\AdminBundle\Form\Type\Filter\DefaultType` must implement `FilterInterface`');
+        $this->expectException(\RuntimeException::class, 'The service `Sonata\AdminBundle\Form\Type\Filter\DefaultType` must implement `FilterInterface`');
 
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
 
         $filter = new FilterFactory($container, []);
-        $filter->create('test', 'Sonata\AdminBundle\Form\Type\Filter\DefaultType');
+        $filter->create('test', DefaultType::class);
     }
 
     public function testInvalidTypeInstance()
     {
-        $this->expectException('\RuntimeException', 'The service `mytype` must implement `FilterInterface`');
+        $this->expectException(\RuntimeException::class, 'The service `mytype` must implement `FilterInterface`');
 
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
             ->will($this->returnValue(false));
@@ -71,11 +74,11 @@ class FilterFactoryTest extends TestCase
 
     public function testCreateFilter()
     {
-        $filter = $this->getMockForAbstractClass('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->getMockForAbstractClass(FilterInterface::class);
         $filter->expects($this->once())
             ->method('initialize');
 
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
             ->will($this->returnValue($filter));

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Filter;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Tests\Fixtures\Filter\FooFilter;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class FilterTest extends TestCase
 {
@@ -20,7 +21,7 @@ class FilterTest extends TestCase
     {
         $filter = new FooFilter();
 
-        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\TextType', $filter->getFieldType());
+        $this->assertSame(TextType::class, $filter->getFieldType());
         $this->assertSame(['required' => false], $filter->getFieldOptions());
         $this->assertNull($filter->getLabel());
 

--- a/tests/Form/ChoiceList/ModelChoiceListTest.php
+++ b/tests/Form/ChoiceList/ModelChoiceListTest.php
@@ -13,7 +13,9 @@ namespace Sonata\AdminBundle\Tests\Form\ChoiceList;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
+use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 
 class ModelChoiceListTest extends TestCase
 {
@@ -21,11 +23,11 @@ class ModelChoiceListTest extends TestCase
 
     public function setUp()
     {
-        if (false === interface_exists('Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList')) {
+        if (false === interface_exists(SimpleChoiceList::class)) {
             $this->markTestSkipped('Test only available for < SF3.0');
         }
 
-        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
 
         $this->modelManager->expects($this->any())
             ->method('getIdentifierFieldNames')
@@ -48,7 +50,7 @@ class ModelChoiceListTest extends TestCase
 
         $modelChoice = new ModelChoiceList(
             $this->modelManager,
-            'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo',
+            \Sonata\AdminBundle\Tests\Fixtures\Entity\Foo::class,
             'bar'
         );
 
@@ -66,7 +68,7 @@ class ModelChoiceListTest extends TestCase
 
         $modelChoice = new ModelChoiceList(
             $this->modelManager,
-            'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo',
+            \Sonata\AdminBundle\Tests\Fixtures\Entity\Foo::class,
             null,
             'SELECT foo, baz from foo'
         );
@@ -80,7 +82,7 @@ class ModelChoiceListTest extends TestCase
         $result = [1, 2];
         $modelChoice = new ModelChoiceList(
             $this->modelManager,
-            'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo',
+            \Sonata\AdminBundle\Tests\Fixtures\Entity\Foo::class,
             null,
             null,
             $result

--- a/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
+++ b/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Form\ChoiceList;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
 
 class ModelChoiceLoaderTest extends TestCase
@@ -21,7 +22,7 @@ class ModelChoiceLoaderTest extends TestCase
 
     public function setUp()
     {
-        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
     }
 
     public function testLoadFromEntityWithSamePropertyValues()
@@ -46,7 +47,7 @@ class ModelChoiceLoaderTest extends TestCase
 
         $modelChoiceLoader = new ModelChoiceLoader(
             $this->modelManager,
-            'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo',
+            \Sonata\AdminBundle\Tests\Fixtures\Entity\Foo::class,
             'baz'
         );
 

--- a/tests/Form/DataTransformer/ArrayToModelTransformerTest.php
+++ b/tests/Form/DataTransformer/ArrayToModelTransformerTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Form\DataTransformer\ArrayToModelTransformer;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity;
 
 /**
@@ -24,12 +25,12 @@ class ArrayToModelTransformerTest extends TestCase
 
     public function setUp()
     {
-        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
     }
 
     public function testReverseTransformEntity()
     {
-        $transformer = new ArrayToModelTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity');
+        $transformer = new ArrayToModelTransformer($this->modelManager, FooEntity::class);
 
         $entity = new FooEntity();
         $this->assertSame($entity, $transformer->reverseTransform($entity));
@@ -40,19 +41,19 @@ class ArrayToModelTransformerTest extends TestCase
      */
     public function testReverseTransform($value)
     {
-        $transformer = new ArrayToModelTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity');
+        $transformer = new ArrayToModelTransformer($this->modelManager, FooEntity::class);
 
         $this->modelManager->expects($this->any())
             ->method('modelReverseTransform')
             ->will($this->returnValue(new FooEntity()));
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity', $transformer->reverseTransform($value));
+        $this->assertInstanceOf(FooEntity::class, $transformer->reverseTransform($value));
     }
 
     public function getReverseTransformTests()
     {
         return [
-            ['Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity'],
+            [FooEntity::class],
             [[]],
             [['foo' => 'bar']],
             ['foo'],
@@ -67,7 +68,7 @@ class ArrayToModelTransformerTest extends TestCase
      */
     public function testTransform($expected, $value)
     {
-        $transformer = new ArrayToModelTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity');
+        $transformer = new ArrayToModelTransformer($this->modelManager, FooEntity::class);
 
         $this->assertSame($expected, $transformer->transform($value));
     }

--- a/tests/Form/DataTransformer/LegacyModelsToArrayTransformerTest.php
+++ b/tests/Form/DataTransformer/LegacyModelsToArrayTransformerTest.php
@@ -13,8 +13,13 @@ namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
 use Sonata\AdminBundle\Form\DataTransformer\LegacyModelsToArrayTransformer;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -29,15 +34,15 @@ class LegacyModelsToArrayTransformerTest extends TestCase
      */
     public function setUp()
     {
-        if (interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) { // SF2.7+
+        if (interface_exists(ChoiceLoaderInterface::class)) { // SF2.7+
             $this->markTestSkipped('Test only available for < SF2.7');
         }
 
-        $this->choiceList = $this->getMockBuilder('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList')
+        $this->choiceList = $this->getMockBuilder(ModelChoiceList::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
 
         // php 5.3 BC
         $modelManager = $this->modelManager;
@@ -94,7 +99,7 @@ class LegacyModelsToArrayTransformerTest extends TestCase
 
     public function testReverseTransformWithException1()
     {
-        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException', 'Expected argument of type "\ArrayAccess", "NULL" given');
+        $this->expectException(UnexpectedTypeException::class, 'Expected argument of type "\ArrayAccess", "NULL" given');
 
         $transformer = new LegacyModelsToArrayTransformer($this->choiceList);
 
@@ -107,7 +112,7 @@ class LegacyModelsToArrayTransformerTest extends TestCase
 
     public function testReverseTransformWithException2()
     {
-        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException', 'Expected argument of type "array", "integer" given');
+        $this->expectException(UnexpectedTypeException::class, 'Expected argument of type "array", "integer" given');
 
         $transformer = new LegacyModelsToArrayTransformer($this->choiceList);
 
@@ -129,7 +134,7 @@ class LegacyModelsToArrayTransformerTest extends TestCase
             ->method('getModelCollectionInstance')
             ->will($this->returnValue(new ArrayCollection()));
 
-        $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $transformer->reverseTransform($keys));
+        $this->assertInstanceOf(ArrayCollection::class, $transformer->reverseTransform($keys));
     }
 
     public function getReverseTransformEmptyTests()
@@ -170,14 +175,14 @@ class LegacyModelsToArrayTransformerTest extends TestCase
             }));
 
         $collection = $transformer->reverseTransform(['foo', 'bar']);
-        $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $collection);
+        $this->assertInstanceOf(ArrayCollection::class, $collection);
         $this->assertSame([$entity1, $entity2], $collection->getValues());
         $this->assertCount(2, $collection);
     }
 
     public function testReverseTransformWithNonexistentEntityKey()
     {
-        $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException', 'The entities with keys "nonexistent" could not be found');
+        $this->expectException(TransformationFailedException::class, 'The entities with keys "nonexistent" could not be found');
 
         $transformer = new LegacyModelsToArrayTransformer($this->choiceList);
 

--- a/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdPropertyTransformer;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooArrayAccess;
 
@@ -23,12 +24,12 @@ class ModelToIdPropertyTransformerTest extends TestCase
 
     public function setUp()
     {
-        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
     }
 
     public function testReverseTransform()
     {
-        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', false);
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', false);
 
         $entity = new Foo();
         $entity->setBar('example');
@@ -37,7 +38,7 @@ class ModelToIdPropertyTransformerTest extends TestCase
             ->expects($this->any())
             ->method('find')
             ->will($this->returnCallback(function ($class, $id) use ($entity) {
-                if ('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo' === $class && 123 === $id) {
+                if (Foo::class === $class && 123 === $id) {
                     return $entity;
                 }
 
@@ -58,13 +59,13 @@ class ModelToIdPropertyTransformerTest extends TestCase
      */
     public function testReverseTransformMultiple($expected, $params, $entity1, $entity2, $entity3)
     {
-        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', true);
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', true);
 
         $this->modelManager
             ->expects($this->any())
             ->method('find')
             ->will($this->returnCallback(function ($className, $value) use ($entity1, $entity2, $entity3) {
-                if ('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo' != $className) {
+                if (Foo::class != $className) {
                     return;
                 }
 
@@ -87,11 +88,11 @@ class ModelToIdPropertyTransformerTest extends TestCase
         $this->modelManager
             ->expects($this->any())
             ->method('getModelCollectionInstance')
-            ->with($this->equalTo('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo'))
+            ->with($this->equalTo(Foo::class))
             ->will($this->returnValue($collection));
 
         $result = $transformer->reverseTransform($params);
-        $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $result);
+        $this->assertInstanceOf(ArrayCollection::class, $result);
         $this->assertSame($expected, $result->getValues());
     }
 
@@ -123,20 +124,20 @@ class ModelToIdPropertyTransformerTest extends TestCase
     public function testReverseTransformMultipleInvalidTypeTests($expected, $params, $type)
     {
         $this->setExpectedException(
-          'UnexpectedValueException', sprintf('Value should be array, %s given.', $type)
+            \UnexpectedValueException::class, sprintf('Value should be array, %s given.', $type)
         );
 
-        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', true);
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', true);
 
         $collection = new ArrayCollection();
         $this->modelManager
             ->expects($this->any())
             ->method('getModelCollectionInstance')
-            ->with($this->equalTo('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo'))
+            ->with($this->equalTo(Foo::class))
             ->will($this->returnValue($collection));
 
         $result = $transformer->reverseTransform($params);
-        $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $result);
+        $this->assertInstanceOf(ArrayCollection::class, $result);
         $this->assertSame($expected, $result->getValues());
     }
 
@@ -160,7 +161,7 @@ class ModelToIdPropertyTransformerTest extends TestCase
             ->method('getIdentifierValues')
             ->will($this->returnValue([123]));
 
-        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', false);
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', false);
 
         $this->assertSame([], $transformer->transform(null));
         $this->assertSame([], $transformer->transform(false));
@@ -180,7 +181,7 @@ class ModelToIdPropertyTransformerTest extends TestCase
             ->method('getIdentifierValues')
             ->will($this->returnValue([123]));
 
-        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\FooArrayAccess', 'bar', false);
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, FooArrayAccess::class, 'bar', false);
 
         $this->assertSame([123, '_labels' => ['example']], $transformer->transform($entity));
     }
@@ -195,7 +196,7 @@ class ModelToIdPropertyTransformerTest extends TestCase
             ->method('getIdentifierValues')
             ->will($this->returnValue([123]));
 
-        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', false, function ($entity) {
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', false, function ($entity) {
             return $entity->getBaz();
         });
 
@@ -216,7 +217,7 @@ class ModelToIdPropertyTransformerTest extends TestCase
             ->method('getIdentifierValues')
             ->will($this->returnValue([123]));
 
-        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', false, '987654');
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', false, '987654');
 
         $transformer->transform($entity);
     }
@@ -255,7 +256,7 @@ class ModelToIdPropertyTransformerTest extends TestCase
                 return [999];
             }));
 
-        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', true);
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', true);
 
         $this->assertSame([], $transformer->transform(null));
         $this->assertSame([], $transformer->transform(false));
@@ -278,7 +279,7 @@ class ModelToIdPropertyTransformerTest extends TestCase
     public function testTransformCollectionException()
     {
         $entity = new Foo();
-        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', true);
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', true);
         $transformer->transform($entity);
     }
 
@@ -290,7 +291,7 @@ class ModelToIdPropertyTransformerTest extends TestCase
     {
         $entity = new FooArrayAccess();
         $entity->setBar('example');
-        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\FooArrayAccess', 'bar', true);
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, FooArrayAccess::class, 'bar', true);
         $transformer->transform($entity);
     }
 
@@ -314,7 +315,7 @@ class ModelToIdPropertyTransformerTest extends TestCase
         $collection[] = $entity2;
         $collection[] = $entity3;
 
-        $transformer = new ModelToIdPropertyTransformer($this->modelManager, 'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo', 'bar', false);
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', false);
 
         $transformer->transform($collection);
     }

--- a/tests/Form/DataTransformer/ModelToIdTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelToIdTransformerTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 
 class ModelToIdTransformerTest extends TestCase
 {
@@ -20,7 +21,7 @@ class ModelToIdTransformerTest extends TestCase
 
     public function setUp()
     {
-        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
     }
 
     public function testReverseTransformWhenPassing0AsId()

--- a/tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -12,7 +12,10 @@
 namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
 use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
 
 class ModelsToArrayTransformerTest extends TestCase
 {
@@ -20,17 +23,17 @@ class ModelsToArrayTransformerTest extends TestCase
 
     protected function setUp()
     {
-        $this->modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface')->reveal();
+        $this->modelManager = $this->prophesize(ModelManagerInterface::class)->reveal();
     }
 
     public function testConstructor()
     {
         $transformer = new ModelsToArrayTransformer(
             $this->modelManager,
-            'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo'
+            Foo::class
         );
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer', $transformer);
+        $this->assertInstanceOf(ModelsToArrayTransformer::class, $transformer);
     }
 
     /**
@@ -38,16 +41,16 @@ class ModelsToArrayTransformerTest extends TestCase
      */
     public function testLegacyConstructor()
     {
-        $choiceListClass = 'Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader';
+        $choiceListClass = ModelChoiceLoader::class;
 
         $choiceList = $this->prophesize($choiceListClass)->reveal();
 
         $transformer = new ModelsToArrayTransformer(
             $choiceList,
             $this->modelManager,
-            'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo'
+            Foo::class
         );
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer', $transformer);
+        $this->assertInstanceOf(ModelsToArrayTransformer::class, $transformer);
     }
 }

--- a/tests/Form/Extension/ChoiceTypeExtensionTest.php
+++ b/tests/Form/Extension/ChoiceTypeExtensionTest.php
@@ -14,13 +14,15 @@ namespace Sonata\AdminBundle\Tests\Form\Extension;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Form\Extension\ChoiceTypeExtension;
 use Sonata\CoreBundle\Form\Extension\DependencyInjectionExtension;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Forms;
 
 class ChoiceTypeExtensionTest extends TestCase
 {
     protected function setup()
     {
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
         $container->expects($this->any())->method('has')->will($this->returnValue(true));
         $container->expects($this->any())->method('get')
             ->with($this->equalTo('sonata.admin.form.choice_extension'))
@@ -30,7 +32,7 @@ class ChoiceTypeExtensionTest extends TestCase
         $typeExtensionServiceIds = [];
         $guesserServiceIds = [];
         $mappingTypes = [
-            'choice' => 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+            'choice' => ChoiceType::class,
         ];
         $extensionTypes = [
             'choice' => [
@@ -57,7 +59,7 @@ class ChoiceTypeExtensionTest extends TestCase
         $extension = new ChoiceTypeExtension();
 
         $this->assertSame(
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+            ChoiceType::class,
             $extension->getExtendedType()
         );
     }
@@ -65,7 +67,7 @@ class ChoiceTypeExtensionTest extends TestCase
     public function testDefaultOptionsWithSortable()
     {
         $view = $this->factory
-            ->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, [
+            ->create(ChoiceType::class, null, [
                 'sortable' => true,
             ])
             ->createView();
@@ -77,7 +79,7 @@ class ChoiceTypeExtensionTest extends TestCase
     public function testDefaultOptionsWithoutSortable()
     {
         $view = $this->factory
-            ->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, [])
+            ->create(ChoiceType::class, null, [])
             ->createView();
 
         $this->assertTrue(isset($view->vars['sortable']));

--- a/tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
+++ b/tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
@@ -12,7 +12,10 @@
 namespace Sonata\AdminBundle\Tests\Form\Extension\Field\Type;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormConfigBuilder;
 use Symfony\Component\Form\FormView;
@@ -24,7 +27,7 @@ class FormTypeFieldExtensionTest extends TestCase
     {
         $extension = new FormTypeFieldExtension([], []);
 
-        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\FormType', $extension->getExtendedType());
+        $this->assertSame(FormType::class, $extension->getExtendedType());
     }
 
     public function testDefaultOptions()
@@ -47,7 +50,7 @@ class FormTypeFieldExtensionTest extends TestCase
 
     public function testbuildViewWithNoSonataAdminArray()
     {
-        $eventDispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->getMockForAbstractClass(EventDispatcherInterface::class);
 
         $parentFormView = new FormView();
         $parentFormView->vars['sonata_admin_enabled'] = false;
@@ -83,10 +86,10 @@ class FormTypeFieldExtensionTest extends TestCase
 
     public function testbuildViewWithWithSonataAdmin()
     {
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->exactly(2))->method('getCode')->will($this->returnValue('my.admin.reference'));
 
-        $eventDispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->getMockForAbstractClass(EventDispatcherInterface::class);
 
         $formView = new FormView();
         $options = [];
@@ -129,7 +132,7 @@ class FormTypeFieldExtensionTest extends TestCase
 
     public function testbuildViewWithNestedForm()
     {
-        $eventDispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->getMockForAbstractClass(EventDispatcherInterface::class);
 
         $formView = new FormView();
         $formView->vars['name'] = 'format';
@@ -188,7 +191,7 @@ class FormTypeFieldExtensionTest extends TestCase
 
     public function testbuildViewWithNestedFormWithNoParent()
     {
-        $eventDispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->getMockForAbstractClass(EventDispatcherInterface::class);
 
         $formView = new FormView();
         $options = [];

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -12,24 +12,33 @@
 namespace Sonata\AdminBundle\Tests\Form;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\BaseFieldDescription;
+use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CleanAdmin;
+use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\ResolvedFormTypeInterface;
 
 class FormMapperTest extends TestCase
 {
     /**
-     * @var \Sonata\AdminBundle\Builder\FormContractorInterface
+     * @var FormContractorInterface
      */
     protected $contractor;
 
     /**
-     * @var \Sonata\AdminBundle\Admin\AdminInterface
+     * @var AdminInterface
      */
     protected $admin;
 
     /**
-     * @var \Sonata\AdminBundle\Model\ModelManagerInterface
+     * @var ModelManagerInterface
      */
     protected $modelManager;
 
@@ -40,16 +49,16 @@ class FormMapperTest extends TestCase
 
     public function setUp()
     {
-        $this->contractor = $this->getMockForAbstractClass('Sonata\AdminBundle\Builder\FormContractorInterface');
+        $this->contractor = $this->getMockForAbstractClass(FormContractorInterface::class);
 
-        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
-        $eventDispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $formFactory = $this->getMockForAbstractClass(FormFactoryInterface::class);
+        $eventDispatcher = $this->getMockForAbstractClass(EventDispatcherInterface::class);
 
         $formBuilder = new FormBuilder('test', 'stdClass', $eventDispatcher, $formFactory);
 
         $this->admin = new CleanAdmin('code', 'class', 'controller');
 
-        $this->modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
 
         // php 5.3 BC
         $fieldDescription = $this->getFieldDescriptionMock();
@@ -66,7 +75,7 @@ class FormMapperTest extends TestCase
 
         $this->admin->setModelManager($this->modelManager);
 
-        $labelTranslatorStrategy = $this->getMockForAbstractClass('Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface');
+        $labelTranslatorStrategy = $this->getMockForAbstractClass(LabelTranslatorStrategyInterface::class);
         $this->admin->setLabelTranslatorStrategy($labelTranslatorStrategy);
 
         $this->formMapper = new FormMapper(
@@ -337,7 +346,7 @@ class FormMapperTest extends TestCase
     public function testAddAcceptFormBuilder()
     {
         $formBuilder = $this
-            ->getMockBuilder('Symfony\Component\Form\FormBuilder')
+            ->getMockBuilder(FormBuilder::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -346,11 +355,11 @@ class FormMapperTest extends TestCase
             ->will($this->returnValue('foo'));
 
         $formType = $this
-            ->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeInterface')
+            ->getMockBuilder(ResolvedFormTypeInterface::class)
             ->getMock();
 
         $innerType = $this
-            ->getMockBuilder('Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->getMockBuilder(FormType::class)
             ->getMock();
 
         $formType->expects($this->once())
@@ -368,7 +377,7 @@ class FormMapperTest extends TestCase
     public function testAddFormBuilderWithType()
     {
         $formBuilder = $this
-            ->getMockBuilder('Symfony\Component\Form\FormBuilder')
+            ->getMockBuilder(FormBuilder::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -379,7 +388,7 @@ class FormMapperTest extends TestCase
         $formBuilder->expects($this->never())
             ->method('getType');
 
-        $this->formMapper->add($formBuilder, 'Symfony\Component\Form\Extension\Core\Type\FormType');
+        $this->formMapper->add($formBuilder, FormType::class);
         $this->assertSame($this->formMapper->get('foo'), $formBuilder);
     }
 
@@ -451,7 +460,7 @@ class FormMapperTest extends TestCase
 
     private function getFieldDescriptionMock($name = null, $label = null, $translationDomain = null)
     {
-        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\BaseFieldDescription');
+        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class);
 
         if (null !== $name) {
             $fieldDescription->setName($name);

--- a/tests/Form/Type/AclMatrixTypeTest.php
+++ b/tests/Form/Type/AclMatrixTypeTest.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Tests\Form\Type;
 use Sonata\AdminBundle\Form\Type\AclMatrixType;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @author Baptiste Meyer <baptiste@les-tilleuls.coop>
@@ -23,7 +24,7 @@ class AclMatrixTypeTest extends TypeTestCase
     public function testGetDefaultOptions()
     {
         $type = new AclMatrixType();
-        $user = $this->getMockForAbstractClass('Symfony\Component\Security\Core\User\UserInterface');
+        $user = $this->getMockForAbstractClass(UserInterface::class);
 
         $permissions = [
             'OWNER' => [
@@ -43,7 +44,7 @@ class AclMatrixTypeTest extends TypeTestCase
             'permissions' => $permissions,
         ]);
 
-        $this->assertInstanceOf('Symfony\Component\Security\Core\User\UserInterface', $options['acl_value']);
+        $this->assertInstanceOf(UserInterface::class, $options['acl_value']);
         $this->assertSame($user, $options['acl_value']);
         $this->assertSame($permissions, $options['permissions']);
     }

--- a/tests/Form/Type/AdminTypeTest.php
+++ b/tests/Form/Type/AdminTypeTest.php
@@ -12,11 +12,19 @@
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Prophecy\Argument\Token\AnyValueToken;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension;
 use Sonata\AdminBundle\Form\Type\AdminType;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
+use Symfony\Component\Form\FormTypeGuesserInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Form\Tests\Fixtures\TestExtension;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 class AdminTypeTest extends TypeTestCase
 {
@@ -40,26 +48,23 @@ class AdminTypeTest extends TypeTestCase
 
     public function testSubmitValidData()
     {
-        $parentAdmin = $this->prophesize('Sonata\AdminBundle\Admin\AdminInterface');
-        $parentField = $this->prophesize('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $parentAdmin = $this->prophesize(AdminInterface::class);
+        $parentField = $this->prophesize(FieldDescriptionInterface::class);
         $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
 
-        $modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
-        $modelManager->modelReverseTransform(
-            'Sonata\AdminBundle\Tests\Fixtures\Entity\Foo',
-            []
-        )->shouldBeCalled();
+        $modelManager = $this->prophesize(ModelManagerInterface::class);
+        $modelManager->modelReverseTransform(Foo::class, [])->shouldBeCalled();
 
-        $admin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $admin = $this->prophesize(AbstractAdmin::class);
         $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(false);
         $admin->getParentFieldDescription()->shouldBeCalled()->willReturn($parentField->reveal());
         $admin->hasAccess('delete')->shouldBeCalled()->willReturn(false);
         $admin->setSubject(null)->shouldBeCalled();
         $admin->defineFormBuilder(new AnyValueToken())->shouldBeCalled();
         $admin->getModelManager()->shouldBeCalled()->willReturn($modelManager);
-        $admin->getClass()->shouldBeCalled()->willReturn('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo');
+        $admin->getClass()->shouldBeCalled()->willReturn(Foo::class);
 
-        $field = $this->prophesize('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $field = $this->prophesize(FieldDescriptionInterface::class);
         $field->getAssociationAdmin()->shouldBeCalled()->willReturn($admin->reveal());
         $field->getAdmin()->shouldBeCalled();
         $field->getName()->shouldBeCalled();
@@ -69,7 +74,7 @@ class AdminTypeTest extends TypeTestCase
         $formData = [];
 
         $form = $this->factory->create(
-            'Sonata\AdminBundle\Form\Type\AdminType',
+            AdminType::class,
             null,
             [
                 'sonata_field_description' => $field->reveal(),
@@ -81,29 +86,29 @@ class AdminTypeTest extends TypeTestCase
 
     public function testDotFields()
     {
-        if (!method_exists('Symfony\Component\PropertyAccess\PropertyAccessor', 'isReadable')) {
+        if (!method_exists(PropertyAccessor::class, 'isReadable')) {
             return $this->markTestSkipped('Testing ancient versions would be more complicated.');
         }
 
         $parentSubject = new \stdClass();
         $parentSubject->foo = 1;
 
-        $parentAdmin = $this->prophesize('Sonata\AdminBundle\Admin\AdminInterface');
+        $parentAdmin = $this->prophesize(AdminInterface::class);
         $parentAdmin->getSubject()->shouldBeCalled()->willReturn($parentSubject);
-        $parentField = $this->prophesize('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $parentField = $this->prophesize(FieldDescriptionInterface::class);
         $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
 
-        $modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->prophesize(ModelManagerInterface::class);
 
-        $admin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $admin = $this->prophesize(AbstractAdmin::class);
         $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(false);
         $admin->getParentFieldDescription()->shouldBeCalled()->willReturn($parentField->reveal());
         $admin->setSubject(1)->shouldBeCalled();
         $admin->defineFormBuilder(new AnyValueToken())->shouldBeCalled();
         $admin->getModelManager()->shouldBeCalled()->willReturn($modelManager);
-        $admin->getClass()->shouldBeCalled()->willReturn('Sonata\AdminBundle\Tests\Fixtures\Entity\Foo');
+        $admin->getClass()->shouldBeCalled()->willReturn(Foo::class);
 
-        $field = $this->prophesize('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $field = $this->prophesize(FieldDescriptionInterface::class);
         $field->getAssociationAdmin()->shouldBeCalled()->willReturn($admin->reveal());
         $field->getFieldName()->shouldBeCalled()->willReturn('foo');
 
@@ -116,7 +121,7 @@ class AdminTypeTest extends TypeTestCase
                 'delete' => false, // not needed
                 'property_path' => 'foo', // actual test case
             ]);
-        } catch (\Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException $exception) {
+        } catch (NoSuchPropertyException $exception) {
             $this->fail($exception->getMessage());
         }
     }
@@ -124,7 +129,7 @@ class AdminTypeTest extends TypeTestCase
     protected function getExtensions()
     {
         $extensions = parent::getExtensions();
-        $guesser = $this->prophesize('Symfony\Component\Form\FormTypeGuesserInterface')->reveal();
+        $guesser = $this->prophesize(FormTypeGuesserInterface::class)->reveal();
         $extension = new TestExtension($guesser);
 
         $extension->addTypeExtension(new FormTypeFieldExtension([], []));

--- a/tests/Form/Type/ChoiceFieldMaskTypeTest.php
+++ b/tests/Form/Type/ChoiceFieldMaskTypeTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -45,6 +46,6 @@ class ChoiceFieldMaskTypeTest extends TypeTestCase
     public function testGetParent()
     {
         $type = new ChoiceFieldMaskType();
-        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\ChoiceType', $type->getParent());
+        $this->assertSame(ChoiceType::class, $type->getParent());
     }
 }

--- a/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
+++ b/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
@@ -14,12 +14,13 @@ namespace Sonata\AdminBundle\Tests\Form\Type;
 use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class DateTimeRangeTypeTest extends TypeTestCase
 {
     public function testGetDefaultOptions()
     {
-        $stub = $this->getMockForAbstractClass('Symfony\Component\Translation\TranslatorInterface');
+        $stub = $this->getMockForAbstractClass(TranslatorInterface::class);
 
         $type = new DateTimeRangeType($stub);
 

--- a/tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -31,7 +32,7 @@ class ModelAutocompleteTypeTest extends TypeTestCase
 
     public function testGetDefaultOptions()
     {
-        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
         $optionResolver = new OptionsResolver();
 
         $this->type->configureOptions($optionResolver);
@@ -40,7 +41,7 @@ class ModelAutocompleteTypeTest extends TypeTestCase
 
         $this->assertSame([], $options['attr']);
         $this->assertFalse($options['compound']);
-        $this->assertInstanceOf('Sonata\AdminBundle\Model\ModelManagerInterface', $options['model_manager']);
+        $this->assertInstanceOf(ModelManagerInterface::class, $options['model_manager']);
         $this->assertSame($modelManager, $options['model_manager']);
         $this->assertSame('Foo', $options['class']);
         $this->assertSame('bar', $options['property']);

--- a/tests/Form/Type/ModelHiddenTypeTest.php
+++ b/tests/Form/Type/ModelHiddenTypeTest.php
@@ -12,6 +12,8 @@
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Sonata\AdminBundle\Form\Type\ModelHiddenType;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -20,14 +22,14 @@ class ModelHiddenTypeTest extends TypeTestCase
     public function testGetDefaultOptions()
     {
         $type = new ModelHiddenType();
-        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
         $optionResolver = new OptionsResolver();
 
         $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve(['model_manager' => $modelManager, 'class' => '\Foo']);
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Model\ModelManagerInterface', $options['model_manager']);
+        $this->assertInstanceOf(ModelManagerInterface::class, $options['model_manager']);
         $this->assertSame($modelManager, $options['model_manager']);
         $this->assertSame('\Foo', $options['class']);
     }
@@ -41,6 +43,6 @@ class ModelHiddenTypeTest extends TypeTestCase
     public function testGetParent()
     {
         $type = new ModelHiddenType();
-        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\HiddenType', $type->getParent());
+        $this->assertSame(HiddenType::class, $type->getParent());
     }
 }

--- a/tests/Form/Type/ModelListTypeTest.php
+++ b/tests/Form/Type/ModelListTypeTest.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
+use Sonata\AdminBundle\Form\Type\ModelListType;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 
 class ModelListTypeTest extends TypeTestCase
@@ -19,7 +21,7 @@ class ModelListTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        $this->modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->prophesize(ModelManagerInterface::class);
 
         parent::setUp();
     }
@@ -29,7 +31,7 @@ class ModelListTypeTest extends TypeTestCase
         $formData = 42;
 
         $form = $this->factory->create(
-            'Sonata\AdminBundle\Form\Type\ModelListType',
+            ModelListType::class,
             null,
             [
                 'model_manager' => $this->modelManager->reveal(),

--- a/tests/Form/Type/ModelReferenceTypeTest.php
+++ b/tests/Form/Type/ModelReferenceTypeTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Sonata\AdminBundle\Form\Type\ModelReferenceType;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 
@@ -21,7 +22,7 @@ class ModelReferenceTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        $this->modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->modelManager = $this->prophesize(ModelManagerInterface::class);
 
         parent::setUp();
     }
@@ -31,7 +32,7 @@ class ModelReferenceTypeTest extends TypeTestCase
         $formData = 42;
 
         $form = $this->factory->create(
-            'Sonata\AdminBundle\Form\Type\ModelReferenceType',
+            ModelReferenceType::class,
             null,
             [
                 'model_manager' => $this->modelManager->reveal(),

--- a/tests/Form/Type/ModelTypeTest.php
+++ b/tests/Form/Type/ModelTypeTest.php
@@ -11,7 +11,9 @@
 
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
+use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
 use Sonata\AdminBundle\Form\Type\ModelType;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -29,7 +31,7 @@ class ModelTypeTest extends TypeTestCase
 
     public function testGetDefaultOptions()
     {
-        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
 
         $optionResolver = new OptionsResolver();
 
@@ -41,7 +43,7 @@ class ModelTypeTest extends TypeTestCase
         $this->assertSame('choice', $options['template']);
         $this->assertFalse($options['multiple']);
         $this->assertFalse($options['expanded']);
-        $this->assertInstanceOf('Sonata\AdminBundle\Model\ModelManagerInterface', $options['model_manager']);
+        $this->assertInstanceOf(ModelManagerInterface::class, $options['model_manager']);
         $this->assertNull($options['class']);
         $this->assertNull($options['property']);
         $this->assertNull($options['query']);
@@ -51,7 +53,7 @@ class ModelTypeTest extends TypeTestCase
         $this->assertSame('link_list', $options['btn_list']);
         $this->assertSame('link_delete', $options['btn_delete']);
         $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);
-        $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader', $options['choice_loader']);
+        $this->assertInstanceOf(ModelChoiceLoader::class, $options['choice_loader']);
     }
 
     /**
@@ -59,7 +61,7 @@ class ModelTypeTest extends TypeTestCase
      */
     public function testCompoundOption($expectedCompound, $multiple, $expanded)
     {
-        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
         $optionResolver = new OptionsResolver();
 
         $this->type->configureOptions($optionResolver);
@@ -70,7 +72,7 @@ class ModelTypeTest extends TypeTestCase
         $this->assertSame('choice', $options['template']);
         $this->assertSame($multiple, $options['multiple']);
         $this->assertSame($expanded, $options['expanded']);
-        $this->assertInstanceOf('Sonata\AdminBundle\Model\ModelManagerInterface', $options['model_manager']);
+        $this->assertInstanceOf(ModelManagerInterface::class, $options['model_manager']);
         $this->assertNull($options['class']);
         $this->assertNull($options['property']);
         $this->assertNull($options['query']);
@@ -80,7 +82,7 @@ class ModelTypeTest extends TypeTestCase
         $this->assertSame('link_list', $options['btn_list']);
         $this->assertSame('link_delete', $options['btn_delete']);
         $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);
-        $this->assertInstanceOf('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader', $options['choice_loader']);
+        $this->assertInstanceOf(ModelChoiceLoader::class, $options['choice_loader']);
     }
 
     public function getCompoundOptionTests()

--- a/tests/Form/Widget/BaseWidgetTest.php
+++ b/tests/Form/Widget/BaseWidgetTest.php
@@ -54,7 +54,7 @@ abstract class BaseWidgetTest extends AbstractWidgetTestCase
     {
         $environment = parent::getEnvironment();
         $environment->addGlobal('sonata_admin', $this->getSonataAdmin());
-        if (!$environment->hasExtension('Symfony\Bridge\Twig\Extension\TranslationExtension')) {
+        if (!$environment->hasExtension(TranslationExtension::class)) {
             $environment->addExtension(new TranslationExtension(new StubTranslator()));
         }
 

--- a/tests/Form/Widget/FilterChoiceWidgetTest.php
+++ b/tests/Form/Widget/FilterChoiceWidgetTest.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\AdminBundle\Tests\Form\Widget;
 
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
 class FilterChoiceWidgetTest extends BaseWidgetTest
 {
     protected $type = 'filter';
@@ -75,7 +77,7 @@ class FilterChoiceWidgetTest extends BaseWidgetTest
 
     protected function getChoiceClass()
     {
-        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
+        return ChoiceType::class;
     }
 
     protected function getDefaultOption()

--- a/tests/Form/Widget/FormChoiceWidgetTest.php
+++ b/tests/Form/Widget/FormChoiceWidgetTest.php
@@ -11,6 +11,9 @@
 
 namespace Sonata\AdminBundle\Tests\Form\Widget;
 
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormTypeInterface;
+
 class FormChoiceWidgetTest extends BaseWidgetTest
 {
     protected $type = 'form';
@@ -23,7 +26,7 @@ class FormChoiceWidgetTest extends BaseWidgetTest
     public function testLabelRendering()
     {
         $choices = ['some', 'choices'];
-        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+        if (!method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
             $choices = array_flip($choices);
         }
 
@@ -99,7 +102,7 @@ class FormChoiceWidgetTest extends BaseWidgetTest
 
     protected function getChoiceClass()
     {
-        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
+        return ChoiceType::class;
     }
 
     protected function getDefaultOption()

--- a/tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
+++ b/tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
@@ -12,7 +12,11 @@
 namespace Sonata\AdminBundle\Tests\Form\Widget;
 
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType as SymfonyChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\RangeType;
+use Symfony\Component\Form\FormTypeGuesserInterface;
 use Symfony\Component\Form\Tests\Fixtures\TestExtension;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
 {
@@ -52,8 +56,8 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
 
     protected function getParentClass()
     {
-        if (class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType')) {
-            return 'Sonata\AdminBundle\Form\Type\Filter\ChoiceType';
+        if (class_exists(RangeType::class)) {
+            return ChoiceType::class;
         }
 
         return 'sonata_type_filter_choice';
@@ -61,8 +65,8 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
 
     protected function getChoiceClass()
     {
-        if (class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType')) {
-            return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
+        if (class_exists(RangeType::class)) {
+            return SymfonyChoiceType::class;
         }
 
         return 'choice';
@@ -70,7 +74,7 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
 
     protected function getExtensions()
     {
-        $mock = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
+        $mock = $this->getMockBuilder(TranslatorInterface::class)->getMock();
 
         $mock->method('trans')
             ->will($this->returnCallback(function ($arg) {
@@ -79,7 +83,7 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
         );
 
         $extensions = parent::getExtensions();
-        $guesser = $this->getMockForAbstractClass('Symfony\Component\Form\FormTypeGuesserInterface');
+        $guesser = $this->getMockForAbstractClass(FormTypeGuesserInterface::class);
         $extension = new TestExtension($guesser);
         $type = new ChoiceType($mock);
         $extension->addType($type);

--- a/tests/Form/Widget/FormSonataNativeCollectionWidgetTest.php
+++ b/tests/Form/Widget/FormSonataNativeCollectionWidgetTest.php
@@ -12,6 +12,8 @@
 namespace Sonata\AdminBundle\Tests\Form\Widget;
 
 use Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension;
+use Sonata\AdminBundle\Form\Type\CollectionType;
+use Symfony\Component\Form\FormTypeGuesserInterface;
 use Symfony\Component\Form\Tests\Fixtures\TestExtension;
 
 class FormSonataNativeCollectionWidgetTest extends BaseWidgetTest
@@ -53,7 +55,7 @@ class FormSonataNativeCollectionWidgetTest extends BaseWidgetTest
     protected function getExtensions()
     {
         $extensions = parent::getExtensions();
-        $guesser = $this->getMockForAbstractClass('Symfony\Component\Form\FormTypeGuesserInterface');
+        $guesser = $this->getMockForAbstractClass(FormTypeGuesserInterface::class);
         $extension = new TestExtension($guesser);
 
         $extension->addTypeExtension(new FormTypeFieldExtension([], [
@@ -66,6 +68,6 @@ class FormSonataNativeCollectionWidgetTest extends BaseWidgetTest
 
     protected function getChoiceClass()
     {
-        return 'Sonata\AdminBundle\Form\Type\CollectionType';
+        return CollectionType::class;
     }
 }

--- a/tests/Generator/AdminGeneratorTest.php
+++ b/tests/Generator/AdminGeneratorTest.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Tests\Generator;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Generator\AdminGenerator;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\ModelAdmin;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
@@ -57,11 +58,11 @@ class AdminGeneratorTest extends TestCase
     {
         $this->adminGenerator->generate($this->bundleMock, 'ModelAdmin', 'Model');
         $file = $this->adminGenerator->getFile();
-        $this->assertSame('Sonata\AdminBundle\Tests\Fixtures\Admin\ModelAdmin', $this->adminGenerator->getClass());
+        $this->assertSame(ModelAdmin::class, $this->adminGenerator->getClass());
         $this->assertSame('ModelAdmin.php', basename($file));
         $this->assertFileEquals(__DIR__.'/../Fixtures/Admin/ModelAdmin.php', $file);
 
-        $this->expectException('\RuntimeException', 'already exists');
+        $this->expectException(\RuntimeException::class, 'already exists');
 
         $this->adminGenerator->generate($this->bundleMock, 'ModelAdmin', 'Model');
     }
@@ -71,7 +72,7 @@ class AdminGeneratorTest extends TestCase
      */
     private function createModelManagerMock()
     {
-        $modelManagerMock = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManagerMock = $this->getMockForAbstractClass(ModelManagerInterface::class);
         $modelManagerMock
             ->expects($this->any())
             ->method('getExportFields')
@@ -87,7 +88,7 @@ class AdminGeneratorTest extends TestCase
      */
     private function createBundleMock()
     {
-        $bundleMock = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundleMock = $this->getMockForAbstractClass(BundleInterface::class);
         $bundleMock
             ->expects($this->any())
             ->method('getNamespace')

--- a/tests/Generator/ControllerGeneratorTest.php
+++ b/tests/Generator/ControllerGeneratorTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Generator;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Generator\ControllerGenerator;
+use Sonata\AdminBundle\Tests\Fixtures\Controller\ModelAdminController;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
@@ -54,13 +55,13 @@ class ControllerGeneratorTest extends TestCase
         $this->controllerGenerator->generate($this->bundleMock, 'ModelAdminController');
         $file = $this->controllerGenerator->getFile();
         $this->assertSame(
-            'Sonata\AdminBundle\Tests\Fixtures\Controller\ModelAdminController',
+            ModelAdminController::class,
             $this->controllerGenerator->getClass()
         );
         $this->assertSame('ModelAdminController.php', basename($file));
         $this->assertFileEquals(__DIR__.'/../Fixtures/Controller/ModelAdminController.php', $file);
 
-        $this->expectException('\RuntimeException', 'already exists');
+        $this->expectException(\RuntimeException::class, 'already exists');
 
         $this->controllerGenerator->generate($this->bundleMock, 'ModelAdminController');
     }
@@ -70,7 +71,7 @@ class ControllerGeneratorTest extends TestCase
      */
     private function createBundleMock()
     {
-        $bundleMock = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundleMock = $this->getMockForAbstractClass(BundleInterface::class);
         $bundleMock
             ->expects($this->any())
             ->method('getNamespace')

--- a/tests/Guesser/TypeGuesserChainTest.php
+++ b/tests/Guesser/TypeGuesserChainTest.php
@@ -13,6 +13,9 @@ namespace Sonata\AdminBundle\Tests\Guesser;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Guesser\TypeGuesserChain;
+use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
@@ -25,7 +28,7 @@ class TypeGuesserChainTest extends TestCase
 {
     public function testConstructorWithException()
     {
-        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
+        $this->expectException(UnexpectedTypeException::class);
 
         $typeGuesserChain = new TypeGuesserChain([new \stdClass()]);
     }
@@ -33,33 +36,33 @@ class TypeGuesserChainTest extends TestCase
     public function testGuessType()
     {
         $typeGuess1 = new TypeGuess('foo1', [], Guess::MEDIUM_CONFIDENCE);
-        $guesser1 = $this->getMockForAbstractClass('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+        $guesser1 = $this->getMockForAbstractClass(TypeGuesserInterface::class);
         $guesser1->expects($this->any())
                 ->method('guessType')
                 ->will($this->returnValue($typeGuess1));
 
         $typeGuess2 = new TypeGuess('foo2', [], Guess::HIGH_CONFIDENCE);
-        $guesser2 = $this->getMockForAbstractClass('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+        $guesser2 = $this->getMockForAbstractClass(TypeGuesserInterface::class);
         $guesser2->expects($this->any())
                 ->method('guessType')
                 ->will($this->returnValue($typeGuess2));
 
         $typeGuess3 = new TypeGuess('foo3', [], Guess::LOW_CONFIDENCE);
-        $guesser3 = $this->getMockForAbstractClass('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+        $guesser3 = $this->getMockForAbstractClass(TypeGuesserInterface::class);
         $guesser3->expects($this->any())
                 ->method('guessType')
                 ->will($this->returnValue($typeGuess3));
 
-        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
 
-        $class = '\stdClass';
+        $class = \stdClass::class;
         $property = 'firstName';
 
         $typeGuesserChain = new TypeGuesserChain([$guesser1, $guesser2, $guesser3]);
         $this->assertSame($typeGuess2, $typeGuesserChain->guessType($class, $property, $modelManager));
 
         $typeGuess4 = new TypeGuess('foo4', [], Guess::LOW_CONFIDENCE);
-        $guesser4 = $this->getMockForAbstractClass('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+        $guesser4 = $this->getMockForAbstractClass(TypeGuesserInterface::class);
         $guesser4->expects($this->any())
                 ->method('guessType')
                 ->will($this->returnValue($typeGuess4));

--- a/tests/Mapper/BaseGroupedMapperTest.php
+++ b/tests/Mapper/BaseGroupedMapperTest.php
@@ -12,9 +12,13 @@
 namespace Sonata\AdminBundle\Tests\Mapper;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Builder\BuilderInterface;
 use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\AbstractDummyGroupedMapper;
+use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Test for BaseGroupedMapper.
@@ -33,11 +37,11 @@ class BaseGroupedMapperTest extends TestCase
 
     public function setUp()
     {
-        $admin = $this->getMockBuilder('Sonata\AdminBundle\Admin\AbstractAdmin')
+        $admin = $this->getMockBuilder(AbstractAdmin::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $labelStrategy = $this->createMock('Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface');
+        $labelStrategy = $this->createMock(LabelTranslatorStrategyInterface::class);
         $labelStrategy->expects($this->any())
             ->method('getLabel')
             ->will($this->returnCallback(function ($label) {
@@ -48,14 +52,14 @@ class BaseGroupedMapperTest extends TestCase
             ->method('getLabelTranslatorStrategy')
             ->will($this->returnValue($labelStrategy));
 
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
         $configurationPool = new Pool($container, 'myTitle', 'myLogoTitle');
 
         $admin->expects($this->any())
             ->method('getConfigurationPool')
             ->will($this->returnValue($configurationPool));
 
-        $builder = $this->getMockForAbstractClass('Sonata\AdminBundle\Builder\BuilderInterface');
+        $builder = $this->getMockForAbstractClass(BuilderInterface::class);
 
         $this->baseGroupedMapper = $this->getMockForAbstractClass(
             AbstractDummyGroupedMapper::class,

--- a/tests/Mapper/BaseMapperTest.php
+++ b/tests/Mapper/BaseMapperTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Mapper;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Builder\BuilderInterface;
 use Sonata\AdminBundle\Mapper\BaseMapper;
 
 /**
@@ -34,10 +35,10 @@ class BaseMapperTest extends TestCase
 
     public function setUp()
     {
-        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
-        $builder = $this->getMockForAbstractClass('Sonata\AdminBundle\Builder\BuilderInterface');
+        $this->admin = $this->getMockForAbstractClass(AdminInterface::class);
+        $builder = $this->getMockForAbstractClass(BuilderInterface::class);
 
-        $this->baseMapper = $this->getMockForAbstractClass('Sonata\AdminBundle\Mapper\BaseMapper', [$builder, $this->admin]);
+        $this->baseMapper = $this->getMockForAbstractClass(BaseMapper::class, [$builder, $this->admin]);
     }
 
     public function testGetAdmin()

--- a/tests/Menu/Integration/BaseMenuTest.php
+++ b/tests/Menu/Integration/BaseMenuTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Tests\Menu\Integration;
 
 use Knp\Menu\ItemInterface;
+use Knp\Menu\Matcher\MatcherInterface;
 use Knp\Menu\Renderer\TwigRenderer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
@@ -52,7 +53,7 @@ abstract class BaseMenuTest extends TestCase
         $this->renderer = new TwigRenderer(
             $this->environment,
             $this->getTemplate(),
-            $this->getMockForAbstractClass('Knp\Menu\Matcher\MatcherInterface')
+            $this->getMockForAbstractClass(MatcherInterface::class)
         );
 
         return $this->renderer->render($item, $options);

--- a/tests/Menu/Integration/TabMenuTest.php
+++ b/tests/Menu/Integration/TabMenuTest.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Tests\Menu\Integration;
 use Knp\Menu\MenuFactory;
 use Knp\Menu\MenuItem;
 use Prophecy\Argument;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class TabMenuTest extends BaseMenuTest
 {
@@ -30,9 +31,7 @@ class TabMenuTest extends BaseMenuTest
 
     public function testLabelTranslationNominalCase()
     {
-        $translatorProphecy = $this->prophesize(
-            'Symfony\Component\Translation\TranslatorInterface'
-        );
+        $translatorProphecy = $this->prophesize(TranslatorInterface::class);
         $translatorProphecy
             ->trans(
                 'some-label',
@@ -52,9 +51,7 @@ class TabMenuTest extends BaseMenuTest
     public function testLabelTranslationWithParameters()
     {
         $params = ['my' => 'param'];
-        $translatorProphecy = $this->prophesize(
-            'Symfony\Component\Translation\TranslatorInterface'
-        );
+        $translatorProphecy = $this->prophesize(TranslatorInterface::class);
         $translatorProphecy
             ->trans(
                 'some-label',
@@ -75,9 +72,7 @@ class TabMenuTest extends BaseMenuTest
 
     public function testLabelTranslationDomainOverride()
     {
-        $translatorProphecy = $this->prophesize(
-            'Symfony\Component\Translation\TranslatorInterface'
-        );
+        $translatorProphecy = $this->prophesize(TranslatorInterface::class);
         $translatorProphecy
             ->trans('some-label', [], 'my_local_domain', null)
             ->willReturn('my-translation');

--- a/tests/Menu/Matcher/Voter/ActiveVoterTest.php
+++ b/tests/Menu/Matcher/Voter/ActiveVoterTest.php
@@ -43,7 +43,7 @@ class ActiveVoterTest extends AbstractVoterTest
      */
     protected function createItem($data)
     {
-        $item = $this->getMockForAbstractClass('Knp\Menu\ItemInterface');
+        $item = $this->getMockForAbstractClass(ItemInterface::class);
         $item->expects($this->any())
              ->method('getExtra')
              ->with($this->logicalOr(

--- a/tests/Menu/Matcher/Voter/AdminVoterTest.php
+++ b/tests/Menu/Matcher/Voter/AdminVoterTest.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\AdminBundle\Tests\Menu\Matcher\Voter;
 
+use Knp\Menu\ItemInterface;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -55,7 +57,7 @@ class AdminVoterTest extends AbstractVoterTest
      */
     protected function createItem($data)
     {
-        $item = $this->getMockForAbstractClass('Knp\Menu\ItemInterface');
+        $item = $this->getMockForAbstractClass(ItemInterface::class);
         $item->expects($this->any())
              ->method('getExtra')
              ->with($this->logicalOr(
@@ -73,7 +75,7 @@ class AdminVoterTest extends AbstractVoterTest
      */
     private function getAdmin($code, $list = false, $granted = false)
     {
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $admin = $this->createMock(AbstractAdmin::class);
         $admin
             ->expects($this->any())
             ->method('hasRoute')
@@ -105,7 +107,7 @@ class AdminVoterTest extends AbstractVoterTest
      */
     private function getChildAdmin($parentCode, $childCode, $list = false, $granted = false)
     {
-        $parentAdmin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $parentAdmin = $this->createMock(AbstractAdmin::class);
         $parentAdmin
             ->expects($this->any())
             ->method('hasRoute')
@@ -124,7 +126,7 @@ class AdminVoterTest extends AbstractVoterTest
             ->will($this->returnValue($parentCode))
         ;
 
-        $childAdmin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $childAdmin = $this->createMock(AbstractAdmin::class);
         $childAdmin
             ->expects($this->any())
             ->method('getBaseCodeRoute')

--- a/tests/Menu/Matcher/Voter/ChildrenVoterTest.php
+++ b/tests/Menu/Matcher/Voter/ChildrenVoterTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Tests\Menu\Matcher\Voter;
 
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Matcher;
 use Sonata\AdminBundle\Menu\Matcher\Voter\ChildrenVoter;
 
@@ -47,14 +48,14 @@ class ChildrenVoterTest extends AbstractVoterTest
     {
         $childItems = [];
         foreach ($data as $childData) {
-            $childItem = $this->getMockForAbstractClass('Knp\Menu\ItemInterface');
+            $childItem = $this->getMockForAbstractClass(ItemInterface::class);
             $childItem->expects($this->any())
                 ->method('isCurrent')
                 ->willReturn($childData);
             $childItems[] = $childItem;
         }
 
-        $item = $this->getMockForAbstractClass('Knp\Menu\ItemInterface');
+        $item = $this->getMockForAbstractClass(ItemInterface::class);
         $item->expects($this->any())
             ->method('getChildren')
             ->will($this->returnValue($childItems));

--- a/tests/Menu/MenuBuilderTest.php
+++ b/tests/Menu/MenuBuilderTest.php
@@ -11,9 +11,15 @@
 
 namespace Sonata\AdminBundle\Tests\Menu;
 
+use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuFactory;
+use Knp\Menu\MenuItem;
+use Knp\Menu\Provider\MenuProviderInterface;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Event\ConfigureMenuEvent;
 use Sonata\AdminBundle\Menu\MenuBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class MenuBuilderTest extends TestCase
 {
@@ -28,10 +34,10 @@ class MenuBuilderTest extends TestCase
 
     protected function setUp()
     {
-        $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
-        $this->provider = $this->getMockForAbstractClass('Knp\Menu\Provider\MenuProviderInterface');
+        $this->pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $this->provider = $this->getMockForAbstractClass(MenuProviderInterface::class);
         $this->factory = new MenuFactory();
-        $this->eventDispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->eventDispatcher = $this->getMockForAbstractClass(EventDispatcherInterface::class);
 
         $this->builder = new MenuBuilder($this->pool, $this->factory, $this->provider, $this->eventDispatcher);
     }
@@ -55,11 +61,11 @@ class MenuBuilderTest extends TestCase
         $this->preparePool($adminGroups);
         $menu = $this->builder->createSidebarMenu();
 
-        $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
+        $this->assertInstanceOf(ItemInterface::class, $menu);
         $this->assertArrayHasKey('bar', $menu->getChildren());
 
         foreach ($menu->getChildren() as $key => $child) {
-            $this->assertInstanceOf('Knp\Menu\MenuItem', $child);
+            $this->assertInstanceOf(MenuItem::class, $child);
             $this->assertSame('bar', $child->getName());
             $this->assertSame('bar', $child->getLabel());
 
@@ -67,7 +73,7 @@ class MenuBuilderTest extends TestCase
             $children = $child->getChildren();
             $this->assertCount(1, $children);
             $this->assertArrayHasKey('foo', $children);
-            $this->assertInstanceOf('Knp\Menu\MenuItem', $child['foo']);
+            $this->assertInstanceOf(MenuItem::class, $child['foo']);
             $this->assertSame('foo', $child['foo']->getLabel());
         }
     }
@@ -92,11 +98,11 @@ class MenuBuilderTest extends TestCase
         $this->preparePool($adminGroups);
         $menu = $this->builder->createSidebarMenu();
 
-        $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
+        $this->assertInstanceOf(ItemInterface::class, $menu);
         $this->assertArrayHasKey('bar', $menu->getChildren());
 
         foreach ($menu->getChildren() as $key => $child) {
-            $this->assertInstanceOf('Knp\Menu\MenuItem', $child);
+            $this->assertInstanceOf(MenuItem::class, $child);
             $this->assertSame('bar', $child->getName());
             $this->assertSame('bar', $child->getLabel());
 
@@ -104,7 +110,7 @@ class MenuBuilderTest extends TestCase
             $children = $child->getChildren();
             $this->assertCount(1, $children);
             $this->assertArrayHasKey('foo', $children);
-            $this->assertInstanceOf('Knp\Menu\MenuItem', $child['foo']);
+            $this->assertInstanceOf(MenuItem::class, $child['foo']);
             $this->assertSame('foo', $child['foo']->getLabel());
         }
     }
@@ -129,7 +135,7 @@ class MenuBuilderTest extends TestCase
             ->method('dispatch')
             ->with(
                 $this->equalTo('sonata.admin.event.configure.menu.sidebar'),
-                $this->isInstanceOf('Sonata\AdminBundle\Event\ConfigureMenuEvent')
+                $this->isInstanceOf(ConfigureMenuEvent::class)
             );
 
         $this->builder->createSidebarMenu();

--- a/tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/tests/Menu/Provider/GroupMenuProviderTest.php
@@ -12,13 +12,17 @@
 namespace Sonata\AdminBundle\Tests\Menu\Provider;
 
 use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuFactory;
+use Knp\Menu\MenuItem;
 use Knp\Menu\Provider\MenuProviderInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Menu\Provider\GroupMenuProvider;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class GroupMenuProviderTest extends TestCase
 {
@@ -42,9 +46,9 @@ class GroupMenuProviderTest extends TestCase
 
     protected function setUp()
     {
-        $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
+        $this->pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
         $this->checker = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')
+            ->getMockBuilder(AuthorizationCheckerInterface::class)
             ->setMethods(['isGranted'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -84,7 +88,7 @@ class GroupMenuProviderTest extends TestCase
             ]
         );
 
-        $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
+        $this->assertInstanceOf(ItemInterface::class, $menu);
         $this->assertSame('foo', $menu->getName());
 
         $children = $menu->getChildren();
@@ -92,7 +96,7 @@ class GroupMenuProviderTest extends TestCase
         $this->assertCount(2, $children);
         $this->assertArrayHasKey('foo_admin_label', $children);
         $this->assertArrayHasKey('route_label', $children);
-        $this->assertInstanceOf('Knp\Menu\MenuItem', $menu['foo_admin_label']);
+        $this->assertInstanceOf(MenuItem::class, $menu['foo_admin_label']);
         $this->assertSame('foo_admin_label', $menu['foo_admin_label']->getLabel());
 
         $extras = $menu['foo_admin_label']->getExtras();
@@ -128,7 +132,7 @@ class GroupMenuProviderTest extends TestCase
             ]
         );
 
-        $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
+        $this->assertInstanceOf(ItemInterface::class, $menu);
         $this->assertSame('foo', $menu->getName());
 
         $children = $menu->getChildren();
@@ -136,7 +140,7 @@ class GroupMenuProviderTest extends TestCase
         $this->assertCount(1, $children);
         $this->assertArrayHasKey('foo_admin_label', $children);
         $this->assertArrayNotHasKey('route_label', $children);
-        $this->assertInstanceOf('Knp\Menu\MenuItem', $menu['foo_admin_label']);
+        $this->assertInstanceOf(MenuItem::class, $menu['foo_admin_label']);
         $this->assertSame('foo_admin_label', $menu['foo_admin_label']->getLabel());
 
         $extras = $menu['foo_admin_label']->getExtras();
@@ -168,7 +172,7 @@ class GroupMenuProviderTest extends TestCase
             ]
         );
 
-        $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
+        $this->assertInstanceOf(ItemInterface::class, $menu);
         $this->assertSame('foo', $menu->getName());
 
         $children = $menu->getChildren();
@@ -176,7 +180,7 @@ class GroupMenuProviderTest extends TestCase
         $this->assertCount(2, $children);
         $this->assertArrayHasKey('foo_admin_label', $children);
         $this->assertArrayHasKey('route_label', $children);
-        $this->assertInstanceOf('Knp\Menu\MenuItem', $menu['foo_admin_label']);
+        $this->assertInstanceOf(MenuItem::class, $menu['foo_admin_label']);
         $this->assertSame('foo_admin_label', $menu['foo_admin_label']->getLabel());
 
         $extras = $menu['foo_admin_label']->getExtras();
@@ -212,7 +216,7 @@ class GroupMenuProviderTest extends TestCase
             ]
         );
 
-        $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
+        $this->assertInstanceOf(ItemInterface::class, $menu);
         $this->assertArrayNotHasKey('foo_admin_label', $menu->getChildren());
         $this->assertArrayHasKey('route_label', $menu->getChildren());
         $this->assertCount(1, $menu->getChildren());
@@ -242,7 +246,7 @@ class GroupMenuProviderTest extends TestCase
             ]
         );
 
-        $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
+        $this->assertInstanceOf(ItemInterface::class, $menu);
         $this->assertArrayNotHasKey('foo_admin_label', $menu->getChildren());
         $this->assertArrayHasKey('route_label', $menu->getChildren());
         $this->assertCount(1, $menu->getChildren());
@@ -268,7 +272,7 @@ class GroupMenuProviderTest extends TestCase
             ]
         );
 
-        $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
+        $this->assertInstanceOf(ItemInterface::class, $menu);
         $this->assertCount(0, $menu->getChildren());
     }
 
@@ -298,7 +302,7 @@ class GroupMenuProviderTest extends TestCase
             ]
         );
 
-        $this->assertInstanceOf('Knp\Menu\ItemInterface', $menu);
+        $this->assertInstanceOf(ItemInterface::class, $menu);
         $this->assertSame('keep-open', $menu->getAttribute('class'));
         $this->assertTrue($menu->getExtra('keep_open'));
     }
@@ -371,7 +375,7 @@ class GroupMenuProviderTest extends TestCase
      */
     private function getAdminMock($hasRoute = true, $isGranted = true)
     {
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $admin = $this->createMock(AbstractAdmin::class);
         $admin->expects($this->once())
             ->method('hasRoute')
             ->with($this->equalTo('list'))

--- a/tests/Model/AuditManagerTest.php
+++ b/tests/Model/AuditManagerTest.php
@@ -13,6 +13,8 @@ namespace Sonata\AdminBundle\Tests\Model;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Model\AuditManager;
+use Sonata\AdminBundle\Model\AuditReaderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Test for AuditManager.
@@ -23,10 +25,10 @@ class AuditManagerTest extends TestCase
 {
     public function testGetReader()
     {
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
 
-        $fooReader = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\AuditReaderInterface');
-        $barReader = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\AuditReaderInterface');
+        $fooReader = $this->getMockForAbstractClass(AuditReaderInterface::class);
+        $barReader = $this->getMockForAbstractClass(AuditReaderInterface::class);
 
         $container->expects($this->any())
             ->method('get')
@@ -54,9 +56,9 @@ class AuditManagerTest extends TestCase
 
     public function testGetReaderWithException()
     {
-        $this->expectException('\RuntimeException', 'The class "Foo\Foo" does not have any reader manager');
+        $this->expectException(\RuntimeException::class, 'The class "Foo\Foo" does not have any reader manager');
 
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
         $auditManager = new AuditManager($container);
 
         $auditManager->getReader('Foo\Foo');

--- a/tests/Route/AdminPoolLoaderTest.php
+++ b/tests/Route/AdminPoolLoaderTest.php
@@ -12,8 +12,13 @@
 namespace Sonata\AdminBundle\Tests\Route;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Route\AdminPoolLoader;
 use Sonata\AdminBundle\Route\RouteCollection;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\Route as SymfonyRoute;
+use Symfony\Component\Routing\RouteCollection as SymfonyRouteCollection;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -22,8 +27,8 @@ class AdminPoolLoaderTest extends TestCase
 {
     public function testSupports()
     {
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
-        $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
+        $pool = $this->getMockBuilder(Pool::class)
             ->setMethods([])
             ->setConstructorArgs([$container, 'title', 'logoTitle'])
             ->getMock();
@@ -36,8 +41,8 @@ class AdminPoolLoaderTest extends TestCase
 
     public function testLoad()
     {
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
-        $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
+        $pool = $this->getMockBuilder(Pool::class)
             ->setMethods([])
             ->setConstructorArgs([$container, 'title', 'logoTitle'])
             ->getMock();
@@ -51,12 +56,12 @@ class AdminPoolLoaderTest extends TestCase
         $routeCollection2->add('bar');
         $routeCollection2->add('baz');
 
-        $admin1 = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin1 = $this->getMockForAbstractClass(AdminInterface::class);
         $admin1->expects($this->once())
             ->method('getRoutes')
             ->will($this->returnValue($routeCollection1));
 
-        $admin2 = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin2 = $this->getMockForAbstractClass(AdminInterface::class);
         $admin2->expects($this->once())
             ->method('getRoutes')
             ->will($this->returnValue($routeCollection2));
@@ -76,9 +81,9 @@ class AdminPoolLoaderTest extends TestCase
 
         $collection = $adminPoolLoader->load('foo', 'sonata_admin');
 
-        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $collection);
-        $this->assertInstanceOf('Symfony\Component\Routing\Route', $collection->get('baseRouteNameFoo_foo'));
-        $this->assertInstanceOf('Symfony\Component\Routing\Route', $collection->get('baseRouteNameBar_bar'));
-        $this->assertInstanceOf('Symfony\Component\Routing\Route', $collection->get('baseRouteNameBar_bar'));
+        $this->assertInstanceOf(SymfonyRouteCollection::class, $collection);
+        $this->assertInstanceOf(SymfonyRoute::class, $collection->get('baseRouteNameFoo_foo'));
+        $this->assertInstanceOf(SymfonyRoute::class, $collection->get('baseRouteNameBar_bar'));
+        $this->assertInstanceOf(SymfonyRoute::class, $collection->get('baseRouteNameBar_bar'));
     }
 }

--- a/tests/Route/DefaultRouteGeneratorTest.php
+++ b/tests/Route/DefaultRouteGeneratorTest.php
@@ -12,10 +12,14 @@
 namespace Sonata\AdminBundle\Tests\Route;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Route\DefaultRouteGenerator;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Route\RoutesCache;
-use Symfony\Component\Routing\Route;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
 
 class DefaultRouteGeneratorTest extends TestCase
 {
@@ -30,7 +34,7 @@ class DefaultRouteGeneratorTest extends TestCase
 
     public function testGenerate()
     {
-        $router = $this->getMockForAbstractClass('\Symfony\Component\Routing\RouterInterface');
+        $router = $this->getMockForAbstractClass(RouterInterface::class);
         $router->expects($this->once())->method('generate')->will($this->returnValue('/foo/bar'));
 
         $cache = new RoutesCache($this->cacheTempFolder, true);
@@ -52,7 +56,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $collection->add('foo');
         $collection->addCollection($childCollection);
 
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(false));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Foo'));
         $admin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(false));
@@ -63,7 +67,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue([]));
 
-        $router = $this->getMockForAbstractClass('Symfony\Component\Routing\RouterInterface');
+        $router = $this->getMockForAbstractClass(RouterInterface::class);
         $router->expects($this->once())
             ->method('generate')
             ->will($this->returnCallback(function ($name, array $parameters = []) {
@@ -99,9 +103,9 @@ class DefaultRouteGeneratorTest extends TestCase
 
     public function testGenerateUrlWithException()
     {
-        $this->expectException('RuntimeException', 'unable to find the route `base.Code.Route.foo`');
+        $this->expectException(\RuntimeException::class, 'unable to find the route `base.Code.Route.foo`');
 
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(false));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Route'));
         $admin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(false));
@@ -110,7 +114,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $admin->expects($this->exactly(2))->method('getRoutes')->will($this->returnValue(new RouteCollection('base.Code.Route', 'baseRouteName', 'baseRoutePattern', 'BundleName:ControllerName')));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue([]));
 
-        $router = $this->getMockForAbstractClass('Symfony\Component\Routing\RouterInterface');
+        $router = $this->getMockForAbstractClass(RouterInterface::class);
 
         $cache = new RoutesCache($this->cacheTempFolder, true);
 
@@ -130,7 +134,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $collection->add('foo');
         $collection->addCollection($childCollection);
 
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Child'));
         $admin->expects($this->any())->method('getBaseCodeRoute')->will($this->returnValue('base.Code.Parent|base.Code.Child'));
@@ -143,7 +147,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($childCollection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue([]));
 
-        $parentAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $parentAdmin = $this->getMockForAbstractClass(AdminInterface::class);
         $parentAdmin->expects($this->any())->method('getIdParameter')->will($this->returnValue('childId'));
         $parentAdmin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
         $parentAdmin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Parent'));
@@ -152,8 +156,8 @@ class DefaultRouteGeneratorTest extends TestCase
         // no request attached in this test, so this will not be used
         $parentAdmin->expects($this->never())->method('getPersistentParameters')->will($this->returnValue(['from' => 'parent']));
 
-        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
-        $request->attributes = $this->createMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $request = $this->createMock(Request::class);
+        $request->attributes = $this->createMock(ParameterBag::class);
         $request->attributes->expects($this->any())->method('has')->will($this->returnValue(true));
         $request->attributes->expects($this->any())
             ->method('get')
@@ -168,7 +172,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $admin->expects($this->any())->method('getRequest')->will($this->returnValue($request));
         $admin->expects($this->any())->method('getParent')->will($this->returnValue($parentAdmin));
 
-        $router = $this->getMockForAbstractClass('\Symfony\Component\Routing\RouterInterface');
+        $router = $this->getMockForAbstractClass(RouterInterface::class);
         $router->expects($this->once())
             ->method('generate')
             ->will($this->returnCallback(function ($name, array $parameters = []) {
@@ -215,7 +219,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $collection->add('foo');
         $collection->addCollection($childCollection);
 
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(false));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Parent'));
         // embeded admin (not nested ...)
@@ -227,7 +231,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue([]));
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
 
-        $router = $this->getMockForAbstractClass('Symfony\Component\Routing\RouterInterface');
+        $router = $this->getMockForAbstractClass(RouterInterface::class);
         $router->expects($this->once())
             ->method('generate')
             ->will($this->returnCallback(function ($name, array $parameters = []) {
@@ -246,10 +250,10 @@ class DefaultRouteGeneratorTest extends TestCase
                 return;
             }));
 
-        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getOption')->will($this->returnValue([]));
 
-        $parentAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $parentAdmin = $this->getMockForAbstractClass(AdminInterface::class);
         $parentAdmin->expects($this->any())->method('getUniqid')->will($this->returnValue('parent_foo_uniqueid'));
         $parentAdmin->expects($this->any())->method('getCode')->will($this->returnValue('parent_foo_code'));
         $parentAdmin->expects($this->any())->method('getExtensions')->will($this->returnValue([]));
@@ -288,7 +292,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $standaloneCollection = new RouteCollection('base.Code.Child', 'admin_acme_child_standalone', '/', 'BundleName:ControllerName');
         $standaloneCollection->add('bar');
 
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->any())->method('isChild')->will($this->returnValue(true));
         $admin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Child'));
         $admin->expects($this->any())->method('getBaseCodeRoute')->will($this->returnValue('base.Code.Parent|base.Code.Child'));
@@ -300,7 +304,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $admin->expects($this->any())->method('getRoutes')->will($this->returnValue($childCollection));
         $admin->expects($this->any())->method('getExtensions')->will($this->returnValue([]));
 
-        $parentAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $parentAdmin = $this->getMockForAbstractClass(AdminInterface::class);
         $parentAdmin->expects($this->any())->method('getIdParameter')->will($this->returnValue('childId'));
         $parentAdmin->expects($this->any())->method('getRoutes')->will($this->returnValue($collection));
         $parentAdmin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Parent'));
@@ -309,8 +313,8 @@ class DefaultRouteGeneratorTest extends TestCase
         // no request attached in this test, so this will not be used
         $parentAdmin->expects($this->never())->method('getPersistentParameters')->will($this->returnValue(['from' => 'parent']));
 
-        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
-        $request->attributes = $this->createMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $request = $this->createMock(Request::class);
+        $request->attributes = $this->createMock(ParameterBag::class);
         $request->attributes->expects($this->any())->method('has')->will($this->returnValue(true));
         $request->attributes->expects($this->any())
             ->method('get')
@@ -325,7 +329,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $admin->expects($this->any())->method('getRequest')->will($this->returnValue($request));
         $admin->expects($this->any())->method('getParent')->will($this->returnValue($parentAdmin));
 
-        $standaloneAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $standaloneAdmin = $this->getMockForAbstractClass(AdminInterface::class);
         $standaloneAdmin->expects($this->any())->method('isChild')->will($this->returnValue(false));
         $standaloneAdmin->expects($this->any())->method('getCode')->will($this->returnValue('base.Code.Child'));
         $standaloneAdmin->expects($this->once())->method('hasParentFieldDescription')->will($this->returnValue(false));
@@ -335,7 +339,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $standaloneAdmin->expects($this->any())->method('getRoutes')->will($this->returnValue($standaloneCollection));
         $standaloneAdmin->expects($this->any())->method('getExtensions')->will($this->returnValue([]));
 
-        $router = $this->getMockForAbstractClass('\Symfony\Component\Routing\RouterInterface');
+        $router = $this->getMockForAbstractClass(RouterInterface::class);
         $router->expects($this->exactly(2))
             ->method('generate')
             ->will($this->returnCallback(function ($name, array $parameters = []) {

--- a/tests/Route/PathInfoBuilderTest.php
+++ b/tests/Route/PathInfoBuilderTest.php
@@ -12,6 +12,8 @@
 namespace Sonata\AdminBundle\Tests\Route;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Model\AuditManagerInterface;
 use Sonata\AdminBundle\Route\PathInfoBuilder;
 use Sonata\AdminBundle\Route\RouteCollection;
 
@@ -19,10 +21,10 @@ class PathInfoBuilderTest extends TestCase
 {
     public function testBuild()
     {
-        $audit = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\AuditManagerInterface');
+        $audit = $this->getMockForAbstractClass(AuditManagerInterface::class);
         $audit->expects($this->once())->method('hasReader')->will($this->returnValue(true));
 
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->once())->method('getChildren')->will($this->returnValue([]));
         $admin->expects($this->once())->method('isAclEnabled')->will($this->returnValue(true));
 

--- a/tests/Route/QueryStringBuilderTest.php
+++ b/tests/Route/QueryStringBuilderTest.php
@@ -12,6 +12,8 @@
 namespace Sonata\AdminBundle\Tests\Route;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Model\AuditManagerInterface;
 use Sonata\AdminBundle\Route\QueryStringBuilder;
 use Sonata\AdminBundle\Route\RouteCollection;
 
@@ -22,10 +24,10 @@ class QueryStringBuilderTest extends TestCase
      */
     public function testBuild(array $expectedRoutes, $hasReader, $aclEnabled, $getParent)
     {
-        $audit = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\AuditManagerInterface');
+        $audit = $this->getMockForAbstractClass(AuditManagerInterface::class);
         $audit->expects($this->once())->method('hasReader')->will($this->returnValue($hasReader));
 
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->once())->method('getParent')->will($this->returnValue($getParent));
         $admin->expects($this->any())->method('getChildren')->will($this->returnValue([]));
         $admin->expects($this->once())->method('isAclEnabled')->will($this->returnValue($aclEnabled));
@@ -49,13 +51,13 @@ class QueryStringBuilderTest extends TestCase
             [['list', 'create', 'batch', 'edit', 'delete', 'show', 'export', 'history', 'history_view_revision', 'history_compare_revisions', 'acl'], true, true, null],
             [['list', 'create', 'batch', 'edit', 'delete', 'show', 'export', 'acl'], false, true, null],
             [['list', 'create', 'batch', 'edit', 'delete', 'show', 'export', 'history', 'history_view_revision', 'history_compare_revisions'], true, false, null],
-            [['list', 'create', 'batch', 'edit', 'delete', 'show', 'export', 'history', 'history_view_revision', 'history_compare_revisions', 'acl'], true, true, $this->createMock('Sonata\AdminBundle\Admin\AdminInterface')],
+            [['list', 'create', 'batch', 'edit', 'delete', 'show', 'export', 'history', 'history_view_revision', 'history_compare_revisions', 'acl'], true, true, $this->createMock(AdminInterface::class)],
         ];
     }
 
     public function testBuildWithChildren()
     {
-        $audit = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\AuditManagerInterface');
+        $audit = $this->getMockForAbstractClass(AuditManagerInterface::class);
         $audit->expects($this->once())->method('hasReader')->will($this->returnValue(true));
 
         $childRouteCollection1 = new RouteCollection('child1.Code.Route', 'child1RouteName', 'child1RoutePattern', 'child1ControllerName');
@@ -65,13 +67,13 @@ class QueryStringBuilderTest extends TestCase
         $childRouteCollection2 = new RouteCollection('child2.Code.Route', 'child2RouteName', 'child2RoutePattern', 'child2ControllerName');
         $childRouteCollection2->add('baz');
 
-        $child1 = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $child1 = $this->getMockForAbstractClass(AdminInterface::class);
         $child1->expects($this->once())->method('getRoutes')->will($this->returnValue($childRouteCollection1));
 
-        $child2 = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $child2 = $this->getMockForAbstractClass(AdminInterface::class);
         $child2->expects($this->once())->method('getRoutes')->will($this->returnValue($childRouteCollection2));
 
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->once())->method('getParent')->will($this->returnValue(null));
         $admin->expects($this->once())->method('getChildren')->will($this->returnValue([$child1, $child2]));
         $admin->expects($this->once())->method('isAclEnabled')->will($this->returnValue(true));

--- a/tests/Route/RouteCollectionTest.php
+++ b/tests/Route/RouteCollectionTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Route;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Route\RouteCollection;
+use Symfony\Component\Routing\Route;
 
 class RouteCollectionTest extends TestCase
 {
@@ -63,7 +64,7 @@ class RouteCollectionTest extends TestCase
         $routeCollection->add('create');
         $route = $routeCollection->get('create');
 
-        $this->assertInstanceOf('Symfony\Component\Routing\Route', $route);
+        $this->assertInstanceOf(Route::class, $route);
 
         $routeCollection->add('view');
         $routeCollection->add('edit');
@@ -89,7 +90,7 @@ class RouteCollectionTest extends TestCase
 
     public function testGetWithException()
     {
-        $this->expectException('\InvalidArgumentException', 'Element "foo" does not exist.');
+        $this->expectException(\InvalidArgumentException::class, 'Element "foo" does not exist.');
 
         $routeCollection = new RouteCollection('base.Code.Route', 'baseRouteName', 'baseRoutePattern', 'baseControllerName');
         $routeCollection->get('foo');

--- a/tests/Route/RoutesCacheWarmUpTest.php
+++ b/tests/Route/RoutesCacheWarmUpTest.php
@@ -12,6 +12,8 @@
 namespace Sonata\AdminBundle\Tests\Route;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Route\RoutesCache;
 use Sonata\AdminBundle\Route\RoutesCacheWarmUp;
 
 class RoutesCacheWarmUpTest extends TestCase
@@ -23,8 +25,8 @@ class RoutesCacheWarmUpTest extends TestCase
 
     public function setUp()
     {
-        $routesCache = $this->getMockBuilder('Sonata\AdminBundle\Route\RoutesCache')->disableOriginalConstructor()->getMock();
-        $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
+        $routesCache = $this->getMockBuilder(RoutesCache::class)->disableOriginalConstructor()->getMock();
+        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
 
         $this->routesCacheWarmUp = new RoutesCacheWarmUp($routesCache, $pool);
     }

--- a/tests/Search/SearchHandlerTest.php
+++ b/tests/Search/SearchHandlerTest.php
@@ -14,7 +14,11 @@ namespace Sonata\AdminBundle\Tests\Search;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\AdminBundle\Datagrid\PagerInterface;
+use Sonata\AdminBundle\Filter\FilterInterface;
 use Sonata\AdminBundle\Search\SearchHandler;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class SearchHandlerTest extends TestCase
@@ -26,7 +30,7 @@ class SearchHandlerTest extends TestCase
      */
     public function getPool(AdminInterface $admin = null)
     {
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
         $container->expects($this->any())->method('get')->will($this->returnCallback(function ($id) use ($admin) {
             if ('fake' == $id) {
                 throw new ServiceNotFoundException('Fake service does not exist');
@@ -40,13 +44,13 @@ class SearchHandlerTest extends TestCase
 
     public function testBuildPagerWithNoGlobalSearchField()
     {
-        $filter = $this->getMockForAbstractClass('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->getMockForAbstractClass(FilterInterface::class);
         $filter->expects($this->once())->method('getOption')->will($this->returnValue(false));
 
-        $datagrid = $this->getMockForAbstractClass('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->getMockForAbstractClass(DatagridInterface::class);
         $datagrid->expects($this->once())->method('getFilters')->will($this->returnValue([$filter]));
 
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->once())->method('getDatagrid')->will($this->returnValue($datagrid));
 
         $handler = new SearchHandler($this->getPool($admin));
@@ -55,22 +59,22 @@ class SearchHandlerTest extends TestCase
 
     public function testBuildPagerWithGlobalSearchField()
     {
-        $filter = $this->getMockForAbstractClass('Sonata\AdminBundle\Filter\FilterInterface');
+        $filter = $this->getMockForAbstractClass(FilterInterface::class);
         $filter->expects($this->once())->method('getOption')->will($this->returnValue(true));
 
-        $pager = $this->getMockForAbstractClass('Sonata\AdminBundle\Datagrid\PagerInterface');
+        $pager = $this->getMockForAbstractClass(PagerInterface::class);
         $pager->expects($this->once())->method('setPage');
         $pager->expects($this->once())->method('setMaxPerPage');
 
-        $datagrid = $this->getMockForAbstractClass('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->getMockForAbstractClass(DatagridInterface::class);
         $datagrid->expects($this->once())->method('getFilters')->will($this->returnValue([$filter]));
         $datagrid->expects($this->once())->method('setValue');
         $datagrid->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->once())->method('getDatagrid')->will($this->returnValue($datagrid));
 
         $handler = new SearchHandler($this->getPool($admin));
-        $this->assertInstanceOf('Sonata\AdminBundle\Datagrid\PagerInterface', $handler->search($admin, 'myservice'));
+        $this->assertInstanceOf(PagerInterface::class, $handler->search($admin, 'myservice'));
     }
 }

--- a/tests/Security/Acl/Permission/AdminPermissionMapTest.php
+++ b/tests/Security/Acl/Permission/AdminPermissionMapTest.php
@@ -24,9 +24,7 @@ class AdminPermissionMapTest extends TestCase
 
     public function testGetMaskReturnsAnArrayOfMasks()
     {
-        $reflection = new \ReflectionClass(
-            'Sonata\AdminBundle\Security\Acl\Permission\AdminPermissionMap'
-        );
+        $reflection = new \ReflectionClass(AdminPermissionMap::class);
         foreach ($reflection->getConstants() as $permission) {
             $masks = $this->permissionMap->getMasks(
                 $permission,
@@ -52,9 +50,7 @@ class AdminPermissionMapTest extends TestCase
     public function permissionProvider()
     {
         $dataSet = [];
-        $reflection = new \ReflectionClass(
-            'Sonata\AdminBundle\Security\Acl\Permission\AdminPermissionMap'
-        );
+        $reflection = new \ReflectionClass(AdminPermissionMap::class);
 
         foreach ($reflection->getConstants() as $permission) {
             $dataSet[$permission] = [true, $permission];

--- a/tests/Security/Handler/AclSecurityHandlerTest.php
+++ b/tests/Security/Handler/AclSecurityHandlerTest.php
@@ -12,24 +12,29 @@
 namespace Sonata\AdminBundle\Tests\Security\Handler;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder;
 use Sonata\AdminBundle\Security\Handler\AclSecurityHandler;
+use Symfony\Component\Security\Acl\Model\MutableAclProviderInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
 class AclSecurityHandlerTest extends TestCase
 {
     public function getTokenStorageMock()
     {
-        return $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        return $this->getMockForAbstractClass(TokenStorageInterface::class);
     }
 
     public function getAuthorizationCheckerMock()
     {
-        return $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        return $this->getMockForAbstractClass(AuthorizationCheckerInterface::class);
     }
 
     public function testAcl()
     {
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->any())
             ->method('getCode')
             ->will($this->returnValue('test'));
@@ -39,9 +44,9 @@ class AclSecurityHandlerTest extends TestCase
             ->method('isGranted')
             ->will($this->returnValue(true));
 
-        $aclProvider = $this->getMockForAbstractClass('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
+        $aclProvider = $this->getMockForAbstractClass(MutableAclProviderInterface::class);
 
-        $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, 'Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder', []);
+        $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, MaskBuilder::class, []);
 
         $this->assertTrue($handler->isGranted($admin, ['TOTO']));
         $this->assertTrue($handler->isGranted($admin, 'TOTO'));
@@ -51,7 +56,7 @@ class AclSecurityHandlerTest extends TestCase
             ->method('isGranted')
             ->will($this->returnValue(false));
 
-        $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, 'Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder', []);
+        $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, MaskBuilder::class, []);
 
         $this->assertFalse($handler->isGranted($admin, ['TOTO']));
         $this->assertFalse($handler->isGranted($admin, 'TOTO'));
@@ -64,7 +69,7 @@ class AclSecurityHandlerTest extends TestCase
         ];
 
         $authorizationChecker = $this->getAuthorizationCheckerMock();
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->once())
             ->method('getCode')
             ->will($this->returnValue('test'));
@@ -73,9 +78,9 @@ class AclSecurityHandlerTest extends TestCase
             ->method('getSecurityInformation')
             ->will($this->returnValue($informations));
 
-        $aclProvider = $this->getMockForAbstractClass('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
+        $aclProvider = $this->getMockForAbstractClass(MutableAclProviderInterface::class);
 
-        $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, 'Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder', []);
+        $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, MaskBuilder::class, []);
 
         $results = $handler->buildSecurityInformation($admin);
 
@@ -84,16 +89,16 @@ class AclSecurityHandlerTest extends TestCase
 
     public function testWithAuthenticationCredentialsNotFoundException()
     {
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
 
         $authorizationChecker = $this->getAuthorizationCheckerMock();
         $authorizationChecker->expects($this->any())
             ->method('isGranted')
             ->will($this->throwException(new AuthenticationCredentialsNotFoundException('FAIL')));
 
-        $aclProvider = $this->getMockForAbstractClass('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
+        $aclProvider = $this->getMockForAbstractClass(MutableAclProviderInterface::class);
 
-        $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, 'Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder', []);
+        $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, MaskBuilder::class, []);
 
         $this->assertFalse($handler->isGranted($admin, 'raise exception', $admin));
     }
@@ -103,16 +108,16 @@ class AclSecurityHandlerTest extends TestCase
      */
     public function testWithNonAuthenticationCredentialsNotFoundException()
     {
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
 
         $authorizationChecker = $this->getAuthorizationCheckerMock();
         $authorizationChecker->expects($this->any())
             ->method('isGranted')
             ->will($this->throwException(new \RuntimeException('FAIL')));
 
-        $aclProvider = $this->getMockForAbstractClass('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
+        $aclProvider = $this->getMockForAbstractClass(MutableAclProviderInterface::class);
 
-        $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, 'Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder', []);
+        $handler = new AclSecurityHandler($this->getTokenStorageMock(), $authorizationChecker, $aclProvider, MaskBuilder::class, []);
 
         $this->assertFalse($handler->isGranted($admin, 'raise exception', $admin));
     }

--- a/tests/Security/Handler/NoopSecurityHandlerTest.php
+++ b/tests/Security/Handler/NoopSecurityHandlerTest.php
@@ -58,6 +58,6 @@ class NoopSecurityHandlerTest extends TestCase
      */
     private function getSonataAdminObject()
     {
-        return $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        return $this->getMockForAbstractClass(AdminInterface::class);
     }
 }

--- a/tests/Security/Handler/RoleSecurityHandlerTest.php
+++ b/tests/Security/Handler/RoleSecurityHandlerTest.php
@@ -36,8 +36,8 @@ class RoleSecurityHandlerTest extends TestCase
 
     public function setUp()
     {
-        $this->authorizationChecker = $this->getMockForAbstractClass('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
-        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->authorizationChecker = $this->getMockForAbstractClass(AuthorizationCheckerInterface::class);
+        $this->admin = $this->getMockForAbstractClass(AdminInterface::class);
     }
 
     /**
@@ -180,7 +180,7 @@ class RoleSecurityHandlerTest extends TestCase
 
     public function testIsGrantedWithException()
     {
-        $this->expectException('RuntimeException', 'Something is wrong');
+        $this->expectException(\RuntimeException::class, 'Something is wrong');
 
         $this->admin->expects($this->any())
             ->method('getCode')
@@ -227,6 +227,6 @@ class RoleSecurityHandlerTest extends TestCase
      */
     private function getSonataAdminObject()
     {
-        return $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        return $this->getMockForAbstractClass(AdminInterface::class);
     }
 }

--- a/tests/Show/ShowMapperTest.php
+++ b/tests/Show/ShowMapperTest.php
@@ -13,8 +13,11 @@ namespace Sonata\AdminBundle\Tests\Show;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CleanAdmin;
 use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
@@ -58,9 +61,9 @@ class ShowMapperTest extends TestCase
 
     public function setUp()
     {
-        $this->showBuilder = $this->getMockForAbstractClass('Sonata\AdminBundle\Builder\ShowBuilderInterface');
+        $this->showBuilder = $this->getMockForAbstractClass(ShowBuilderInterface::class);
         $this->fieldDescriptionCollection = new FieldDescriptionCollection();
-        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->getMockForAbstractClass(AdminInterface::class);
 
         $this->admin->expects($this->any())
             ->method('getLabel')
@@ -97,7 +100,7 @@ class ShowMapperTest extends TestCase
                 $groups = $showGroups;
             }));
 
-        $modelManager = $this->getMockForAbstractClass('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
 
         // php 5.3 BC
         $fieldDescription = $this->getFieldDescriptionMock();
@@ -169,7 +172,7 @@ class ShowMapperTest extends TestCase
 
         $fieldDescription = $this->showMapper->get('fooName');
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $fieldDescription);
         $this->assertSame('fooName', $fieldDescription->getName());
         $this->assertSame('fooName', $fieldDescription->getOption('label'));
     }
@@ -183,7 +186,7 @@ class ShowMapperTest extends TestCase
         $this->assertTrue($this->showMapper->has('fooName'));
         $fieldDescription = $this->showMapper->get('fooName');
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $fieldDescription);
         $this->assertSame('fooName', $fieldDescription->getName());
         $this->assertSame('fooName', $fieldDescription->getOption('label'));
     }
@@ -208,7 +211,7 @@ class ShowMapperTest extends TestCase
         $this->assertTrue($this->showMapper->has('barName'));
         $fieldDescription = $this->showMapper->get('barName');
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $fieldDescription);
         $this->assertSame('barName', $fieldDescription->getName());
         $this->assertSame('barName', $fieldDescription->getOption('label'));
     }
@@ -222,7 +225,7 @@ class ShowMapperTest extends TestCase
         $this->assertTrue($this->showMapper->has('fooName'));
         $fieldDescription = $this->showMapper->get('fooName');
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $fieldDescription);
         $this->assertSame('fooName', $fieldDescription->getName());
         $this->assertSame('fooName', $fieldDescription->getOption('label'));
     }
@@ -247,7 +250,7 @@ class ShowMapperTest extends TestCase
         $this->assertTrue($this->showMapper->has('barName'));
         $fieldDescription = $this->showMapper->get('barName');
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface', $fieldDescription);
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $fieldDescription);
         $this->assertSame('barName', $fieldDescription->getName());
         $this->assertSame('barName', $fieldDescription->getOption('label'));
     }
@@ -327,7 +330,7 @@ class ShowMapperTest extends TestCase
 
     public function testAddException()
     {
-        $this->expectException('\RuntimeException', 'invalid state');
+        $this->expectException(\RuntimeException::class, 'invalid state');
 
         $this->showMapper->add(12345);
     }
@@ -335,7 +338,7 @@ class ShowMapperTest extends TestCase
     public function testAddDuplicateFieldNameException()
     {
         $name = 'name';
-        $this->expectException('\RuntimeException', sprintf('Duplicate field %s "name" in show mapper. Names should be unique.', $name));
+        $this->expectException(\RuntimeException::class, sprintf('Duplicate field %s "name" in show mapper. Names should be unique.', $name));
 
         $this->showMapper->add($name);
         $this->showMapper->add($name);
@@ -446,7 +449,7 @@ class ShowMapperTest extends TestCase
 
     private function cleanShowMapper()
     {
-        $this->showBuilder = $this->getMockForAbstractClass('Sonata\AdminBundle\Builder\ShowBuilderInterface');
+        $this->showBuilder = $this->getMockForAbstractClass(ShowBuilderInterface::class);
         $this->fieldDescriptionCollection = new FieldDescriptionCollection();
         $this->admin = new CleanAdmin('code', 'class', 'controller');
         $this->showMapper = new ShowMapper($this->showBuilder, $this->fieldDescriptionCollection, $this->admin);
@@ -454,7 +457,7 @@ class ShowMapperTest extends TestCase
 
     private function getFieldDescriptionMock($name = null, $label = null)
     {
-        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\BaseFieldDescription');
+        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class);
 
         if (null !== $name) {
             $fieldDescription->setName($name);

--- a/tests/SonataAdminBundleTest.php
+++ b/tests/SonataAdminBundleTest.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Sonata\AdminBundle\SonataAdminBundle;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Test for SonataAdminBundle.
@@ -29,7 +30,7 @@ class SonataAdminBundleTest extends TestCase
 {
     public function testBuild()
     {
-        $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+        $containerBuilder = $this->getMockBuilder(ContainerBuilder::class)
             ->setMethods(['addCompilerPass'])
             ->getMock();
 

--- a/tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
+++ b/tests/Translator/Extractor/JMSTranslatorBundle/AdminExtractorTest.php
@@ -12,10 +12,15 @@
 namespace Sonata\AdminBundle\Tests\Translator\Extractor\JMSTranslatorBundle;
 
 use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Translation\ExtractorInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Translator\Extractor\JMSTranslatorBundle\AdminExtractor;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Test for AdminExtractor.
@@ -51,18 +56,18 @@ class AdminExtractorTest extends TestCase
 
     public function setUp()
     {
-        if (!interface_exists('JMS\TranslationBundle\Translation\ExtractorInterface')) {
+        if (!interface_exists(ExtractorInterface::class)) {
             $this->markTestSkipped('JMS Translator Bundle does not exist');
         }
 
-        $this->fooAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
-        $this->barAdmin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->fooAdmin = $this->getMockForAbstractClass(AdminInterface::class);
+        $this->barAdmin = $this->getMockForAbstractClass(AdminInterface::class);
 
         // php 5.3 BC
         $fooAdmin = $this->fooAdmin;
         $barAdmin = $this->barAdmin;
 
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
         $container->expects($this->any())
             ->method('get')
             ->will($this->returnCallback(function ($id) use ($fooAdmin, $barAdmin) {
@@ -76,9 +81,9 @@ class AdminExtractorTest extends TestCase
                 return;
             }));
 
-        $logger = $this->getMockForAbstractClass('Psr\Log\LoggerInterface');
+        $logger = $this->getMockForAbstractClass(LoggerInterface::class);
 
-        $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
+        $this->pool = $this->getMockBuilder(Pool::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->pool->expects($this->any())
@@ -96,7 +101,7 @@ class AdminExtractorTest extends TestCase
         $this->adminExtractor = new AdminExtractor($this->pool, $logger);
         $this->adminExtractor->setLogger($logger);
 
-        $this->breadcrumbsBuilder = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface');
+        $this->breadcrumbsBuilder = $this->getMockForAbstractClass(BreadcrumbsBuilderInterface::class);
         $this->adminExtractor->setBreadcrumbsBuilder($this->breadcrumbsBuilder);
     }
 
@@ -104,7 +109,7 @@ class AdminExtractorTest extends TestCase
     {
         $catalogue = $this->adminExtractor->extract();
 
-        $this->assertInstanceOf('JMS\TranslationBundle\Model\MessageCatalogue', $catalogue);
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
         $this->assertFalse($catalogue->has(new Message('foo', 'foo_admin_domain')));
     }
 
@@ -136,7 +141,7 @@ class AdminExtractorTest extends TestCase
         $this->assertTrue($catalogue->has(new Message('foo', 'foo_admin_domain')));
         $this->assertFalse($catalogue->has(new Message('nonexistent', 'foo_admin_domain')));
 
-        $this->assertInstanceOf('JMS\TranslationBundle\Model\Message', $catalogue->get('foo', 'foo_admin_domain'));
+        $this->assertInstanceOf(Message::class, $catalogue->get('foo', 'foo_admin_domain'));
 
         $message = $catalogue->get('foo', 'foo_admin_domain');
         $this->assertSame('foo', $message->getId());
@@ -148,7 +153,7 @@ class AdminExtractorTest extends TestCase
 
     public function testExtractWithException()
     {
-        $this->expectException('RuntimeException', 'Foo throws exception');
+        $this->expectException(\RuntimeException::class, 'Foo throws exception');
 
         $this->fooAdmin->expects($this->any())
             ->method('getShow')

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
@@ -23,6 +24,7 @@ use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubFilesystemLoader;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\RequestContext;
@@ -93,13 +95,13 @@ class SonataAdminExtensionTest extends TestCase
     {
         date_default_timezone_set('Europe/London');
 
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
 
         $this->pool = new Pool($container, '', '');
         $this->pool->setAdminServiceIds(['sonata_admin_foo_service']);
         $this->pool->setAdminClasses(['fooClass' => ['sonata_admin_foo_service']]);
 
-        $this->logger = $this->getMockForAbstractClass('Psr\Log\LoggerInterface');
+        $this->logger = $this->getMockForAbstractClass(LoggerInterface::class);
         $this->xEditableTypeMapping = [
             'choice' => 'select',
             'boolean' => 'select',
@@ -166,7 +168,7 @@ class SonataAdminExtensionTest extends TestCase
         $this->object = new \stdClass();
 
         // initialize admin
-        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $this->admin = $this->createMock(AbstractAdmin::class);
 
         $this->admin->expects($this->any())
             ->method('getCode')
@@ -188,7 +190,7 @@ class SonataAdminExtensionTest extends TestCase
                 return $translator->trans($id, $parameters, $domain);
             }));
 
-        $this->adminBar = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $this->adminBar = $this->createMock(AbstractAdmin::class);
         $this->adminBar->expects($this->any())
             ->method('hasAccess')
             ->will($this->returnValue(true));
@@ -214,7 +216,7 @@ class SonataAdminExtensionTest extends TestCase
             }));
 
         // initialize field description
-        $this->fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $this->fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
 
         $this->fieldDescription->expects($this->any())
             ->method('getName')
@@ -1956,7 +1958,7 @@ EOT
     public function testGetValueFromFieldDescription()
     {
         $object = new \stdClass();
-        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
 
         $fieldDescription->expects($this->any())
             ->method('getValue')
@@ -1967,10 +1969,10 @@ EOT
 
     public function testGetValueFromFieldDescriptionWithRemoveLoopException()
     {
-        $object = $this->createMock('\ArrayAccess');
-        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $object = $this->createMock(\ArrayAccess::class);
+        $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
 
-        $this->expectException('\RuntimeException', 'remove the loop requirement');
+        $this->expectException(\RuntimeException::class, 'remove the loop requirement');
 
         $this->assertSame(
             'anything',
@@ -1981,7 +1983,7 @@ EOT
     public function testGetValueFromFieldDescriptionWithNoValueException()
     {
         $object = new \stdClass();
-        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
 
         $fieldDescription->expects($this->any())
             ->method('getValue')
@@ -1999,7 +2001,7 @@ EOT
     public function testGetValueFromFieldDescriptionWithNoValueExceptionNewAdminInstance()
     {
         $object = new \stdClass();
-        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
 
         $fieldDescription->expects($this->any())
             ->method('getValue')
@@ -2148,7 +2150,7 @@ EOT
             }));
 
         $element = new \stdClass();
-        $this->expectException('\RuntimeException', 'You must define an `associated_property` option or create a `stdClass::__toString');
+        $this->expectException(\RuntimeException::class, 'You must define an `associated_property` option or create a `stdClass::__toString');
 
         $this->twigExtension->renderRelationElement($element, $this->fieldDescription);
     }
@@ -2271,7 +2273,7 @@ EOT
      */
     public function testGetXEditableChoicesIsIdempotent(array $input)
     {
-        $fieldDescription = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->exactly(2))
             ->method('getOption')
             ->withConsecutive(

--- a/tests/Twig/GlobalVariablesTest.php
+++ b/tests/Twig/GlobalVariablesTest.php
@@ -12,7 +12,10 @@
 namespace Sonata\AdminBundle\Tests\Twig;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Twig\GlobalVariables;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -29,8 +32,8 @@ class GlobalVariablesTest extends TestCase
     {
         $this->code = 'sonata.page.admin.page|sonata.page.admin.snapshot';
         $this->action = 'list';
-        $this->admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
-        $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
+        $this->admin = $this->getMockForAbstractClass(AdminInterface::class);
+        $this->pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
     }
 
     public function testUrl()
@@ -83,7 +86,7 @@ class GlobalVariablesTest extends TestCase
             ->with('sonata.page.admin.page')
             ->willReturn($this->admin);
 
-        $container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
             ->with('sonata.admin.pool')
@@ -100,7 +103,7 @@ class GlobalVariablesTest extends TestCase
     public function testInvalidArgumentException()
     {
         $this->expectException(
-            'InvalidArgumentException',
+            \InvalidArgumentException::class,
             '$adminPool should be an instance of Sonata\AdminBundle\Admin\Pool'
         );
 

--- a/tests/Util/AdminObjectAclDataTest.php
+++ b/tests/Util/AdminObjectAclDataTest.php
@@ -12,7 +12,12 @@
 namespace Sonata\AdminBundle\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface;
 use Sonata\AdminBundle\Util\AdminObjectAclData;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Security\Acl\Domain\Acl;
+use Symfony\Component\Security\Acl\Permission\MaskBuilder;
 
 /**
  * @author Kévin Dunglas <kevin@les-tilleuls.coop>
@@ -22,30 +27,30 @@ class AdminObjectAclDataTest extends TestCase
     public function testGetAdmin()
     {
         $adminObjectAclData = $this->createAdminObjectAclData();
-        $this->isInstanceOf('Sonata\AdminBundle\Admin\AdminInterface', $adminObjectAclData->getAdmin());
+        $this->isInstanceOf(AdminInterface::class, $adminObjectAclData->getAdmin());
     }
 
     public function testGetObject()
     {
         $adminObjectAclData = $this->createAdminObjectAclData();
-        $this->isInstanceOf('stdClass', $adminObjectAclData->getObject());
+        $this->isInstanceOf(\stdClass::class, $adminObjectAclData->getObject());
     }
 
     public function testGetAclUsers()
     {
         $adminObjectAclData = $this->createAdminObjectAclData();
-        $this->assertInstanceOf('ArrayIterator', $adminObjectAclData->getAclUsers());
+        $this->assertInstanceOf(\ArrayIterator::class, $adminObjectAclData->getAclUsers());
     }
 
     public function testGetAclRoles()
     {
         $adminObjectAclData = $this->createAdminObjectAclData();
-        $this->assertInstanceOf('ArrayIterator', $adminObjectAclData->getAclRoles());
+        $this->assertInstanceOf(\ArrayIterator::class, $adminObjectAclData->getAclRoles());
     }
 
     public function testSetAcl()
     {
-        $acl = $this->getMockBuilder('Symfony\Component\Security\Acl\Domain\Acl')
+        $acl = $this->getMockBuilder(Acl::class)
             ->disableOriginalConstructor()
             ->getMock();
         $adminObjectAclData = $this->createAdminObjectAclData();
@@ -61,7 +66,7 @@ class AdminObjectAclDataTest extends TestCase
      */
     public function testGetAcl($adminObjectAclData)
     {
-        $this->isInstanceOf('Symfony\Component\Security\Acl\Domain\Acl', $adminObjectAclData->getAcl());
+        $this->isInstanceOf(Acl::class, $adminObjectAclData->getAcl());
     }
 
     public function testGetMasks()
@@ -80,7 +85,7 @@ class AdminObjectAclDataTest extends TestCase
      */
     public function testSetForm()
     {
-        $form = $this->getMockBuilder('\Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
         $adminObjectAclData = $this->createAdminObjectAclData();
@@ -98,12 +103,12 @@ class AdminObjectAclDataTest extends TestCase
      */
     public function testGetForm($adminObjectAclData)
     {
-        $this->isInstanceOf('Symfony\Component\Form\Form', $adminObjectAclData->getAclUsersForm());
+        $this->isInstanceOf(Form::class, $adminObjectAclData->getAclUsersForm());
     }
 
     public function testSetAclUsersForm()
     {
-        $form = $this->getMockBuilder('\Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
         $adminObjectAclData = $this->createAdminObjectAclData();
@@ -119,12 +124,12 @@ class AdminObjectAclDataTest extends TestCase
      */
     public function testGetAclUsersForm($adminObjectAclData)
     {
-        $this->isInstanceOf('Symfony\Component\Form\Form', $adminObjectAclData->getAclUsersForm());
+        $this->isInstanceOf(Form::class, $adminObjectAclData->getAclUsersForm());
     }
 
     public function testSetAclRolesForm()
     {
-        $form = $this->getMockBuilder('\Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
         $adminObjectAclData = $this->createAdminObjectAclData();
@@ -140,7 +145,7 @@ class AdminObjectAclDataTest extends TestCase
      */
     public function testGetAclRolesForm($adminObjectAclData)
     {
-        $this->isInstanceOf('Symfony\Component\Form\Form', $adminObjectAclData->getAclRolesForm());
+        $this->isInstanceOf(Form::class, $adminObjectAclData->getAclRolesForm());
     }
 
     public function testGetPermissions()
@@ -189,7 +194,7 @@ class AdminObjectAclDataTest extends TestCase
     {
         $adminObjectAclData = $this->createAdminObjectAclData();
 
-        $this->isInstanceOf('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface', $adminObjectAclData->getSecurityHandler());
+        $this->isInstanceOf(AclSecurityHandlerInterface::class, $adminObjectAclData->getSecurityHandler());
     }
 
     public function testGetSecurityInformation()
@@ -211,12 +216,12 @@ class AdminObjectAclDataTest extends TestCase
 
     protected function createAdminObjectAclData($isOwner = true)
     {
-        return new AdminObjectAclData($this->createAdmin($isOwner), new \stdClass(), self::createAclUsers(), '\Symfony\Component\Security\Acl\Permission\MaskBuilder', self::createAclRoles());
+        return new AdminObjectAclData($this->createAdmin($isOwner), new \stdClass(), self::createAclUsers(), MaskBuilder::class, self::createAclRoles());
     }
 
     protected function createAdmin($isOwner = true)
     {
-        $securityHandler = $this->getMockForAbstractClass('Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface');
+        $securityHandler = $this->getMockForAbstractClass(AclSecurityHandlerInterface::class);
 
         $securityHandler->expects($this->any())
             ->method('getObjectPermissions')
@@ -225,11 +230,11 @@ class AdminObjectAclDataTest extends TestCase
 
         $securityHandler->expects($this->any())
             ->method('buildSecurityInformation')
-            ->with($this->isInstanceOf('Sonata\AdminBundle\Admin\AdminInterface'))
+            ->with($this->isInstanceOf(AdminInterface::class))
             ->will($this->returnValue([]))
         ;
 
-        $admin = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->getMockForAbstractClass(AdminInterface::class);
 
         $admin->expects($this->any())
             ->method('isGranted')

--- a/tests/Util/AdminObjectAclManipulatorTest.php
+++ b/tests/Util/AdminObjectAclManipulatorTest.php
@@ -13,13 +13,15 @@ namespace Sonata\AdminBundle\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Security\Acl\Permission\MaskBuilder;
 
 /**
  * @author Kévin Dunglas <kevin@les-tilleuls.coop>
  */
 class AdminObjectAclManipulatorTest extends TestCase
 {
-    const MASK_BUILDER_CLASS = '\Symfony\Component\Security\Acl\Permission\MaskBuilder';
+    const MASK_BUILDER_CLASS = MaskBuilder::class;
 
     public function testGetMaskBuilder()
     {
@@ -29,6 +31,6 @@ class AdminObjectAclManipulatorTest extends TestCase
 
     protected function createAdminObjectAclManipulator()
     {
-        return new AdminObjectAclManipulator($this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface'), self::MASK_BUILDER_CLASS);
+        return new AdminObjectAclManipulator($this->getMockForAbstractClass(FormFactoryInterface::class), self::MASK_BUILDER_CLASS);
     }
 }

--- a/tests/Util/FormBuilderIteratorTest.php
+++ b/tests/Util/FormBuilderIteratorTest.php
@@ -39,8 +39,8 @@ class FormBuilderIteratorTest extends TestCase
 
     protected function setUp()
     {
-        $this->dispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->factory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
+        $this->dispatcher = $this->getMockForAbstractClass(EventDispatcherInterface::class);
+        $this->factory = $this->getMockForAbstractClass(FormFactoryInterface::class);
         $this->builder = new TestFormBuilder('name', null, $this->dispatcher, $this->factory);
         $this->factory->expects($this->any())->method('createNamedBuilder')->willReturn($this->builder);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because we discussed it at #4729.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Replace FQCN strings with `::class` constants
```
