### PR TITLE
Add missing getOwnerPermissions to AdminObjectAclData

### DIFF
--- a/src/Util/AdminObjectAclData.php
+++ b/src/Util/AdminObjectAclData.php
@@ -280,6 +280,11 @@ class AdminObjectAclData
         return $permissions;
     }
 
+    public function getOwnerPermissions()
+    {
+        return self::$ownerPermissions;
+    }
+
     /**
      * Tests if the current user has the OWNER right.
      *


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #2349
Closes #3209

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Missing `getOwnerPermissions` to `AdminObjectAclData`
```

## Subject

<!-- Describe your Pull Request content here -->
I was travelling through time, and found that 2 issues that was unresolved. Looked to the code and found that a method was missing since 5 years ago when it was added.

This code fixes the issue and adds tests to cover a little this code.

I do not use anything about ACL so I tried my best on the tests.

Code added here: https://github.com/sonata-project/SonataAdminBundle/pull/1475