### PR TITLE
Fix "request" attribute deprecation on "knp_menu.voter"

### DIFF
--- a/src/Menu/Matcher/Voter/AdminVoter.php
+++ b/src/Menu/Matcher/Voter/AdminVoter.php
@@ -15,6 +15,7 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\VoterInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Admin menu voter based on extra `admin`.
@@ -24,15 +25,36 @@ use Symfony\Component\HttpFoundation\Request;
 class AdminVoter implements VoterInterface
 {
     /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
      * @var Request
      */
     private $request = null;
 
+    public function __construct(RequestStack $requestStack = null)
+    {
+        $this->requestStack = $requestStack;
+    }
+
     /**
+     * @deprecated since version 3.x. Pass a RequestStack to the constructor instead.
+     *
      * @return $this
      */
     public function setRequest($request)
     {
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated since version 3.x.
+                Pass a Symfony\Component\HttpFoundation\RequestStack
+                in the constructor instead.',
+            __METHOD__),
+            E_USER_DEPRECATED
+        );
+
         $this->request = $request;
 
         return $this;
@@ -42,11 +64,16 @@ class AdminVoter implements VoterInterface
     {
         $admin = $item->getExtra('admin');
 
+        $request = $this->request;
+        if (null !== $this->requestStack) {
+            $request = $this->requestStack->getMasterRequest();
+        }
+
         if ($admin instanceof AdminInterface
             && $admin->hasRoute('list') && $admin->hasAccess('list')
-            && $this->request
+            && $request
         ) {
-            $requestCode = $this->request->get('_sonata_admin');
+            $requestCode = $request->get('_sonata_admin');
 
             if ($admin->getCode() === $requestCode) {
                 return true;
@@ -60,7 +87,7 @@ class AdminVoter implements VoterInterface
         }
 
         $route = $item->getExtra('route');
-        if ($route && $this->request && $route == $this->request->get('_route')) {
+        if ($route && $request && $route == $request->get('_route')) {
             return true;
         }
 

--- a/src/Resources/config/menu.xml
+++ b/src/Resources/config/menu.xml
@@ -18,7 +18,8 @@
             <tag name="knp_menu.provider"/>
         </service>
         <service id="sonata.admin.menu.matcher.voter.admin" class="Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter" public="true">
-            <tag name="knp_menu.voter" request="true"/>
+            <argument type="service" id="request_stack"/>
+            <tag name="knp_menu.voter"/>
         </service>
         <service id="sonata.admin.menu.matcher.voter.children" class="Sonata\AdminBundle\Menu\Matcher\Voter\ChildrenVoter" public="true">
             <deprecated>The "%service_id%" service is deprecated since 3.28 and will be removed in 4.0.</deprecated>

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -655,6 +656,9 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $container
             ->register('form.factory')
             ->setClass(FormFactoryInterface::class);
+        $container
+            ->register('request_stack')
+            ->setClass(RequestStack::class);
         foreach ([
             'doctrine_phpcr' => 'PHPCR',
             'orm' => 'ORM', ] as $key => $bundleSubstring) {

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -378,6 +379,9 @@ class ExtensionCompilerPassTest extends TestCase
         $container
             ->register('knp_menu.menu_provider')
             ->setClass(MenuProviderInterface::class);
+        $container
+            ->register('request_stack')
+            ->setClass(RequestStack::class);
 
         // Add admin definition's
         $container

--- a/tests/Menu/Matcher/Voter/AdminVoterTest.php
+++ b/tests/Menu/Matcher/Voter/AdminVoterTest.php
@@ -15,6 +15,7 @@ use Knp\Menu\ItemInterface;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class AdminVoterTest extends AbstractVoterTest
 {
@@ -39,15 +40,32 @@ class AdminVoterTest extends AbstractVoterTest
     }
 
     /**
+     * @group legacy
+     */
+    public function testDeprecatedRequestSetter()
+    {
+        $request = new Request();
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $voter = new AdminVoter();
+        $voter->setRequest($request);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function createVoter($dataVoter, $route)
     {
-        $voter = new AdminVoter();
         $request = new Request();
         $request->request->set('_sonata_admin', $dataVoter);
         $request->request->set('_route', $route);
-        $voter->setRequest($request);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $voter = new AdminVoter($requestStack);
 
         return $voter;
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

@TorbenLundsgaard seems to be away, so I fixed the last issues and merged the conflicts

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataAdminBundle/pull/4808

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `request` attribute deprecation on `knp_menu.voter`

```

## Subject

Using the "request" attribute of the "knp_menu.voter" tag is deprecated since KnpMenuBundle version 2.2. The RequestStack should be injected in the voter instead.
