### PR TITLE
Nested arrays now displays correctly on show/list views

### DIFF
--- a/src/Resources/views/CRUD/base_array_macro.html.twig
+++ b/src/Resources/views/CRUD/base_array_macro.html.twig
@@ -9,9 +9,10 @@ file that was distributed with this source code.
 
 #}
 {% macro render_array(value, inline) %}
+    {% from _self import render_array %}
     {% for key, val in value %}
         {% if val is iterable %}
-            [{{ key }} => {{ _self.render_array(val, inline) }}]
+            [{{ key }} => {{ render_array(val, inline) }}]
         {%  else %}
             [{{ key }} => {{ val }}]
         {%  endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4684 #4436 #4683

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Nested arrays will show properly on show/list fields
```

## Subject

<!-- Describe your Pull Request content here -->
There was an error with newer versions of twig where you need to explicit load macros even when you are recursively calling a macro.