### PR TITLE
Quickfix path in routing (revert)

### DIFF
--- a/docs/reference/dashboard.rst
+++ b/docs/reference/dashboard.rst
@@ -7,7 +7,7 @@ as defined by your ``Admin`` services. This is useful to help you start using
 advantage of the Dashboard.
 
 The Dashboard is, by default, available at ``/admin/dashboard``, which is handled by
-the ``@SonataAdmin/Core/dashboard`` controller action. The default view file for
+the ``SonataAdminBundle:Core:dashboard`` controller action. The default view file for
 this action is ``@SonataAdmin/Core/dashboard.html.twig``, but you can change
 this in your ``config.yml``:
 

--- a/src/Resources/config/routing/sonata_admin.xml
+++ b/src/Resources/config/routing/sonata_admin.xml
@@ -6,7 +6,7 @@
         <default key="permanent">true</default>
     </route>
     <route id="sonata_admin_dashboard" path="/dashboard">
-        <default key="_controller">@SonataAdmin/Core/dashboard</default>
+        <default key="_controller">SonataAdminBundle:Core:dashboard</default>
     </route>
     <route id="sonata_admin_retrieve_form_element" path="/core/get-form-field-element">
         <default key="_controller">sonata.admin.controller.admin:retrieveFormFieldElementAction</default>
@@ -23,7 +23,7 @@
         <default key="_controller">sonata.admin.controller.admin:setObjectFieldValueAction</default>
     </route>
     <route id="sonata_admin_search" path="/search">
-        <default key="_controller">@SonataAdmin/Core/search</default>
+        <default key="_controller">SonataAdminBundle:Core:search</default>
     </route>
     <route id="sonata_admin_retrieve_autocomplete_items" path="/core/get-autocomplete-items">
         <default key="_controller">sonata.admin.controller.admin:retrieveAutocompleteItemsAction</default>


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- path to dashboard
```

## Subject

In the previous PR the routing path was unnecessarily overwritten.