### PR TITLE
Keep menu on left side hidden when browsing

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -217,6 +217,7 @@ Full Configuration Options
                     - bundles/sonataadmin/vendor/waypoints/lib/shortcuts/sticky.min.js
                     - bundles/sonataadmin/Admin.js
                     - bundles/sonataadmin/treeview.js
+                    - bundles/sonataadmin/sidebar.js
 
                 # javascript paths to add to the page in addition to the list above
                 extra_javascripts: []

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -403,6 +403,7 @@ class Configuration implements ConfigurationInterface
 
                                 'bundles/sonataadmin/Admin.js',
                                 'bundles/sonataadmin/treeview.js',
+                                'bundles/sonataadmin/sidebar.js',
                             ])
                             ->prototype('scalar')->end()
                         ->end()

--- a/src/Resources/public/sidebar.js
+++ b/src/Resources/public/sidebar.js
@@ -1,0 +1,20 @@
+/*
+
+ This file is part of the Sonata package.
+
+ (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+ */
+
+jQuery(document).ready(function(){
+    $('.sidebar-toggle').click(function(){
+        if (~document.cookie.indexOf('sonata_sidebar_hide=1')) {
+            return document.cookie = 'sonata_sidebar_hide=0';
+        }
+
+        document.cookie = 'sonata_sidebar_hide=1';
+    });
+});

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -115,7 +115,14 @@ file that was distributed with this source code.
         {% endblock %}
         </title>
     </head>
-    <body {% block body_attributes %}class="sonata-bc skin-black fixed"{% endblock %}>
+    <body
+            {% block body_attributes -%}
+                class="sonata-bc skin-black fixed
+                {% if app.request.cookies.get('sonata_sidebar_hide') -%}
+                    sidebar-collapse
+                {%- endif -%}"
+            {%- endblock -%}
+    >
 
     <div class="wrapper">
 

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -147,6 +147,7 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
             'bundles/sonataadmin/vendor/masonry/dist/masonry.pkgd.min.js',
             'bundles/sonataadmin/Admin.js',
             'bundles/sonataadmin/treeview.js',
+            'bundles/sonataadmin/sidebar.js',
             'foo/bar.js',
             'bar/quux.js',
         ]);
@@ -184,6 +185,7 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
             'bundles/sonataadmin/vendor/masonry/dist/masonry.pkgd.min.js',
             'bundles/sonataadmin/Admin.js',
             'bundles/sonataadmin/treeview.js',
+            'bundles/sonataadmin/sidebar.js',
         ]);
     }
 
@@ -249,6 +251,7 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
             'bundles/sonataadmin/vendor/masonry/dist/masonry.pkgd.min.js',
             'bundles/sonataadmin/Admin.js',
             'bundles/sonataadmin/treeview.js',
+            'bundles/sonataadmin/sidebar.js',
             'foo/bar.js',
             'bar/quux.js',
         ]);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am adding a feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4837

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Menu on the left side stays hidden while changing pages.
```

## Subject

Something I wished I had when working with multiple pages on one screen. When I saw the issue I asked on slack and @Xymanek mentioned that cookies would be a good solution so here it is. I was not sure where should I put the javascript (or should I even use jquery?) so I will move it if you tell me where.
