### PR TITLE
Moved Twig getTemplate calls to Twig extension

### DIFF
--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -144,7 +144,7 @@ of objects to manipulate. We can override this behavior by changing our list tem
     {# src/AppBundle/Resources/views/CRUD/list__batch.html.twig #}
     {# see @SonataAdmin/CRUD/list__batch.html.twig for the current default template #}
 
-    {% extends admin.getTemplate('base_list_field') %}
+    {% extends get_admin_template('base_list_field') %}
 
     {% block field %}
         <input type="checkbox" name="idx[]" value="{{ admin.id(object) }}" />

--- a/docs/reference/templates.rst
+++ b/docs/reference/templates.rst
@@ -187,12 +187,32 @@ specify the templates to use in the ``Admin`` service definition:
 
 .. note::
 
-    A ``setTemplates(array $templates)`` (notice the plural) function also exists, that allows
-    you to set multiple templates at once. Notice that, if used outside of the service definition
-    context, ``setTemplates(array $templates)`` will replace the whole template list for that
-    ``Admin`` class, meaning you have to explicitly pass the full template list in the
-    ``$templates`` argument.
+    A ``setTemplates(array $templates)`` (notice the plural) method also
+    exists, that allows you to set multiple templates at once. Notice that,
+    if used outside of the service definition context,
+    ``setTemplates(array $templates)`` will replace the whole template list
+    for that ``Admin`` class, meaning you have to explicitly pass the full
+    template list in the ``$templates`` argument.
 
-Changes made using the ``setTemplate()`` and ``setTemplates()`` functions override the customizations
-made in the configuration file, so you can specify a global custom template and then override that
-customization on a specific ``Admin`` class.
+Changes made using the ``setTemplate()`` and ``setTemplates()`` methods
+override the customizations made in the configuration file, so you can specify
+a global custom template and then override that customization on a specific
+``Admin`` class.
+
+Finding configured templates
+----------------------------
+Templates that are set using the ``setTemplate()`` or ``setTemplates()``
+methods can be accessed through the ``getTemplate($name)`` method of an
+Admin.
+
+Within Twig templates, you can use the ``get_admin_template($name)`` function
+to access the templates of the current Admin, or the
+``get_admin_pool_template($name)`` function to access global templates.
+
+.. code-block:: html+jinja
+
+    {% extends get_admin_template('base_list_field') %}
+
+    {% block field %}
+        {# ... #}
+    {% endblock %}

--- a/src/Resources/config/twig.xml
+++ b/src/Resources/config/twig.xml
@@ -29,5 +29,10 @@
                 <argument>%sonata.admin.twig.extension.x_editable_type_mapping%</argument>
             </call>
         </service>
+        <service id="sonata.templates.twig.extension" class="Sonata\AdminBundle\Twig\Extension\TemplateRegistryExtension" public="false">
+            <tag name="twig.extension"/>
+            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="request_stack"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/views/CRUD/Association/list_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/list_many_to_many.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/Association/list_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/list_many_to_one.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     {% if value %}

--- a/src/Resources/views/CRUD/Association/list_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/list_one_to_many.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/Association/list_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/list_one_to_one.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/action.html.twig
+++ b/src/Resources/views/CRUD/action.html.twig
@@ -15,11 +15,14 @@ file that was distributed with this source code.
     {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
 {%- endblock -%}
 
-{% block tab_menu %}
+{%- block tab_menu -%}
     {% if action is defined %}
-        {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}
+        {{ knp_menu_render(admin.sidemenu(action), {
+            'currentClass': 'active',
+            'template': get_admin_pool_template('tab_menu_template')
+        }, 'twig') }}
     {% endif %}
-{% endblock %}
+{%- endblock -%}
 
 {% block content %}
 

--- a/src/Resources/views/CRUD/base_edit.html.twig
+++ b/src/Resources/views/CRUD/base_edit.html.twig
@@ -28,7 +28,12 @@ file that was distributed with this source code.
     {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
 {%- endblock -%}
 
-{% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
+{%- block tab_menu -%}
+    {{ knp_menu_render(admin.sidemenu(action), {
+        'currentClass': 'active',
+        'template': get_admin_pool_template('tab_menu_template')
+    }, 'twig') }}
+{%- endblock -%}
 
 {% use '@SonataAdmin/CRUD/base_edit_form.html.twig' with form as parentForm %}
 

--- a/src/Resources/views/CRUD/base_history.html.twig
+++ b/src/Resources/views/CRUD/base_history.html.twig
@@ -35,7 +35,7 @@ file that was distributed with this source code.
                         {% for revision in revisions %}
                             <tr class="{% if (currentRevision != false and revision.rev == currentRevision.rev) %}current-revision{% endif %}">
                                 <td>{{ revision.rev }}</td>
-                                <td>{% include admin.getTemplate('history_revision_timestamp') %}</td>
+                                <td>{% include get_admin_template('history_revision_timestamp') %}</td>
                                 <td>{{ revision.username|default('label_unknown_user'|trans({}, 'SonataAdminBundle')) }}</td>
                                 <td><a href="{{ admin.generateObjectUrl('history_view_revision', object, {'revision': revision.rev }) }}" class="revision-link" rel="{{ revision.rev }}">{{ "label_view_revision"|trans({}, 'SonataAdminBundle') }}</a></td>
                                 <td>

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -15,7 +15,12 @@ file that was distributed with this source code.
     {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
 {%- endblock -%}
 
-{% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
+{%- block tab_menu -%}
+    {{ knp_menu_render(admin.sidemenu(action), {
+        'currentClass': 'active',
+        'template': get_admin_pool_template('tab_menu_template')
+    }, 'twig') }}
+{%- endblock -%}
 
 {% block title %}
     {#
@@ -91,7 +96,7 @@ file that was distributed with this source code.
 
                         {% block table_body %}
                             <tbody>
-                                {% include admin.getTemplate('outer_list_rows_' ~ admin.getListMode()) %}
+                                {% include get_admin_template('outer_list_rows_' ~ admin.getListMode()) %}
                             </tbody>
                         {% endblock %}
 
@@ -206,7 +211,7 @@ file that was distributed with this source code.
                                     {% endif %}
 
                                     {% block pager_results %}
-                                        {% include admin.getTemplate('pager_results') %}
+                                        {% include get_admin_template('pager_results') %}
                                     {% endblock %}
                                 </div>
                             {% endif %}
@@ -215,7 +220,7 @@ file that was distributed with this source code.
                         {% block pager_links %}
                             {% if admin.datagrid.pager.haveToPaginate() %}
                                 <hr/>
-                                {% include admin.getTemplate('pager_links') %}
+                                {% include get_admin_template('pager_links') %}
                             {% endif %}
                         {% endblock %}
                     </div>
@@ -257,7 +262,7 @@ file that was distributed with this source code.
 
 {% block list_filters %}
     {% if admin.datagrid.filters %}
-        {% form_theme form admin.getTemplate('filter') %}
+        {% form_theme form get_admin_template('filter') %}
 
         <div class="col-xs-12 col-md-12 sonata-filters-box" style="display: {{ admin.datagrid.hasDisplayableFilters ? 'block' : 'none' }}" id="filter-container-{{ admin.uniqid() }}">
             <div class="box box-primary" >

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -26,7 +26,7 @@ file that was distributed with this source code.
 {% block tab_menu %}
     {{ knp_menu_render(admin.sidemenu(action), {
         'currentClass' : 'active',
-        'template': sonata_admin.adminPool.getTemplate('tab_menu_template')
+        'template': get_admin_pool_template('tab_menu_template')
     }, 'twig') }}
 {% endblock %}
 

--- a/src/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/src/Resources/views/CRUD/batch_confirmation.html.twig
@@ -15,7 +15,12 @@ file that was distributed with this source code.
     {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
 {%- endblock -%}
 
-{% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
+{%- block tab_menu -%}
+    {{ knp_menu_render(admin.sidemenu(action), {
+        'currentClass': 'active',
+        'template': get_admin_pool_template('tab_menu_template')
+    }, 'twig') }}
+{%- endblock -%}
 
 {% block content %}
     <div class="sonata-ba-delete">

--- a/src/Resources/views/CRUD/delete.html.twig
+++ b/src/Resources/views/CRUD/delete.html.twig
@@ -15,7 +15,12 @@ file that was distributed with this source code.
     {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
 {%- endblock -%}
 
-{% block tab_menu %}{{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active', 'template': sonata_admin.adminPool.getTemplate('tab_menu_template')}, 'twig') }}{% endblock %}
+{%- block tab_menu -%}
+    {{ knp_menu_render(admin.sidemenu(action), {
+        'currentClass': 'active',
+        'template': get_admin_pool_template('tab_menu_template')
+    }, 'twig') }}
+{%- endblock -%}
 
 {% block content %}
     <div class="sonata-ba-delete">

--- a/src/Resources/views/CRUD/list__action.html.twig
+++ b/src/Resources/views/CRUD/list__action.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     <div class="btn-group">

--- a/src/Resources/views/CRUD/list__batch.html.twig
+++ b/src/Resources/views/CRUD/list__batch.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     <input type="checkbox" name="idx[]" value="{{ admin.id(object) }}">

--- a/src/Resources/views/CRUD/list__select.html.twig
+++ b/src/Resources/views/CRUD/list__select.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     <a class="btn btn-primary" href="{{ admin.generateUrl('list') }}">

--- a/src/Resources/views/CRUD/list_array.html.twig
+++ b/src/Resources/views/CRUD/list_array.html.twig
@@ -10,7 +10,7 @@ file that was distributed with this source code.
 #}
 {% import '@SonataAdmin/CRUD/base_array_macro.html.twig' as list %}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     {{ list.render_array(value, field_description.options.inline is not defined or field_description.options.inline) }}

--- a/src/Resources/views/CRUD/list_boolean.html.twig
+++ b/src/Resources/views/CRUD/list_boolean.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% set isEditable = field_description.options.editable is defined and field_description.options.editable and admin.hasAccess('edit', object) %}
 {% set xEditableType = field_description.type|sonata_xeditable_type %}

--- a/src/Resources/views/CRUD/list_choice.html.twig
+++ b/src/Resources/views/CRUD/list_choice.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% set is_editable =
     field_description.options.editable is defined and

--- a/src/Resources/views/CRUD/list_currency.html.twig
+++ b/src/Resources/views/CRUD/list_currency.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     {% if value is not null %}

--- a/src/Resources/views/CRUD/list_date.html.twig
+++ b/src/Resources/views/CRUD/list_date.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field%}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/list_datetime.html.twig
+++ b/src/Resources/views/CRUD/list_datetime.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/list_email.html.twig
+++ b/src/Resources/views/CRUD/list_email.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     {% include '@SonataAdmin/CRUD/_email_link.html.twig' %}

--- a/src/Resources/views/CRUD/list_html.html.twig
+++ b/src/Resources/views/CRUD/list_html.html.twig
@@ -1,4 +1,4 @@
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/list_outer_rows_list.html.twig
+++ b/src/Resources/views/CRUD/list_outer_rows_list.html.twig
@@ -11,6 +11,6 @@ file that was distributed with this source code.
 
 {% for object in admin.datagrid.results %}
     <tr>
-        {% include admin.getTemplate('inner_list_row') %}
+        {% include get_admin_template('inner_list_row') %}
     </tr>
 {% endfor %}

--- a/src/Resources/views/CRUD/list_percent.html.twig
+++ b/src/Resources/views/CRUD/list_percent.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     {% set value = value * 100 %}

--- a/src/Resources/views/CRUD/list_string.html.twig
+++ b/src/Resources/views/CRUD/list_string.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}

--- a/src/Resources/views/CRUD/list_time.html.twig
+++ b/src/Resources/views/CRUD/list_time.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/list_trans.html.twig
+++ b/src/Resources/views/CRUD/list_trans.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field%}
     {% set translationDomain = field_description.options.catalogue|default(admin.translationDomain) %}

--- a/src/Resources/views/CRUD/list_url.html.twig
+++ b/src/Resources/views/CRUD/list_url.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field') %}
 
 {% block field %}
 {% spaceless %}

--- a/src/Resources/views/empty_layout.html.twig
+++ b/src/Resources/views/empty_layout.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin_pool.getTemplate('layout') %}
+{% extends get_admin_pool_template('layout') %}
 
 {% block sonata_header %}{% endblock %}
 {% block sonata_left_side %}{% endblock %}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -202,7 +202,7 @@ file that was distributed with this source code.
                                                 <a class="dropdown-toggle" data-toggle="dropdown" href="#">
                                                     <i class="fa fa-plus-square fa-fw" aria-hidden="true"></i> <i class="fa fa-caret-down" aria-hidden="true"></i>
                                                 </a>
-                                                {% include sonata_admin.adminPool.getTemplate('add_block') %}
+                                                {% include get_admin_pool_template('add_block') %}
                                             </li>
                                         {% endblock %}
                                         {% block sonata_top_nav_menu_user_block %}
@@ -211,7 +211,7 @@ file that was distributed with this source code.
                                                     <i class="fa fa-user fa-fw" aria-hidden="true"></i> <i class="fa fa-caret-down" aria-hidden="true"></i>
                                                 </a>
                                                 <ul class="dropdown-menu dropdown-user">
-                                                    {% include sonata_admin.adminPool.getTemplate('user_block') %}
+                                                    {% include get_admin_pool_template('user_block') %}
                                                 </ul>
                                             </li>
                                         {% endblock %}
@@ -244,7 +244,7 @@ file that was distributed with this source code.
 
                             {% block side_bar_before_nav %} {% endblock %}
                             {% block side_bar_nav %}
-                                {{ knp_menu_render('sonata_admin_sidebar', {template: sonata_admin.adminPool.getTemplate('knp_menu_template')}) }}
+                                {{ knp_menu_render('sonata_admin_sidebar', {template: get_admin_pool_template('knp_menu_template')}) }}
                             {% endblock side_bar_nav %}
                             {% block side_bar_after_nav %}
                                 <p class="text-center small" style="border-top: 1px solid #444444; padding-top: 10px">

--- a/src/Twig/Extension/TemplateRegistryExtension.php
+++ b/src/Twig/Extension/TemplateRegistryExtension.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class TemplateRegistryExtension extends AbstractExtension
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    public function __construct(Pool $pool, RequestStack $requestStack)
+    {
+        $this->pool = $pool;
+        $this->requestStack = $requestStack;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('get_admin_template', [$this, 'getTemplate']),
+            new TwigFunction('get_admin_pool_template', [$this, 'getPoolTemplate']),
+        ];
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return null|string
+     */
+    public function getTemplate($name)
+    {
+        return $this->getAdmin()->getTemplate($name);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return null|string
+     */
+    public function getPoolTemplate($name)
+    {
+        return $this->pool->getTemplate($name);
+    }
+
+    /**
+     * @return AdminInterface|false|null
+     */
+    private function getAdmin()
+    {
+        return $this->pool->getAdminByAdminCode(
+            $this->requestStack->getCurrentRequest()->get('_sonata_admin')
+        );
+    }
+}

--- a/tests/Twig/Extension/TemplateRegistryExtensionTest.php
+++ b/tests/Twig/Extension/TemplateRegistryExtensionTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Twig\Extension\TemplateRegistryExtension;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Class TemplateRegistryExtensionTest.
+ */
+class TemplateRegistryExtensionTest extends TestCase
+{
+    /**
+     * @var TemplateRegistryExtension
+     */
+    private $extension;
+
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    protected function setUp()
+    {
+        $this->request = $this->prophesize(Request::class);
+        $this->pool = $this->prophesize(Pool::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->admin = $this->prophesize(AdminInterface::class);
+
+        $this->requestStack->getCurrentRequest()->willReturn($this->request);
+        $this->request->get('_sonata_admin')->willReturn('admin.post');
+        $this->pool->getAdminByAdminCode('admin.post')->willReturn($this->admin);
+
+        $this->extension = new TemplateRegistryExtension(
+            $this->pool->reveal(),
+            $this->requestStack->reveal()
+        );
+    }
+
+    public function testGetTemplate()
+    {
+        $this->admin->getTemplate('edit')->willReturn('@SonataAdmin/CRUD/edit.html.twig');
+
+        $this->assertEquals(
+            '@SonataAdmin/CRUD/edit.html.twig',
+            $this->extension->getTemplate('edit')
+        );
+    }
+
+    public function testGetPoolTemplate()
+    {
+        $this->pool->getTemplate('edit')->willReturn('@SonataAdmin/CRUD/edit.html.twig');
+
+        $this->assertEquals(
+            '@SonataAdmin/CRUD/edit.html.twig',
+            $this->extension->getPoolTemplate('edit')
+        );
+    }
+}


### PR DESCRIPTION
I am targeting this branch, because it is BC.

## Changelog

```markdown
### Added
- Added Twig function `get_admin_template`
- Added Twig function `get_admin_pool_template`

### Changed
- Changed calls to `admin.getTemplate()` in Twig templates to `get_admin_template()`
- Changed calls to `adminPool.getTemplate()` in Twig templates to `get_admin_pool_template()`
```

## Subject

This PR is part of a series of PRs to eventually move all admin template related functions to a separate component.

This PR itself moves all direct calls to `AbstractAdmin::getTemplate()` and `Pool::getTemplate()` from Twig templates to a Twig extension.