### PR TITLE
Fix missing trans filter in form_group and form_tab description

### DIFF
--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -44,7 +44,9 @@
                                         <div class="box-body  container-fluid">
                                             <div class="sonata-ba-collapsed-fields">
                                                 {% if form_tab.description != false %}
-                                                    <p>{{ form_tab.description|raw }}</p>
+                                                    <p>
+                                                        {{ form_tab.description|trans({}, form_tab.translation_domain ?: admin.translationDomain) }}
+                                                    </p>
                                                 {% endif %}
 
                                                 {{ form_helper.render_groups(admin, form, form_tab['groups'], has_tab) }}

--- a/src/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -14,7 +14,7 @@
                 <div class="box-body">
                     <div class="sonata-ba-collapsed-fields">
                         {% if form_group.description %}
-                            <p>{{ form_group.description|raw }}</p>
+                            <p>{{ form_group.description|trans({}, form_group.translation_domain ?: admin.translationDomain) }}</p>
                         {% endif %}
 
                         {% for field_name in form_group.fields if form[field_name] is defined %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because some texts are not translatable in admin.

## Changelog
```markdown
### Fixed
- Add trans filter to form_group and form_tab description
```

## Subject

Fix missing trans filter in form_group and form_tab description
