### PR TITLE
[Docs] Child admin

### DIFF
--- a/docs/reference/child_admin.rst
+++ b/docs/reference/child_admin.rst
@@ -105,10 +105,6 @@ of them, you may override the ``configureRoutes`` method::
         protected function configureRoutes(RouteCollection $collection)
         {
             if ($this->isChild()) {
-
-                // This is the route configuration as a child
-                $collection->clearExcept(['show', 'edit']);
-
                 return;
             }
 


### PR DESCRIPTION
I am targeting this branch, because it is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4916 

## Subject
According to documentation:

```
protected function configureRoutes(RouteCollection $collection)
{
        if ($this->isChild()) {

            // This is the route configuration as a child
            $collection->clearExcept(['show', 'edit']);

            return;
        }

        // This is the route configuration as a parent
        $collection->clear();
 }
```

Clearing **list action** in child admin can cause an error - route doesn't exist, if I want to list child items.

```
        if ($this->isGranted('LIST')) {
            $menu->addChild('Manage Videos', [
                'uri' => $admin->generateUrl('sonata.admin.video.list', ['id' => $id])
            ]);
        }
```