### PR TITLE
Add twig extension for deprecating templates

### DIFF
--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -23,6 +23,7 @@ use Twig\Error\LoaderError;
 use Twig\Extension\AbstractExtension;
 use Twig\Template;
 use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -113,6 +114,15 @@ class SonataAdminExtension extends AbstractExtension
             new TwigFilter(
                 'sonata_xeditable_choices',
                 [$this, 'getXEditableChoices']
+            ),
+        ];
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('deprecate_template',
+                [$this, 'deprecateTemplate']
             ),
         ];
     }
@@ -485,5 +495,15 @@ EOT;
         }
 
         return $template;
+    }
+
+    public function deprecateTemplate($oldTemplateName, $newTemplateName)
+    {
+        @trigger_error(sprintf(
+            'The "%s" template is deprecated.'
+            .' Use "@SonataAdminBundle/CRUD/Association/%s" instead.',
+            $oldTemplateName,
+            $newTemplateName
+        ), E_USER_DEPRECATED);
     }
 }

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -2309,4 +2309,13 @@ EOT
             $string
         ));
     }
+
+    /**
+     * @expectedDeprecation The "old.html.twig" template is deprecated. Use "@SonataAdminBundle/CRUD/Association/new.html.twig" instead.
+     * @group legacy
+     */
+    public function testDeprecateTemplate()
+    {
+        $this->twigExtension->deprecateTemplate('old.html.twig', 'new.html.twig');
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am adding a twig function for deprecating templates, needed for https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/772

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added twig extension for deprecating templates
```

## To do

- [x] Update the tests
- [ ] Update documentation
## Subject

We needed a way to deprecate old templates, this is used for https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/772 as suggested it is better to be in this bundle than in `SonataDoctrineORMAdminBundle`.