### PR TITLE
improvments on getClass() method

### DIFF
--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -713,14 +713,21 @@ class AdminTest extends TestCase
         $admin->setSubject(new BlogPost());
         $this->assertSame(BlogPost::class, $admin->getClass());
 
-        $admin->setSubClasses(['extended1' => 'NewsBundle\Entity\PostExtended1', 'extended2' => 'NewsBundle\Entity\PostExtended2']);
+        $admin->setSubClasses([
+            'extended1' => 'NewsBundle\Entity\PostExtended1',
+            'extended2' => 'NewsBundle\Entity\PostExtended2',
+        ]);
         $this->assertFalse($admin->hasSubClass('test'));
         $this->assertTrue($admin->hasSubClass('extended1'));
         $this->assertFalse($admin->hasActiveSubClass());
         $this->assertCount(2, $admin->getSubClasses());
         $this->assertNull($admin->getActiveSubClass());
         $this->assertNull($admin->getActiveSubclassCode());
-        $this->assertSame(BlogPost::class, $admin->getClass());
+        $this->assertSame(
+            BlogPost::class,
+            $admin->getClass(),
+            'When there is no subclass in the query the class parameter should be returned'
+        );
 
         $request = new Request(['subclass' => 'extended1']);
         $admin->setRequest($request);
@@ -728,9 +735,17 @@ class AdminTest extends TestCase
         $this->assertTrue($admin->hasSubClass('extended1'));
         $this->assertTrue($admin->hasActiveSubClass());
         $this->assertCount(2, $admin->getSubClasses());
-        $this->assertSame(BlogPost::class, $admin->getActiveSubClass());
+        $this->assertSame(
+            'NewsBundle\Entity\PostExtended1',
+            $admin->getActiveSubClass(),
+            'It should return the curently active sub class.'
+        );
         $this->assertSame('extended1', $admin->getActiveSubclassCode());
-        $this->assertSame(BlogPost::class, $admin->getClass());
+        $this->assertSame(
+            'NewsBundle\Entity\PostExtended1',
+            $admin->getClass(),
+            'getClass() should return the name of the sub class when passed through a request query parameter.'
+        );
 
         $request->query->set('subclass', 'inject');
         $this->assertNull($admin->getActiveSubclassCode());


### PR DESCRIPTION
I am targeting this branch, because the issue (loops in our phpcr admin) occurs on this branch.

## Changelog
```Markdown
### Changed
- Improvements on `AbstractAdmin::getClass()` method
```

## Subject

I faced some loops in our phpcr admin imlementation casuse we used `getClass() method in our `AbstractAdmin::getSubject()` implementation, cause getClass() calls getSubject() again. We had to solve our issue in our code, but here are some fixes to make the code consistent to the doc block information.