### PR TITLE
Fix #4906 Only apply filters if it has a value other than empty

### DIFF
--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -138,7 +138,7 @@ class Datagrid implements DatagridInterface
         foreach ($this->getFilters() as $name => $filter) {
             $this->values[$name] = isset($this->values[$name]) ? $this->values[$name] : null;
             $filterFormName = $filter->getFormName();
-            if (isset($this->values[$filterFormName]['value']) && $this->values[$filterFormName]['value'] != '') {
+            if (isset($this->values[$filterFormName]['value']) && $this->values[$filterFormName]['value'] !== '') {
                 $filter->apply($this->query, $data[$filterFormName]);
             }
         }

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -137,8 +137,9 @@ class Datagrid implements DatagridInterface
 
         foreach ($this->getFilters() as $name => $filter) {
             $this->values[$name] = isset($this->values[$name]) ? $this->values[$name] : null;
-            if ($filter->isActive()) {
-                $filter->apply($this->query, $data[$filter->getFormName()]);
+            $filterFormName = $filter->getFormName();
+            if (isset($this->values[$filterFormName]['value']) && $this->values[$filterFormName]['value'] != '') {
+                $filter->apply($this->query, $data[$filterFormName]);
             }
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a regression in 3.x per issue #4906 and PR #4907 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4906 
Closes #4161 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Only do `$filter->apply` if the filter has a value that is not empty string
```
## Subject
Check that $this->values has a value that is not the empty string before applying the filter.
<!-- Describe your Pull Request content here -->