### PR TITLE
Check abstract model class on retrieveAutocompleteItemsAction 

### DIFF
--- a/src/Controller/HelperController.php
+++ b/src/Controller/HelperController.php
@@ -360,7 +360,10 @@ class HelperController
         }
 
         // subject will be empty to avoid unnecessary database requests and keep autocomplete function fast
-        $admin->setSubject($admin->getNewInstance());
+        $adminModelClass = new \ReflectionClass($admin->getClass());
+        if (!$adminModelClass->isAbstract()) {
+            $admin->setSubject($admin->getNewInstance());
+        }
 
         if ('filter' === $context) {
             // filter


### PR DESCRIPTION
if the model class of an admin instance is abstrac , when using doctrine_orm_model_autocomplete  or sonata_type_model_autocomplete we get an exception : 

> Cannot initialize abstract class

I am targeting this branch, because the change  is backward compatible.

```markdown
### Changed
- Changed `HelperController::retrieveAutocompleteItemsAction` check if admin model class is abstract 
```
