### PR TITLE
custom mask builder is a parameter not a service

### DIFF
--- a/docs/reference/security.rst
+++ b/docs/reference/security.rst
@@ -345,8 +345,8 @@ The following configuration for the SonataUserBundle defines:
               class: Sonata\AdminBundle\Security\Acl\Permission\AdminPermissionMap
 
             # optionally use a custom MaskBuilder
-            #sonata.admin.security.mask.builder:
-            #  class: Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder
+        parameters:    
+            #sonata.admin.security.mask.builder.class: Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder
 
         # Symfony < 3
         parameters:


### PR DESCRIPTION
There is no service with the id sonata.admin.security.mask.builder, there for creating one will not make a difference in Symfony >= 3. You still need to create a parameter for your own class, as was before the case.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod` to do great stuff

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
