### PR TITLE
removed PropelBundle from docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,13 +1,12 @@
 Admin Bundle
 ============
 
-**SonataAdminBundle is split into 5 bundles:**
+**SonataAdminBundle is split into 4 bundles:**
 
 * SonataAdminBundle: contains core libraries and services
 * `SonataDoctrineORMAdminBundle <https://github.com/sonata-project/SonataDoctrineORMAdminBundle>`_: integrates Doctrine ORM project with the core admin bundle
-* `SonataDoctrineMongoDBAdminBundle <https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle>`_: integrates MongoDB with the core admin bundle (early stage)
-* `SonataDoctrinePhpcrAdminBundle <https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle>`_: integrates PHPCR with the core admin bundle (early stage)
-* `SonataPropelAdminBundle <https://github.com/sonata-project/SonataPropelAdminBundle>`_: integrates Propel with the core admin bundle (early stage)
+* `SonataDoctrineMongoDBAdminBundle <https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle>`_: integrates MongoDB with the core admin bundle
+* `SonataDoctrinePhpcrAdminBundle <https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle>`_: integrates PHPCR with the core admin bundle
 
 The demo website can be found at http://demo.sonata-project.org.
 


### PR DESCRIPTION
We should remove this from the website too:
https://sonata-project.org/bundles/propel-admin/master/doc/index.html

