### PR TITLE
Add merged changes from old templates

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_one_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_script.html.twig
@@ -47,7 +47,16 @@ This code manages the one-to-many association field popup
                     return;
                 }
 
-                jQuery('#field_container_{{ id }}').replaceWith(html); // replace the html
+                var $newForm = jQuery(html);
+                var $oldForm = jQuery('#field_container_{{ id }}');
+
+                // Maintain state of file inputs
+                $oldForm.find('input[type="file"]').each(function(){
+                    var id = '#'+$(this).attr('id');
+                    $newForm.find(id).replaceWith($(this));
+                });
+
+                $oldForm.replaceWith($newForm); // replace the html
 
                 Admin.shared_setup(jQuery('#field_container_{{ id }}'));
 

--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
@@ -34,7 +34,7 @@ file that was distributed with this source code.
                         >
                             <fieldset>
                                 <div class="sonata-ba-collapsed-fields">
-                                    {% for field_name in form_group.fields %}
+                                    {% for field_name in form_group.fields if nested_group_field.children[field_name] is defined %}
                                         {% set nested_field = nested_group_field.children[field_name] %}
                                         <div class="sonata-ba-field-{{ id }}-{{ field_name }}">
                                             {% if associationAdmin.formfielddescriptions[field_name] is defined %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am moving merged changes from `SonataDoctrineORMAdminBundle` to templates in this bundle.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added changes that were merged after moving of templates
```

## Subject

As we forgot that association templates were moved to `SonataAdminBundle` people still continued to submit PRs to `SonataDoctrineORMAdminBundle` to change templates, https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/675 and https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/720 are PRs that were merged after moving the temapltes and now as we are deprecating templates in `SonataDoctrineORMAdminBundle` we have to update templates here.
