### PR TITLE
Make actions button more compact

### DIFF
--- a/src/Resources/views/CRUD/list__action_delete.html.twig
+++ b/src/Resources/views/CRUD/list__action_delete.html.twig
@@ -12,6 +12,8 @@ file that was distributed with this source code.
 {% if admin.hasAccess('delete', object) and admin.hasRoute('delete') %}
     <a href="{{ admin.generateObjectUrl('delete', object) }}" class="btn btn-sm btn-default delete_link" title="{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}">
         <i class="fa fa-times" aria-hidden="true"></i>
-        {{ 'action_delete'|trans({}, 'SonataAdminBundle') }}
+        <span class="sr-only">
+            {{ 'action_delete'|trans({}, 'SonataAdminBundle') }}
+        </span>
     </a>
 {% endif %}

--- a/src/Resources/views/CRUD/list__action_edit.html.twig
+++ b/src/Resources/views/CRUD/list__action_edit.html.twig
@@ -12,6 +12,8 @@ file that was distributed with this source code.
 {% if admin.hasAccess('edit', object) and admin.hasRoute('edit') %}
     <a href="{{ admin.generateObjectUrl('edit', object) }}" class="btn btn-sm btn-default edit_link" title="{{ 'action_edit'|trans({}, 'SonataAdminBundle') }}">
         <i class="fa fa-pencil" aria-hidden="true"></i>
-        {{ 'action_edit'|trans({}, 'SonataAdminBundle') }}
+        <span class="sr-only">
+            {{ 'action_edit'|trans({}, 'SonataAdminBundle') }}
+        </span>
     </a>
 {% endif %}

--- a/src/Resources/views/CRUD/list__action_show.html.twig
+++ b/src/Resources/views/CRUD/list__action_show.html.twig
@@ -12,6 +12,8 @@ file that was distributed with this source code.
 {% if admin.hasAccess('show', object) and admin.hasRoute('show') %}
     <a href="{{ admin.generateObjectUrl('show', object) }}" class="btn btn-sm btn-default view_link" title="{{ 'action_show'|trans({}, 'SonataAdminBundle') }}">
         <i class="fa fa-eye" aria-hidden="true"></i>
-        {{ 'action_show'|trans({}, 'SonataAdminBundle') }}
+        <span class="sr-only">
+            {{ 'action_show'|trans({}, 'SonataAdminBundle') }}
+        </span>
     </a>
 {% endif %}


### PR DESCRIPTION
I am targeting this branch, because it's an improvement.

## Changelog

```markdown
### Changed
- More compact action buttons
```

Before:

![image](https://user-images.githubusercontent.com/1698357/36494994-17e29d56-1734-11e8-8832-7c0dff6f7f5f.png)

After:

![image](https://user-images.githubusercontent.com/1698357/36495003-1b7d45a6-1734-11e8-84f4-bde57e8bbb0d.png)

The goal is to make buttons more compact to allow more space for the data on the table.

The buttons are still accessible thanks to the `title` attribute and the `sr-only` class.