### PR TITLE
Use ModelAutocompleteType without a linked admin class

### DIFF
--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
         {% endif -%}
     </div>
 
-    {% if sonata_admin.field_description.associationadmin is not null %}
+    {% if sonata_admin.field_description.hasAssociationAdmin %}
         <div id="field_actions_{{ id }}" class="field-actions">
             {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') 
                                      and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
         {% endif -%}
     </div>
 
-    {% if sonata_admin.field_description.associationadmin is defined %}
+    {% if sonata_admin.field_description.associationadmin is not null %}
         <div id="field_actions_{{ id }}" class="field-actions">
             {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') 
                                      and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because there is no BC-break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `ModelAutocompleteType` can now be used without a linked admin class
```
## Subject

<!-- Describe your Pull Request content here -->

The variable `sonata_admin.field_description.associationadmin` can be defined but is null

so `{% if sonata_admin.field_description.associationadmin is defined %} ` is TRUE

but the method hasRoute does not exist in object sonata_admin.field_description.associationadmin = null 

please see this article https://straightupcraft.com/articles/testing-if-something-exists-is-defined-length-is-not-null-is-not-empty


Example: I want to use the type sonata_type_model_autocomplete for a field not linked to an admin

```php
<?php

// NavAdmin.php
protected function configureFormFields(FormMapper $formMapper)
   {
			$formMapper
                ->add('share', 'sonata_type_model_autocomplete', [
                'route' => ['name' => 'share_autocomplete'],
                'to_string_callback' => function ($entity, $property) {
                    return $entity->getLabel();
                },
            ]);
     }
```

And

```php
<?php
// ShareController.php
	
 /**
     * @Route("/share/autocomplete", name="share_autocomplete")
     * @param Request $request
     *
     * @return JsonResponse
     */
public function shareAutocompleteAction(Request $request)
    {
        $limit = $request->get('_per_page');
        $query =    /* ...*/ 
        
        $items = $query->getQuery()->getArrayResult();

        return new JsonResponse(['status' => 'OK', 'items' => $items]);
    }	

```
I have this exception

![image](https://user-images.githubusercontent.com/893494/35521707-b8c3c1cc-051a-11e8-8a42-f3d46c405f91.png)


