### PR TITLE
Add asset component to enable use of asset twig function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "sonata-project/block-bundle": "^3.2",
         "sonata-project/core-bundle": "^3.6",
         "sonata-project/exporter": "^1.7.1",
+        "symfony/asset": "^2.8 || ^3.2 || ^4.0",
         "symfony/class-loader": "^2.8 || ^3.2 || ^4.0",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Make explicit dependency with `symfony/asset`
```

## Subject

<!-- Describe your Pull Request content here -->
Trying to make SonataDoctrinePHPCRAdminBundle build pass I saw we make use of `asset` function on twig, but we are not depending on the package that enables this function.