### PR TITLE
Throw exception instead of returning null when a template doesn't exist

### DIFF
--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -144,7 +144,7 @@ of objects to manipulate. We can override this behavior by changing our list tem
     {# src/AppBundle/Resources/views/CRUD/list__batch.html.twig #}
     {# see @SonataAdmin/CRUD/list__batch.html.twig for the current default template #}
 
-    {% extends admin.getTemplate('base_list_field') %}
+    {% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
     {% block field %}
         <input type="checkbox" name="idx[]" value="{{ admin.id(object) }}" />

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -378,11 +378,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     protected $filterTheme = [];
 
     /**
-     * @var array
-     */
-    protected $templates = [];
-
-    /**
      * @var AdminExtensionInterface[]
      */
     protected $extensions = [];
@@ -432,6 +427,11 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      * @var array [action1 => requiredRole1, action2 => [requiredRole2, requiredRole3]]
      */
     protected $accessMapping = [];
+
+    /**
+     * @var TemplateRegistry
+     */
+    private $templateRegistry;
 
     /**
      * The class name managed by the admin class.
@@ -1021,32 +1021,14 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return $this->routeGenerator->generateMenuUrl($this, $name, $parameters, $absolute);
     }
 
-    public function setTemplates(array $templates): void
+    public function setTemplateRegistry(TemplateRegistry $templateRegistry): void
     {
-        $this->templates = $templates;
+        $this->templateRegistry = $templateRegistry;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setTemplate($name, $template): void
+    public function getTemplateRegistry(): TemplateRegistry
     {
-        $this->templates[$name] = $template;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTemplates()
-    {
-        return $this->templates;
-    }
-
-    public function getTemplate($name)
-    {
-        if (isset($this->templates[$name])) {
-            return $this->templates[$name];
-        }
+        return $this->templateRegistry;
     }
 
     public function getNewInstance()
@@ -2271,7 +2253,7 @@ EOT;
             && $this->hasRoute('create')
         ) {
             $buttonList['create'] = [
-                'template' => $this->getTemplate('button_create'),
+                'template' => $this->getTemplateRegistry()->getTemplate('button_create'),
             ];
         }
 
@@ -2280,7 +2262,7 @@ EOT;
             && $this->hasRoute('edit')
         ) {
             $buttonList['edit'] = [
-                'template' => $this->getTemplate('button_edit'),
+                'template' => $this->getTemplateRegistry()->getTemplate('button_edit'),
             ];
         }
 
@@ -2289,7 +2271,7 @@ EOT;
             && $this->hasRoute('history')
         ) {
             $buttonList['history'] = [
-                'template' => $this->getTemplate('button_history'),
+                'template' => $this->getTemplateRegistry()->getTemplate('button_history'),
             ];
         }
 
@@ -2299,7 +2281,7 @@ EOT;
             && $this->hasRoute('acl')
         ) {
             $buttonList['acl'] = [
-                'template' => $this->getTemplate('button_acl'),
+                'template' => $this->getTemplateRegistry()->getTemplate('button_acl'),
             ];
         }
 
@@ -2309,7 +2291,7 @@ EOT;
             && $this->hasRoute('show')
         ) {
             $buttonList['show'] = [
-                'template' => $this->getTemplate('button_show'),
+                'template' => $this->getTemplateRegistry()->getTemplate('button_show'),
             ];
         }
 
@@ -2318,7 +2300,7 @@ EOT;
             && $this->hasRoute('list')
         ) {
             $buttonList['list'] = [
-                'template' => $this->getTemplate('button_list'),
+                'template' => $this->getTemplateRegistry()->getTemplate('button_list'),
             ];
         }
 
@@ -2342,7 +2324,7 @@ EOT;
             $actions['create'] = [
                 'label' => 'link_add',
                 'translation_domain' => 'SonataAdminBundle',
-                'template' => $this->getTemplate('action_create'),
+                'template' => $this->getTemplateRegistry()->getTemplate('action_create'),
                 'url' => $this->generateUrl('create'),
                 'icon' => 'plus-circle',
             ];
@@ -2564,7 +2546,7 @@ EOT;
             );
 
             $fieldDescription->setAdmin($this);
-            $fieldDescription->setTemplate($this->getTemplate('batch'));
+            $fieldDescription->setTemplate($this->getTemplateRegistry()->getTemplate('batch'));
 
             $mapper->add($fieldDescription, 'batch');
         }
@@ -2588,7 +2570,7 @@ EOT;
             );
 
             $fieldDescription->setAdmin($this);
-            $fieldDescription->setTemplate($this->getTemplate('select'));
+            $fieldDescription->setTemplate($this->getTemplateRegistry()->getTemplate('select'));
 
             $mapper->add($fieldDescription, 'select');
         }

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -32,7 +32,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface
+interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface, AdminTemplateRegistryInterface
 {
     public function setMenuFactory(MenuFactoryInterface $menuFactory);
 
@@ -98,28 +98,6 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @return string
      */
     public function getBaseControllerName();
-
-    /**
-     * Sets a list of templates.
-     *
-     * @param array $templates
-     */
-    public function setTemplates(array $templates);
-
-    /**
-     * Sets a specific template.
-     *
-     * @param string $name
-     * @param string $template
-     */
-    public function setTemplate($name, $template);
-
-    /**
-     * Get all templates.
-     *
-     * @return array
-     */
-    public function getTemplates();
 
     /**
      * @return \Sonata\AdminBundle\Model\ModelManagerInterface
@@ -486,15 +464,6 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @return bool
      */
     public function isChild();
-
-    /**
-     * Returns template.
-     *
-     * @param string $name
-     *
-     * @return null|string
-     */
-    public function getTemplate($name);
 
     /**
      * Set the translation domain.

--- a/src/Admin/AdminTemplateRegistryInterface.php
+++ b/src/Admin/AdminTemplateRegistryInterface.php
@@ -15,13 +15,7 @@ namespace Sonata\AdminBundle\Admin;
 
 interface AdminTemplateRegistryInterface
 {
-    /**
-     * @param TemplateRegistry $templateRegistry
-     */
     public function setTemplateRegistry(TemplateRegistry $templateRegistry): void;
 
-    /**
-     * @return TemplateRegistry
-     */
     public function getTemplateRegistry(): TemplateRegistry;
 }

--- a/src/Admin/AdminTemplateRegistryInterface.php
+++ b/src/Admin/AdminTemplateRegistryInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+interface AdminTemplateRegistryInterface
+{
+    /**
+     * @param TemplateRegistry $templateRegistry
+     */
+    public function setTemplateRegistry(TemplateRegistry $templateRegistry): void;
+
+    /**
+     * @return TemplateRegistry
+     */
+    public function getTemplateRegistry(): TemplateRegistry;
+}

--- a/src/Admin/TemplateRegistry.php
+++ b/src/Admin/TemplateRegistry.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+class TemplateRegistry implements TemplateRegistryInterface
+{
+    private $templates = [];
+
+    public function __construct(array $templates)
+    {
+        $this->templates = $templates;
+    }
+
+    public function setTemplate(string $name, string $template): void
+    {
+        $this->templates[$name] = $template;
+    }
+
+    public function getTemplates(): array
+    {
+        return $this->templates;
+    }
+
+    public function getTemplate(string $name): string
+    {
+        if ($this->hasTemplate($name)) {
+            return $this->templates[$name];
+        }
+
+        throw new \InvalidArgumentException(sprintf('Template "%s" not found in template registry', $name));
+    }
+
+    public function hasTemplate(string $name): bool
+    {
+        return isset($this->templates[$name]);
+    }
+}

--- a/src/Admin/TemplateRegistryInterface.php
+++ b/src/Admin/TemplateRegistryInterface.php
@@ -15,40 +15,25 @@ namespace Sonata\AdminBundle\Admin;
 
 interface TemplateRegistryInterface
 {
-    public function __construct(array $templates);
-
     /**
      * Sets a specific template.
-     *
-     * @param string $name
-     * @param string $template
      */
     public function setTemplate(string $name, string $template): void;
 
     /**
      * Get all templates.
-     *
-     * @return array
      */
     public function getTemplates(): array;
 
     /**
      * Returns template.
      *
-     * @param string $name
-     *
      * @throws \InvalidArgumentException
-     *
-     * @return string
      */
     public function getTemplate(string $name): string;
 
     /**
      * Return true if the template is set.
-     *
-     * @param string $name
-     *
-     * @return bool
      */
     public function hasTemplate(string $name): bool;
 }

--- a/src/Admin/TemplateRegistryInterface.php
+++ b/src/Admin/TemplateRegistryInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+interface TemplateRegistryInterface
+{
+    public function __construct(array $templates);
+
+    /**
+     * Sets a specific template.
+     *
+     * @param string $name
+     * @param string $template
+     */
+    public function setTemplate(string $name, string $template): void;
+
+    /**
+     * Get all templates.
+     *
+     * @return array
+     */
+    public function getTemplates(): array;
+
+    /**
+     * Returns template.
+     *
+     * @param string $name
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return string
+     */
+    public function getTemplate(string $name): string;
+
+    /**
+     * Return true if the template is set.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasTemplate(string $name): bool;
+}

--- a/src/Block/AdminSearchBlockService.php
+++ b/src/Block/AdminSearchBlockService.php
@@ -70,7 +70,7 @@ class AdminSearchBlockService extends AbstractBlockService
             $blockContext->getSetting('per_page')
         );
 
-        return $this->renderPrivateResponse($admin->getTemplate('search_result_block'), [
+        return $this->renderPrivateResponse($admin->getTemplateRegistry()->getTemplate('search_result_block'), [
             'block' => $blockContext->getBlock(),
             'settings' => $blockContext->getSettings(),
             'admin_pool' => $this->pool,

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -159,7 +159,7 @@ class CRUDController implements ContainerAwareInterface
         // set the theme for the current Admin Form
         $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-        return $this->renderWithExtraParams($this->admin->getTemplate('list'), [
+        return $this->renderWithExtraParams($this->admin->getTemplateRegistry()->getTemplate('list'), [
             'action' => 'list',
             'form' => $formView,
             'datagrid' => $datagrid,
@@ -268,7 +268,7 @@ class CRUDController implements ContainerAwareInterface
             return $this->redirectTo($object);
         }
 
-        return $this->renderWithExtraParams($this->admin->getTemplate('delete'), [
+        return $this->renderWithExtraParams($this->admin->getTemplateRegistry()->getTemplate('delete'), [
             'object' => $object,
             'action' => 'delete',
             'csrf_token' => $this->getCsrfToken('sonata.delete'),
@@ -380,7 +380,7 @@ class CRUDController implements ContainerAwareInterface
         // set the theme for the current Admin Form
         $this->setFormTheme($formView, $this->admin->getFormTheme());
 
-        return $this->renderWithExtraParams($this->admin->getTemplate($templateKey), [
+        return $this->renderWithExtraParams($this->admin->getTemplateRegistry()->getTemplate($templateKey), [
             'action' => 'edit',
             'form' => $formView,
             'object' => $existingObject,
@@ -468,7 +468,7 @@ class CRUDController implements ContainerAwareInterface
             $formView = $datagrid->getForm()->createView();
             $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-            return $this->renderWithExtraParams($this->admin->getTemplate('batch_confirmation'), [
+            return $this->renderWithExtraParams($this->admin->getTemplateRegistry()->getTemplate('batch_confirmation'), [
                 'action' => 'list',
                 'action_label' => $actionLabel,
                 'batch_translation_domain' => $batchTranslationDomain,
@@ -610,7 +610,7 @@ class CRUDController implements ContainerAwareInterface
         // set the theme for the current Admin Form
         $this->setFormTheme($formView, $this->admin->getFormTheme());
 
-        return $this->renderWithExtraParams($this->admin->getTemplate($templateKey), [
+        return $this->renderWithExtraParams($this->admin->getTemplateRegistry()->getTemplate($templateKey), [
             'action' => 'create',
             'form' => $formView,
             'object' => $newObject,
@@ -648,7 +648,7 @@ class CRUDController implements ContainerAwareInterface
 
         $this->admin->setSubject($object);
 
-        return $this->renderWithExtraParams($this->admin->getTemplate('show'), [
+        return $this->renderWithExtraParams($this->admin->getTemplateRegistry()->getTemplate('show'), [
             'action' => 'show',
             'object' => $object,
             'elements' => $this->admin->getShow(),
@@ -693,7 +693,7 @@ class CRUDController implements ContainerAwareInterface
 
         $revisions = $reader->findRevisions($this->admin->getClass(), $id);
 
-        return $this->renderWithExtraParams($this->admin->getTemplate('history'), [
+        return $this->renderWithExtraParams($this->admin->getTemplateRegistry()->getTemplate('history'), [
             'action' => 'history',
             'object' => $object,
             'revisions' => $revisions,
@@ -754,7 +754,7 @@ class CRUDController implements ContainerAwareInterface
 
         $this->admin->setSubject($object);
 
-        return $this->renderWithExtraParams($this->admin->getTemplate('show'), [
+        return $this->renderWithExtraParams($this->admin->getTemplateRegistry()->getTemplate('show'), [
             'action' => 'show',
             'object' => $object,
             'elements' => $this->admin->getShow(),
@@ -828,7 +828,7 @@ class CRUDController implements ContainerAwareInterface
 
         $this->admin->setSubject($base_object);
 
-        return $this->renderWithExtraParams($this->admin->getTemplate('show_compare'), [
+        return $this->renderWithExtraParams($this->admin->getTemplateRegistry()->getTemplate('show_compare'), [
             'action' => 'show',
             'object' => $base_object,
             'object_compare' => $compare_object,
@@ -960,7 +960,7 @@ class CRUDController implements ContainerAwareInterface
             }
         }
 
-        return $this->renderWithExtraParams($this->admin->getTemplate('acl'), [
+        return $this->renderWithExtraParams($this->admin->getTemplateRegistry()->getTemplate('acl'), [
             'action' => 'acl',
             'permissions' => $adminObjectAclData->getUserPermissions(),
             'object' => $object,
@@ -1099,10 +1099,10 @@ class CRUDController implements ContainerAwareInterface
     protected function getBaseTemplate()
     {
         if ($this->isXmlHttpRequest()) {
-            return $this->admin->getTemplate('ajax');
+            return $this->admin->getTemplateRegistry()->getTemplate('ajax');
         }
 
-        return $this->admin->getTemplate('layout');
+        return $this->admin->getTemplateRegistry()->getTemplate('layout');
     }
 
     /**

--- a/src/Controller/HelperController.php
+++ b/src/Controller/HelperController.php
@@ -205,7 +205,7 @@ class HelperController
                 'label' => $admin->toString($object),
             ]]);
         } elseif ('html' == $request->get('_format')) {
-            return new Response($this->twig->render($admin->getTemplate('short_object_description'), [
+            return new Response($this->twig->render($admin->getTemplateRegistry()->getTemplate('short_object_description'), [
                 'admin' => $admin,
                 'description' => $admin->toString($object),
                 'object' => $object,

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -329,7 +329,12 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         $definition->addMethodCall('showMosaicButton', [$showMosaicButton]);
 
-        $this->fixTemplates($serviceId, $container, $definition, $overwriteAdminConfiguration['templates'] ?? ['view' => []]);
+        $this->fixTemplates(
+            $serviceId,
+            $container,
+            $definition,
+            $overwriteAdminConfiguration['templates'] ?? ['view' => []]
+        );
 
         if ($container->hasParameter('sonata.admin.configuration.security.information') && !$definition->hasMethodCall('setSecurityInformation')) {
             $definition->addMethodCall('setSecurityInformation', ['%sonata.admin.configuration.security.information%']);
@@ -340,8 +345,12 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
         return $definition;
     }
 
-    public function fixTemplates(string $serviceId, ContainerBuilder $container, Definition $definition, array $overwrittenTemplates = []): void
-    {
+    public function fixTemplates(
+        string $serviceId,
+        ContainerBuilder $container,
+        Definition $definition,
+        array $overwrittenTemplates = []
+    ): void {
         $definedTemplates = $container->getParameter('sonata.admin.configuration.templates');
 
         $methods = [];

--- a/src/Resources/views/CRUD/Association/list_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/list_many_to_many.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/Association/list_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/list_many_to_one.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     {% if value %}

--- a/src/Resources/views/CRUD/Association/list_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/list_one_to_many.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/Association/list_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/list_one_to_one.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/base_history.html.twig
+++ b/src/Resources/views/CRUD/base_history.html.twig
@@ -35,7 +35,7 @@ file that was distributed with this source code.
                         {% for revision in revisions %}
                             <tr class="{% if (currentRevision != false and revision.rev == currentRevision.rev) %}current-revision{% endif %}">
                                 <td>{{ revision.rev }}</td>
-                                <td>{% include admin.getTemplate('history_revision_timestamp') %}</td>
+                                <td>{% include admin.getTemplateRegistry().getTemplate('history_revision_timestamp') %}</td>
                                 <td>{{ revision.username|default('label_unknown_user'|trans({}, 'SonataAdminBundle')) }}</td>
                                 <td><a href="{{ admin.generateObjectUrl('history_view_revision', object, {'revision': revision.rev }) }}" class="revision-link" rel="{{ revision.rev }}">{{ "label_view_revision"|trans({}, 'SonataAdminBundle') }}</a></td>
                                 <td>

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -91,7 +91,7 @@ file that was distributed with this source code.
 
                         {% block table_body %}
                             <tbody>
-                                {% include admin.getTemplate('outer_list_rows_' ~ admin.getListMode()) %}
+                                {% include admin.getTemplateRegistry().getTemplate('outer_list_rows_' ~ admin.getListMode()) %}
                             </tbody>
                         {% endblock %}
 
@@ -206,7 +206,7 @@ file that was distributed with this source code.
                                     {% endif %}
 
                                     {% block pager_results %}
-                                        {% include admin.getTemplate('pager_results') %}
+                                        {% include admin.getTemplateRegistry().getTemplate('pager_results') %}
                                     {% endblock %}
                                 </div>
                             {% endif %}
@@ -215,7 +215,7 @@ file that was distributed with this source code.
                         {% block pager_links %}
                             {% if admin.datagrid.pager.haveToPaginate() %}
                                 <hr/>
-                                {% include admin.getTemplate('pager_links') %}
+                                {% include admin.getTemplateRegistry().getTemplate('pager_links') %}
                             {% endif %}
                         {% endblock %}
                     </div>
@@ -257,7 +257,7 @@ file that was distributed with this source code.
 
 {% block list_filters %}
     {% if admin.datagrid.filters %}
-        {% form_theme form admin.getTemplate('filter') %}
+        {% form_theme form admin.getTemplateRegistry().getTemplate('filter') %}
 
         <div class="col-xs-12 col-md-12 sonata-filters-box" style="display: {{ admin.datagrid.hasDisplayableFilters ? 'block' : 'none' }}" id="filter-container-{{ admin.uniqid() }}">
             <div class="box box-primary" >

--- a/src/Resources/views/CRUD/list__action.html.twig
+++ b/src/Resources/views/CRUD/list__action.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     <div class="btn-group">

--- a/src/Resources/views/CRUD/list__batch.html.twig
+++ b/src/Resources/views/CRUD/list__batch.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     <input type="checkbox" name="idx[]" value="{{ admin.id(object) }}">

--- a/src/Resources/views/CRUD/list__select.html.twig
+++ b/src/Resources/views/CRUD/list__select.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     <a class="btn btn-primary" href="{{ admin.generateUrl('list') }}">

--- a/src/Resources/views/CRUD/list_array.html.twig
+++ b/src/Resources/views/CRUD/list_array.html.twig
@@ -10,7 +10,7 @@ file that was distributed with this source code.
 #}
 {% import '@SonataAdmin/CRUD/base_array_macro.html.twig' as list %}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     {{ list.render_array(value, field_description.options.inline is not defined or field_description.options.inline) }}

--- a/src/Resources/views/CRUD/list_boolean.html.twig
+++ b/src/Resources/views/CRUD/list_boolean.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% set isEditable = field_description.options.editable is defined and field_description.options.editable and admin.hasAccess('edit', object) %}
 {% set xEditableType = field_description.type|sonata_xeditable_type %}

--- a/src/Resources/views/CRUD/list_choice.html.twig
+++ b/src/Resources/views/CRUD/list_choice.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% set is_editable =
     field_description.options.editable is defined and

--- a/src/Resources/views/CRUD/list_currency.html.twig
+++ b/src/Resources/views/CRUD/list_currency.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     {% if value is not null %}

--- a/src/Resources/views/CRUD/list_date.html.twig
+++ b/src/Resources/views/CRUD/list_date.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field%}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/list_datetime.html.twig
+++ b/src/Resources/views/CRUD/list_datetime.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/list_email.html.twig
+++ b/src/Resources/views/CRUD/list_email.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     {% include '@SonataAdmin/CRUD/_email_link.html.twig' %}

--- a/src/Resources/views/CRUD/list_html.html.twig
+++ b/src/Resources/views/CRUD/list_html.html.twig
@@ -1,4 +1,4 @@
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/list_outer_rows_list.html.twig
+++ b/src/Resources/views/CRUD/list_outer_rows_list.html.twig
@@ -11,6 +11,6 @@ file that was distributed with this source code.
 
 {% for object in admin.datagrid.results %}
     <tr>
-        {% include admin.getTemplate('inner_list_row') %}
+        {% include admin.getTemplateRegistry().getTemplate('inner_list_row') %}
     </tr>
 {% endfor %}

--- a/src/Resources/views/CRUD/list_percent.html.twig
+++ b/src/Resources/views/CRUD/list_percent.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     {% set value = value * 100 %}

--- a/src/Resources/views/CRUD/list_string.html.twig
+++ b/src/Resources/views/CRUD/list_string.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}

--- a/src/Resources/views/CRUD/list_time.html.twig
+++ b/src/Resources/views/CRUD/list_time.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/list_trans.html.twig
+++ b/src/Resources/views/CRUD/list_trans.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field%}
     {% set translationDomain = field_description.options.catalogue|default(admin.translationDomain) %}

--- a/src/Resources/views/CRUD/list_url.html.twig
+++ b/src/Resources/views/CRUD/list_url.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends admin.getTemplateRegistry().getTemplate('base_list_field') %}
 
 {% block field %}
 {% spaceless %}

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -139,7 +139,7 @@ final class SonataAdminExtension extends AbstractExtension
     ) {
         $template = $this->getTemplate(
             $fieldDescription,
-            $fieldDescription->getAdmin()->getTemplate('base_list_field'),
+            $fieldDescription->getAdmin()->getTemplateRegistry()->getTemplate('base_list_field'),
             $environment
         );
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -23,6 +23,7 @@ use Sonata\AdminBundle\Admin\AdminExtensionInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Admin\TemplateRegistry;
 use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
@@ -1137,53 +1138,6 @@ class AdminTest extends TestCase
         $this->assertSame('SonataNewsBundle:FooAdmin', $admin->getBaseControllerName());
     }
 
-    public function testGetTemplates(): void
-    {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-
-        $this->assertSame([], $admin->getTemplates());
-
-        $templates = [
-            'list' => '@FooAdmin/CRUD/list.html.twig',
-            'show' => '@FooAdmin/CRUD/show.html.twig',
-            'edit' => '@FooAdmin/CRUD/edit.html.twig',
-        ];
-
-        $admin->setTemplates($templates);
-        $this->assertSame($templates, $admin->getTemplates());
-    }
-
-    public function testGetTemplate1(): void
-    {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-
-        $this->assertNull($admin->getTemplate('edit'));
-
-        $admin->setTemplate('edit', '@FooAdmin/CRUD/edit.html.twig');
-        $admin->setTemplate('show', '@FooAdmin/CRUD/show.html.twig');
-
-        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $admin->getTemplate('edit'));
-        $this->assertSame('@FooAdmin/CRUD/show.html.twig', $admin->getTemplate('show'));
-    }
-
-    public function testGetTemplate2(): void
-    {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-
-        $this->assertNull($admin->getTemplate('edit'));
-
-        $templates = [
-            'list' => '@FooAdmin/CRUD/list.html.twig',
-            'show' => '@FooAdmin/CRUD/show.html.twig',
-            'edit' => '@FooAdmin/CRUD/edit.html.twig',
-        ];
-
-        $admin->setTemplates($templates);
-
-        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $admin->getTemplate('edit'));
-        $this->assertSame('@FooAdmin/CRUD/show.html.twig', $admin->getTemplate('show'));
-    }
-
     public function testGetIdParameter(): void
     {
         $postAdmin = new PostAdmin(
@@ -1817,6 +1771,9 @@ class AdminTest extends TestCase
         ];
 
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin->setTemplateRegistry(new TemplateRegistry([
+            'button_create' => 'Foo.html.twig',
+        ]));
 
         $securityHandler = $this->createMock(SecurityHandlerInterface::class);
         $securityHandler
@@ -1833,8 +1790,6 @@ class AdminTest extends TestCase
             ->with($admin, 'create')
             ->will($this->returnValue(true));
         $admin->setRouteGenerator($routeGenerator);
-
-        $admin->setTemplate('button_create', 'Foo.html.twig');
 
         $this->assertSame($expected, $admin->getActionButtons('list', null));
     }
@@ -1962,6 +1917,10 @@ class AdminTest extends TestCase
         $admin = new PostAdmin('sonata.post.admin.post', $objFqn, 'SonataNewsBundle:PostAdmin');
         $admin->setRouteBuilder($pathInfo);
         $admin->setRouteGenerator($routeGenerator);
+        $admin->setTemplateRegistry(new TemplateRegistry([
+            'action_create' => '@Foo/view/action_create.html.twig',
+            'list' => '@Foo/view/action_create.html.twig',
+        ]));
         $admin->initialize();
 
         $securityHandler = $this->createMock(SecurityHandlerInterface::class);

--- a/tests/Admin/TemplateRegistryTest.php
+++ b/tests/Admin/TemplateRegistryTest.php
@@ -16,9 +16,6 @@ namespace Sonata\AdminBundle\Tests\Admin;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\TemplateRegistry;
 
-/**
- * Class TemplateRegistryTest.
- */
 class TemplateRegistryTest extends TestCase
 {
     public function testGetTemplates(): void

--- a/tests/Admin/TemplateRegistryTest.php
+++ b/tests/Admin/TemplateRegistryTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Admin;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\TemplateRegistry;
+
+/**
+ * Class TemplateRegistryTest.
+ */
+class TemplateRegistryTest extends TestCase
+{
+    public function testGetTemplates(): void
+    {
+        $templates = [
+            'list' => '@FooAdmin/CRUD/list.html.twig',
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
+        ];
+
+        $templateRegistry = new TemplateRegistry($templates);
+
+        $this->assertSame($templates, $templateRegistry->getTemplates());
+    }
+
+    public function testGetTemplate1(): void
+    {
+        $templateRegistry = new TemplateRegistry([
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+        ]);
+
+        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $templateRegistry->getTemplate('edit'));
+        $this->assertSame('@FooAdmin/CRUD/show.html.twig', $templateRegistry->getTemplate('show'));
+    }
+
+    public function testGetTemplate2(): void
+    {
+        $templateRegistry = new TemplateRegistry([
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+        ]);
+
+        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $templateRegistry->getTemplate('edit'));
+        $this->assertSame('@FooAdmin/CRUD/show.html.twig', $templateRegistry->getTemplate('show'));
+
+        $this->assertFalse($templateRegistry->hasTemplate('list'));
+
+        $templateRegistry->setTemplate('list', '@FooAdmin/CRUD/list.html.twig');
+
+        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $templateRegistry->getTemplate('edit'));
+        $this->assertSame('@FooAdmin/CRUD/show.html.twig', $templateRegistry->getTemplate('show'));
+        $this->assertSame('@FooAdmin/CRUD/list.html.twig', $templateRegistry->getTemplate('list'));
+    }
+
+    public function testGetTemplate3(): void
+    {
+        $templateRegistry = new TemplateRegistry([]);
+
+        $this->assertFalse($templateRegistry->hasTemplate('edit'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Template "edit" not found in template registry');
+
+        $templateRegistry->getTemplate('edit');
+    }
+
+    public function testHasTemplate(): void
+    {
+        $templateRegistry = new TemplateRegistry([
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
+        ]);
+
+        $this->assertFalse($templateRegistry->hasTemplate('list'));
+        $this->assertTrue($templateRegistry->hasTemplate('show'));
+        $this->assertTrue($templateRegistry->hasTemplate('edit'));
+    }
+}

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -21,6 +21,7 @@ use Psr\Log\LoggerInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Admin\TemplateRegistry;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
@@ -82,6 +83,11 @@ class CRUDControllerTest extends TestCase
      * @var AdminInterface
      */
     private $admin;
+
+    /**
+     * @var TemplateRegistry
+     */
+    private $templateRegistry;
 
     /**
      * @var Pool
@@ -149,6 +155,9 @@ class CRUDControllerTest extends TestCase
         $this->pool = new Pool($this->container, 'title', 'logo.png');
         $this->pool->setAdminServiceIds(['foo.admin']);
         $this->request->attributes->set('_sonata_admin', 'foo.admin');
+        $this->templateRegistry = $this->getMockBuilder(TemplateRegistry::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->admin = $this->getMockBuilder(AdminInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -330,6 +339,10 @@ class CRUDControllerTest extends TestCase
             }));
 
         $this->admin->expects($this->any())
+            ->method('getTemplateRegistry')
+            ->willReturn($this->templateRegistry);
+
+        $this->templateRegistry->expects($this->any())
             ->method('getTemplate')
             ->will($this->returnCallback(function ($name) {
                 switch ($name) {

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -20,6 +20,7 @@ use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Admin\TemplateRegistry;
 use Sonata\AdminBundle\Controller\HelperController;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\Pager;
@@ -207,9 +208,12 @@ class HelperControllerTest extends TestCase
     {
         $mockTemplate = 'AdminHelperTest:mock-short-object-description.html.twig';
 
+        $templateRegistry = $this->createMock(TemplateRegistry::class);
+        $templateRegistry->expects($this->once())->method('getTemplate')->will($this->returnValue($mockTemplate));
+
         $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->once())->method('setUniqid');
-        $admin->expects($this->once())->method('getTemplate')->will($this->returnValue($mockTemplate));
+        $admin->expects($this->once())->method('getTemplateRegistry')->willReturn($templateRegistry);
         $admin->expects($this->once())->method('getObject')->will($this->returnValue(new AdminControllerHelper_Foo()));
         $admin->expects($this->once())->method('toString')->will($this->returnValue('bar'));
         $admin->expects($this->once())->method('generateObjectUrl')->will($this->returnCallback(function ($type, $object, $parameters = []) {

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Admin\TemplateRegistry;
 use Sonata\AdminBundle\Exception\NoValueException;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
@@ -94,6 +95,11 @@ class SonataAdminExtensionTest extends TestCase
      * @var TranslatorInterface
      */
     private $translator;
+
+    /**
+     * @var TemplateRegistry
+     */
+    private $templateRegistry;
 
     public function setUp(): void
     {
@@ -172,6 +178,9 @@ class SonataAdminExtensionTest extends TestCase
         // initialize object
         $this->object = new \stdClass();
 
+        // initialize template registry
+        $this->templateRegistry = $this->createMock(TemplateRegistry::class);
+
         // initialize admin
         $this->admin = $this->createMock(AbstractAdmin::class);
 
@@ -194,6 +203,10 @@ class SonataAdminExtensionTest extends TestCase
             ->will($this->returnCallback(function ($id, $parameters = [], $domain = null) use ($translator) {
                 return $translator->trans($id, $parameters, $domain);
             }));
+
+        $this->admin->expects($this->any())
+            ->method('getTemplateRegistry')
+            ->willReturn($this->templateRegistry);
 
         $this->adminBar = $this->createMock(AbstractAdmin::class);
         $this->adminBar->expects($this->any())
@@ -243,7 +256,7 @@ class SonataAdminExtensionTest extends TestCase
             ->method('hasAccess')
             ->will($this->returnValue(true));
 
-        $this->admin->expects($this->any())
+        $this->templateRegistry->expects($this->any())
             ->method('getTemplate')
             ->with($this->equalTo('base_list_field'))
             ->will($this->returnValue('@SonataAdmin/CRUD/base_list_field.html.twig'));
@@ -1226,7 +1239,7 @@ EOT
      */
     public function testRenderViewElement($expected, $type, $value, array $options): void
     {
-        $this->admin->expects($this->any())
+        $this->templateRegistry->expects($this->any())
             ->method('getTemplate')
             ->will($this->returnValue('@SonataAdmin/CRUD/base_show_field.html.twig'));
 


### PR DESCRIPTION
I am targeting this branch, because this breaks BC.

Closes #4905

## Todo

- [ ] Update changelog to latest changes
- [ ] Create a PR for deprecations in 3.x

## Changelog

```markdown
### Added
- Added `AbstractAdmin::hasTemplate($name)` method

### Changed
- `AbstractAdmin::getTemplate($name)` now throws a `\RuntimeException` when a template is not found, instead of returning null
```

## Subject

`AbstractAdmin::getTemplate($name)` now no longer returns void (or null) when a template wasn't previously set. Instead, it now throws a `\RuntimeException`.
In order to avoid Exceptions, the new method `AbstractAdmin::hasTemplate($name)` can be used. This method has also been added to the `AdminInterface`.

The test `AdminTest::testGetTemplate3()` has been added to test for the exception. The test `AdminTest::testHasTemplate()` was added to test the `AbstractAdmin::hasTemplate($name)` method. Other tests have been changed to avoid getting exceptions.