### PR TITLE
Get form field without calling the children first

### DIFF
--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -273,16 +273,16 @@ file that was distributed with this source code.
                                     {% set filterVisible = filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null %}
                                     <div class="form-group {% block sonata_list_filter_group_class %}{% endblock %}" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ filterVisible ? 'true' : 'false' }}" style="display: {% if filterActive %}block{% else %}none{% endif %}">
                                         {% if filter.label is not same as(false) %}
-                                            <label for="{{ form.children[filter.formName].children['value'].vars.id }}" class="col-sm-3 control-label">{{ filter.label|trans({}, filter.translationDomain ?: admin.translationDomain) }}</label>
+                                            <label for="{{ form[filter.formName].children['value'].vars.id }}" class="col-sm-3 control-label">{{ filter.label|trans({}, filter.translationDomain ?: admin.translationDomain) }}</label>
                                         {% endif %}
-                                        {% set attr = form.children[filter.formName].children['type'].vars.attr|default({}) %}
+                                        {% set attr = form[filter.formName].children['type'].vars.attr|default({}) %}
 
                                         <div class="col-sm-4 advanced-filter">
-                                            {{ form_widget(form.children[filter.formName].children['type'], {'attr':  attr}) }}
+                                            {{ form_widget(form[filter.formName].children['type'], {'attr':  attr}) }}
                                         </div>
 
                                         <div class="col-sm-4">
-                                            {{ form_widget(form.children[filter.formName].children['value']) }}
+                                            {{ form_widget(form[filter.formName].children['value']) }}
                                         </div>
 
                                         <div class="col-sm-1">
@@ -302,7 +302,7 @@ file that was distributed with this source code.
                             <div class="col-sm-3 text-center">
                                 <input type="hidden" name="filter[_page]" id="filter__page" value="1">
 
-                                {% set foo = form.children['_page'].setRendered() %}
+                                {% set foo = form['_page'].setRendered() %}
                                 {{ form_rest(form) }}
 
                                 <div class="form-group">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #2203

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Error if the field in filter list is named `children`
```

## Subject

The issue is with Symfony Forms, in our code, we have `form.children[filter.formName]` and then Symfony gives us the children FormView instead of the property in children array.

```
FormView {#1510 ▼
  +vars: array:30 [▶]
  +parent: null
  +children: array:7 [▼
    "name" => FormView {#1584 ▶}
    "value" => FormView {#1226 ▶}
    "children" => FormView {#1578 ▶}
    "_sort_by" => FormView {#1513 ▶}
    "_sort_order" => FormView {#1526 ▶}
    "_page" => FormView {#1588 ▶}
    "_per_page" => FormView {#1585 ▶}
  ]
  -rendered: false
  -methodRendered: false
}

```

Remove `.children` from `form.children[filter.formName]` fixes the issue.