### PR TITLE
Decouple from Templating Component, Stage 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/common": "^2.2",
         "doctrine/inflector": "^1.0",
         "knplabs/knp-menu-bundle": "^2.1.1",
-        "sonata-project/block-bundle": "^3.2",
+        "sonata-project/block-bundle": "^3.11",
         "sonata-project/core-bundle": "^3.6",
         "sonata-project/exporter": "^1.7.1",
         "symfony/asset": "^2.8 || ^3.2 || ^4.0",

--- a/docs/cookbook/recipe_custom_action.rst
+++ b/docs/cookbook/recipe_custom_action.rst
@@ -196,7 +196,7 @@ Next we have to add the action in ``configureListFields`` specifying the templat
                     // ...
 
                     'clone' => [
-                        'template' => 'AppBundle:CRUD:list__action_clone.html.twig'
+                        'template' => '@App/CRUD/list__action_clone.html.twig'
                     ]
                 ]
             ])
@@ -250,7 +250,7 @@ The full ``CarAdmin.php`` example looks like this:
                         'edit' => [],
                         'delete' => [],
                         'clone' => [
-                            'template' => 'AppBundle:CRUD:list__action_clone.html.twig'
+                            'template' => '@App/CRUD/list__action_clone.html.twig'
                         ]
                     ]
                 ]);

--- a/docs/cookbook/recipe_customizing_a_mosaic_list.rst
+++ b/docs/cookbook/recipe_customizing_a_mosaic_list.rst
@@ -21,7 +21,7 @@ First, configure the ``outer_list_rows_mosaic`` template key:
             <argument>%sonata.media.admin.media.controller%</argument>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="outer_list_rows_mosaic">SonataMediaBundle:MediaAdmin:list_outer_rows_mosaic.html.twig</argument>
+                    <argument key="outer_list_rows_mosaic">@SonataMedia/MediaAdmin/list_outer_rows_mosaic.html.twig</argument>
                 </argument>
             </call>
 

--- a/docs/cookbook/recipe_knp_menu.rst
+++ b/docs/cookbook/recipe_knp_menu.rst
@@ -90,7 +90,7 @@ You can also override the template of knp_menu used by sonata. The default one i
 
         sonata_admin:
             templates:
-                knp_menu_template:           ApplicationAdminBundle:Menu:custom_knp_menu.html.twig
+                knp_menu_template:           "@ApplicationAdmin/Menu/custom_knp_menu.html.twig"
 
 And voilà, now you have a menu group which contains a link to a sonata admin via its id, to your blog and to a specific article.
 

--- a/docs/cookbook/recipe_row_templates.rst
+++ b/docs/cookbook/recipe_row_templates.rst
@@ -41,7 +41,7 @@ Two template keys need to be set:
             <call method="setTemplates">
                 <argument type="collection">
                     <argument key="inner_list_row">
-                        AppBundle:Admin:inner_row_comment.html.twig
+                        @App/Admin/inner_row_comment.html.twig
                     </argument>
                     <argument key="base_list_field">
                         @SonataAdmin/CRUD/base_list_flat_field.html.twig
@@ -57,7 +57,7 @@ Once the templates are defined, create the template to render the row:
 
 .. code-block:: jinja
 
-    {# AppBundle:Admin:inner_row_comment.html.twig #}
+    {# @App/Admin/inner_row_comment.html.twig #}
 
     {# Extend the default template, which provides batch and action cells #}
     {#     as well as the valid colspan computation #}

--- a/docs/cookbook/recipe_sortable_listing.rst
+++ b/docs/cookbook/recipe_sortable_listing.rst
@@ -78,7 +78,7 @@ and use the default twig template provided in the ``pixSortableBehaviorBundle``
         ->add('_action', null, [
             'actions' => [
                 'move' => [
-                    'template' => 'PixSortableBehaviorBundle:Default:_sort.html.twig'
+                    'template' => '@PixSortableBehavior/Default/_sort.html.twig'
                 ],
             ]
         ]);
@@ -154,7 +154,7 @@ Now we need to define the sort by field to be ``$position``:
                 ->add('_action', null, [
                     'actions' => [
                         'move' => [
-                            'template' => 'AppBundle:Admin:_sort.html.twig'
+                            'template' => '@App/Admin/_sort.html.twig'
                         ],
                     ],
                 ])

--- a/docs/reference/action_show.rst
+++ b/docs/reference/action_show.rst
@@ -157,7 +157,7 @@ The first thing you need to do is define it in app/config/config/yml:
             title:      Acme
             title_logo: img/logo_small.png
             templates:
-                show:       AppBundle:Admin:Display_Client.html.twig
+                show:       "@App/Admin/Display_Client.html.twig
 
 Once you have defined this, Sonata Admin looks for it in the following location:
 

--- a/docs/reference/action_show.rst
+++ b/docs/reference/action_show.rst
@@ -157,7 +157,7 @@ The first thing you need to do is define it in app/config/config/yml:
             title:      Acme
             title_logo: img/logo_small.png
             templates:
-                show:       "@App/Admin/Display_Client.html.twig
+                show:       "@App/Admin/Display_Client.html.twig"
 
 Once you have defined this, Sonata Admin looks for it in the following location:
 

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -291,7 +291,7 @@ If you want to use the Tab Menu in a different way, you can replace the Menu Tem
 
         sonata_admin:
             templates:
-                tab_menu_template:  AppBundle:Admin:own_tab_menu_template.html.twig
+                tab_menu_template:  "@App/Admin/own_tab_menu_template.html.twig"
 
 Translations
 ^^^^^^^^^^^^
@@ -373,7 +373,7 @@ You can add custom items to the actions menu for a specific action by overriding
     {
         if (in_array($action, ['show', 'edit', 'acl']) && $object) {
             $list['custom'] = [
-                'template' => 'AppBundle:Button:custom_button.html.twig',
+                'template' => '@App/Button/custom_button.html.twig',
             ];
         }
 

--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -372,7 +372,7 @@ The available options are:
   items per page.
 
 ``template``
-  defaults to ``SonataAdminBundle:Form/Type:sonata_type_model_autocomplete.html.twig``.
+  defaults to ``@SonataAdmin/Form/Type/sonata_type_model_autocomplete.html.twig``.
   Use this option if you want to override the default template of this form type.
 
 ``btn_add`` and ``btn_catalogue``:
@@ -396,7 +396,7 @@ The available options are:
             $formMapper
                 ->add('category', ModelAutocompleteType::class, [
                     'property' => 'title',
-                    'template' => 'AppBundle:Form/Type:sonata_type_model_autocomplete.html.twig',
+                    'template' => '@App/Form/Type/sonata_type_model_autocomplete.html.twig',
                 ])
             ;
         }
@@ -406,7 +406,7 @@ The available options are:
 
     {# src/AppBundle/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig #}
 
-    {% extends 'SonataAdminBundle:Form/Type:sonata_type_model_autocomplete.html.twig' %}
+    {% extends '@SonataAdmin/Form/Type/sonata_type_model_autocomplete.html.twig' %}
 
     {# change the default selection format #}
     {% block sonata_type_model_autocomplete_selection_format %}'<b>'+item.label+'</b>'{% endblock %}

--- a/docs/reference/preview_mode.rst
+++ b/docs/reference/preview_mode.rst
@@ -53,7 +53,7 @@ globally through the template configuration for the key 'preview':
 
         sonata_admin:
             templates:
-                preview:  AppBundle:CRUD:preview.html.twig
+                preview:  "@App/CRUD/preview.html.twig"
 
 Or per admin entity by overriding the ``getTemplate($name)`` and returning the appropriate template when the key
 matches 'preview':
@@ -69,7 +69,7 @@ matches 'preview':
     {
         switch ($name) {
             case 'preview':
-                return 'AppBundle:CRUD:preview.html.twig';
+                return '@App/CRUD/preview.html.twig';
                 break;
             default:
                 return parent::getTemplate($name);
@@ -86,15 +86,15 @@ a different object you can just set your own variables prior to calling parent()
 
 .. code-block:: jinja
 
-    {# 'AppBundle:CRUD:preview.html.twig #}
+    {# '@App/CRUD/preview.html.twig #}
 
-    {% extends 'AppBundle::layout.html.twig' %}
+    {% extends '@App/layout.html.twig' %}
 
     {% use '@SonataAdmin/CRUD/base_edit_form.html.twig' with form as parentForm %}
 
     {% import '@SonataAdmin/CRUD/base_edit_form_macro.html.twig' as form_helper %}
 
-    {# a block in 'AppBundle::layout.html.twig' expecting article #}
+    {# a block in '@App/layout.html.twig' expecting article #}
     {% block templateContent %}
         {% set article = object %}
 

--- a/docs/reference/search.rst
+++ b/docs/reference/search.rst
@@ -51,7 +51,7 @@ You can also configure the block template per admin while defining the admin:
               <argument />
               <call method="setTemplate">
                   <argument>search_result_block</argument>
-                  <argument>SonataPostBundle:Block:block_search_result.html.twig</argument>
+                  <argument>@SonataPost/Block/block_search_result.html.twig</argument>
               </call>
           </service>
 

--- a/docs/reference/templates.rst
+++ b/docs/reference/templates.rst
@@ -166,7 +166,7 @@ specify the templates to use in the ``Admin`` service definition:
             <argument />
             <call method="setTemplate">
                 <argument>edit</argument>
-                <argument>AppBundle:PostAdmin:edit.html.twig</argument>
+                <argument>@App/PostAdmin/edit.html.twig</argument>
             </call>
         </service>
 
@@ -182,7 +182,7 @@ specify the templates to use in the ``Admin`` service definition:
                     - AppBundle\Entity\Post
                     - ~
                 calls:
-                    - [ setTemplate, [edit, AppBundle:PostAdmin:edit.html.twig]]
+                    - [ setTemplate, [edit, "@App/PostAdmin/edit.html.twig"]]
                 public: true
 
 .. note::

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -118,7 +118,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
             // integrate the SonataUserBundle / FOSUserBundle if the bundle exists
             array_unshift($configs, [
                 'templates' => [
-                    'user_block' => 'SonataUserBundle:Admin/Core:user_block.html.twig',
+                    'user_block' => '@SonataUser/Admin/Core/user_block.html.twig',
                 ],
             ]);
         }

--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -152,7 +152,7 @@ class ModelAutocompleteType extends AbstractType
             // allow HTML
             'safe_label' => false,
 
-            'template' => 'SonataAdminBundle:Form/Type:sonata_type_model_autocomplete.html.twig',
+            'template' => '@SonataAdmin/Form/Type/sonata_type_model_autocomplete.html.twig',
         ]);
 
         $resolver->setRequired(['property']);

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -4,20 +4,20 @@
         <service id="sonata.admin.block.admin_list" class="Sonata\AdminBundle\Block\AdminListBlockService" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.admin.block.admin_list</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="sonata.admin.pool"/>
         </service>
         <service id="sonata.admin.block.search_result" class="Sonata\AdminBundle\Block\AdminSearchBlockService" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.admin.block.search_result</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="sonata.admin.pool"/>
             <argument type="service" id="sonata.admin.search.handler"/>
         </service>
         <service id="sonata.admin.block.stats" class="Sonata\AdminBundle\Block\AdminStatsBlockService" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.admin.block.stats</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="sonata.admin.pool"/>
         </service>
     </services>

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1161,9 +1161,9 @@ class AdminTest extends TestCase
         $this->assertSame([], $admin->getTemplates());
 
         $templates = [
-            'list' => 'FooAdminBundle:CRUD:list.html.twig',
-            'show' => 'FooAdminBundle:CRUD:show.html.twig',
-            'edit' => 'FooAdminBundle:CRUD:edit.html.twig',
+            'list' => '@FooAdmin/CRUD/list.html.twig',
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
         ];
 
         $admin->setTemplates($templates);
@@ -1176,11 +1176,11 @@ class AdminTest extends TestCase
 
         $this->assertNull($admin->getTemplate('edit'));
 
-        $admin->setTemplate('edit', 'FooAdminBundle:CRUD:edit.html.twig');
-        $admin->setTemplate('show', 'FooAdminBundle:CRUD:show.html.twig');
+        $admin->setTemplate('edit', '@FooAdmin/CRUD/edit.html.twig');
+        $admin->setTemplate('show', '@FooAdmin/CRUD/show.html.twig');
 
-        $this->assertSame('FooAdminBundle:CRUD:edit.html.twig', $admin->getTemplate('edit'));
-        $this->assertSame('FooAdminBundle:CRUD:show.html.twig', $admin->getTemplate('show'));
+        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $admin->getTemplate('edit'));
+        $this->assertSame('@FooAdmin/CRUD/show.html.twig', $admin->getTemplate('show'));
     }
 
     public function testGetTemplate2()
@@ -1190,15 +1190,15 @@ class AdminTest extends TestCase
         $this->assertNull($admin->getTemplate('edit'));
 
         $templates = [
-            'list' => 'FooAdminBundle:CRUD:list.html.twig',
-            'show' => 'FooAdminBundle:CRUD:show.html.twig',
-            'edit' => 'FooAdminBundle:CRUD:edit.html.twig',
+            'list' => '@FooAdmin/CRUD/list.html.twig',
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
         ];
 
         $admin->setTemplates($templates);
 
-        $this->assertSame('FooAdminBundle:CRUD:edit.html.twig', $admin->getTemplate('edit'));
-        $this->assertSame('FooAdminBundle:CRUD:show.html.twig', $admin->getTemplate('show'));
+        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $admin->getTemplate('edit'));
+        $this->assertSame('@FooAdmin/CRUD/show.html.twig', $admin->getTemplate('show'));
     }
 
     public function testGetIdParameter()

--- a/tests/Command/ExplainAdminCommandTest.php
+++ b/tests/Command/ExplainAdminCommandTest.php
@@ -116,7 +116,7 @@ class ExplainAdminCommandTest extends TestCase
 
         $this->admin->expects($this->any())
             ->method('getFormTheme')
-            ->will($this->returnValue(['FooBundle::bar.html.twig']));
+            ->will($this->returnValue(['@Foo/bar.html.twig']));
 
         $this->admin->expects($this->any())
             ->method('getFormFieldDescriptions')

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -574,12 +574,12 @@ class CRUDControllerTest extends TestCase
         $this->parameters = [];
         $this->assertInstanceOf(
             Response::class,
-            $this->controller->renderWithExtraParams('FooAdminBundle::foo.html.twig', [], null)
+            $this->controller->renderWithExtraParams('@FooAdmin/foo.html.twig', [], null)
         );
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
-        $this->assertSame('FooAdminBundle::foo.html.twig', $this->template);
+        $this->assertSame('@FooAdmin/foo.html.twig', $this->template);
     }
 
     public function testRenderWithResponse()
@@ -587,14 +587,14 @@ class CRUDControllerTest extends TestCase
         $this->parameters = [];
         $response = $response = new Response();
         $response->headers->set('X-foo', 'bar');
-        $responseResult = $this->controller->renderWithExtraParams('FooAdminBundle::foo.html.twig', [], $response);
+        $responseResult = $this->controller->renderWithExtraParams('@FooAdmin/foo.html.twig', [], $response);
 
         $this->assertSame($response, $responseResult);
         $this->assertSame('bar', $responseResult->headers->get('X-foo'));
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
-        $this->assertSame('FooAdminBundle::foo.html.twig', $this->template);
+        $this->assertSame('@FooAdmin/foo.html.twig', $this->template);
     }
 
     public function testRenderCustomParams()
@@ -603,7 +603,7 @@ class CRUDControllerTest extends TestCase
         $this->assertInstanceOf(
             Response::class,
             $this->controller->renderWithExtraParams(
-                'FooAdminBundle::foo.html.twig',
+                '@FooAdmin/foo.html.twig',
                 ['foo' => 'bar'],
                 null
             )
@@ -612,7 +612,7 @@ class CRUDControllerTest extends TestCase
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
         $this->assertSame('bar', $this->parameters['foo']);
-        $this->assertSame('FooAdminBundle::foo.html.twig', $this->template);
+        $this->assertSame('@FooAdmin/foo.html.twig', $this->template);
     }
 
     public function testRenderAjax()
@@ -622,7 +622,7 @@ class CRUDControllerTest extends TestCase
         $this->assertInstanceOf(
             Response::class,
             $this->controller->renderWithExtraParams(
-                'FooAdminBundle::foo.html.twig',
+                '@FooAdmin/foo.html.twig',
                 ['foo' => 'bar'],
                 null
             )
@@ -631,7 +631,7 @@ class CRUDControllerTest extends TestCase
         $this->assertSame('@SonataAdmin/ajax_layout.html.twig', $this->parameters['base_template']);
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
         $this->assertSame('bar', $this->parameters['foo']);
-        $this->assertSame('FooAdminBundle::foo.html.twig', $this->template);
+        $this->assertSame('@FooAdmin/foo.html.twig', $this->template);
     }
 
     public function testListActionAccessDenied()

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -18,12 +18,14 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
 use Sonata\AdminBundle\Route\RoutesCache;
+use Sonata\BlockBundle\DependencyInjection\SonataBlockExtension;
 use Sonata\DoctrinePHPCRAdminBundle\Route\PathInfoBuilderSlashes;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Bundle\FrameworkBundle\Translation\TranslatorInterface;
 use Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory;
 use Symfony\Bundle\FrameworkBundle\Validator\Validator;
+use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -31,6 +33,7 @@ use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -753,6 +756,17 @@ class AddDependencyCallsCompilerPassTest extends TestCase
             ->register('translator.default')
             ->setClass(Translator::class);
         $container->setAlias('translator', 'translator.default');
+
+        // Add definitions for sonata.templating service
+        $container
+            ->register('kernel')
+            ->setClass(KernelInterface::class);
+        $container
+            ->register('file_locator')
+            ->setClass(FileLocatorInterface::class);
+
+        $blockExtension = new SonataBlockExtension();
+        $blockExtension->load([], $container);
 
         return $container;
     }

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -20,14 +20,17 @@ use Sonata\AdminBundle\Admin\AdminExtensionInterface;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
 use Sonata\AdminBundle\Tests\Fixtures\DependencyInjection\TimestampableTrait;
+use Sonata\BlockBundle\DependencyInjection\SonataBlockExtension;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Bundle\FrameworkBundle\Translation\TranslatorInterface;
 use Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -436,6 +439,17 @@ class ExtensionCompilerPassTest extends TestCase
             ->setClass($extensionClass)
             ->addTag('sonata.admin.extension', ['target' => 'sonata_news_admin'])
             ->addTag('sonata.admin.extension', ['target' => 'sonata_article_admin']);
+
+        // Add definitions for sonata.templating service
+        $container
+            ->register('kernel')
+            ->setClass(KernelInterface::class);
+        $container
+            ->register('file_locator')
+            ->setClass(FileLocatorInterface::class);
+
+        $blockExtension = new SonataBlockExtension();
+        $blockExtension->load([], $container);
 
         return $container;
     }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -53,14 +53,14 @@ class ConfigurationTest extends TestCase
                 'my_admin_id' => [
                     'templates' => [
                         'form' => ['form.twig.html', 'form_extra.twig.html'],
-                        'view' => ['user_block' => 'SonataAdminBundle:mycustomtemplate.html.twig'],
+                        'view' => ['user_block' => '@SonataAdmin/mycustomtemplate.html.twig'],
                         'filter' => [],
                     ],
                 ],
             ],
         ]]);
 
-        $this->assertSame('SonataAdminBundle:mycustomtemplate.html.twig', $config['admin_services']['my_admin_id']['templates']['view']['user_block']);
+        $this->assertSame('@SonataAdmin/mycustomtemplate.html.twig', $config['admin_services']['my_admin_id']['templates']['view']['user_block']);
     }
 
     public function testAdminServicesDefault()

--- a/tests/Fixtures/Command/explain_admin.txt
+++ b/tests/Fixtures/Command/explain_admin.txt
@@ -22,7 +22,7 @@ Datagrid Filters
   - barDateTimeField           datetime        @SonataAdmin/CRUD/bar_datetime.html.twig
 
 Form theme(s)
-  - FooBundle::bar.html.twig
+  - @Foo/bar.html.twig
 
 Form Fields
   - fooTextField               text            @SonataAdmin/CRUD/foo_text.html.twig

--- a/tests/Fixtures/Command/explain_admin_empty_validator.txt
+++ b/tests/Fixtures/Command/explain_admin_empty_validator.txt
@@ -22,7 +22,7 @@ Datagrid Filters
   - barDateTimeField           datetime        @SonataAdmin/CRUD/bar_datetime.html.twig
 
 Form theme(s)
-  - FooBundle::bar.html.twig
+  - @Foo/bar.html.twig
 
 Form Fields
   - fooTextField               text            @SonataAdmin/CRUD/foo_text.html.twig

--- a/tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -68,7 +68,7 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $this->assertSame('', $options['dropdown_css_class']);
         $this->assertSame('', $options['dropdown_item_css_class']);
 
-        $this->assertSame('SonataAdminBundle:Form/Type:sonata_type_model_autocomplete.html.twig', $options['template']);
+        $this->assertSame('@SonataAdmin/Form/Type/sonata_type_model_autocomplete.html.twig', $options['template']);
 
         $this->assertSame('', $options['context']);
 


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Switch all templates references to Twig namespaced syntax
- Switch from templating service to sonata.templating
```

## To do

- [X] Switch all templates references to Twig namespaced syntax. Update docs, src and tests
- [x] Add `sonata-project/block-bundle` to composer.json
- [x] Switch from `templating` service to `sonata.templating`

## Subject

This PR is a part of a big plan of decoupling sonata-project bundles from Templating Component. See sonata-project/dev-kit#380 for details