### PR TITLE
Better handling of ChoiceFieldMaskType option 'map'

### DIFF
--- a/src/Form/Type/ChoiceFieldMaskType.php
+++ b/src/Form/Type/ChoiceFieldMaskType.php
@@ -26,17 +26,18 @@ class ChoiceFieldMaskType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $sanitizedMap = [];
+        $allFieldNames = [];
         foreach ($options['map'] as $value => $fieldNames) {
-            foreach ($fieldNames as $fieldName) {
-                $sanitizedMap[$value][] =
-                    str_replace(['__', '.'], ['____', '__'], $fieldName);
+            if (is_array($fieldNames) || $fieldNames instanceof \Traversable) {
+                foreach ($fieldNames as $fieldName) {
+                    $sanitizedFieldName = str_replace(['__', '.'], ['____', '__'], $fieldName);
+                    $sanitizedMap[$value][] = $sanitizedFieldName;
+                    $allFieldNames[] = $sanitizedFieldName;
+                }
             }
         }
 
-        $allFieldNames = call_user_func_array('array_merge', $sanitizedMap);
-        $allFieldNames = array_unique($allFieldNames);
-
-        $view->vars['all_fields'] = $allFieldNames;
+        $view->vars['all_fields'] = array_unique($allFieldNames);
         $view->vars['map'] = $sanitizedMap;
 
         $options['expanded'] = false;
@@ -61,6 +62,8 @@ class ChoiceFieldMaskType extends AbstractType
         $resolver->setDefaults([
             'map' => [],
         ]);
+
+        $resolver->setAllowedTypes('map', 'array');
     }
 
     public function getParent()

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -481,14 +481,20 @@ file that was distributed with this source code.
     {{ block('choice_widget') }}
     {# Taking the form name excluding ending field glue character #}
     {% set main_form_name = id|slice(0, (id|length - name|length)-1) %}
+    {% if expanded %}
+        {% set js_selector = '#' ~ main_form_name ~ '_' ~ name ~ ' input' %}
+        {% set js_event = 'ifChecked' %}
+    {% else %}
+        {% set js_selector = '#' ~ main_form_name ~ '_' ~ name %}
+        {% set js_event = 'change' %}
+    {% endif %}
     <script>
         jQuery(document).ready(function() {
-            var allFields = {{ all_fields|json_encode|raw }};
-            var map = {{ map|json_encode|raw }};
+            var allFields = {{ all_fields|json_encode|raw }},
+                map = {{ map|json_encode|raw }},
+                showMaskChoiceEl = jQuery("{{ js_selector }}");
 
-            var showMaskChoiceEl = jQuery('#{{ main_form_name }}_{{ name }}');
-
-            showMaskChoiceEl.on('change', function () {
+            showMaskChoiceEl.on("{{ js_event }}", function () {
                 choice_field_mask_show(jQuery(this).val());
             });
 
@@ -515,7 +521,8 @@ file that was distributed with this source code.
                     });
                 }
             }
-            choice_field_mask_show(showMaskChoiceEl.val());
+
+            choice_field_mask_show('{{ value }}');
         });
 
     </script>

--- a/tests/Form/Type/ChoiceFieldMaskTypeTest.php
+++ b/tests/Form/Type/ChoiceFieldMaskTypeTest.php
@@ -13,28 +13,53 @@ namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ChoiceFieldMaskTypeTest extends TypeTestCase
 {
     public function testGetDefaultOptions()
     {
-        $type = new ChoiceFieldMaskType();
-
-        $optionResolver = new OptionsResolver();
-
-        $type->configureOptions($optionResolver);
-
-        $options = $optionResolver->resolve(
-            [
-                'map' => [
-                    'foo' => ['field1', 'field2'],
-                    'bar' => ['field3'],
+        $options = $this->resolveOptions([
+            'map' => [
+                'foo' => ['field1', 'field2'],
+                'bar' => ['field3'],
             ],
         ]);
 
         $this->assertSame(['foo' => ['field1', 'field2'], 'bar' => ['field3']], $options['map']);
+    }
+
+    public function testGetDefaultOptions2()
+    {
+        $options = $this->resolveOptions([]);
+
+        $this->assertSame(['map' => []], $options);
+    }
+
+    public function setAllowedTypesProvider()
+    {
+        return [
+            'null' => [null],
+            'integer' => [1],
+            'boolean' => [false],
+            'string' => ['string'],
+            'class' => [new \stdClass()],
+        ];
+    }
+
+    /**
+     * @dataProvider setAllowedTypesProvider
+     */
+    public function testSetAllowedTypes($map)
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessageRegExp('/The option "map" with value .* is expected to be of type "array", but is of type ".*"/');
+
+        $this->resolveOptions(['map' => $map]);
     }
 
     public function testGetBlockPrefix()
@@ -47,5 +72,96 @@ class ChoiceFieldMaskTypeTest extends TypeTestCase
     {
         $type = new ChoiceFieldMaskType();
         $this->assertSame(ChoiceType::class, $type->getParent());
+    }
+
+    public function testBuildView()
+    {
+        $choiceFieldMaskType = new ChoiceFieldMaskType();
+
+        $view = $this->prophesize(FormView::class);
+        $form = $this->prophesize(FormInterface::class);
+        $options = [
+            'map' => [
+                'choice_1' => ['field1', 'field2'],
+                'choice_2' => ['field__3', 'field.4'],
+                'choice_3' => ['field1', 'field5'],
+            ],
+        ];
+
+        $choiceFieldMaskType->buildView(
+            $view->reveal(),
+            $form->reveal(),
+            $options
+        );
+
+        $expectedAllFields = [
+            'field1',
+            'field2',
+            'field____3',
+            'field__4',
+            'field5',
+        ];
+
+        $expectedMap = [
+            'choice_1' => [
+                'field1',
+                'field2',
+            ],
+            'choice_2' => [
+                'field____3',
+                'field__4',
+            ],
+            'choice_3' => [
+                'field1',
+                'field5',
+            ],
+        ];
+
+        $this->assertSame(array_values($expectedAllFields), array_values($view->reveal()->vars['all_fields']), '"all_fields" is not as expected');
+        $this->assertSame($expectedMap, $view->reveal()->vars['map'], '"map" is not as expected');
+    }
+
+    public function testBuildViewWithFaultyMapValues()
+    {
+        $options = ['map' => [
+            'int' => 1,
+            'string' => 'string',
+            'boolean' => false,
+            'array' => ['field_1', 'field_2'],
+            'empty_array' => [],
+            'class' => new \stdClass(),
+        ]];
+
+        $choiceFieldMaskType = new ChoiceFieldMaskType();
+
+        $view = $this->prophesize(FormView::class);
+        $form = $this->prophesize(FormInterface::class);
+
+        $choiceFieldMaskType->buildView(
+            $view->reveal(),
+            $form->reveal(),
+            $options
+        );
+
+        $expectedAllFields = ['field_1', 'field_2'];
+        $expectedMap = [
+            'array' => ['field_1', 'field_2'],
+        ];
+
+        $this->assertSame(array_values($expectedAllFields), array_values($view->reveal()->vars['all_fields']), '"all_fields" is not as expected');
+        $this->assertSame($expectedMap, $view->reveal()->vars['map'], '"map" is not as expected');
+    }
+
+    /**
+     * @return array
+     */
+    private function resolveOptions(array $options)
+    {
+        $type = new ChoiceFieldMaskType();
+        $optionResolver = new OptionsResolver();
+
+        $type->configureOptions($optionResolver);
+
+        return $optionResolver->resolve($options);
     }
 }


### PR DESCRIPTION
I am targeting this branch, because this is a minor, BC fix.

Closes #4717
Closes #4127

## Changelog

```markdown

### Fixed
- Fixed PHP warnings when `ChoiceFieldMaskType` option `map` is invalid or empty
- Fixed javascript handling of `ChoiceFieldMaskType` when option `expanded` is `true`

```

## Subject

The `ChoiceFieldMaskType` option `map` was not handled safely enough:
- It gave a `Warning: array_merge() expects at least 1 parameter, 0 given` if the option was not set or was set to an empty array.
- It gave a `Warning: Invalid argument supplied for foreach()` if the option was anything but an array.

Also, the javascript function to show/hide fields did not work if the `ChoiceFieldMaskType` field was expanded (radio buttons instead of a select).

I changed the following:
- Set the allowed types for the `map` option to array only.
- Added a check before the `array_merge` call, so empty arrays will no longer cause problems.
- Fixed the javascript handling, so the code also works with expanded choice fields.