### PR TITLE
Don't show admin blocks in global search results when no filters are set for global_search

### DIFF
--- a/src/Block/AdminSearchBlockService.php
+++ b/src/Block/AdminSearchBlockService.php
@@ -68,6 +68,12 @@ class AdminSearchBlockService extends AbstractBlockService
             $blockContext->getSetting('per_page')
         );
 
+        if (false === $pager) {
+            $response = $response ?: new Response();
+
+            return $response->setContent('')->setStatusCode(204);
+        }
+
         return $this->renderPrivateResponse($admin->getTemplate('search_result_block'), [
             'block' => $blockContext->getBlock(),
             'settings' => $blockContext->getSettings(),

--- a/tests/Block/AdminSearchBlockServiceTest.php
+++ b/tests/Block/AdminSearchBlockServiceTest.php
@@ -11,10 +11,12 @@
 
 namespace Sonata\AdminBundle\Tests\Block;
 
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Block\AdminSearchBlockService;
 use Sonata\AdminBundle\Search\SearchHandler;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\BlockBundle\Test\FakeTemplating;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
@@ -51,5 +53,27 @@ class AdminSearchBlockServiceTest extends AbstractBlockServiceTestCase
             'per_page' => 10,
             'icon' => '<i class="fa fa-list"></i>',
         ], $blockContext);
+    }
+
+    public function testGlobalSearchReturnsEmptyWhenFiltersAreDisabled()
+    {
+        $admin = $this->getMockBuilder(AbstractAdmin::class)->disableOriginalConstructor()->getMock();
+        $templating = $this->getMockBuilder(FakeTemplating::class)->disableOriginalConstructor()->getMock();
+
+        $blockService = new AdminSearchBlockService('foo', $templating, $this->pool, $this->searchHandler);
+        $blockContext = $this->getBlockContext($blockService);
+
+        $this->searchHandler->expects(self::once())->method('search')->willReturn(false);
+        $this->pool->expects(self::once())->method('getAdminByAdminCode')->willReturn($admin);
+        $admin->expects(self::once())->method('checkAccess')->with('list')->willReturn(true);
+
+        // Make sure the template is never generated (empty response is required,
+        // but the FakeTemplate always returns an empty response)
+        $templating->expects(self::never())->method('renderResponse');
+
+        $response = $blockService->execute($blockContext);
+
+        static::assertEquals('', $response->getContent());
+        static::assertEquals(204, $response->getStatusCode());
     }
 }


### PR DESCRIPTION
I am targeting this branch, because it is BC.

Closes #4574

## Changelog

```markdown
### Fixed
- Admins without global search filters will no longer be shown in the global search.
```

## Subject
It was not possible to remove an Admin from the global search blocks.

The global search would list all the Admins. An Admin was shown with "no results found" if that Admin had no filters specified, no filters of that Admin had `'global_search' => true`, or no results were found within that Admin.

After this change, the Admin block will not be shown in the global search results if there are no filters specified or all specified filters have `'global_search' => false`.
The Admin block is still shown, however, if there are filters for global search, but no results were found.
