### PR TITLE
Remove BC-break with introducing new redirectToList method

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1197,11 +1197,12 @@ class CRUDController implements ContainerAwareInterface
     }
 
     /**
+     * @final Since 4.0
      * Redirects the user to the list view.
      *
      * @return RedirectResponse
      */
-    final protected function redirectToList()
+    protected function redirectToList()
     {
         $parameters = [];
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this BC-break fix

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4822

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed BC-break with introducing new redirectToList method

```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

Fixed BC-break with introducing new redirectToList method
