### PR TITLE
Added filter counter

### DIFF
--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -206,6 +206,13 @@ var Admin = {
 
     add_filters: function(subject) {
         Admin.log('[core|add_filters] configure filters on', subject);
+
+        function updateCounter() {
+            var count = jQuery('a.sonata-toggle-filter .fa-check-square-o', subject).length;
+
+            jQuery('.sonata-filter-count', subject).text(count);
+        }
+
         jQuery('a.sonata-toggle-filter', subject).on('click', function(e) {
             e.preventDefault();
             e.stopPropagation();
@@ -249,6 +256,8 @@ var Admin = {
             } else {
                 jQuery(filters_container).slideUp();
             }
+
+            updateCounter();
         });
 
         jQuery('.sonata-filter-form', subject).on('submit', function () {
@@ -263,6 +272,8 @@ var Admin = {
         jQuery('[data-toggle="advanced-filter"]', subject).click(function() {
             jQuery('.advanced-filter').toggle();
         });
+
+        updateCounter();
     },
 
     /**

--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -236,6 +236,7 @@ var Admin = {
 
             if (jQuery(target).is(":visible")) {
                 filterToggler
+                    .filter(':not(.fa-minus-circle)')
                     .removeClass('fa-check-square-o')
                     .addClass('fa-square-o')
                 ;
@@ -244,6 +245,7 @@ var Admin = {
 
             } else {
                 filterToggler
+                    .filter(':not(.fa-minus-circle)')
                     .removeClass('fa-square-o')
                     .addClass('fa-check-square-o')
                 ;

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -235,7 +235,9 @@ file that was distributed with this source code.
             <li class="dropdown sonata-actions">
                 <a href="#" class="dropdown-toggle sonata-ba-action" data-toggle="dropdown">
                     <i class="fa fa-filter" aria-hidden="true"></i>
-                    {{ 'link_filters'|trans({}, 'SonataAdminBundle') }} <b class="caret"></b>
+                    {{ 'link_filters'|trans({}, 'SonataAdminBundle') }}
+                    <span class="badge sonata-filter-count"></span>
+                    <b class="caret"></b>
                 </a>
 
                 <ul class="dropdown-menu" role="menu">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC feature.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
 - Added filter counter to admin lists
```

## Subject

<img width="1032" alt="bildschirmfoto 2018-01-02 um 22 47 53" src="https://user-images.githubusercontent.com/3440437/34501521-952b434a-f00f-11e7-911f-8358f16316ca.PNG">
