### PR TITLE
Only call filter->apply if active (issue #4906)

### DIFF
--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -137,7 +137,9 @@ class Datagrid implements DatagridInterface
 
         foreach ($this->getFilters() as $name => $filter) {
             $this->values[$name] = isset($this->values[$name]) ? $this->values[$name] : null;
-            $filter->apply($this->query, $data[$filter->getFormName()]);
+            if ($filter->isActive()) {
+                $filter->apply($this->query, $data[$filter->getFormName()]);
+            }
         }
 
         if (isset($this->values['_sort_by'])) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a bug in 3.x per issue #4906
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4161
Closes #4906 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Only do `$filter->apply` if the filter is "active" on the datagrid list

```
## Subject

Just added an if ($filter->isActive()) block around the $filter->apply as described in the issue.