### PR TITLE
Extra and remove assets added to configuration

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -173,7 +173,7 @@ Full Configuration Options
             assets:
                 stylesheets:
 
-                    # Defaults:
+                    # The default stylesheet list:
                     - bundles/sonatacore/vendor/bootstrap/dist/css/bootstrap.min.css
                     - bundles/sonatacore/vendor/components-font-awesome/css/font-awesome.min.css
                     - bundles/sonatacore/vendor/ionicons/css/ionicons.min.css
@@ -189,9 +189,16 @@ Full Configuration Options
                     - bundles/sonataadmin/css/layout.css
                     - bundles/sonataadmin/css/tree.css
                     - bundles/sonataadmin/css/colors.css
+
+                # stylesheet paths to add to the page in addition to the list above
+                extra_stylesheets: []
+
+                # stylesheet paths to remove from the page
+                remove_stylesheets: []
+
                 javascripts:
 
-                    # Defaults:
+                    # The default javascript list:
                     - bundles/sonatacore/vendor/jquery/dist/jquery.min.js
                     - bundles/sonataadmin/vendor/jquery.scrollTo/jquery.scrollTo.min.js
                     - bundles/sonatacore/vendor/moment/min/moment.min.js
@@ -210,6 +217,13 @@ Full Configuration Options
                     - bundles/sonataadmin/vendor/waypoints/lib/shortcuts/sticky.min.js
                     - bundles/sonataadmin/Admin.js
                     - bundles/sonataadmin/treeview.js
+
+                # javascript paths to add to the page in addition to the list above
+                extra_javascripts: []
+
+                # javascript paths to remove from the page
+                remove_javascripts: []
+
             extensions:
 
                 # Prototype

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -361,6 +361,16 @@ class Configuration implements ConfigurationInterface
                             ])
                             ->prototype('scalar')->end()
                         ->end()
+                        ->arrayNode('extra_stylesheets')
+                            ->info('stylesheets to add to the page')
+                            ->defaultValue([])
+                            ->prototype('scalar')->end()
+                        ->end()
+                        ->arrayNode('remove_stylesheets')
+                            ->info('stylesheets to remove from the page')
+                            ->defaultValue([])
+                            ->prototype('scalar')->end()
+                        ->end()
                         ->arrayNode('javascripts')
                             ->defaultValue([
                                 'bundles/sonatacore/vendor/jquery/dist/jquery.min.js',
@@ -394,6 +404,16 @@ class Configuration implements ConfigurationInterface
                                 'bundles/sonataadmin/Admin.js',
                                 'bundles/sonataadmin/treeview.js',
                             ])
+                            ->prototype('scalar')->end()
+                        ->end()
+                        ->arrayNode('extra_javascripts')
+                            ->info('javascripts to add to the page')
+                            ->defaultValue([])
+                            ->prototype('scalar')->end()
+                        ->end()
+                        ->arrayNode('remove_javascripts')
+                            ->info('javascripts to remove from the page')
+                            ->defaultValue([])
                             ->prototype('scalar')->end()
                         ->end()
                     ->end()

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -153,8 +153,8 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
-        $config['options']['javascripts'] = $config['assets']['javascripts'];
-        $config['options']['stylesheets'] = $config['assets']['stylesheets'];
+        $config['options']['javascripts'] = $this->buildJavascripts($config);
+        $config['options']['stylesheets'] = $this->buildStylesheets($config);
         $config['options']['role_admin'] = $config['security']['role_admin'];
         $config['options']['role_super_admin'] = $config['security']['role_super_admin'];
 
@@ -449,6 +449,38 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
     public function getNamespace()
     {
         return 'https://sonata-project.org/schema/dic/admin';
+    }
+
+    private function buildStylesheets($config)
+    {
+        return $this->mergeArray(
+            $config['assets']['stylesheets'],
+            $config['assets']['extra_stylesheets'],
+            $config['assets']['remove_stylesheets']
+        );
+    }
+
+    private function buildJavascripts($config)
+    {
+        return $this->mergeArray(
+            $config['assets']['javascripts'],
+            $config['assets']['extra_javascripts'],
+            $config['assets']['remove_javascripts']
+        );
+    }
+
+    private function mergeArray($array, $addArray, $removeArray = [])
+    {
+        foreach ($addArray as $toAdd) {
+            array_push($array, $toAdd);
+        }
+        foreach ($removeArray as $toRemove) {
+            if (in_array($toRemove, $array)) {
+                array_splice($array, array_search($toRemove, $array), 1);
+            }
+        }
+
+        return $array;
     }
 
     private function replacePropertyAccessor(ContainerBuilder $container)

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -219,6 +219,22 @@ class ConfigurationTest extends TestCase
         $this->assertSame('ROLE_SUPER_ADMIN', $config['security']['role_super_admin']);
     }
 
+    public function testExtraAssetsDefaults()
+    {
+        $config = $this->process([[]]);
+
+        $this->assertSame([], $config['assets']['extra_stylesheets']);
+        $this->assertSame([], $config['assets']['extra_javascripts']);
+    }
+
+    public function testRemoveAssetsDefaults()
+    {
+        $config = $this->process([[]]);
+
+        $this->assertSame([], $config['assets']['remove_stylesheets']);
+        $this->assertSame([], $config['assets']['remove_javascripts']);
+    }
+
     /**
      * Processes an array of configurations and returns a compiled version.
      *

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -50,6 +50,210 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('sonata.admin.configuration.security.role_super_admin');
     }
 
+    public function testExtraStylesheetsGetAdded()
+    {
+        $this->container->setParameter('kernel.bundles', []);
+        $this->load([
+            'assets' => [
+                'extra_stylesheets' => [
+                    'foo/bar.css',
+                    'bar/quux.css',
+                ],
+            ],
+        ]);
+        $stylesheets = $this->container->getDefinition('sonata.admin.pool')->getArgument(3)['stylesheets'];
+
+        $this->assertEquals($stylesheets, [
+            'bundles/sonatacore/vendor/bootstrap/dist/css/bootstrap.min.css',
+            'bundles/sonatacore/vendor/components-font-awesome/css/font-awesome.min.css',
+            'bundles/sonatacore/vendor/ionicons/css/ionicons.min.css',
+            'bundles/sonataadmin/vendor/admin-lte/dist/css/AdminLTE.min.css',
+            'bundles/sonataadmin/vendor/admin-lte/dist/css/skins/skin-black.min.css',
+            'bundles/sonataadmin/vendor/iCheck/skins/square/blue.css',
+            'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css',
+            'bundles/sonataadmin/vendor/jqueryui/themes/base/jquery-ui.css',
+            'bundles/sonatacore/vendor/select2/select2.css',
+            'bundles/sonatacore/vendor/select2-bootstrap-css/select2-bootstrap.min.css',
+            'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/css/bootstrap-editable.css',
+            'bundles/sonataadmin/css/styles.css',
+            'bundles/sonataadmin/css/layout.css',
+            'bundles/sonataadmin/css/tree.css',
+            'foo/bar.css',
+            'bar/quux.css',
+        ]);
+    }
+
+    public function testRemoveStylesheetsGetRemoved()
+    {
+        $this->container->setParameter('kernel.bundles', []);
+        $this->load([
+            'assets' => [
+                'remove_stylesheets' => [
+                    'bundles/sonataadmin/vendor/admin-lte/dist/css/skins/skin-black.min.css',
+                    'bundles/sonataadmin/vendor/jqueryui/themes/base/jquery-ui.css',
+                ],
+            ],
+        ]);
+
+        $stylesheets = $this->container->getDefinition('sonata.admin.pool')->getArgument(3)['stylesheets'];
+
+        $this->assertEquals($stylesheets, [
+            'bundles/sonatacore/vendor/bootstrap/dist/css/bootstrap.min.css',
+            'bundles/sonatacore/vendor/components-font-awesome/css/font-awesome.min.css',
+            'bundles/sonatacore/vendor/ionicons/css/ionicons.min.css',
+            'bundles/sonataadmin/vendor/admin-lte/dist/css/AdminLTE.min.css',
+            'bundles/sonataadmin/vendor/iCheck/skins/square/blue.css',
+            'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css',
+            'bundles/sonatacore/vendor/select2/select2.css',
+            'bundles/sonatacore/vendor/select2-bootstrap-css/select2-bootstrap.min.css',
+            'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/css/bootstrap-editable.css',
+            'bundles/sonataadmin/css/styles.css',
+            'bundles/sonataadmin/css/layout.css',
+            'bundles/sonataadmin/css/tree.css',
+        ]);
+    }
+
+    public function testExtraJavascriptsGetAdded()
+    {
+        $this->container->setParameter('kernel.bundles', []);
+        $this->load([
+            'assets' => [
+                'extra_javascripts' => [
+                    'foo/bar.js',
+                    'bar/quux.js',
+                ],
+            ],
+        ]);
+        $javascripts = $this->container->getDefinition('sonata.admin.pool')->getArgument(3)['javascripts'];
+
+        $this->assertEquals($javascripts, [
+            'bundles/sonatacore/vendor/jquery/dist/jquery.min.js',
+            'bundles/sonataadmin/vendor/jquery.scrollTo/jquery.scrollTo.min.js',
+            'bundles/sonatacore/vendor/moment/min/moment.min.js',
+            'bundles/sonataadmin/vendor/jqueryui/ui/minified/jquery-ui.min.js',
+            'bundles/sonataadmin/vendor/jqueryui/ui/minified/i18n/jquery-ui-i18n.min.js',
+            'bundles/sonatacore/vendor/bootstrap/dist/js/bootstrap.min.js',
+            'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js',
+            'bundles/sonataadmin/vendor/jquery-form/jquery.form.js',
+            'bundles/sonataadmin/jquery/jquery.confirmExit.js',
+            'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/js/bootstrap-editable.min.js',
+            'bundles/sonatacore/vendor/select2/select2.min.js',
+            'bundles/sonataadmin/vendor/admin-lte/dist/js/app.min.js',
+            'bundles/sonataadmin/vendor/iCheck/icheck.min.js',
+            'bundles/sonataadmin/vendor/slimScroll/jquery.slimscroll.min.js',
+            'bundles/sonataadmin/vendor/waypoints/lib/jquery.waypoints.min.js',
+            'bundles/sonataadmin/vendor/waypoints/lib/shortcuts/sticky.min.js',
+            'bundles/sonataadmin/vendor/readmore-js/readmore.min.js',
+            'bundles/sonataadmin/vendor/masonry/dist/masonry.pkgd.min.js',
+            'bundles/sonataadmin/Admin.js',
+            'bundles/sonataadmin/treeview.js',
+            'foo/bar.js',
+            'bar/quux.js',
+        ]);
+    }
+
+    public function testRemoveJavascriptsGetRemoved()
+    {
+        $this->container->setParameter('kernel.bundles', []);
+        $this->load([
+            'assets' => [
+                'remove_javascripts' => [
+                    'bundles/sonataadmin/vendor/readmore-js/readmore.min.js',
+                    'bundles/sonataadmin/jquery/jquery.confirmExit.js',
+                ],
+            ],
+        ]);
+        $javascripts = $this->container->getDefinition('sonata.admin.pool')->getArgument(3)['javascripts'];
+
+        $this->assertEquals($javascripts, [
+            'bundles/sonatacore/vendor/jquery/dist/jquery.min.js',
+            'bundles/sonataadmin/vendor/jquery.scrollTo/jquery.scrollTo.min.js',
+            'bundles/sonatacore/vendor/moment/min/moment.min.js',
+            'bundles/sonataadmin/vendor/jqueryui/ui/minified/jquery-ui.min.js',
+            'bundles/sonataadmin/vendor/jqueryui/ui/minified/i18n/jquery-ui-i18n.min.js',
+            'bundles/sonatacore/vendor/bootstrap/dist/js/bootstrap.min.js',
+            'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js',
+            'bundles/sonataadmin/vendor/jquery-form/jquery.form.js',
+            'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/js/bootstrap-editable.min.js',
+            'bundles/sonatacore/vendor/select2/select2.min.js',
+            'bundles/sonataadmin/vendor/admin-lte/dist/js/app.min.js',
+            'bundles/sonataadmin/vendor/iCheck/icheck.min.js',
+            'bundles/sonataadmin/vendor/slimScroll/jquery.slimscroll.min.js',
+            'bundles/sonataadmin/vendor/waypoints/lib/jquery.waypoints.min.js',
+            'bundles/sonataadmin/vendor/waypoints/lib/shortcuts/sticky.min.js',
+            'bundles/sonataadmin/vendor/masonry/dist/masonry.pkgd.min.js',
+            'bundles/sonataadmin/Admin.js',
+            'bundles/sonataadmin/treeview.js',
+        ]);
+    }
+
+    public function testAssetsCanBeAddedAndRemoved()
+    {
+        $this->container->setParameter('kernel.bundles', []);
+        $this->load([
+            'assets' => [
+                'extra_stylesheets' => [
+                    'foo/bar.css',
+                    'bar/quux.css',
+                ],
+                'remove_stylesheets' => [
+                    'bundles/sonataadmin/vendor/admin-lte/dist/css/skins/skin-black.min.css',
+                    'bundles/sonataadmin/vendor/jqueryui/themes/base/jquery-ui.css',
+                ],
+                'extra_javascripts' => [
+                    'foo/bar.js',
+                    'bar/quux.js',
+                ],
+                'remove_javascripts' => [
+                    'bundles/sonataadmin/vendor/readmore-js/readmore.min.js',
+                    'bundles/sonataadmin/jquery/jquery.confirmExit.js',
+                ],
+            ],
+        ]);
+        $stylesheets = $this->container->getDefinition('sonata.admin.pool')->getArgument(3)['stylesheets'];
+        $javascripts = $this->container->getDefinition('sonata.admin.pool')->getArgument(3)['javascripts'];
+
+        $this->assertEquals($stylesheets, [
+            'bundles/sonatacore/vendor/bootstrap/dist/css/bootstrap.min.css',
+            'bundles/sonatacore/vendor/components-font-awesome/css/font-awesome.min.css',
+            'bundles/sonatacore/vendor/ionicons/css/ionicons.min.css',
+            'bundles/sonataadmin/vendor/admin-lte/dist/css/AdminLTE.min.css',
+            'bundles/sonataadmin/vendor/iCheck/skins/square/blue.css',
+            'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css',
+            'bundles/sonatacore/vendor/select2/select2.css',
+            'bundles/sonatacore/vendor/select2-bootstrap-css/select2-bootstrap.min.css',
+            'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/css/bootstrap-editable.css',
+            'bundles/sonataadmin/css/styles.css',
+            'bundles/sonataadmin/css/layout.css',
+            'bundles/sonataadmin/css/tree.css',
+            'foo/bar.css',
+            'bar/quux.css',
+        ]);
+
+        $this->assertEquals($javascripts, [
+            'bundles/sonatacore/vendor/jquery/dist/jquery.min.js',
+            'bundles/sonataadmin/vendor/jquery.scrollTo/jquery.scrollTo.min.js',
+            'bundles/sonatacore/vendor/moment/min/moment.min.js',
+            'bundles/sonataadmin/vendor/jqueryui/ui/minified/jquery-ui.min.js',
+            'bundles/sonataadmin/vendor/jqueryui/ui/minified/i18n/jquery-ui-i18n.min.js',
+            'bundles/sonatacore/vendor/bootstrap/dist/js/bootstrap.min.js',
+            'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js',
+            'bundles/sonataadmin/vendor/jquery-form/jquery.form.js',
+            'bundles/sonataadmin/vendor/x-editable/dist/bootstrap3-editable/js/bootstrap-editable.min.js',
+            'bundles/sonatacore/vendor/select2/select2.min.js',
+            'bundles/sonataadmin/vendor/admin-lte/dist/js/app.min.js',
+            'bundles/sonataadmin/vendor/iCheck/icheck.min.js',
+            'bundles/sonataadmin/vendor/slimScroll/jquery.slimscroll.min.js',
+            'bundles/sonataadmin/vendor/waypoints/lib/jquery.waypoints.min.js',
+            'bundles/sonataadmin/vendor/waypoints/lib/shortcuts/sticky.min.js',
+            'bundles/sonataadmin/vendor/masonry/dist/masonry.pkgd.min.js',
+            'bundles/sonataadmin/Admin.js',
+            'bundles/sonataadmin/treeview.js',
+            'foo/bar.js',
+            'bar/quux.js',
+        ]);
+    }
+
     protected function getContainerExtensions()
     {
         return [new SonataAdminExtension()];


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because my change is backwards compatible. It only adds additional configuration features.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #2425
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added possibility to add and remove javascripts/stylesheets without adding all defaults again
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [x] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
This PR will allow developers to add additional stylesheets and javascripts to the page without having to edit the defaults. It also adds configuration to remove stylesheets and javascripts that are added in the default array. Fixes #2425. 