### PR TITLE
Translate some locales in order to match locales available from bower dependencies

### DIFF
--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -65,23 +65,21 @@ file that was distributed with this source code.
                 {% endfor %}
             {% endblock %}
 
-            {% set locale = app.request.locale %}
             {# localize moment #}
-            {% if locale[:2] != 'en' %}
+            {% set localeForMoment = canonicalize_locale_for_moment() %}
+            {% if localeForMoment %}
                 <script src="{{ asset(
                     'bundles/sonatacore/vendor/moment/locale/' ~
-                    locale|lower|replace({'_':'-'}) ~
+                    localeForMoment ~
                     '.js'
                 ) }}"></script>
             {% endif %}
 
             {# localize select2 #}
             {% if sonata_admin.adminPool.getOption('use_select2') %}
-                {% if locale == 'pt' %}{% set locale = 'pt_PT' %}{% endif %}
-
-                {# omit default EN locale #}
-                {% if locale[:2] != 'en' %}
-                    <script src="{{ asset('bundles/sonatacore/vendor/select2/select2_locale_' ~ locale|replace({'_':'-'}) ~ '.js') }}"></script>
+                {% set localeForSelect2 = canonicalize_locale_for_select2() %}
+                {% if localeForSelect2 %}
+                    <script src="{{ asset('bundles/sonatacore/vendor/select2/select2_locale_' ~ localeForSelect2 ~ '.js') }}"></script>
                 {% endif %}
             {% endif %}
         {% endblock %}

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -20,11 +20,13 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Exception\NoValueException;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
+use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubFilesystemLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\RequestContext;
@@ -2290,6 +2292,196 @@ EOT
         );
     }
 
+    public function select2LocalesProvider()
+    {
+        return [
+            ['ar', 'ar'],
+            ['az', 'az'],
+            ['bg', 'bg'],
+            ['ca', 'ca'],
+            ['cs', 'cs'],
+            ['da', 'da'],
+            ['de', 'de'],
+            ['el', 'el'],
+            [null, 'en'],
+            ['es', 'es'],
+            ['et', 'et'],
+            ['eu', 'eu'],
+            ['fa', 'fa'],
+            ['fi', 'fi'],
+            ['fr', 'fr'],
+            ['gl', 'gl'],
+            ['he', 'he'],
+            ['hr', 'hr'],
+            ['hu', 'hu'],
+            ['id', 'id'],
+            ['is', 'is'],
+            ['it', 'it'],
+            ['ja', 'ja'],
+            ['ka', 'ka'],
+            ['ko', 'ko'],
+            ['lt', 'lt'],
+            ['lv', 'lv'],
+            ['mk', 'mk'],
+            ['ms', 'ms'],
+            ['nb', 'nb'],
+            ['nl', 'nl'],
+            ['pl', 'pl'],
+            ['pt-PT', 'pt'],
+            ['pt-BR', 'pt-BR'],
+            ['pt-PT', 'pt-PT'],
+            ['ro', 'ro'],
+            ['rs', 'rs'],
+            ['ru', 'ru'],
+            ['sk', 'sk'],
+            ['sv', 'sv'],
+            ['th', 'th'],
+            ['tr', 'tr'],
+            ['ug-CN', 'ug'],
+            ['ug-CN', 'ug-CN'],
+            ['uk', 'uk'],
+            ['vi', 'vi'],
+            ['zh-CN', 'zh'],
+            ['zh-CN', 'zh-CN'],
+            ['zh-TW', 'zh-TW'],
+        ];
+    }
+
+    /**
+     * @dataProvider select2LocalesProvider
+     */
+    public function testCanonicalizedLocaleForSelect2($expected, $original)
+    {
+        $this->assertSame($expected, $this->twigExtension->getCanonicalizedLocaleForSelect2($this->mockExtensionContext($original)));
+    }
+
+    public function momentLocalesProvider()
+    {
+        return [
+            ['af', 'af'],
+            ['ar-dz', 'ar-dz'],
+            ['ar', 'ar'],
+            ['ar-ly', 'ar-ly'],
+            ['ar-ma', 'ar-ma'],
+            ['ar-sa', 'ar-sa'],
+            ['ar-tn', 'ar-tn'],
+            ['az', 'az'],
+            ['be', 'be'],
+            ['bg', 'bg'],
+            ['bn', 'bn'],
+            ['bo', 'bo'],
+            ['br', 'br'],
+            ['bs', 'bs'],
+            ['ca', 'ca'],
+            ['cs', 'cs'],
+            ['cv', 'cv'],
+            ['cy', 'cy'],
+            ['da', 'da'],
+            ['de-at', 'de-at'],
+            ['de', 'de'],
+            ['dv', 'dv'],
+            ['el', 'el'],
+            [null, 'en'],
+            [null, 'en-us'],
+            ['en-au', 'en-au'],
+            ['en-ca', 'en-ca'],
+            ['en-gb', 'en-gb'],
+            ['en-ie', 'en-ie'],
+            ['en-nz', 'en-nz'],
+            ['eo', 'eo'],
+            ['es-do', 'es-do'],
+            ['es', 'es-ar'],
+            ['es', 'es-mx'],
+            ['es', 'es'],
+            ['et', 'et'],
+            ['eu', 'eu'],
+            ['fa', 'fa'],
+            ['fi', 'fi'],
+            ['fo', 'fo'],
+            ['fr-ca', 'fr-ca'],
+            ['fr-ch', 'fr-ch'],
+            ['fr', 'fr'],
+            ['fy', 'fy'],
+            ['gd', 'gd'],
+            ['gl', 'gl'],
+            ['he', 'he'],
+            ['hi', 'hi'],
+            ['hr', 'hr'],
+            ['hu', 'hu'],
+            ['hy-am', 'hy-am'],
+            ['id', 'id'],
+            ['is', 'is'],
+            ['it', 'it'],
+            ['ja', 'ja'],
+            ['jv', 'jv'],
+            ['ka', 'ka'],
+            ['kk', 'kk'],
+            ['km', 'km'],
+            ['ko', 'ko'],
+            ['ky', 'ky'],
+            ['lb', 'lb'],
+            ['lo', 'lo'],
+            ['lt', 'lt'],
+            ['lv', 'lv'],
+            ['me', 'me'],
+            ['mi', 'mi'],
+            ['mk', 'mk'],
+            ['ml', 'ml'],
+            ['mr', 'mr'],
+            ['ms', 'ms'],
+            ['ms-my', 'ms-my'],
+            ['my', 'my'],
+            ['nb', 'nb'],
+            ['ne', 'ne'],
+            ['nl-be', 'nl-be'],
+            ['nl', 'nl'],
+            ['nl', 'nl-nl'],
+            ['nn', 'nn'],
+            ['pa-in', 'pa-in'],
+            ['pl', 'pl'],
+            ['pt-br', 'pt-br'],
+            ['pt', 'pt'],
+            ['ro', 'ro'],
+            ['ru', 'ru'],
+            ['se', 'se'],
+            ['si', 'si'],
+            ['sk', 'sk'],
+            ['sl', 'sl'],
+            ['sq', 'sq'],
+            ['sr-cyrl', 'sr-cyrl'],
+            ['sr', 'sr'],
+            ['ss', 'ss'],
+            ['sv', 'sv'],
+            ['sw', 'sw'],
+            ['ta', 'ta'],
+            ['te', 'te'],
+            ['tet', 'tet'],
+            ['th', 'th'],
+            ['tlh', 'tlh'],
+            ['tl-ph', 'tl-ph'],
+            ['tr', 'tr'],
+            ['tzl', 'tzl'],
+            ['tzm', 'tzm'],
+            ['tzm-latn', 'tzm-latn'],
+            ['uk', 'uk'],
+            ['uz', 'uz'],
+            ['vi', 'vi'],
+            ['x-pseudo', 'x-pseudo'],
+            ['yo', 'yo'],
+            ['zh-cn', 'zh-cn'],
+            ['zh-hk', 'zh-hk'],
+            ['zh-tw', 'zh-tw'],
+        ];
+    }
+
+    /**
+     * @dataProvider momentLocalesProvider
+     */
+    public function testCanonicalizedLocaleForMoment($expected, $original)
+    {
+        $this->assertSame($expected, $this->twigExtension->getCanonicalizedLocaleForMoment($this->mockExtensionContext($original)));
+    }
+
     /**
      * This method generates url part for Twig layout.
      *
@@ -2309,5 +2501,15 @@ EOT
             ' ',
             $string
         ));
+    }
+
+    private function mockExtensionContext($locale)
+    {
+        $request = $this->createMock(Request::class);
+        $request->method('getLocale')->willReturn($locale);
+        $appVariable = $this->createMock(AppVariable::class);
+        $appVariable->method('getRequest')->willReturn($request);
+
+        return ['app' => $appVariable];
     }
 }


### PR DESCRIPTION
I am targeting this branch, because there are some locales from bower dependencies which are not found under the current implementation.
## Changelog
```Markdown
### Fixed
- Not found issues for some locales which are not present in frontend dependencies like `moment` or `select2`
```

![image](https://user-images.githubusercontent.com/1231441/34543698-0b5ece9a-f0c1-11e7-8bcf-136f5d795f77.png)

### TODO
- [x] Add tests.

Closes #3642.