### PR TITLE
Fix autocomplete fields with composite keys

### DIFF
--- a/src/Form/ChoiceList/ModelChoiceLoader.php
+++ b/src/Form/ChoiceList/ModelChoiceLoader.php
@@ -13,7 +13,6 @@ namespace Sonata\AdminBundle\Form\ChoiceList;
 
 use Doctrine\Common\Util\ClassUtils;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\Exception\RuntimeException;
@@ -111,7 +110,7 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
                     }
                 }
 
-                $id = implode(AdapterInterface::ID_SEPARATOR, $this->getIdentifierValues($entity));
+                $id = $this->getNormalizedIdentifier($entity);
 
                 if (!array_key_exists($valueObject, $choices)) {
                     $choices[$valueObject] = [];
@@ -152,10 +151,10 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
      *
      * @return array
      */
-    private function getIdentifierValues($entity)
+    private function getNormalizedIdentifier($entity)
     {
         try {
-            return $this->modelManager->getIdentifierValues($entity);
+            return $this->modelManager->getNormalizedIdentifier($entity);
         } catch (\Exception $e) {
             throw new \InvalidArgumentException(sprintf('Unable to retrieve the identifier values for entity %s', ClassUtils::getClass($entity)), 0, $e);
         }

--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -13,7 +13,6 @@ namespace Sonata\AdminBundle\Form\DataTransformer;
 
 use Doctrine\Common\Util\ClassUtils;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 
 /**
@@ -131,12 +130,7 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
         }
 
         foreach ($collection as $entity) {
-            $ids = $this->modelManager->getIdentifierValues($entity);
-            if (count($ids) > 1) {
-                $id = implode(AdapterInterface::ID_SEPARATOR, $ids);
-            } else {
-                $id = current($ids);
-            }
+            $id = $this->modelManager->getNormalizedIdentifier($entity);
 
             if (null !== $this->toStringCallback) {
                 if (!is_callable($this->toStringCallback)) {

--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -134,8 +134,7 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
             $ids = $this->modelManager->getIdentifierValues($entity);
             if (count($ids) > 1) {
                 $id = implode(AdapterInterface::ID_SEPARATOR, $ids);
-            }
-            else {
+            } else {
                 $id = current($ids);
             }
 

--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -130,7 +130,13 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
         }
 
         foreach ($collection as $entity) {
-            $id = current($this->modelManager->getIdentifierValues($entity));
+            $ids = $this->modelManager->getIdentifierValues($entity);
+            if (count($ids) > 1) {
+                $id = implode('~', $ids);
+            }
+            else {
+                $id = current($ids);
+            }
 
             if (null !== $this->toStringCallback) {
                 if (!is_callable($this->toStringCallback)) {

--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Form\DataTransformer;
 
 use Doctrine\Common\Util\ClassUtils;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 
 /**
@@ -132,7 +133,7 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
         foreach ($collection as $entity) {
             $ids = $this->modelManager->getIdentifierValues($entity);
             if (count($ids) > 1) {
-                $id = implode('~', $ids);
+                $id = implode(AdapterInterface::ID_SEPARATOR, $ids);
             }
             else {
                 $id = current($ids);

--- a/src/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/src/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -15,7 +15,6 @@ use Doctrine\Common\Util\ClassUtils;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 use Symfony\Component\Form\ChoiceList\LazyChoiceList;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\RuntimeException;
@@ -127,7 +126,7 @@ class ModelsToArrayTransformer implements DataTransformerInterface
 
         $array = [];
         foreach ($collection as $key => $entity) {
-            $id = implode(AdapterInterface::ID_SEPARATOR, $this->getIdentifierValues($entity));
+            $id = $this->getNormalizedIdentifier($entity);
 
             $array[] = $id;
         }
@@ -188,10 +187,10 @@ class ModelsToArrayTransformer implements DataTransformerInterface
      *
      * @return array
      */
-    private function getIdentifierValues($entity)
+    private function getNormalizedIdentifier($entity)
     {
         try {
-            return $this->modelManager->getIdentifierValues($entity);
+            return $this->modelManager->getNormalizedIdentifier($entity);
         } catch (\Exception $e) {
             throw new \InvalidArgumentException(sprintf('Unable to retrieve the identifier values for entity %s', ClassUtils::getClass($entity)), 0, $e);
         }

--- a/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
+++ b/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
@@ -40,9 +40,9 @@ class ModelChoiceLoaderTest extends TestCase
             ->will($this->returnValue([$fooA, $fooB]));
 
         $this->modelManager->expects($this->any())
-            ->method('getIdentifierValues')
+            ->method('getNormalizedIdentifier')
             ->will($this->returnCallback(function (Foo $foo) {
-                return [$foo->getBar()];
+                return $foo->getBar();
             }));
 
         $modelChoiceLoader = new ModelChoiceLoader(

--- a/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
@@ -183,6 +183,18 @@ class ModelToIdPropertyTransformerTest extends TestCase
         $this->assertSame([123, '_labels' => ['example']], $transformer->transform($entity));
     }
 
+    public function testTransformWorksWithCompositeKeys()
+    {
+        $entity = new Foo();
+        $entity->setBar('example');
+        $this->modelManager->expects($this->once())
+            ->method('getIdentifierValues')
+            ->will($this->returnValue([123, 456]));
+
+        $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', false);
+        $this->assertSame(['123~456', '_labels' => ['example']], $transformer->transform($entity));
+    }
+
     public function testTransformToStringCallback()
     {
         $entity = new Foo();

--- a/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
@@ -155,8 +155,8 @@ class ModelToIdPropertyTransformerTest extends TestCase
         $entity->setBar('example');
 
         $this->modelManager->expects($this->once())
-            ->method('getIdentifierValues')
-            ->will($this->returnValue([123]));
+            ->method('getNormalizedIdentifier')
+            ->will($this->returnValue('123'));
 
         $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', false);
 
@@ -166,7 +166,7 @@ class ModelToIdPropertyTransformerTest extends TestCase
         $this->assertSame([], $transformer->transform(0));
         $this->assertSame([], $transformer->transform('0'));
 
-        $this->assertSame([123, '_labels' => ['example']], $transformer->transform($entity));
+        $this->assertSame(['123', '_labels' => ['example']], $transformer->transform($entity));
     }
 
     public function testTransformWorksWithArrayAccessEntity()
@@ -175,12 +175,12 @@ class ModelToIdPropertyTransformerTest extends TestCase
         $entity->setBar('example');
 
         $this->modelManager->expects($this->once())
-            ->method('getIdentifierValues')
-            ->will($this->returnValue([123]));
+            ->method('getNormalizedIdentifier')
+            ->will($this->returnValue('123'));
 
         $transformer = new ModelToIdPropertyTransformer($this->modelManager, FooArrayAccess::class, 'bar', false);
 
-        $this->assertSame([123, '_labels' => ['example']], $transformer->transform($entity));
+        $this->assertSame(['123', '_labels' => ['example']], $transformer->transform($entity));
     }
 
     public function testTransformWorksWithCompositeKeys()
@@ -188,8 +188,8 @@ class ModelToIdPropertyTransformerTest extends TestCase
         $entity = new Foo();
         $entity->setBar('example');
         $this->modelManager->expects($this->once())
-            ->method('getIdentifierValues')
-            ->will($this->returnValue([123, 456]));
+            ->method('getNormalizedIdentifier')
+            ->will($this->returnValue('123~456'));
 
         $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', false);
         $this->assertSame(['123~456', '_labels' => ['example']], $transformer->transform($entity));
@@ -202,14 +202,14 @@ class ModelToIdPropertyTransformerTest extends TestCase
         $entity->setBaz('bazz');
 
         $this->modelManager->expects($this->once())
-            ->method('getIdentifierValues')
-            ->will($this->returnValue([123]));
+            ->method('getNormalizedIdentifier')
+            ->will($this->returnValue('123'));
 
         $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', false, function ($entity) {
             return $entity->getBaz();
         });
 
-        $this->assertSame([123, '_labels' => ['bazz']], $transformer->transform($entity));
+        $this->assertSame(['123', '_labels' => ['bazz']], $transformer->transform($entity));
     }
 
     public function testTransformToStringCallbackException()
@@ -222,8 +222,8 @@ class ModelToIdPropertyTransformerTest extends TestCase
         $entity->setBaz('bazz');
 
         $this->modelManager->expects($this->once())
-            ->method('getIdentifierValues')
-            ->will($this->returnValue([123]));
+            ->method('getNormalizedIdentifier')
+            ->will($this->returnValue('123'));
 
         $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', false, '987654');
 
@@ -247,21 +247,21 @@ class ModelToIdPropertyTransformerTest extends TestCase
         $collection[] = $entity3;
 
         $this->modelManager->expects($this->exactly(3))
-            ->method('getIdentifierValues')
+            ->method('getNormalizedIdentifier')
             ->will($this->returnCallback(function ($value) use ($entity1, $entity2, $entity3) {
                 if ($value == $entity1) {
-                    return [123];
+                    return '123';
                 }
 
                 if ($value == $entity2) {
-                    return [456];
+                    return '456';
                 }
 
                 if ($value == $entity3) {
-                    return [789];
+                    return '789';
                 }
 
-                return [999];
+                return '999';
             }));
 
         $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', true);
@@ -273,10 +273,10 @@ class ModelToIdPropertyTransformerTest extends TestCase
         $this->assertSame([], $transformer->transform('0'));
 
         $this->assertSame([
-            123,
+            '123',
             '_labels' => ['foo', 'bar', 'baz'],
-            456,
-            789,
+            '456',
+            '789',
         ], $transformer->transform($collection));
     }
 


### PR DESCRIPTION
I am targeting this branch because this PR is a bug fix and is backward compatible with the rest of the 3.x versions.

Closes #4958

## Changelog

```markdown
### Fixed
 - Fix composite primary key management in the `ModelToIdPropertyTransformer` class
```

## Subject

This PR fixes form errors when editing many to many relations with a child entity having composite priomary key.

