### PR TITLE
Fix including wrong template

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many.html.twig
@@ -91,7 +91,7 @@ file that was distributed with this source code.
 
             {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
 
-            {% include '@SonataAdmin/CRUD/Association/edit_one_script.html.twig' %}
+            {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
         {% endif %}
     </div>
 {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/813

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- including wrong javascript code for associations modals
```