### PR TITLE
Class loader does not have 4.0 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "sonata-project/core-bundle": "^3.6",
         "sonata-project/exporter": "^1.7.1",
         "symfony/asset": "^2.8 || ^3.2 || ^4.0",
-        "symfony/class-loader": "^2.8 || ^3.2 || ^4.0",
+        "symfony/class-loader": "^2.8 || ^3.2",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
It was added here: https://github.com/sonata-project/SonataAdminBundle/pull/1607
To test a command added here: https://github.com/sonata-project/SonataAdminBundle/commit/c91a0ffdde47b3b41eb73bfa1ab4d4aef4a2cf22

I've never seen that command or use it, but the `class-loader` is only used there, and it is a deprecated component, so it does not have a 4.0 version. https://github.com/symfony/class-loader

On a first step, removing the ^4.0 version is a must, but I don't know if we should try move this to the require-dev and deprecate that code, or remove it directly. I don't even know what the command does, but seems something like is not needed now with the newer versions of PHP.