### PR TITLE
Use form event listener to fix preValidation

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -40,6 +40,8 @@ use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface as RoutingUrlGeneratorInterface;
@@ -2837,7 +2839,12 @@ EOT;
             }
         }
 
-        $this->form = $this->getFormBuilder()->getForm();
+        $formBuilder = $this->getFormBuilder();
+        $formBuilder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
+            $this->preValidate($event->getData());
+        }, 100);
+
+        $this->form = $formBuilder->getForm();
     }
 
     /**

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -314,10 +314,6 @@ class CRUDController implements ContainerAwareInterface
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
-            //TODO: remove this check for 4.0
-            if (method_exists($this->admin, 'preValidate')) {
-                $this->admin->preValidate($existingObject);
-            }
             $isFormValid = $form->isValid();
 
             // persist if the form was valid and if in preview mode the preview was approved
@@ -564,10 +560,6 @@ class CRUDController implements ContainerAwareInterface
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
-            //TODO: remove this check for 4.0
-            if (method_exists($this->admin, 'preValidate')) {
-                $this->admin->preValidate($newObject);
-            }
             $isFormValid = $form->isValid();
 
             // persist if the form was valid and if in preview mode the preview was approved


### PR DESCRIPTION
I am targeting this branch, because is BC.

Closes #4859 

## Changelog

```markdown
### Fixed
- fix behaviour of `AbstractAdmin::preValidate` by relying on form event listener
```

## Subject

The `AbstractAdmin::preValidate` method was not called before the effective symfony validation. This PR fix that by relying on form event listener.

The real Symfony validation is done by the [ValidatorListener](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php) on `FormEvents::POST_SUBMIT` event with the priority 0. 

With this patch, the `preValidation` is called on `FormEvents::POST_SUBMIT` event with the priority 100 (the highest the priority, the earlier a listener is executed).
