### PR TITLE
Fix bug when we pass null as fieldName to BaseFieldDescriptor::getFieldValue

### DIFF
--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -262,8 +262,6 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
             return;
         }
 
-        $camelizedFieldName = Inflector::classify($fieldName);
-
         $getters = [];
         $parameters = [];
 
@@ -275,9 +273,14 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         if ($this->getOption('parameters')) {
             $parameters = $this->getOption('parameters');
         }
-        $getters[] = 'get'.$camelizedFieldName;
-        $getters[] = 'is'.$camelizedFieldName;
-        $getters[] = 'has'.$camelizedFieldName;
+
+        if (is_string($fieldName) && '' !== $fieldName) {
+            $camelizedFieldName = Inflector::classify($fieldName);
+
+            $getters[] = 'get'.$camelizedFieldName;
+            $getters[] = 'is'.$camelizedFieldName;
+            $getters[] = 'has'.$camelizedFieldName;
+        }
 
         foreach ($getters as $getter) {
             if (method_exists($object, $getter)) {

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -157,6 +157,18 @@ class BaseFieldDescriptionTest extends TestCase
             $mock3->expects($this->once())->method($method)->will($this->returnValue(42));
             $this->assertSame(42, $description3->getFieldValue($mock3, '_fake'));
         }
+
+        $mock4 = $this->getMockBuilder('MockedTestObject')
+            ->setMethods(['myMethod'])
+            ->getMock();
+        $mock4->expects($this->once())
+            ->method('myMethod')
+            ->will($this->returnValue('myMethodValue'));
+
+        $description4 = new FieldDescription();
+        $description4->setOption('code', 'myMethod');
+
+        $this->assertEquals($description4->getFieldValue($mock4, null), 'myMethodValue');
     }
 
     public function testGetValueNoValueException()


### PR DESCRIPTION
I am targeting this branch, because this is backward compatible bug fix.

## Changelog

```markdown
### Fixed
- Fix bug when we pass null as fieldName to BaseFieldDescriptor::getFieldValue
```

## Subject

After releasing `doctrine/inflector` v1.3.0 unit tests of `sonata-project/doctrine-mongodb-admin-bundle` became failing. That tests tested behavior of `FieldDescriptor` when only `code` option was given before calling `getFieldValue`.

This PR fix bug when we pass null as fieldName to BaseFieldDescriptor::getFieldValue, so only method name given in the `code` option will be used to get a value