### PR TITLE
Update documentation about configuration of BlockBundle

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -109,7 +109,7 @@ admin block:
 
     # app/config/config.yml
     sonata_block:
-        default_contexts: [cms]
+        default_contexts: [] # this line can be removed for sonata-project/block-bundle >= 3.10.0
         blocks:
             # enable the SonataAdminBundle block
             sonata.admin.block.admin_list:


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

```markdown
### Changed
- Update documentation about configuration of block default contexts
```

## Subject

This PR updates documentation about optional parameter `sonata_block.default_contexts`. See https://github.com/sonata-project/SonataBlockBundle/pull/464#issuecomment-356209084 for details