### PR TITLE
Add path to cookie to avoid multiple cookies

### DIFF
--- a/src/Resources/public/sidebar.js
+++ b/src/Resources/public/sidebar.js
@@ -12,9 +12,9 @@
 jQuery(document).ready(function(){
     $('.sidebar-toggle').click(function(){
         if (~document.cookie.indexOf('sonata_sidebar_hide=1')) {
-            return document.cookie = 'sonata_sidebar_hide=0';
+            return document.cookie = 'sonata_sidebar_hide=0;path=/';
         }
 
-        document.cookie = 'sonata_sidebar_hide=1';
+        document.cookie = 'sonata_sidebar_hide=1;path=/';
     });
 });


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am fixing a bug with cookies when hiding sidebar.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Added path to cookies when hiding sidebar to avoid creating multiple cookies
```

## Subject

As @jordisala1991 pointed out [here](https://github.com/sonata-project/SonataAdminBundle/pull/4854#issuecomment-354736451), as I did not add the path every page had it own cookie, which leads to some pages having sidebar even when it should be hidden and vice versa, this should fix it.

  