### PR TITLE
Fix twig dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "symfony/templating": "^2.8 || ^3.2 || ^4.0",
         "symfony/translation": "^2.8 || ^3.2 || ^4.0",
         "symfony/twig-bridge": "^2.8 || ^3.2 || ^4.0",
+        "symfony/twig-bundle": "^2.8 || ^3.2 || ^4.0",
         "symfony/validator": "^2.8 || ^3.2 || ^4.0",
         "twig/extensions": "^1.0",
         "twig/twig": "^1.34 || ^2.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed twig dependency for sonata.admin.controller.admin service
```

## Subject

`sonata-project/admin-bundle` actualy depends on `symfony/twig-bundle`, not from `symfony/twig-bridge`+`twig/twig`.

`sonata.admin.controller.admin` service, defined in `src/Resources/config/core.xml` depends on `twig` service, which defined in `symfony/twig-bundle`. See https://github.com/symfony/twig-bundle/blob/master/Resources/config/twig.xml