### PR TITLE
Add admin code to Twig get_admin_template function

### DIFF
--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -144,7 +144,7 @@ of objects to manipulate. We can override this behavior by changing our list tem
     {# src/AppBundle/Resources/views/CRUD/list__batch.html.twig #}
     {# see @SonataAdmin/CRUD/list__batch.html.twig for the current default template #}
 
-    {% extends get_admin_template('base_list_field') %}
+    {% extends get_admin_template('base_list_field', admin.code) %}
 
     {% block field %}
         <input type="checkbox" name="idx[]" value="{{ admin.id(object) }}" />

--- a/docs/reference/templates.rst
+++ b/docs/reference/templates.rst
@@ -205,13 +205,13 @@ Templates that are set using the ``setTemplate()`` or ``setTemplates()``
 methods can be accessed through the ``getTemplate($name)`` method of an
 Admin.
 
-Within Twig templates, you can use the ``get_admin_template($name)`` function
-to access the templates of the current Admin, or the
+Within Twig templates, you can use the ``get_admin_template($name, $adminCode)``
+function to access the templates of the current Admin, or the
 ``get_admin_pool_template($name)`` function to access global templates.
 
 .. code-block:: html+jinja
 
-    {% extends get_admin_template('base_list_field') %}
+    {% extends get_admin_template('base_list_field', admin.code) %}
 
     {% block field %}
         {# ... #}

--- a/src/Resources/config/twig.xml
+++ b/src/Resources/config/twig.xml
@@ -32,7 +32,6 @@
         <service id="sonata.templates.twig.extension" class="Sonata\AdminBundle\Twig\Extension\TemplateRegistryExtension" public="false">
             <tag name="twig.extension"/>
             <argument type="service" id="sonata.admin.pool"/>
-            <argument type="service" id="request_stack"/>
         </service>
     </services>
 </container>

--- a/src/Resources/views/CRUD/Association/list_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/list_many_to_many.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/Association/list_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/list_many_to_one.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     {% if value %}

--- a/src/Resources/views/CRUD/Association/list_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/list_one_to_many.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/Association/list_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/list_one_to_one.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/base_history.html.twig
+++ b/src/Resources/views/CRUD/base_history.html.twig
@@ -35,7 +35,7 @@ file that was distributed with this source code.
                         {% for revision in revisions %}
                             <tr class="{% if (currentRevision != false and revision.rev == currentRevision.rev) %}current-revision{% endif %}">
                                 <td>{{ revision.rev }}</td>
-                                <td>{% include get_admin_template('history_revision_timestamp') %}</td>
+                                <td>{% include get_admin_template('history_revision_timestamp', admin.code) %}</td>
                                 <td>{{ revision.username|default('label_unknown_user'|trans({}, 'SonataAdminBundle')) }}</td>
                                 <td><a href="{{ admin.generateObjectUrl('history_view_revision', object, {'revision': revision.rev }) }}" class="revision-link" rel="{{ revision.rev }}">{{ "label_view_revision"|trans({}, 'SonataAdminBundle') }}</a></td>
                                 <td>

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -96,7 +96,7 @@ file that was distributed with this source code.
 
                         {% block table_body %}
                             <tbody>
-                                {% include get_admin_template('outer_list_rows_' ~ admin.getListMode()) %}
+                                {% include get_admin_template('outer_list_rows_' ~ admin.getListMode(), admin.code) %}
                             </tbody>
                         {% endblock %}
 
@@ -211,7 +211,7 @@ file that was distributed with this source code.
                                     {% endif %}
 
                                     {% block pager_results %}
-                                        {% include get_admin_template('pager_results') %}
+                                        {% include get_admin_template('pager_results', admin.code) %}
                                     {% endblock %}
                                 </div>
                             {% endif %}
@@ -220,7 +220,7 @@ file that was distributed with this source code.
                         {% block pager_links %}
                             {% if admin.datagrid.pager.haveToPaginate() %}
                                 <hr/>
-                                {% include get_admin_template('pager_links') %}
+                                {% include get_admin_template('pager_links', admin.code) %}
                             {% endif %}
                         {% endblock %}
                     </div>
@@ -262,7 +262,7 @@ file that was distributed with this source code.
 
 {% block list_filters %}
     {% if admin.datagrid.filters %}
-        {% form_theme form get_admin_template('filter') %}
+        {% form_theme form get_admin_template('filter', admin.code) %}
 
         <div class="col-xs-12 col-md-12 sonata-filters-box" style="display: {{ admin.datagrid.hasDisplayableFilters ? 'block' : 'none' }}" id="filter-container-{{ admin.uniqid() }}">
             <div class="box box-primary" >

--- a/src/Resources/views/CRUD/list__action.html.twig
+++ b/src/Resources/views/CRUD/list__action.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     <div class="btn-group">

--- a/src/Resources/views/CRUD/list__batch.html.twig
+++ b/src/Resources/views/CRUD/list__batch.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     <input type="checkbox" name="idx[]" value="{{ admin.id(object) }}">

--- a/src/Resources/views/CRUD/list__select.html.twig
+++ b/src/Resources/views/CRUD/list__select.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     <a class="btn btn-primary" href="{{ admin.generateUrl('list') }}">

--- a/src/Resources/views/CRUD/list_array.html.twig
+++ b/src/Resources/views/CRUD/list_array.html.twig
@@ -10,7 +10,7 @@ file that was distributed with this source code.
 #}
 {% import '@SonataAdmin/CRUD/base_array_macro.html.twig' as list %}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     {{ list.render_array(value, field_description.options.inline is not defined or field_description.options.inline) }}

--- a/src/Resources/views/CRUD/list_boolean.html.twig
+++ b/src/Resources/views/CRUD/list_boolean.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% set isEditable = field_description.options.editable is defined and field_description.options.editable and admin.hasAccess('edit', object) %}
 {% set xEditableType = field_description.type|sonata_xeditable_type %}

--- a/src/Resources/views/CRUD/list_choice.html.twig
+++ b/src/Resources/views/CRUD/list_choice.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% set is_editable =
     field_description.options.editable is defined and

--- a/src/Resources/views/CRUD/list_currency.html.twig
+++ b/src/Resources/views/CRUD/list_currency.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     {% if value is not null %}

--- a/src/Resources/views/CRUD/list_date.html.twig
+++ b/src/Resources/views/CRUD/list_date.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field%}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/list_datetime.html.twig
+++ b/src/Resources/views/CRUD/list_datetime.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/list_email.html.twig
+++ b/src/Resources/views/CRUD/list_email.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     {% include '@SonataAdmin/CRUD/_email_link.html.twig' %}

--- a/src/Resources/views/CRUD/list_html.html.twig
+++ b/src/Resources/views/CRUD/list_html.html.twig
@@ -1,4 +1,4 @@
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/list_outer_rows_list.html.twig
+++ b/src/Resources/views/CRUD/list_outer_rows_list.html.twig
@@ -11,6 +11,6 @@ file that was distributed with this source code.
 
 {% for object in admin.datagrid.results %}
     <tr>
-        {% include get_admin_template('inner_list_row') %}
+        {% include get_admin_template('inner_list_row', admin.code) %}
     </tr>
 {% endfor %}

--- a/src/Resources/views/CRUD/list_percent.html.twig
+++ b/src/Resources/views/CRUD/list_percent.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     {% set value = value * 100 %}

--- a/src/Resources/views/CRUD/list_string.html.twig
+++ b/src/Resources/views/CRUD/list_string.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}

--- a/src/Resources/views/CRUD/list_time.html.twig
+++ b/src/Resources/views/CRUD/list_time.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/list_trans.html.twig
+++ b/src/Resources/views/CRUD/list_trans.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field%}
     {% set translationDomain = field_description.options.catalogue|default(admin.translationDomain) %}

--- a/src/Resources/views/CRUD/list_url.html.twig
+++ b/src/Resources/views/CRUD/list_url.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_template('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
 {% spaceless %}

--- a/src/Twig/Extension/TemplateRegistryExtension.php
+++ b/src/Twig/Extension/TemplateRegistryExtension.php
@@ -13,7 +13,6 @@ namespace Sonata\AdminBundle\Twig\Extension;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -24,33 +23,28 @@ final class TemplateRegistryExtension extends AbstractExtension
      */
     private $pool;
 
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
-    public function __construct(Pool $pool, RequestStack $requestStack)
+    public function __construct(Pool $pool)
     {
         $this->pool = $pool;
-        $this->requestStack = $requestStack;
     }
 
     public function getFunctions()
     {
         return [
-            new TwigFunction('get_admin_template', [$this, 'getTemplate']),
+            new TwigFunction('get_admin_template', [$this, 'getAdminTemplate']),
             new TwigFunction('get_admin_pool_template', [$this, 'getPoolTemplate']),
         ];
     }
 
     /**
      * @param string $name
+     * @param string $adminCode
      *
      * @return null|string
      */
-    public function getTemplate($name)
+    public function getAdminTemplate($name, $adminCode)
     {
-        return $this->getAdmin()->getTemplate($name);
+        return $this->getAdmin($adminCode)->getTemplate($name);
     }
 
     /**
@@ -64,12 +58,12 @@ final class TemplateRegistryExtension extends AbstractExtension
     }
 
     /**
+     * @param string $adminCode
+     *
      * @return AdminInterface|false|null
      */
-    private function getAdmin()
+    private function getAdmin($adminCode)
     {
-        return $this->pool->getAdminByAdminCode(
-            $this->requestStack->getCurrentRequest()->get('_sonata_admin')
-        );
+        return $this->pool->getAdminByAdminCode($adminCode);
     }
 }

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -28,7 +28,6 @@ use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubFilesystemLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\RequestContext;
@@ -150,9 +149,7 @@ class SonataAdminExtensionTest extends TestCase
         $request = $this->createMock(Request::class);
         $request->expects($this->any())->method('get')->with('_sonata_admin')->willReturn('sonata_admin_foo_service');
 
-        $requestStack = $this->createMock(RequestStack::class);
-        $requestStack->expects($this->any())->method('getCurrentRequest')->willReturn($request);
-        $this->templateRegistryExtension = new TemplateRegistryExtension($this->pool, $requestStack);
+        $this->templateRegistryExtension = new TemplateRegistryExtension($this->pool);
 
         $loader = new StubFilesystemLoader([
             __DIR__.'/../../../src/Resources/views/CRUD',
@@ -190,7 +187,7 @@ class SonataAdminExtensionTest extends TestCase
 
         $this->admin->expects($this->any())
             ->method('getCode')
-            ->will($this->returnValue('xyz'));
+            ->will($this->returnValue('sonata_admin_foo_service'));
 
         $this->admin->expects($this->any())
             ->method('id')
@@ -685,7 +682,7 @@ class SonataAdminExtensionTest extends TestCase
         data-value="1"
         data-title="Data"
         data-pk="12345"
-        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=xyz"
+        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=sonata_admin_foo_service"
         data-source="[{value: 0, text: 'no'},{value: 1, text: 'yes'}]"
     >
         <span class="label label-success">yes</span>
@@ -706,7 +703,7 @@ EOT
         data-value="0"
         data-title="Data"
         data-pk="12345"
-        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=xyz"
+        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=sonata_admin_foo_service"
         data-source="[{value: 0, text: 'no'},{value: 1, text: 'yes'}]"
     >
     <span class="label label-danger">no</span> </span>
@@ -726,7 +723,7 @@ EOT
         data-value="0"
         data-title="Data"
         data-pk="12345"
-        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=xyz"
+        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=sonata_admin_foo_service"
         data-source="[{value: 0, text: 'no'},{value: 1, text: 'yes'}]" >
         <span class="label label-danger">no</span> </span>
 </td>
@@ -894,7 +891,7 @@ EOT
         data-value="Status1"
         data-title="Data"
         data-pk="12345"
-        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=xyz"
+        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=sonata_admin_foo_service"
         data-source="[]"
     >
         Status1
@@ -915,7 +912,7 @@ EOT
         data-value="Status1"
         data-title="Data"
         data-pk="12345"
-        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=xyz"
+        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=sonata_admin_foo_service"
         data-source="[{&quot;value&quot;:&quot;Status1&quot;,&quot;text&quot;:&quot;Alias1&quot;},{&quot;value&quot;:&quot;Status2&quot;,&quot;text&quot;:&quot;Alias2&quot;},{&quot;value&quot;:&quot;Status3&quot;,&quot;text&quot;:&quot;Alias3&quot;}]" >
         Alias1 </span>
 </td>
@@ -941,7 +938,7 @@ EOT
         data-value=""
         data-title="Data"
         data-pk="12345"
-        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=xyz"
+        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=sonata_admin_foo_service"
         data-source="[{&quot;value&quot;:&quot;Status1&quot;,&quot;text&quot;:&quot;Alias1&quot;},{&quot;value&quot;:&quot;Status2&quot;,&quot;text&quot;:&quot;Alias2&quot;},{&quot;value&quot;:&quot;Status3&quot;,&quot;text&quot;:&quot;Alias3&quot;}]" >
 
     </span>
@@ -967,7 +964,7 @@ EOT
         data-type="select"
         data-value="NoValidKeyInChoices"
         data-title="Data" data-pk="12345"
-        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=xyz"
+        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=sonata_admin_foo_service"
         data-source="[{&quot;value&quot;:&quot;Status1&quot;,&quot;text&quot;:&quot;Alias1&quot;},{&quot;value&quot;:&quot;Status2&quot;,&quot;text&quot;:&quot;Alias2&quot;},{&quot;value&quot;:&quot;Status3&quot;,&quot;text&quot;:&quot;Alias3&quot;}]" >
         NoValidKeyInChoices
     </span>
@@ -994,7 +991,7 @@ EOT
         data-value="Foo"
         data-title="Data"
         data-pk="12345"
-        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=xyz"
+        data-url="/core/set-object-field-value?context=list&amp;field=fd_name&amp;objectId=12345&amp;code=sonata_admin_foo_service"
         data-source="[{&quot;value&quot;:&quot;Foo&quot;,&quot;text&quot;:&quot;Delete&quot;},{&quot;value&quot;:&quot;Status2&quot;,&quot;text&quot;:&quot;Alias2&quot;},{&quot;value&quot;:&quot;Status3&quot;,&quot;text&quot;:&quot;Alias3&quot;}]" >
          Delete
     </span>

--- a/tests/Twig/Extension/TemplateRegistryExtensionTest.php
+++ b/tests/Twig/Extension/TemplateRegistryExtensionTest.php
@@ -15,8 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Twig\Extension\TemplateRegistryExtension;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Class TemplateRegistryExtensionTest.
@@ -34,35 +32,18 @@ class TemplateRegistryExtensionTest extends TestCase
     private $pool;
 
     /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
-    /**
-     * @var Request
-     */
-    private $request;
-
-    /**
      * @var AdminInterface
      */
     private $admin;
 
     protected function setUp()
     {
-        $this->request = $this->prophesize(Request::class);
         $this->pool = $this->prophesize(Pool::class);
-        $this->requestStack = $this->prophesize(RequestStack::class);
         $this->admin = $this->prophesize(AdminInterface::class);
 
-        $this->requestStack->getCurrentRequest()->willReturn($this->request);
-        $this->request->get('_sonata_admin')->willReturn('admin.post');
         $this->pool->getAdminByAdminCode('admin.post')->willReturn($this->admin);
 
-        $this->extension = new TemplateRegistryExtension(
-            $this->pool->reveal(),
-            $this->requestStack->reveal()
-        );
+        $this->extension = new TemplateRegistryExtension($this->pool->reveal());
     }
 
     public function testGetTemplate()
@@ -71,7 +52,7 @@ class TemplateRegistryExtensionTest extends TestCase
 
         $this->assertEquals(
             '@SonataAdmin/CRUD/edit.html.twig',
-            $this->extension->getTemplate('edit')
+            $this->extension->getAdminTemplate('edit', 'admin.post')
         );
     }
 


### PR DESCRIPTION
I am targeting this branch, because this is a BC fix for an earlier PR to 3.x.

## Changelog

```markdown
### Fixed
- Templates that rely on the `admin` variable in Twig can now use the `get_admin_template` function correctly.
```

## Subject
In a [previous PR](https://github.com/sonata-project/SonataAdminBundle/pull/4948), the Twig function `get_admin_template` was added. This function pulled the current admin code from the `Request` object through `RequestStack::getCurrentRequest()`.
@andrewmy pointed out that this is not (always) the correct way to do this. Thank you.

In order to fix this, I added a `$adminCode` parameter to the `get_admin_template` Twig function, so that the correct admin is used again.

I changed the `SonataAdminExtensionTest` test case, because a different admin code was used in the test, then the one used in the setup. That caused the admin lookup in the pool to fail.