### PR TITLE
update MenuAdminVoter use RequestStack

### DIFF
--- a/src/Menu/Matcher/Voter/AdminVoter.php
+++ b/src/Menu/Matcher/Voter/AdminVoter.php
@@ -15,6 +15,7 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\VoterInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Admin menu voter based on extra `admin`.
@@ -27,6 +28,11 @@ class AdminVoter implements VoterInterface
      * @var Request
      */
     private $request = null;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->request = $requestStack->getMasterRequest();
+    }
 
     /**
      * @return $this

--- a/src/Resources/config/menu.xml
+++ b/src/Resources/config/menu.xml
@@ -18,7 +18,8 @@
             <tag name="knp_menu.provider"/>
         </service>
         <service id="sonata.admin.menu.matcher.voter.admin" class="Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter" public="true">
-            <tag name="knp_menu.voter" request="true"/>
+            <argument type="service" id="request_stack" />
+            <tag name="knp_menu.voter"/>
         </service>
         <service id="sonata.admin.menu.matcher.voter.children" class="Sonata\AdminBundle\Menu\Matcher\Voter\ChildrenVoter" public="true">
             <deprecated>The "%service_id%" service is deprecated since 3.28 and will be removed in 4.0.</deprecated>

--- a/tests/Menu/Matcher/Voter/AdminVoterTest.php
+++ b/tests/Menu/Matcher/Voter/AdminVoterTest.php
@@ -15,6 +15,7 @@ use Knp\Menu\ItemInterface;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class AdminVoterTest extends AbstractVoterTest
 {
@@ -43,13 +44,13 @@ class AdminVoterTest extends AbstractVoterTest
      */
     protected function createVoter($dataVoter, $route)
     {
-        $voter = new AdminVoter();
         $request = new Request();
+        $stack = new RequestStack();
         $request->request->set('_sonata_admin', $dataVoter);
         $request->request->set('_route', $route);
-        $voter->setRequest($request);
+        $stack->push($request);
 
-        return $voter;
+        return new AdminVoter($stack);
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because Using the "request" attribute of the "knp_menu.voter" tag is deprecated since version 2.2.

## Changelog
```markdown
### Changed
- Inject the RequestStack in the Menu AdminVoter instead
```