### PR TITLE
Allow HTML pass-through for autocomplete form type

### DIFF
--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -359,7 +359,7 @@ The available options are:
 
 ``safe_label``
   defaults to ``false``. Set to ``true`` to enable the label to be displayed as Raw HTML,
-  which may cause XSS vulnerability.
+  which may cause an XSS vulnerability.
 
 ``req_param_name_search``
   defaults to "q". Ajax request parameter name which contains the searched text.

--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -358,7 +358,7 @@ The available options are:
   defaults to "". CSS class of dropdown item.
 
 ``safe_label``
-  defaults to ``false``. Set to ``true`` to enable the label to be displayed as Raw HTML,
+  defaults to ``false``. Set to ``true`` to enable the label to be displayed as raw HTML,
   which may cause an XSS vulnerability.
 
 ``req_param_name_search``

--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -357,6 +357,10 @@ The available options are:
 ``dropdown_item_css_class``
   defaults to "". CSS class of dropdown item.
 
+``safe_label``
+  defaults to ``false``. Set to ``true`` to enable the label to be displayed as Raw HTML,
+  which may cause XSS vulnerability
+
 ``req_param_name_search``
   defaults to "q". Ajax request parameter name which contains the searched text.
 

--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -359,7 +359,7 @@ The available options are:
 
 ``safe_label``
   defaults to ``false``. Set to ``true`` to enable the label to be displayed as Raw HTML,
-  which may cause XSS vulnerability
+  which may cause XSS vulnerability.
 
 ``req_param_name_search``
   defaults to "q". Ajax request parameter name which contains the searched text.

--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -84,6 +84,8 @@ class ModelAutocompleteType extends AbstractType
             // add button
             'btn_add',
             'btn_catalogue',
+            // allow HTML
+            'safe_label',
         ] as $passthroughOption) {
             $view->vars[$passthroughOption] = $options[$passthroughOption];
         }
@@ -146,6 +148,9 @@ class ModelAutocompleteType extends AbstractType
             'dropdown_item_css_class' => '',
 
             'dropdown_auto_width' => false,
+
+            // allow HTML
+            'safe_label' => false,
 
             'template' => 'SonataAdminBundle:Form/Type:sonata_type_model_autocomplete.html.twig',
         ]);

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -148,7 +148,11 @@ file that was distributed with this source code.
             // NEXT_MAJOR: Remove this BC layer while upgrading to v4.
             var templateResult = function (item) {
                 return {% block sonata_type_model_autocomplete_dropdown_item_format -%}
-                    jQuery('<div class="{{ dropdown_item_css_class }}">').text(item.label).prop('outerHTML')
+                    {% if safe_label is defined and not safe_label %}
+                        jQuery('<div class="{{ dropdown_item_css_class }}">').text(item.label).prop('outerHTML')
+                    {% else %}
+                        item.label
+                    {% endif %}
                 {%- endblock %}; // format of one dropdown item
             };
             var templateSelection = function (item) {
@@ -157,7 +161,11 @@ file that was distributed with this source code.
                     item.label = item.text;
                 }
                 return {% block sonata_type_model_autocomplete_selection_format -%}
-                    jQuery('<div>').text(item.label).prop('innerHTML')
+                    {% if safe_label is defined and not safe_label %}
+                        jQuery('<div>').text(item.label).prop('innerHTML')
+                    {% else %}
+                        item.label 
+                    {% endif %}
                 {%- endblock %}; // format selected item '<b>'+item.label+'</b>';
             };
 

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -149,7 +149,7 @@ file that was distributed with this source code.
             var templateResult = function (item) {
                 return {% block sonata_type_model_autocomplete_dropdown_item_format -%}
                     {% if safe_label|default(false) %}
-                        item.label
+                        '<div class="{{ dropdown_item_css_class }}">'+item.label+'<\/div>'
                     {% else %}
                         jQuery('<div class="{{ dropdown_item_css_class }}">').text(item.label).prop('outerHTML')
                     {% endif %}

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -148,10 +148,10 @@ file that was distributed with this source code.
             // NEXT_MAJOR: Remove this BC layer while upgrading to v4.
             var templateResult = function (item) {
                 return {% block sonata_type_model_autocomplete_dropdown_item_format -%}
-                    {% if safe_label is defined and not safe_label %}
-                        jQuery('<div class="{{ dropdown_item_css_class }}">').text(item.label).prop('outerHTML')
-                    {% else %}
+                    {% if safe_label is defined and safe_label %}
                         item.label
+                    {% else %}
+                        jQuery('<div class="{{ dropdown_item_css_class }}">').text(item.label).prop('outerHTML')
                     {% endif %}
                 {%- endblock %}; // format of one dropdown item
             };
@@ -161,10 +161,10 @@ file that was distributed with this source code.
                     item.label = item.text;
                 }
                 return {% block sonata_type_model_autocomplete_selection_format -%}
-                    {% if safe_label is defined and not safe_label %}
-                        jQuery('<div>').text(item.label).prop('innerHTML')
+                    {% if safe_label is defined and safe_label %}
+                        item.label
                     {% else %}
-                        item.label 
+                        jQuery('<div>').text(item.label).prop('innerHTML')
                     {% endif %}
                 {%- endblock %}; // format selected item '<b>'+item.label+'</b>';
             };

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -12,13 +12,13 @@ file that was distributed with this source code.
 
     <input type="text" id="{{ id }}_autocomplete_input" value=""
         {%- for attribute,value in attr %} {{attribute}}="{{value}}" {% endfor -%}
-        {%- if read_only is defined and read_only %} readonly="readonly"{% endif -%}    {# NEXT_MAJOR: remove #}
+        {%- if read_only|default(false) %} readonly="readonly"{% endif -%}    {# NEXT_MAJOR: remove #}
         {%- if disabled %} disabled="disabled"{% endif -%}
         {%- if required %} required="required"{% endif %}
     />
 
     <select id="{{ id }}_autocomplete_input_v4" data-sonata-select2="false"
-        {%- if read_only is defined and read_only %} readonly="readonly"{% endif -%}
+        {%- if read_only|default(false) %} readonly="readonly"{% endif -%}
         {%- if disabled %} disabled="disabled"{% endif -%}
         {%- if required %} required="required"{% endif %}
     >
@@ -74,8 +74,8 @@ file that was distributed with this source code.
                 placeholder: '{{ placeholder ?: allowClearPlaceholder }}', // allowClear needs placeholder to work properly
                 allowClear: {{ required ? 'false' : 'true' }},
                 enable: {{ disabled ? 'false' : 'true' }},
-                readonly: {{ read_only is defined and read_only or attr.readonly is defined and attr.readonly ? 'true' : 'false' }}, {# NEXT_MAJOR: remove #}
-                {# readonly: {{ attr.readonly is defined and attr.readonly ? 'true' : 'false' }}, #}    {# NEXT_MAJOR: uncomment #}
+                readonly: {{ read_only|default(false) or attr.read_only|default(false) ? 'true' : 'false' }}, {# NEXT_MAJOR: remove #}
+                {# readonly: {{ attr.read_only|default(false) ? 'true' : 'false' }}, #}    {# NEXT_MAJOR: uncomment #}
                 minimumInputLength: {{ minimum_input_length }},
                 multiple: {{ multiple ? 'true' : 'false' }},
                 width: function() {
@@ -148,7 +148,7 @@ file that was distributed with this source code.
             // NEXT_MAJOR: Remove this BC layer while upgrading to v4.
             var templateResult = function (item) {
                 return {% block sonata_type_model_autocomplete_dropdown_item_format -%}
-                    {% if safe_label is defined and safe_label %}
+                    {% if safe_label|default(false) %}
                         item.label
                     {% else %}
                         jQuery('<div class="{{ dropdown_item_css_class }}">').text(item.label).prop('outerHTML')
@@ -161,7 +161,7 @@ file that was distributed with this source code.
                     item.label = item.text;
                 }
                 return {% block sonata_type_model_autocomplete_selection_format -%}
-                    {% if safe_label is defined and safe_label %}
+                    {% if safe_label|default(false) %}
                         item.label
                     {% else %}
                         jQuery('<div>').text(item.label).prop('innerHTML')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because "Fix XSS vulnerability in autocomplete" #4796 prevent passing HTML through label string, due to security reason. I have added an new option called 'safe_label' which follows KNP menu render wording. By default the safe label is false.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4815

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added new 'safe_label' option to allow HTML pass-through on autocomplete form type
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the documentation
