### PR TITLE
Fix error if no object in relationship

### DIFF
--- a/src/Resources/views/CRUD/Association/list_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/list_many_to_one.html.twig
@@ -14,10 +14,11 @@ file that was distributed with this source code.
 {% block field %}
     {% if value %}
         {% set route_name = field_description.options.route.name %}
-        {% if not field_description.options.identifier|default(false) and
-              field_description.hasAssociationAdmin and
-              field_description.associationadmin.hasRoute(route_name) and
-              field_description.associationadmin.hasAccess(route_name, value)
+        {% if not field_description.options.identifier|default(false)
+            and field_description.hasAssociationAdmin
+            and field_description.associationadmin.hasRoute(route_name)
+            and field_description.associationadmin.hasAccess(route_name, value)
+            and field_description.associationadmin.id(value)
         %}
             <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
                 {{ value|render_relation_element(field_description) }}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/330

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- if object is empty, don't try to create an edit route
```

## Subject

Currently, there is no check if the object has an id and tries to generate the route for edit on many-to-one in the list.
