### PR TITLE
improve mosaic template

### DIFF
--- a/src/Resources/public/css/styles.css
+++ b/src/Resources/public/css/styles.css
@@ -497,6 +497,10 @@ div.mosaic-box.sonata-ba-list-row-selected > div.mosaic-inner-text {
     border-top: none;
 }
 
+.modal .mosaic-inner-text .icheckbox_square-blue {
+    display: none;
+}
+
 div.sonata-filters-box div.form-group div.form-group {
     margin: 0;
 }

--- a/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
+++ b/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
@@ -21,9 +21,7 @@ This template can be customized to match your needs. You should only extends the
         <div class="row">
             {% for object in admin.datagrid.results %}
                 {% set meta = admin.getObjectMetadata(object) %}
-
-                <div class="col-xs-6 col-sm-3 mosaic-box sonata-ba-list-field-batch sonata-ba-list-field" objectId="{{ admin.id(object) }}">
-
+                {% set mosaic_content %}
                     <div class="mosaic-box-outter">
                         <div class="mosaic-inner-box">
                             {#
@@ -62,16 +60,26 @@ This template can be customized to match your needs. You should only extends the
                             {% endif %}
 
                             {% block sonata_mosaic_description %}
-                                {% if admin.hasAccess('edit', object) and admin.hasRoute('edit') %}
-                                    <a class="mosaic-inner-link" href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|truncate(40) }}</a>
-                                {% elseif admin.hasAccess('show', object) and admin.hasRoute('show') %}
-                                    <a class="mosaic-inner-link" href="{{ admin.generateUrl('show', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|truncate(40) }}</a>
-                                {% else %}
-                                    {{ meta.title|truncate(40) }}
-                                {% endif %}
+                                {{ meta.title|truncate(40) }}
                             {% endblock %}
                         </div>
                     </div>
+                {% endset %}
+                <div class="col-xs-6 col-sm-3 mosaic-box sonata-ba-list-field-batch sonata-ba-list-field"
+                     objectId="{{ admin.id(object) }}">
+                    {% if admin.hasAccess('edit', object) and admin.hasRoute('edit') %}
+                        <a class="mosaic-inner-link"
+                           href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid(admin) }) }}">
+                            {{ mosaic_content }}
+                        </a>
+                    {% elseif admin.hasAccess('show', object) and admin.hasRoute('show') %}
+                        <a class="mosaic-inner-link"
+                           href="{{ admin.generateUrl('show', {'id' : object|sonata_urlsafeid(admin) }) }}">
+                            {{ mosaic_content }}
+                        </a>
+                    {% else %}
+                        {{ mosaic_content }}
+                    {% endif %}
                 </div>
 
                 {% if loop.index % 4 == 0 %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4969

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- batch checkbox is hidden when using the mosaic view in modal
- whole mosaic item is now wrapped in a tag instead of just title
```
Before:

![screenshot from 2018-02-22 21-33-07](https://user-images.githubusercontent.com/13528674/36563064-41b0dd42-1819-11e8-839d-00bdcf77234d.png)

After:

![screenshot from 2018-02-22 21-32-35](https://user-images.githubusercontent.com/13528674/36563068-453ab87a-1819-11e8-88ba-4fe82678fe1b.png)

## Subject

This will hide checkbox for batch action when in modal because we do not have batch actions there. Instead of making just the title clickable now the whole item can be clicked.
