### PR TITLE
Deprecated AbstractAdmin::addSubClass()

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,11 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated AbstractAdmin::addSubClass
+
+This method was inconsistent with the structure of `AbstractAdmin::$subClasses`,
+which is supposed to contain a hash that associates aliases with FQCNs. Use `AbstractAdmin::setSubClasses` instead.
+
 UPGRADE FROM 3.27 to 3.28
 =========================
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -959,8 +959,16 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return $this->subClasses;
     }
 
+    /**
+     * NEXT_MAJOR: remove this method.
+     */
     public function addSubClass($subClass)
     {
+        @trigger_error(sprintf(
+            'Method "%s" is deprecated since 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if (!in_array($subClass, $this->subClasses)) {
             $this->subClasses[] = $subClass;
         }

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -779,6 +779,20 @@ class AdminTest extends TestCase
         $this->assertTrue($admin->hasActiveSubClass());
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Method "Sonata\AdminBundle\Admin\AbstractAdmin::addSubClass" is deprecated since 3.x and will be removed in 4.0.
+     */
+    public function testAddSubClassIsDeprecated()
+    {
+        $admin = new PostAdmin(
+            'sonata.post.admin.post',
+            Post::class,
+            'SonataNewsBundle:PostAdmin'
+        );
+        $admin->addSubClass('whatever');
+    }
+
     public function testGetPerPageOptions()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');


### PR DESCRIPTION

I am targeting this branch, because this is BC.

Refs #4543 @vyshkant , I did not have the courage to read it again, but maybe using `setSubClasses` would solve the issues you had.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `AbstractAdmin::addSubClass()`
```

## Subject

As spotted by @ElectricMaxxx , this method is incoherent with the underlying property, which is supposed to be a hash and not a simple array.
