### PR TITLE
Fixed invalid class name DependencyInjection\Configuration

### DIFF
--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\AdminBundle\DependencyInjection;
 
-use JMS\DiExtraBundle\DependencyInjection\Configuration;
+use JMS\DiExtraBundle\DependencyInjection\Configuration as JMSDiExtraBundleDependencyInjectionConfiguration;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminExtensionInterface;
@@ -346,7 +346,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
             $annotationPatterns = [$sonataAdminPattern];
         } else {
             // get annotation_patterns default from DiExtraBundle configuration
-            $diExtraConfigDefinition = new Configuration();
+            $diExtraConfigDefinition = new JMSDiExtraBundleDependencyInjectionConfiguration();
             // FIXME: this will break if DiExtraBundle adds any mandatory configuration
             $diExtraConfig = $this->processConfiguration($diExtraConfigDefinition, []);
 

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -17,6 +17,18 @@ use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
 
 class SonataAdminExtensionTest extends AbstractExtensionTestCase
 {
+    /**
+     * @group legacy
+     */
+    public function testContainerCompileWithJMSDiExtraBundle()
+    {
+        $this->container->setParameter('kernel.bundles', [
+            'JMSDiExtraBundle' => true,
+        ]);
+
+        $this->container->compile();
+    }
+
     public function testHasServiceDefinitionForLockExtension()
     {
         $this->container->setParameter('kernel.bundles', []);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed container compile error, if JMSDiExtraBundle is enabled.
```
## Subject

After this changes https://github.com/sonata-project/SonataAdminBundle/commit/d6ffaef34cf6e0b08a12478478d5105eec592b50#diff-156ed93418fe946ee724987b790b24baR349

```
Unrecognized options "security, title, title_logo, options, persist_filters, show_mosaic_button, templates, dashboard, extensions, assets" under "jms_di_extra"
```

Because class `Sonata\AdminBundle\DependencyInjection\Configuration` overrided `JMS\DiExtraBundle\DependencyInjection\Configuration`
