### PR TITLE
Update deprecated twig paths

### DIFF
--- a/src/Resources/views/Block/block_admin_list.html.twig
+++ b/src/Resources/views/Block/block_admin_list.html.twig
@@ -35,7 +35,7 @@ file that was distributed with this source code.
                                                 <td>
                                                     <div class="btn-group">
                                                         {% for action in admin.dashboardActions %}
-                                                            {% include action.template|default('SonataAdminBundle:CRUD:dashboard__action.html.twig') with {'action': action} %}
+                                                            {% include action.template|default('@SonataAdmin/CRUD/dashboard__action.html.twig') with {'action': action} %}
                                                         {% endfor %}
                                                     </div>
                                                 </td>

--- a/src/Resources/views/Block/block_rss_dashboard.html.twig
+++ b/src/Resources/views/Block/block_rss_dashboard.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends "SonataBlockBundle:Block:block_core_rss.html.twig" %}
+{% extends "@SonataBlock/Block/block_core_rss.html.twig" %}
 
 {% block block %}
     <div class="box box-warning">

--- a/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
@@ -96,7 +96,7 @@ file that was distributed with this source code.
             {% endif %}
 
             {# include association code #}
-            {% include 'SonataAdminBundle:CRUD/Association:edit_one_script.html.twig' %}
+            {% include '@SonataAdmin/CRUD/Association/edit_one_script.html.twig' %}
 
         {% else %}
             <div id="field_container_{{ id }}" class="field-container">
@@ -118,10 +118,10 @@ file that was distributed with this source code.
                     {% endif %}
                 </span>
 
-                {% include 'SonataAdminBundle:CRUD/Association:edit_modal.html.twig' %}
+                {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
             </div>
 
-            {% include 'SonataAdminBundle:CRUD/Association:edit_many_script.html.twig' %}
+            {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
         {% endif %}
     </div>
 {% endif %}

--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -82,8 +82,8 @@ file that was distributed with this source code.
             {% endif %}
         </div>
 
-        {% include 'SonataAdminBundle:CRUD/Association:edit_modal.html.twig' %}
+        {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
     </div>
 
-    {% include 'SonataAdminBundle:CRUD/Association:edit_many_script.html.twig' %}
+    {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
 {% endif %}

--- a/src/Resources/views/CRUD/Association/edit_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many.html.twig
@@ -19,11 +19,11 @@ file that was distributed with this source code.
             {% if sonata_admin.edit == 'inline' %}
                 {% if sonata_admin.inline == 'table' %}
                     {% if form.children|length > 0 %}
-                        {% include 'SonataAdminBundle:CRUD/Association:edit_one_to_many_inline_table.html.twig' %}
+                        {% include '@SonataAdmin/CRUD/Association/edit_one_to_many_inline_table.html.twig' %}
                     {% endif %}
                 {% elseif form.children|length > 0 %}
                     {% set associationAdmin = sonata_admin.field_description.associationadmin %}
-                    {% include 'SonataAdminBundle:CRUD/Association:edit_one_to_many_inline_tabs.html.twig' %}
+                    {% include '@SonataAdmin/CRUD/Association/edit_one_to_many_inline_tabs.html.twig' %}
 
                 {% endif %}
             {% else %}
@@ -62,14 +62,14 @@ file that was distributed with this source code.
             {# add code for the sortable options #}
             {% if sonata_admin.field_description.options.sortable is defined %}
                 {% if sonata_admin.inline == 'table' %}
-                    {% include 'SonataAdminBundle:CRUD/Association:edit_one_to_many_sortable_script_table.html.twig' %}
+                    {% include '@SonataAdmin/CRUD/Association/edit_one_to_many_sortable_script_table.html.twig' %}
                 {% else %}
-                    {% include 'SonataAdminBundle:CRUD/Association:edit_one_to_many_sortable_script_tabs.html.twig' %}
+                    {% include '@SonataAdmin/CRUD/Association/edit_one_to_many_sortable_script_tabs.html.twig' %}
                 {% endif %}
             {% endif %}
 
             {# include association code #}
-            {% include 'SonataAdminBundle:CRUD/Association:edit_one_script.html.twig' %}
+            {% include '@SonataAdmin/CRUD/Association/edit_one_script.html.twig' %}
 
         {% else %}
             <span id="field_actions_{{ id }}" >
@@ -89,9 +89,9 @@ file that was distributed with this source code.
                 {% endif %}
             </span>
 
-            {% include 'SonataAdminBundle:CRUD/Association:edit_modal.html.twig' %}
+            {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
 
-            {% include 'SonataAdminBundle:CRUD/Association:edit_one_script.html.twig' %}
+            {% include '@SonataAdmin/CRUD/Association/edit_one_script.html.twig' %}
         {% endif %}
     </div>
 {% endif %}

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -82,8 +82,8 @@ file that was distributed with this source code.
             {% endif %}
         </div>
 
-        {% include 'SonataAdminBundle:CRUD/Association:edit_modal.html.twig' %}
+        {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
     </div>
 
-    {% include 'SonataAdminBundle:CRUD/Association:edit_many_script.html.twig' %}
+    {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
 {% endif %}

--- a/src/Resources/views/CRUD/Association/show_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/show_many_to_many.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
     <ul class="sonata-ba-show-many-to-many">

--- a/src/Resources/views/CRUD/Association/show_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/show_many_to_one.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
     {% if value %}

--- a/src/Resources/views/CRUD/Association/show_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/show_one_to_many.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
     <ul class="sonata-ba-show-one-to-many">

--- a/src/Resources/views/CRUD/Association/show_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/show_one_to_one.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/acl.html.twig
+++ b/src/Resources/views/CRUD/acl.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_acl.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_acl.html.twig' %}

--- a/src/Resources/views/CRUD/action.html.twig
+++ b/src/Resources/views/CRUD/action.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends base_template %}
 
 {%- block actions -%}
-    {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
+    {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
 {%- endblock -%}
 
 {% block tab_menu %}

--- a/src/Resources/views/CRUD/base_acl.html.twig
+++ b/src/Resources/views/CRUD/base_acl.html.twig
@@ -12,10 +12,10 @@ file that was distributed with this source code.
 {% extends base_template %}
 
 {%- block actions -%}
-    {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
+    {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
 {%- endblock -%}
 
-{% import 'SonataAdminBundle:CRUD:base_acl_macro.html.twig' as acl %}
+{% import '@SonataAdmin/CRUD/base_acl_macro.html.twig' as acl %}
 
 {% block form %}
     {% block form_acl_roles %}

--- a/src/Resources/views/CRUD/base_acl_macro.html.twig
+++ b/src/Resources/views/CRUD/base_acl_macro.html.twig
@@ -17,7 +17,7 @@ file that was distributed with this source code.
             {% if not admin_pool.getOption('html5_validate') %}novalidate="novalidate"{% endif %}
             >
 
-        {{ include('SonataAdminBundle:Helper:render_form_dismissable_errors.html.twig') }}
+        {{ include('@SonataAdmin/Helper/render_form_dismissable_errors.html.twig') }}
 
         <div class="box box-success">
             <div class="body table-responsive no-padding">

--- a/src/Resources/views/CRUD/base_edit.html.twig
+++ b/src/Resources/views/CRUD/base_edit.html.twig
@@ -25,12 +25,12 @@ file that was distributed with this source code.
 {% endblock %}
 
 {%- block actions -%}
-    {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
+    {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
 {%- endblock -%}
 
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
 
-{% use 'SonataAdminBundle:CRUD:base_edit_form.html.twig' with form as parentForm %}
+{% use '@SonataAdmin/CRUD/base_edit_form.html.twig' with form as parentForm %}
 
 {% block form %}
     {{ block('parentForm') }}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -1,5 +1,5 @@
 {% block form %}
-    {% import "SonataAdminBundle:CRUD:base_edit_form_macro.html.twig" as form_helper %}
+    {% import "@SonataAdmin/CRUD/base_edit_form_macro.html.twig" as form_helper %}
     {{ sonata_block_render_event('sonata.admin.edit.form.top', { 'admin': admin, 'object': object }) }}
 
     {# NEXT_MAJOR: remove default filter #}
@@ -21,7 +21,7 @@
               {% block sonata_form_attributes %}{% endblock %}
               >
 
-            {{ include('SonataAdminBundle:Helper:render_form_dismissable_errors.html.twig') }}
+            {{ include('@SonataAdmin/Helper/render_form_dismissable_errors.html.twig') }}
 
             {% block sonata_pre_fieldsets %}
                 <div class="row">

--- a/src/Resources/views/CRUD/base_history.html.twig
+++ b/src/Resources/views/CRUD/base_history.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends base_template %}
 
 {%- block actions -%}
-    {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
+    {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
 {%- endblock -%}
 
 {% block content %}

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends base_template %}
 
 {%- block actions -%}
-    {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
+    {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
 {%- endblock -%}
 
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
@@ -110,7 +110,7 @@ file that was distributed with this source code.
                                 <span class="progress-description">
                                     {% if not app.request.xmlHttpRequest %}
                                     <ul class="list-unstyled">
-                                        {% include 'SonataAdminBundle:Button:create_button.html.twig' %}
+                                        {% include '@SonataAdmin/Button/create_button.html.twig' %}
                                     </ul>
                                     {% endif %}
                                 </span>

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -20,7 +20,7 @@ file that was distributed with this source code.
 {% endblock %}
 
 {%- block actions -%}
-    {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
+    {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
 {%- endblock -%}
 
 {% block tab_menu %}

--- a/src/Resources/views/CRUD/base_show_compare.html.twig
+++ b/src/Resources/views/CRUD/base_show_compare.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show.html.twig' %}
 
 {% block show_field %}
     <tr class="sonata-ba-view-container history-audit-compare">

--- a/src/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/src/Resources/views/CRUD/batch_confirmation.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends base_template %}
 
 {%- block actions -%}
-    {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
+    {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
 {%- endblock -%}
 
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}

--- a/src/Resources/views/CRUD/delete.html.twig
+++ b/src/Resources/views/CRUD/delete.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends base_template %}
 
 {%- block actions -%}
-    {% include 'SonataAdminBundle:CRUD:action_buttons.html.twig' %}
+    {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
 {%- endblock -%}
 
 {% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}

--- a/src/Resources/views/CRUD/edit.html.twig
+++ b/src/Resources/views/CRUD/edit.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_edit.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_edit.html.twig' %}

--- a/src/Resources/views/CRUD/history.html.twig
+++ b/src/Resources/views/CRUD/history.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_history.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_history.html.twig' %}

--- a/src/Resources/views/CRUD/list.html.twig
+++ b/src/Resources/views/CRUD/list.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list.html.twig' %}

--- a/src/Resources/views/CRUD/list_array.html.twig
+++ b/src/Resources/views/CRUD/list_array.html.twig
@@ -8,7 +8,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% import 'SonataAdminBundle:CRUD:base_array_macro.html.twig' as list %}
+{% import '@SonataAdmin/CRUD/base_array_macro.html.twig' as list %}
 
 {% extends admin.getTemplate('base_list_field') %}
 

--- a/src/Resources/views/CRUD/list_boolean.html.twig
+++ b/src/Resources/views/CRUD/list_boolean.html.twig
@@ -24,5 +24,5 @@ file that was distributed with this source code.
 {% endif %}
 
 {% block field %}
-    {%- include 'SonataAdminBundle:CRUD:display_boolean.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_boolean.html.twig' -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_email.html.twig
+++ b/src/Resources/views/CRUD/list_email.html.twig
@@ -12,5 +12,5 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    {% include 'SonataAdminBundle:CRUD:_email_link.html.twig' %}
+    {% include '@SonataAdmin/CRUD/_email_link.html.twig' %}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_inner_row.html.twig
+++ b/src/Resources/views/CRUD/list_inner_row.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list_inner_row.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list_inner_row.html.twig' %}

--- a/src/Resources/views/CRUD/preview.html.twig
+++ b/src/Resources/views/CRUD/preview.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:edit.html.twig' %}
+{% extends '@SonataAdmin/CRUD/edit.html.twig' %}
 
 {% block actions %}
 {% endblock %}

--- a/src/Resources/views/CRUD/show.html.twig
+++ b/src/Resources/views/CRUD/show.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show.html.twig' %}

--- a/src/Resources/views/CRUD/show_array.html.twig
+++ b/src/Resources/views/CRUD/show_array.html.twig
@@ -8,9 +8,9 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% import 'SonataAdminBundle:CRUD:base_array_macro.html.twig' as show %}
+{% import '@SonataAdmin/CRUD/base_array_macro.html.twig' as show %}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field%}
     {{ show.render_array(value, field_description.options.inline|default(false)) }}

--- a/src/Resources/views/CRUD/show_boolean.html.twig
+++ b/src/Resources/views/CRUD/show_boolean.html.twig
@@ -9,8 +9,8 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- include 'SonataAdminBundle:CRUD:display_boolean.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_boolean.html.twig' -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_choice.html.twig
+++ b/src/Resources/views/CRUD/show_choice.html.twig
@@ -8,7 +8,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field%}
 {% spaceless %}

--- a/src/Resources/views/CRUD/show_compare.html.twig
+++ b/src/Resources/views/CRUD/show_compare.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_compare.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_compare.html.twig' %}

--- a/src/Resources/views/CRUD/show_currency.html.twig
+++ b/src/Resources/views/CRUD/show_currency.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
     {% if value is not null %}

--- a/src/Resources/views/CRUD/show_date.html.twig
+++ b/src/Resources/views/CRUD/show_date.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field%}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/show_datetime.html.twig
+++ b/src/Resources/views/CRUD/show_datetime.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/show_email.html.twig
+++ b/src/Resources/views/CRUD/show_email.html.twig
@@ -1,5 +1,5 @@
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {% include 'SonataAdminBundle:CRUD:_email_link.html.twig' %}
+    {% include '@SonataAdmin/CRUD/_email_link.html.twig' %}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_html.html.twig
+++ b/src/Resources/views/CRUD/show_html.html.twig
@@ -1,4 +1,4 @@
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field%}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/show_percent.html.twig
+++ b/src/Resources/views/CRUD/show_percent.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
     {% set value = value * 100 %}

--- a/src/Resources/views/CRUD/show_time.html.twig
+++ b/src/Resources/views/CRUD/show_time.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/show_trans.html.twig
+++ b/src/Resources/views/CRUD/show_trans.html.twig
@@ -8,7 +8,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field%}
     {% if field_description.options.catalogue is not defined %}

--- a/src/Resources/views/CRUD/show_url.html.twig
+++ b/src/Resources/views/CRUD/show_url.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
 {% spaceless %}

--- a/src/Resources/views/CRUD/tree.html.twig
+++ b/src/Resources/views/CRUD/tree.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
     This template is not used at all, it is just a template that you can use to create
     your own custom tree view.
 #}
-{% extends 'SonataAdminBundle:CRUD:base_list.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list.html.twig' %}
 
 {% import _self as tree %}
 {% macro navigate_child(collection, admin, root) %}
@@ -38,7 +38,7 @@ file that was distributed with this source code.
 {% endmacro %}
 
 {% block tab_menu %}
-    {% include 'SonataAdminBundle:CRUD:list_tab_menu.html.twig' with {
+    {% include '@SonataAdmin/CRUD/list_tab_menu.html.twig' with {
         'mode':   'tree',
         'action': action,
         'admin':  admin,

--- a/src/Resources/views/Core/create_button.html.twig
+++ b/src/Resources/views/Core/create_button.html.twig
@@ -10,6 +10,6 @@ file that was distributed with this source code.
 #}
 
 {# DEPRECATED #}
-{# This file is kept here for backward compatibility - Rather use SonataAdminBundle:Button:create_button.html.twig #}
+{# This file is kept here for backward compatibility - Rather use @SonataAdmin/Button/create_button.html.twig #}
 
-{% extends 'SonataAdminBundle:Button:create_button.html.twig' %}
+{% extends '@SonataAdmin/Button/create_button.html.twig' %}

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -53,8 +53,8 @@ file that was distributed with this source code.
                     {{ btn_add|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}
-            {% include 'SonataAdminBundle:CRUD/Association:edit_modal.html.twig' %}
-            {% include 'SonataAdminBundle:CRUD/Association:edit_many_script.html.twig' %}
+            {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
+            {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
         </div>
     {% endif %}
 

--- a/src/Resources/views/Pager/links.html.twig
+++ b/src/Resources/views/Pager/links.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:Pager:base_links.html.twig' %}
+{% extends '@SonataAdmin/Pager/base_links.html.twig' %}

--- a/src/Resources/views/Pager/results.html.twig
+++ b/src/Resources/views/Pager/results.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:Pager:base_results.html.twig' %}
+{% extends '@SonataAdmin/Pager/base_results.html.twig' %}

--- a/src/Resources/views/Pager/simple_pager_results.html.twig
+++ b/src/Resources/views/Pager/simple_pager_results.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:Pager:base_results.html.twig' %}
+{% extends '@SonataAdmin/Pager/base_results.html.twig' %}
 
 {% block num_results %}
     {% if admin.datagrid.pager.lastPage != admin.datagrid.pager.page %}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -328,7 +328,7 @@ file that was distributed with this source code.
                         {% block sonata_admin_content %}
 
                             {% block notice %}
-                                {% include 'SonataCoreBundle:FlashMessage:render.html.twig' %}
+                                {% include '@SonataCore/FlashMessage/render.html.twig' %}
                             {% endblock notice %}
 
                             {% if _preview is not empty %}

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -141,6 +141,7 @@ class SonataAdminExtensionTest extends TestCase
         $loader = new StubFilesystemLoader([
             __DIR__.'/../../../src/Resources/views/CRUD',
         ]);
+        $loader->addPath(__DIR__.'/../../../src/Resources/views/', 'SonataAdmin');
 
         $this->environment = new \Twig_Environment($loader, [
             'strict_variables' => true,
@@ -241,7 +242,7 @@ class SonataAdminExtensionTest extends TestCase
         $this->admin->expects($this->any())
             ->method('getTemplate')
             ->with($this->equalTo('base_list_field'))
-            ->will($this->returnValue('SonataAdminBundle:CRUD:base_list_field.html.twig'));
+            ->will($this->returnValue('@SonataAdmin/CRUD/base_list_field.html.twig'));
 
         $this->fieldDescription->expects($this->any())
             ->method('getValue')
@@ -266,34 +267,34 @@ class SonataAdminExtensionTest extends TestCase
             ->will($this->returnCallback(function () use ($type) {
                 switch ($type) {
                     case 'string':
-                        return 'SonataAdminBundle:CRUD:list_string.html.twig';
+                        return '@SonataAdmin/CRUD/list_string.html.twig';
                     case 'boolean':
-                        return 'SonataAdminBundle:CRUD:list_boolean.html.twig';
+                        return '@SonataAdmin/CRUD/list_boolean.html.twig';
                     case 'datetime':
-                        return 'SonataAdminBundle:CRUD:list_datetime.html.twig';
+                        return '@SonataAdmin/CRUD/list_datetime.html.twig';
                     case 'date':
-                        return 'SonataAdminBundle:CRUD:list_date.html.twig';
+                        return '@SonataAdmin/CRUD/list_date.html.twig';
                     case 'time':
-                        return 'SonataAdminBundle:CRUD:list_time.html.twig';
+                        return '@SonataAdmin/CRUD/list_time.html.twig';
                     case 'currency':
-                        return 'SonataAdminBundle:CRUD:list_currency.html.twig';
+                        return '@SonataAdmin/CRUD/list_currency.html.twig';
                     case 'percent':
-                        return 'SonataAdminBundle:CRUD:list_percent.html.twig';
+                        return '@SonataAdmin/CRUD/list_percent.html.twig';
                     case 'email':
-                        return 'SonataAdminBundle:CRUD:list_email.html.twig';
+                        return '@SonataAdmin/CRUD/list_email.html.twig';
                     case 'choice':
-                        return 'SonataAdminBundle:CRUD:list_choice.html.twig';
+                        return '@SonataAdmin/CRUD/list_choice.html.twig';
                     case 'array':
-                        return 'SonataAdminBundle:CRUD:list_array.html.twig';
+                        return '@SonataAdmin/CRUD/list_array.html.twig';
                     case 'trans':
-                        return 'SonataAdminBundle:CRUD:list_trans.html.twig';
+                        return '@SonataAdmin/CRUD/list_trans.html.twig';
                     case 'url':
-                        return 'SonataAdminBundle:CRUD:list_url.html.twig';
+                        return '@SonataAdmin/CRUD/list_url.html.twig';
                     case 'html':
-                        return 'SonataAdminBundle:CRUD:list_html.html.twig';
+                        return '@SonataAdmin/CRUD/list_html.html.twig';
                     case 'nonexistent':
                         // template doesn`t exist
-                        return 'SonataAdminBundle:CRUD:list_nonexistent_template.html.twig';
+                        return '@SonataAdmin/CRUD/list_nonexistent_template.html.twig';
                     default:
                         return false;
                 }
@@ -322,7 +323,7 @@ class SonataAdminExtensionTest extends TestCase
         $this->admin->expects($this->any())
             ->method('getTemplate')
             ->with($this->equalTo('base_list_field'))
-            ->will($this->returnValue('SonataAdminBundle:CRUD:base_list_field.html.twig'));
+            ->will($this->returnValue('@SonataAdmin/CRUD/base_list_field.html.twig'));
 
         $this->fieldDescription->expects($this->any())
             ->method('getValue')
@@ -344,7 +345,7 @@ class SonataAdminExtensionTest extends TestCase
 
         $this->fieldDescription->expects($this->any())
             ->method('getTemplate')
-            ->will($this->returnValue('SonataAdminBundle:CRUD:list_nonexistent_template.html.twig'));
+            ->will($this->returnValue('@SonataAdmin/CRUD/list_nonexistent_template.html.twig'));
 
         $this->assertSame(
             $this->removeExtraWhitespace($expected),
@@ -1287,7 +1288,7 @@ EOT
         $this->admin->expects($this->once())
             ->method('getTemplate')
             ->with($this->equalTo('base_list_field'))
-            ->will($this->returnValue('SonataAdminBundle:CRUD:base_list_field.html.twig'));
+            ->will($this->returnValue('@SonataAdmin/CRUD/base_list_field.html.twig'));
 
         $this->fieldDescription->expects($this->once())
             ->method('getValue')
@@ -1303,15 +1304,15 @@ EOT
 
         $this->fieldDescription->expects($this->once())
             ->method('getTemplate')
-            ->will($this->returnValue('SonataAdminBundle:CRUD:list_nonexistent_template.html.twig'));
+            ->will($this->returnValue('@SonataAdmin/CRUD/list_nonexistent_template.html.twig'));
 
         $this->logger->expects($this->once())
             ->method('warning')
             ->with(($this->stringStartsWith($this->removeExtraWhitespace(
                 'An error occured trying to load the template
-                "SonataAdminBundle:CRUD:list_nonexistent_template.html.twig"
+                "@SonataAdmin/CRUD/list_nonexistent_template.html.twig"
                 for the field "Foo_name", the default template
-                    "SonataAdminBundle:CRUD:base_list_field.html.twig" was used
+                    "@SonataAdmin/CRUD/base_list_field.html.twig" was used
                     instead.'
             ))));
 
@@ -1324,16 +1325,16 @@ EOT
     public function testRenderListElementErrorLoadingTemplate()
     {
         $this->expectException(\Twig_Error_Loader::class);
-        $this->expectExceptionMessage('Unable to find template "base_list_nonexistent_field.html.twig"');
+        $this->expectExceptionMessage('Unable to find template "@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig"');
 
         $this->admin->expects($this->once())
             ->method('getTemplate')
             ->with($this->equalTo('base_list_field'))
-            ->will($this->returnValue('SonataAdminBundle:CRUD:base_list_nonexistent_field.html.twig'));
+            ->will($this->returnValue('@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig'));
 
         $this->fieldDescription->expects($this->once())
             ->method('getTemplate')
-            ->will($this->returnValue('SonataAdminBundle:CRUD:list_nonexistent_template.html.twig'));
+            ->will($this->returnValue('@SonataAdmin/CRUD/list_nonexistent_template.html.twig'));
 
         $this->twigExtension->renderListElement($this->environment, $this->object, $this->fieldDescription);
     }
@@ -1345,7 +1346,7 @@ EOT
     {
         $this->admin->expects($this->any())
             ->method('getTemplate')
-            ->will($this->returnValue('SonataAdminBundle:CRUD:base_show_field.html.twig'));
+            ->will($this->returnValue('@SonataAdmin/CRUD/base_show_field.html.twig'));
 
         $this->fieldDescription->expects($this->any())
             ->method('getValue')
@@ -1370,29 +1371,29 @@ EOT
             ->will($this->returnCallback(function () use ($type) {
                 switch ($type) {
                     case 'boolean':
-                        return 'SonataAdminBundle:CRUD:show_boolean.html.twig';
+                        return '@SonataAdmin/CRUD/show_boolean.html.twig';
                     case 'datetime':
-                        return 'SonataAdminBundle:CRUD:show_datetime.html.twig';
+                        return '@SonataAdmin/CRUD/show_datetime.html.twig';
                     case 'date':
-                        return 'SonataAdminBundle:CRUD:show_date.html.twig';
+                        return '@SonataAdmin/CRUD/show_date.html.twig';
                     case 'time':
-                        return 'SonataAdminBundle:CRUD:show_time.html.twig';
+                        return '@SonataAdmin/CRUD/show_time.html.twig';
                     case 'currency':
-                        return 'SonataAdminBundle:CRUD:show_currency.html.twig';
+                        return '@SonataAdmin/CRUD/show_currency.html.twig';
                     case 'percent':
-                        return 'SonataAdminBundle:CRUD:show_percent.html.twig';
+                        return '@SonataAdmin/CRUD/show_percent.html.twig';
                     case 'email':
-                        return 'SonataAdminBundle:CRUD:show_email.html.twig';
+                        return '@SonataAdmin/CRUD/show_email.html.twig';
                     case 'choice':
-                        return 'SonataAdminBundle:CRUD:show_choice.html.twig';
+                        return '@SonataAdmin/CRUD/show_choice.html.twig';
                     case 'array':
-                        return 'SonataAdminBundle:CRUD:show_array.html.twig';
+                        return '@SonataAdmin/CRUD/show_array.html.twig';
                     case 'trans':
-                        return 'SonataAdminBundle:CRUD:show_trans.html.twig';
+                        return '@SonataAdmin/CRUD/show_trans.html.twig';
                     case 'url':
-                        return 'SonataAdminBundle:CRUD:show_url.html.twig';
+                        return '@SonataAdmin/CRUD/show_url.html.twig';
                     case 'html':
-                        return 'SonataAdminBundle:CRUD:show_html.html.twig';
+                        return '@SonataAdmin/CRUD/show_html.html.twig';
                     default:
                         return false;
                 }
@@ -2019,7 +2020,7 @@ EOT
     {
         $this->fieldDescription->expects($this->any())
             ->method('getTemplate')
-            ->will($this->returnValue('SonataAdminBundle:CRUD:base_list_field.html.twig'));
+            ->will($this->returnValue('@SonataAdmin/CRUD/base_list_field.html.twig'));
 
         $this->fieldDescription->expects($this->any())
             ->method('getFieldName')
@@ -2034,7 +2035,7 @@ EOT
             'object' => $this->object,
         ];
 
-        $template = $this->environment->loadTemplate('SonataAdminBundle:CRUD:base_list_field.html.twig');
+        $template = $this->environment->loadTemplate('@SonataAdmin/CRUD/base_list_field.html.twig');
 
         $this->assertSame(
             '<td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> foo </td>',
@@ -2051,8 +2052,8 @@ EOT
             $this->removeExtraWhitespace(<<<'EOT'
 <!-- START
     fieldName: fd_name
-    template: SonataAdminBundle:CRUD:base_list_field.html.twig
-    compiled template: SonataAdminBundle:CRUD:base_list_field.html.twig
+    template: @SonataAdmin/CRUD/base_list_field.html.twig
+    compiled template: @SonataAdmin/CRUD/base_list_field.html.twig
 -->
     <td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> foo </td>
 <!-- END - fieldName: fd_name -->


### PR DESCRIPTION
I am targeting this branch, because https://github.com/sonata-project/dev-kit/issues/374.

Reference https://github.com/sonata-project/dev-kit/issues/374

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Replace twig paths with new naming conventions
```

## Subject
Colon separators in twig paths is no longer recommended https://symfony.com/doc/3.3/templating/namespaced_paths.html