### PR TITLE
Allow Admin to have multiple parents

### DIFF
--- a/docs/reference/child_admin.rst
+++ b/docs/reference/child_admin.rst
@@ -5,11 +5,10 @@ Let us say you have a ``PlaylistAdmin`` and a ``VideoAdmin``. You can optionally
 to be a child of the ``PlaylistAdmin``. This will create new routes like, for example, ``/playlist/{id}/video/list``,
 where the videos will automatically be filtered by post.
 
-To do this, you first need to call the ``addChild`` method in your ``PlaylistAdmin`` service configuration:
-
-To do this, you first need to call the ``addChild`` method in your ``PlaylistAdmin`` service configuration with two arguments,
-the child admin name (in this case ``VideoAdmin`` service) and the Entity field that relates our child Entity with
-its parent :
+To do this, you first need to call the ``addChild`` method in your ``PlaylistAdmin``
+service configuration with two arguments, the child admin name (in this case
+``VideoAdmin`` service) and the Entity field that relates our child Entity with
+its parent:
 
 .. configuration-block::
 
@@ -24,28 +23,6 @@ its parent :
                 <argument>playlist</<argument>
             </call>
         </service>
-
-Then, you have to set the VideoAdmin ``parentAssociationMapping`` attribute to ``playlist`` :
-
-.. code-block:: php
-
-    <?php
-
-    namespace AppBundle\Admin;
-
-    // ...
-
-    class VideoAdmin extends AbstractAdmin
-    {
-        protected $parentAssociationMapping = 'playlist';
-
-        // OR
-
-        public function getParentAssociationMapping()
-        {
-            return 'playlist';
-        }
-    }
 
 To display the ``VideoAdmin`` extend the menu in your ``PlaylistAdmin`` class:
 

--- a/docs/reference/child_admin.rst
+++ b/docs/reference/child_admin.rst
@@ -7,6 +7,10 @@ where the videos will automatically be filtered by post.
 
 To do this, you first need to call the ``addChild`` method in your ``PlaylistAdmin`` service configuration:
 
+To do this, you first need to call the ``addChild`` method in your ``PlaylistAdmin`` service configuration with two arguments,
+the child admin name (in this case ``VideoAdmin`` service) and the Entity field that relates our child Entity with
+its parent :
+
 .. configuration-block::
 
     .. code-block:: xml
@@ -17,6 +21,7 @@ To do this, you first need to call the ``addChild`` method in your ``PlaylistAdm
 
             <call method="addChild">
                 <argument type="service" id="sonata.admin.video" />
+                <argument>playlist</<argument>
             </call>
         </service>
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -819,9 +819,9 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      * Returns the name of the parent related field, so the field can be use to set the default
      * value (ie the parent object) or to filter the object.
      *
-     * @return null|string
-     *
      * @throws \InvalidArgumentException
+     *
+     * @return null|string
      */
     public function getParentAssociationMapping()
     {
@@ -1681,9 +1681,6 @@ EOT;
         return $this->filterFieldDescriptions;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function addChild(AdminInterface $child, $field = null)
     {
         for ($parentAdmin = $this; null !== $parentAdmin; $parentAdmin = $parentAdmin->getParent()) {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -240,7 +240,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      * The related parent association, ie if OrderElement has a parent property named order,
      * then the $parentAssociationMapping must be a string named `order`.
      *
-     * @var string
+     * @var string|mixed
      */
     protected $parentAssociationMapping = null;
 
@@ -819,11 +819,38 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      * Returns the name of the parent related field, so the field can be use to set the default
      * value (ie the parent object) or to filter the object.
      *
-     * @return string the name of the parent related field
+     * @return null|string
+     *
+     * @throws \InvalidArgumentException
      */
     public function getParentAssociationMapping()
     {
+        if (is_array($this->parentAssociationMapping) && $this->getParent()) {
+            $parent = $this->getParent()->getCode();
+            if (array_key_exists($parent, $this->parentAssociationMapping)) {
+                return $this->parentAssociationMapping[$parent];
+            }
+            throw new \InvalidArgumentException(sprintf(
+                "There's no association between %s and %s.",
+                $this->getCode(),
+                $this->getParent()->getCode()
+            ));
+        }
+
         return $this->parentAssociationMapping;
+    }
+
+    /**
+     * @param string $code
+     * @param string $value
+     *
+     * @return $this
+     */
+    final public function addParentAssociationMapping($code, $value)
+    {
+        $this->parentAssociationMapping[$code] = $value;
+
+        return $this;
     }
 
     /**
@@ -1654,7 +1681,10 @@ EOT;
         return $this->filterFieldDescriptions;
     }
 
-    public function addChild(AdminInterface $child)
+    /**
+     * {@inheritdoc}
+     */
+    public function addChild(AdminInterface $child, $field = null)
     {
         for ($parentAdmin = $this; null !== $parentAdmin; $parentAdmin = $parentAdmin->getParent()) {
             if ($parentAdmin->getCode() !== $child->getCode()) {
@@ -1670,6 +1700,9 @@ EOT;
         $this->children[$child->getCode()] = $child;
 
         $child->setParent($this);
+        if ($field) {
+            $child->addParentAssociationMapping($this->getCode(), $field);
+        }
     }
 
     public function hasChild($code)

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -256,7 +256,7 @@ class AdminTest extends TestCase
         $this->assertFalse($postAdmin->hasChild('comment'));
 
         $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
-        $postAdmin->addChild($commentAdmin);
+        $postAdmin->addChild($commentAdmin, 'post');
         $this->assertTrue($postAdmin->hasChildren());
         $this->assertTrue($postAdmin->hasChild('sonata.post.admin.comment'));
 
@@ -539,7 +539,7 @@ class AdminTest extends TestCase
         $commentAdmin->setRouteGenerator($routeGenerator);
         $commentAdmin->initialize();
 
-        $postAdmin->addChild($commentAdmin);
+        $postAdmin->addChild($commentAdmin, 'post');
 
         $commentVoteAdmin = new CommentVoteAdmin(
             'sonata.post.admin.comment_vote',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataAdminBundle/pull/3339

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed `AbstractAdmin:: addChild` to accept a second parameter with the name of the parent related field.
```
## Subject

<!-- Describe your Pull Request content here -->
This is just PR https://github.com/sonata-project/SonataAdminBundle/pull/3339 rebased