### PR TITLE
fixes #4945: adds prophecy composer dev requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "jms/di-extra-bundle": "^1.7",
         "jms/translation-bundle": "^1.2",
         "matthiasnoback/symfony-dependency-injection-test": "^1.1",
+        "phpspec/prophecy": "^1.7",
         "sensio/generator-bundle": "^3.1",
         "sonata-project/intl-bundle": "^2.2.4",
         "symfony/phpunit-bridge": "^3.4 || ^4.0",


### PR DESCRIPTION
I am targeting this branch, because it's a minor bugfix.

Closes #4945

## Changelog

```markdown
### Added
- Added a composer dev requirement for phpspec/prophecy package
```

## Subject

Added a composer dev requirement for phpspec/prophecy package to be able to run the current test suite.
