### PR TITLE
Catch all clicks on a link

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -175,7 +175,7 @@ This code manages the many-to-[one|many] association field popup
 
                 // capture the submit event to make an ajax call, ie : POST data to the
                 // related create admin
-                jQuery('a', field_dialog_{{ id }}).on('click', field_dialog_form_action_{{ id }});
+                jQuery(document).on('click','#field_dialog_{{ id }} a', field_dialog_form_action_{{ id }});
                 jQuery('form', field_dialog_{{ id }}).on('submit', field_dialog_form_action_{{ id }});
 
                 // open the dialog in modal mode
@@ -215,7 +215,7 @@ This code manages the many-to-[one|many] association field popup
 
                 // capture the submit event to make an ajax call, ie : POST data to the
                 // related create admin
-                jQuery('a', field_dialog_{{ id }}).on('click', field_dialog_form_action_{{ id }});
+                jQuery(document).on('click','#field_dialog_{{ id }} a', field_dialog_form_action_{{ id }});
                 jQuery('form', field_dialog_{{ id }}).on('submit', field_dialog_form_action_{{ id }});
 
                 // open the dialog in modal mode


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this should be BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Allow capturing of any link click inside of modal
```

## Subject

Currently, if Entity is implementing `Sonata\TranslationBundle\Model\Gedmo\TranslatableInterface` we get flags in the form that allow us to change the language. If we use `ModelListType` on associated Entity we get the same flags in the popup.

![screenshot from 2018-02-20 23-56-47](https://user-images.githubusercontent.com/13528674/36453940-398d20ba-169a-11e8-82db-4acc2eeb9345.png)

The problem is if we click 1 time on any flag the form in modal is reloaded and we will save it in that language. If we click again on some other flag we get redirected to that page with that language selected instead of reloading the modal again, so we lose info from the page where we opened the modal. With this fix, we capture any click inside of modal and reload the form without redirecting.

Not sure if this can break something and if this is a BC or not, any help on that?