### PR TITLE
Modify sonata-project/exporter requirement to ^1.7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "knplabs/knp-menu-bundle": "^2.1.1",
         "sonata-project/block-bundle": "^3.2",
         "sonata-project/core-bundle": "^3.6",
-        "sonata-project/exporter": "^1.7",
+        "sonata-project/exporter": "^1.7.1",
         "symfony/class-loader": "^2.8 || ^3.2 || ^4.0",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",


### PR DESCRIPTION
Closes #4841 

```markdown
### Fixed
-  exporter-related error during cache:clear command.
```