### PR TITLE
Move templates from AbstractAdmin and Pool to TemplateRegistry

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,20 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated use of $templates in AbstractAdmin and Pool
+
+The `AbstractAdmin::$templates` attribute and the methods `getTemplate()` and
+`getTemplates()` are deprecated. Please use the new TemplateRegistry services
+instead. One per admin is generated and available through the admin code +
+`.template_registry` (for example, `app.admin.news` uses `app.admin.news.template_registry`).
+
+The `Pool::$templates` attribute and the methods `getTemplate()`, `getTemplates()`
+and `setTemplates()` are deprecated. Please use the TemplateRegistry service
+`sonata.admin.global_template_registry` instead.
+
+The Twig function `get_admin_pool_template()` is deprecated. Please use
+`get_global_template()` instead.
+
 ## Deprecated AbstractAdmin::$persistFilters
 
 The `AbstractAdmin::$persistFilters` is deprecated and should not be used anymore.

--- a/docs/reference/templates.rst
+++ b/docs/reference/templates.rst
@@ -153,12 +153,13 @@ You can specify your templates in the config.yml file, like so:
                 button_list:                    '@SonataAdmin/Button/list_button.html.twig'
                 button_show:                    '@SonataAdmin/Button/show_button.html.twig'
 
-Notice that this is a global change, meaning it will affect all model mappings automatically,
-both for ``Admin`` mappings defined by you and by other bundles.
+Notice that this is a global change, meaning it will affect all model mappings
+automatically, both for ``Admin`` mappings defined by you and by other bundles.
 
-If you wish, you can specify custom templates on a per ``Admin`` mapping basis. Internally,
-the ``CRUDController`` fetches this information from the ``Admin`` class instance, so you can
-specify the templates to use in the ``Admin`` service definition:
+If you wish, you can specify custom templates on a per ``Admin`` mapping
+basis. Internally, the ``CRUDController`` fetches this information from the
+``TemplateRegistry`` class instance that belongs with the ``Admin``, so you
+can specify the templates to use in the ``Admin`` service definition:
 
 .. configuration-block::
 
@@ -206,13 +207,21 @@ a global custom template and then override that customization on a specific
 
 Finding configured templates
 ----------------------------
-Templates that are set using the ``setTemplate()`` or ``setTemplates()``
-methods can be accessed through the ``getTemplate($name)`` method of an
-Admin.
+Each ``Admin`` has a ``TemplateRegistry`` service connected to it that holds
+the templates registered through the configuration above. Through the method
+``getTemplate($name)`` of that class, you can access the templates set for
+that ``Admin``. The ``TemplateRegistry`` is available through ``$this->getTemplateRegistry()``
+within the ``Admin``. Using the service container the template registries can
+be accessed outside an ``Admin``. Use the ``Admin`` code + ``.template_registry``
+as the service ID (i.e. "app.admin.post" uses the Template Registry
+"app.admin.post.template_registry").
+
+The ``TemplateRegistry`` service that holds the global templates can be accessed
+using the service ID "sonata.admin.global_template_registry".
 
 Within Twig templates, you can use the ``get_admin_template($name, $adminCode)``
-function to access the templates of the current Admin, or the
-``get_admin_pool_template($name)`` function to access global templates.
+function to access the templates of the current ``Admin``, or the
+``get_global_template($name)`` function to access global templates.
 
 .. code-block:: html+jinja
 

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Admin;
 
+use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -41,7 +42,9 @@ class Pool
     protected $adminClasses = [];
 
     /**
-     * @var string[]
+     * @deprecated since 3.x, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
+     *
+     * @var array
      */
     protected $templates = [];
 
@@ -69,6 +72,11 @@ class Pool
      * @var PropertyAccessorInterface
      */
     protected $propertyAccessor;
+
+    /**
+     * @var MutableTemplateRegistryInterface
+     */
+    private $templateRegistry;
 
     /**
      * @param string $title
@@ -315,29 +323,42 @@ class Pool
         return $this->adminClasses;
     }
 
-    public function setTemplates(array $templates)
+    final public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry)
     {
-        $this->templates = $templates;
+        $this->templateRegistry = $templateRegistry;
     }
 
     /**
+     * @deprecated since 3.x, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
+     */
+    public function setTemplates(array $templates)
+    {
+        // NEXT MAJOR: Remove this line
+        $this->templates = $templates;
+
+        $this->templateRegistry->setTemplates($templates);
+    }
+
+    /**
+     * @deprecated since 3.x, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
+     *
      * @return array
      */
     public function getTemplates()
     {
-        return $this->templates;
+        return $this->templateRegistry->getTemplates();
     }
 
     /**
+     * @deprecated since 3.x, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
+     *
      * @param string $name
      *
      * @return null|string
      */
     public function getTemplate($name)
     {
-        if (isset($this->templates[$name])) {
-            return $this->templates[$name];
-        }
+        return $this->templateRegistry->getTemplate($name);
     }
 
     /**

--- a/src/Block/AdminListBlockService.php
+++ b/src/Block/AdminListBlockService.php
@@ -12,6 +12,8 @@
 namespace Sonata\AdminBundle\Block;
 
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistry;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
@@ -23,16 +25,29 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class AdminListBlockService extends AbstractBlockService
 {
+    /**
+     * @var Pool
+     */
     protected $pool;
+
+    /**
+     * @var TemplateRegistryInterface
+     */
+    private $templateRegistry;
 
     /**
      * @param string $name
      */
-    public function __construct($name, EngineInterface $templating, Pool $pool)
-    {
+    public function __construct(
+        $name,
+        EngineInterface $templating,
+        Pool $pool,
+        TemplateRegistryInterface $templateRegistry = null
+    ) {
         parent::__construct($name, $templating);
 
         $this->pool = $pool;
+        $this->templateRegistry = $templateRegistry ?: new TemplateRegistry();
     }
 
     public function execute(BlockContextInterface $blockContext, Response $response = null)
@@ -48,7 +63,7 @@ class AdminListBlockService extends AbstractBlockService
             }
         }
 
-        return $this->renderPrivateResponse($this->pool->getTemplate('list_block'), [
+        return $this->renderPrivateResponse($this->templateRegistry->getTemplate('list_block'), [
             'block' => $blockContext->getBlock(),
             'settings' => $settings,
             'admin_pool' => $this->pool,

--- a/src/Controller/CoreController.php
+++ b/src/Controller/CoreController.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Controller;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Search\SearchHandler;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -52,7 +53,7 @@ class CoreController extends Controller
             $parameters['breadcrumbs_builder'] = $this->get('sonata.admin.breadcrumbs_builder');
         }
 
-        return $this->render($this->getAdminPool()->getTemplate('dashboard'), $parameters);
+        return $this->render($this->getTemplateRegistry()->getTemplate('dashboard'), $parameters);
     }
 
     /**
@@ -100,7 +101,7 @@ class CoreController extends Controller
             return $response;
         }
 
-        return $this->render($this->container->get('sonata.admin.pool')->getTemplate('search'), [
+        return $this->render($this->getTemplateRegistry()->getTemplate('search'), [
             'base_template' => $this->getBaseTemplate(),
             'breadcrumbs_builder' => $this->get('sonata.admin.breadcrumbs_builder'),
             'admin_pool' => $this->container->get('sonata.admin.pool'),
@@ -154,10 +155,18 @@ class CoreController extends Controller
     protected function getBaseTemplate()
     {
         if ($this->getCurrentRequest()->isXmlHttpRequest()) {
-            return $this->getAdminPool()->getTemplate('ajax');
+            return $this->getTemplateRegistry()->getTemplate('ajax');
         }
 
-        return $this->getAdminPool()->getTemplate('layout');
+        return $this->getTemplateRegistry()->getTemplate('layout');
+    }
+
+    /**
+     * @return TemplateRegistryInterface
+     */
+    private function getTemplateRegistry()
+    {
+        return $this->container->get('sonata.admin.global_template_registry');
     }
 
     /**

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
 use Doctrine\Common\Inflector\Inflector;
 use Sonata\AdminBundle\Datagrid\Pager;
+use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -333,7 +334,12 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         $definition->addMethodCall('showMosaicButton', [$showMosaicButton]);
 
-        $this->fixTemplates($container, $definition, isset($overwriteAdminConfiguration['templates']) ? $overwriteAdminConfiguration['templates'] : ['view' => []]);
+        $this->fixTemplates(
+            $serviceId,
+            $container,
+            $definition,
+            isset($overwriteAdminConfiguration['templates']) ? $overwriteAdminConfiguration['templates'] : ['view' => []]
+        );
 
         if ($container->hasParameter('sonata.admin.configuration.security.information') && !$definition->hasMethodCall('setSecurityInformation')) {
             $definition->addMethodCall('setSecurityInformation', ['%sonata.admin.configuration.security.information%']);
@@ -344,8 +350,15 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         return $definition;
     }
 
-    public function fixTemplates(ContainerBuilder $container, Definition $definition, array $overwrittenTemplates = [])
-    {
+    /**
+     * @param string $serviceId
+     */
+    public function fixTemplates(
+        $serviceId,
+        ContainerBuilder $container,
+        Definition $definition,
+        array $overwrittenTemplates = []
+    ) {
         $definedTemplates = $container->getParameter('sonata.admin.configuration.templates');
 
         $methods = [];
@@ -382,11 +395,19 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         $definedTemplates = $overwrittenTemplates['view'] + $definedTemplates;
 
+        $templateRegistryId = $serviceId.'.template_registry';
+        $templateRegistryDefinition = $container
+            ->register($templateRegistryId, TemplateRegistry::class)
+            ->addTag('sonata.admin.template_registry')
+            ->setPublic(true); // Temporary fix until we can support service locators
+
         if ($container->getParameter('sonata.admin.configuration.templates') !== $definedTemplates) {
-            $definition->addMethodCall('setTemplates', [$definedTemplates]);
+            $templateRegistryDefinition->addArgument($definedTemplates);
         } else {
-            $definition->addMethodCall('setTemplates', ['%sonata.admin.configuration.templates%']);
+            $templateRegistryDefinition->addArgument('%sonata.admin.configuration.templates%');
         }
+
+        $definition->addMethodCall('setTemplateRegistry', [new Reference($templateRegistryId)]);
     }
 
     /**

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -6,6 +6,7 @@
             <argument>sonata.admin.block.admin_list</argument>
             <argument type="service" id="sonata.templating"/>
             <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="sonata.admin.global_template_registry"/>
         </service>
         <service id="sonata.admin.block.search_result" class="Sonata\AdminBundle\Block\AdminSearchBlockService" public="true">
             <tag name="sonata.block"/>

--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -7,8 +7,8 @@
             <argument/>
             <argument type="collection"/>
             <argument type="service" id="property_accessor"/>
-            <call method="setTemplates">
-                <argument>%sonata.admin.configuration.templates%</argument>
+            <call method="setTemplateRegistry">
+                <argument type="service" id="sonata.admin.global_template_registry"/>
             </call>
         </service>
         <service id="sonata.admin.route_loader" class="Sonata\AdminBundle\Route\AdminPoolLoader" public="true">
@@ -76,6 +76,10 @@
         <!-- filter persister -->
         <service id="sonata.admin.filter_persister.session" class="Sonata\AdminBundle\Filter\Persister\SessionFilterPersister">
             <argument type="service" id="session"/>
+        </service>
+        <!-- templating -->
+        <service id="sonata.admin.global_template_registry" class="Sonata\AdminBundle\Templating\TemplateRegistry" public="true">
+            <argument>%sonata.admin.configuration.templates%</argument>
         </service>
     </services>
 </container>

--- a/src/Resources/config/twig.xml
+++ b/src/Resources/config/twig.xml
@@ -25,13 +25,15 @@
             <argument type="service" id="sonata.admin.pool"/>
             <argument type="service" id="logger" on-invalid="ignore"/>
             <argument type="service" id="translator"/>
+            <argument type="service" id="service_container"/>
             <call method="setXEditableTypeMapping">
                 <argument>%sonata.admin.twig.extension.x_editable_type_mapping%</argument>
             </call>
         </service>
         <service id="sonata.templates.twig.extension" class="Sonata\AdminBundle\Twig\Extension\TemplateRegistryExtension" public="false">
             <tag name="twig.extension"/>
-            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="sonata.admin.global_template_registry"/>
+            <argument type="service" id="service_container"/>
         </service>
     </services>
 </container>

--- a/src/Resources/views/CRUD/action.html.twig
+++ b/src/Resources/views/CRUD/action.html.twig
@@ -19,7 +19,7 @@ file that was distributed with this source code.
     {% if action is defined %}
         {{ knp_menu_render(admin.sidemenu(action), {
             'currentClass': 'active',
-            'template': get_admin_pool_template('tab_menu_template')
+            'template': get_global_template('tab_menu_template')
         }, 'twig') }}
     {% endif %}
 {%- endblock -%}

--- a/src/Resources/views/CRUD/base_edit.html.twig
+++ b/src/Resources/views/CRUD/base_edit.html.twig
@@ -31,7 +31,7 @@ file that was distributed with this source code.
 {%- block tab_menu -%}
     {{ knp_menu_render(admin.sidemenu(action), {
         'currentClass': 'active',
-        'template': get_admin_pool_template('tab_menu_template')
+        'template': get_global_template('tab_menu_template')
     }, 'twig') }}
 {%- endblock -%}
 

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -18,7 +18,7 @@ file that was distributed with this source code.
 {%- block tab_menu -%}
     {{ knp_menu_render(admin.sidemenu(action), {
         'currentClass': 'active',
-        'template': get_admin_pool_template('tab_menu_template')
+        'template': get_global_template('tab_menu_template')
     }, 'twig') }}
 {%- endblock -%}
 

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -26,7 +26,7 @@ file that was distributed with this source code.
 {% block tab_menu %}
     {{ knp_menu_render(admin.sidemenu(action), {
         'currentClass' : 'active',
-        'template': get_admin_pool_template('tab_menu_template')
+        'template': get_global_template('tab_menu_template')
     }, 'twig') }}
 {% endblock %}
 

--- a/src/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/src/Resources/views/CRUD/batch_confirmation.html.twig
@@ -18,7 +18,7 @@ file that was distributed with this source code.
 {%- block tab_menu -%}
     {{ knp_menu_render(admin.sidemenu(action), {
         'currentClass': 'active',
-        'template': get_admin_pool_template('tab_menu_template')
+        'template': get_global_template('tab_menu_template')
     }, 'twig') }}
 {%- endblock -%}
 

--- a/src/Resources/views/CRUD/delete.html.twig
+++ b/src/Resources/views/CRUD/delete.html.twig
@@ -18,7 +18,7 @@ file that was distributed with this source code.
 {%- block tab_menu -%}
     {{ knp_menu_render(admin.sidemenu(action), {
         'currentClass': 'active',
-        'template': get_admin_pool_template('tab_menu_template')
+        'template': get_global_template('tab_menu_template')
     }, 'twig') }}
 {%- endblock -%}
 

--- a/src/Resources/views/empty_layout.html.twig
+++ b/src/Resources/views/empty_layout.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends get_admin_pool_template('layout') %}
+{% extends get_global_template('layout') %}
 
 {% block sonata_header %}{% endblock %}
 {% block sonata_left_side %}{% endblock %}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -202,7 +202,7 @@ file that was distributed with this source code.
                                                 <a class="dropdown-toggle" data-toggle="dropdown" href="#">
                                                     <i class="fa fa-plus-square fa-fw" aria-hidden="true"></i> <i class="fa fa-caret-down" aria-hidden="true"></i>
                                                 </a>
-                                                {% include get_admin_pool_template('add_block') %}
+                                                {% include get_global_template('add_block') %}
                                             </li>
                                         {% endblock %}
                                         {% block sonata_top_nav_menu_user_block %}
@@ -211,7 +211,7 @@ file that was distributed with this source code.
                                                     <i class="fa fa-user fa-fw" aria-hidden="true"></i> <i class="fa fa-caret-down" aria-hidden="true"></i>
                                                 </a>
                                                 <ul class="dropdown-menu dropdown-user">
-                                                    {% include get_admin_pool_template('user_block') %}
+                                                    {% include get_global_template('user_block') %}
                                                 </ul>
                                             </li>
                                         {% endblock %}
@@ -244,7 +244,7 @@ file that was distributed with this source code.
 
                             {% block side_bar_before_nav %} {% endblock %}
                             {% block side_bar_nav %}
-                                {{ knp_menu_render('sonata_admin_sidebar', {template: get_admin_pool_template('knp_menu_template')}) }}
+                                {{ knp_menu_render('sonata_admin_sidebar', {template: get_global_template('knp_menu_template')}) }}
                             {% endblock side_bar_nav %}
                             {% block side_bar_after_nav %}
                                 <p class="text-center small" style="border-top: 1px solid #444444; padding-top: 10px">

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Templating;
+
+/**
+ * @author Timo Bakx <timobakx@gmail.com>
+ */
+interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
+{
+    /**
+     * @param array $templates 'name' => 'file_path.html.twig'
+     */
+    public function setTemplates(array $templates);
+
+    /**
+     * @param string $name
+     * @param string $template
+     */
+    public function setTemplate($name, $template);
+}

--- a/src/Templating/TemplateRegistry.php
+++ b/src/Templating/TemplateRegistry.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Templating;
+
+/**
+ * @author Timo Bakx <timobakx@gmail.com>
+ */
+final class TemplateRegistry implements MutableTemplateRegistryInterface
+{
+    private $templates = [];
+
+    public function __construct(array $templates = [])
+    {
+        $this->templates = $templates;
+    }
+
+    public function getTemplates()
+    {
+        return $this->templates;
+    }
+
+    public function setTemplates(array $templates)
+    {
+        $this->templates = $templates;
+    }
+
+    public function getTemplate($name)
+    {
+        if (isset($this->templates[$name])) {
+            return $this->templates[$name];
+        }
+    }
+
+    public function setTemplate($name, $template)
+    {
+        $this->templates[$name] = $template;
+    }
+}

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Templating;
+
+/**
+ * @author Timo Bakx <timobakx@gmail.com>
+ */
+interface TemplateRegistryInterface
+{
+    /**
+     * @return array 'name' => 'file_path.html.twig'
+     */
+    public function getTemplates();
+
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    public function getTemplate($name);
+}

--- a/src/Twig/Extension/TemplateRegistryExtension.php
+++ b/src/Twig/Extension/TemplateRegistryExtension.php
@@ -11,28 +11,39 @@
 
 namespace Sonata\AdminBundle\Twig\Extension;
 
-use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 final class TemplateRegistryExtension extends AbstractExtension
 {
     /**
-     * @var Pool
+     * @var TemplateRegistryInterface
      */
-    private $pool;
+    private $globalTemplateRegistry;
 
-    public function __construct(Pool $pool)
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function __construct(TemplateRegistryInterface $globalTemplateRegistry, ContainerInterface $container)
     {
-        $this->pool = $pool;
+        $this->globalTemplateRegistry = $globalTemplateRegistry;
+        $this->container = $container;
     }
 
     public function getFunctions()
     {
         return [
             new TwigFunction('get_admin_template', [$this, 'getAdminTemplate']),
-            new TwigFunction('get_admin_pool_template', [$this, 'getPoolTemplate']),
+            new TwigFunction('get_global_template', [$this, 'getGlobalTemplate']),
+
+            // NEXT MAJOR: Remove this line
+            new TwigFunction('get_admin_pool_template', [$this, 'getPoolTemplate'], ['deprecated' => true]),
         ];
     }
 
@@ -40,11 +51,26 @@ final class TemplateRegistryExtension extends AbstractExtension
      * @param string $name
      * @param string $adminCode
      *
+     * @throws ServiceNotFoundException
+     * @throws ServiceCircularReferenceException
+     *
      * @return null|string
      */
     public function getAdminTemplate($name, $adminCode)
     {
-        return $this->getAdmin($adminCode)->getTemplate($name);
+        return $this->getTemplateRegistry($adminCode)->getTemplate($name);
+    }
+
+    /**
+     * @deprecated Sinds 3.x, to be removed in 4.0. Use getGlobalTemplate instead.
+     *
+     * @param $name
+     *
+     * @return null|string
+     */
+    public function getPoolTemplate($name)
+    {
+        return $this->getGlobalTemplate($name);
     }
 
     /**
@@ -52,18 +78,27 @@ final class TemplateRegistryExtension extends AbstractExtension
      *
      * @return null|string
      */
-    public function getPoolTemplate($name)
+    public function getGlobalTemplate($name)
     {
-        return $this->pool->getTemplate($name);
+        return $this->globalTemplateRegistry->getTemplate($name);
     }
 
     /**
      * @param string $adminCode
      *
-     * @return AdminInterface|false|null
+     * @throws ServiceNotFoundException
+     * @throws ServiceCircularReferenceException
+     *
+     * @return TemplateRegistryInterface
      */
-    private function getAdmin($adminCode)
+    private function getTemplateRegistry($adminCode)
     {
-        return $this->pool->getAdminByAdminCode($adminCode);
+        $serviceId = $adminCode.'.template_registry';
+        $templateRegistry = $this->container->get($serviceId);
+        if ($templateRegistry instanceof TemplateRegistryInterface) {
+            return $templateRegistry;
+        }
+
+        throw new ServiceNotFoundException($serviceId);
     }
 }

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -38,6 +38,7 @@ use Sonata\AdminBundle\Route\RouteGeneratorInterface;
 use Sonata\AdminBundle\Route\RoutesCache;
 use Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface;
 use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentVoteAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentWithCustomRouteAdmin;
@@ -1162,15 +1163,17 @@ class AdminTest extends TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertSame([], $admin->getTemplates());
-
         $templates = [
             'list' => '@FooAdmin/CRUD/list.html.twig',
             'show' => '@FooAdmin/CRUD/show.html.twig',
             'edit' => '@FooAdmin/CRUD/edit.html.twig',
         ];
 
-        $admin->setTemplates($templates);
+        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
+        $templateRegistry->getTemplates()->shouldBeCalled()->willReturn($templates);
+
+        $admin->setTemplateRegistry($templateRegistry->reveal());
+
         $this->assertSame($templates, $admin->getTemplates());
     }
 
@@ -1178,28 +1181,11 @@ class AdminTest extends TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertNull($admin->getTemplate('edit'));
+        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
+        $templateRegistry->getTemplate('edit')->shouldBeCalled()->willReturn('@FooAdmin/CRUD/edit.html.twig');
+        $templateRegistry->getTemplate('show')->shouldBeCalled()->willReturn('@FooAdmin/CRUD/show.html.twig');
 
-        $admin->setTemplate('edit', '@FooAdmin/CRUD/edit.html.twig');
-        $admin->setTemplate('show', '@FooAdmin/CRUD/show.html.twig');
-
-        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $admin->getTemplate('edit'));
-        $this->assertSame('@FooAdmin/CRUD/show.html.twig', $admin->getTemplate('show'));
-    }
-
-    public function testGetTemplate2()
-    {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-
-        $this->assertNull($admin->getTemplate('edit'));
-
-        $templates = [
-            'list' => '@FooAdmin/CRUD/list.html.twig',
-            'show' => '@FooAdmin/CRUD/show.html.twig',
-            'edit' => '@FooAdmin/CRUD/edit.html.twig',
-        ];
-
-        $admin->setTemplates($templates);
+        $admin->setTemplateRegistry($templateRegistry->reveal());
 
         $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $admin->getTemplate('edit'));
         $this->assertSame('@FooAdmin/CRUD/show.html.twig', $admin->getTemplate('show'));
@@ -1902,6 +1888,11 @@ class AdminTest extends TestCase
 
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
+        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
+        $templateRegistry->getTemplate('button_create')->willReturn('Foo.html.twig');
+
+        $admin->setTemplateRegistry($templateRegistry->reveal());
+
         $securityHandler = $this->createMock(SecurityHandlerInterface::class);
         $securityHandler
             ->expects($this->once())
@@ -1917,8 +1908,6 @@ class AdminTest extends TestCase
             ->with($admin, 'create')
             ->will($this->returnValue(true));
         $admin->setRouteGenerator($routeGenerator);
-
-        $admin->setTemplate('button_create', 'Foo.html.twig');
 
         $this->assertSame($expected, $admin->getActionButtons('list', null));
     }
@@ -2047,6 +2036,11 @@ class AdminTest extends TestCase
         $admin->setRouteBuilder($pathInfo);
         $admin->setRouteGenerator($routeGenerator);
         $admin->initialize();
+
+        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
+        $templateRegistry->getTemplate('action_create')->willReturn('Foo.html.twig');
+
+        $admin->setTemplateRegistry($templateRegistry->reveal());
 
         $securityHandler = $this->createMock(SecurityHandlerInterface::class);
         $securityHandler->expects($this->any())

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Tests\Admin;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class PoolTest extends TestCase
@@ -257,14 +258,43 @@ class PoolTest extends TestCase
         $this->assertInstanceOf(ContainerInterface::class, $this->pool->getContainer());
     }
 
-    public function testTemplates()
+    /**
+     * @group legacy
+     */
+    public function testTemplate()
     {
-        $this->assertInternalType('array', $this->pool->getTemplates());
+        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
+        $templateRegistry->getTemplate('ajax')
+            ->shouldBeCalledTimes(1)
+            ->willReturn('Foo.html.twig');
 
-        $this->pool->setTemplates(['ajax' => 'Foo.html.twig']);
+        $this->pool->setTemplateRegistry($templateRegistry->reveal());
 
-        $this->assertNull($this->pool->getTemplate('bar'));
         $this->assertSame('Foo.html.twig', $this->pool->getTemplate('ajax'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testSetGetTemplates()
+    {
+        $templates = [
+            'ajax' => 'Foo.html.twig',
+            'layout' => 'Bar.html.twig',
+        ];
+
+        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
+        $templateRegistry->setTemplates($templates)
+            ->shouldBeCalledTimes(1);
+        $templateRegistry->getTemplates()
+            ->shouldBeCalledTimes(1)
+            ->willReturn($templates);
+
+        $this->pool->setTemplateRegistry($templateRegistry->reveal());
+
+        $this->pool->setTemplates($templates);
+
+        $this->assertSame($templates, $this->pool->getTemplates());
     }
 
     public function testGetTitleLogo()

--- a/tests/Block/AdminListBlockServiceTest.php
+++ b/tests/Block/AdminListBlockServiceTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Block;
 
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Block\AdminListBlockService;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Block\FakeBlockService;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 
@@ -26,16 +27,23 @@ class AdminListBlockServiceTest extends AbstractBlockServiceTestCase
      */
     private $pool;
 
+    /**
+     * @var TemplateRegistryInterface
+     */
+    private $templateRegistry;
+
     protected function setUp()
     {
         parent::setUp();
 
         $this->pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+
+        $this->templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
     }
 
     public function testDefaultSettings()
     {
-        $blockService = new AdminListBlockService('foo', $this->templating, $this->pool);
+        $blockService = new AdminListBlockService('foo', $this->templating, $this->pool, $this->templateRegistry->reveal());
         $blockContext = $this->getBlockContext($blockService);
 
         $this->assertSettings([
@@ -45,7 +53,7 @@ class AdminListBlockServiceTest extends AbstractBlockServiceTestCase
 
     public function testOverriddenDefaultSettings()
     {
-        $blockService = new FakeBlockService('foo', $this->templating, $this->pool);
+        $blockService = new FakeBlockService('foo', $this->templating, $this->pool, $this->templateRegistry->reveal());
         $blockContext = $this->getBlockContext($blockService);
 
         $this->assertSettings([

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -30,6 +30,7 @@ use Sonata\AdminBundle\Model\AuditReaderInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Security\Acl\Permission\AdminPermissionMap;
 use Sonata\AdminBundle\Security\Handler\AclSecurityHandler;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Controller\BatchAdminController;
 use Sonata\AdminBundle\Tests\Fixtures\Controller\PreCRUDController;
 use Sonata\AdminBundle\Util\AdminObjectAclData;
@@ -80,6 +81,11 @@ class CRUDControllerTest extends TestCase
      * @var AbstractAdmin
      */
     private $admin;
+
+    /**
+     * @var TemplateRegistryInterface
+     */
+    private $templateRegistry;
 
     /**
      * @var Pool
@@ -153,6 +159,8 @@ class CRUDControllerTest extends TestCase
         $this->translator = $this->createMock(TranslatorInterface::class);
         $this->parameters = [];
         $this->template = '';
+
+        $this->templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
 
         $templating = $this->getMockBuilder(DelegatingEngine::class)
             ->setConstructorArgs([$this->container, []])
@@ -269,6 +277,8 @@ class CRUDControllerTest extends TestCase
                         return $requestStack;
                     case 'foo.admin':
                         return $this->admin;
+                    case 'foo.admin.template_registry':
+                        return $this->templateRegistry->reveal();
                     case 'templating':
                         return $templating;
                     case 'twig':
@@ -327,40 +337,20 @@ class CRUDControllerTest extends TestCase
                 }
             }));
 
-        $this->admin->expects($this->any())
-            ->method('getTemplate')
-            ->will($this->returnCallback(function ($name) {
-                switch ($name) {
-                    case 'ajax':
-                        return '@SonataAdmin/ajax_layout.html.twig';
-                    case 'layout':
-                        return '@SonataAdmin/standard_layout.html.twig';
-                    case 'show':
-                        return '@SonataAdmin/CRUD/show.html.twig';
-                    case 'show_compare':
-                        return '@SonataAdmin/CRUD/show_compare.html.twig';
-                    case 'edit':
-                        return '@SonataAdmin/CRUD/edit.html.twig';
-                    case 'dashboard':
-                        return '@SonataAdmin/Core/dashboard.html.twig';
-                    case 'search':
-                        return '@SonataAdmin/Core/search.html.twig';
-                    case 'list':
-                        return '@SonataAdmin/CRUD/list.html.twig';
-                    case 'preview':
-                        return '@SonataAdmin/CRUD/preview.html.twig';
-                    case 'history':
-                        return '@SonataAdmin/CRUD/history.html.twig';
-                    case 'acl':
-                        return '@SonataAdmin/CRUD/acl.html.twig';
-                    case 'delete':
-                        return '@SonataAdmin/CRUD/delete.html.twig';
-                    case 'batch':
-                        return '@SonataAdmin/CRUD/list__batch.html.twig';
-                    case 'batch_confirmation':
-                        return '@SonataAdmin/CRUD/batch_confirmation.html.twig';
-                }
-            }));
+        $this->templateRegistry->getTemplate('ajax')->willReturn('@SonataAdmin/ajax_layout.html.twig');
+        $this->templateRegistry->getTemplate('layout')->willReturn('@SonataAdmin/standard_layout.html.twig');
+        $this->templateRegistry->getTemplate('show')->willReturn('@SonataAdmin/CRUD/show.html.twig');
+        $this->templateRegistry->getTemplate('show_compare')->willReturn('@SonataAdmin/CRUD/show_compare.html.twig');
+        $this->templateRegistry->getTemplate('edit')->willReturn('@SonataAdmin/CRUD/edit.html.twig');
+        $this->templateRegistry->getTemplate('dashboard')->willReturn('@SonataAdmin/Core/dashboard.html.twig');
+        $this->templateRegistry->getTemplate('search')->willReturn('@SonataAdmin/Core/search.html.twig');
+        $this->templateRegistry->getTemplate('list')->willReturn('@SonataAdmin/CRUD/list.html.twig');
+        $this->templateRegistry->getTemplate('preview')->willReturn('@SonataAdmin/CRUD/preview.html.twig');
+        $this->templateRegistry->getTemplate('history')->willReturn('@SonataAdmin/CRUD/history.html.twig');
+        $this->templateRegistry->getTemplate('acl')->willReturn('@SonataAdmin/CRUD/acl.html.twig');
+        $this->templateRegistry->getTemplate('delete')->willReturn('@SonataAdmin/CRUD/delete.html.twig');
+        $this->templateRegistry->getTemplate('batch')->willReturn('@SonataAdmin/CRUD/list__batch.html.twig');
+        $this->templateRegistry->getTemplate('batch_confirmation')->willReturn('@SonataAdmin/CRUD/batch_confirmation.html.twig');
 
         $this->admin->expects($this->any())
             ->method('getIdParameter')
@@ -399,6 +389,10 @@ class CRUDControllerTest extends TestCase
                     }
                 )
             );
+
+        $this->admin->expects($this->any())
+            ->method('getCode')
+            ->willReturn('foo.admin');
 
         $this->controller = new CRUDController();
         $this->controller->setContainer($this->container);

--- a/tests/Controller/CoreControllerTest.php
+++ b/tests/Controller/CoreControllerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Controller\CoreController;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,11 +28,13 @@ class CoreControllerTest extends TestCase
     {
         $container = $this->createMock(ContainerInterface::class);
 
+        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
+        $templateRegistry->getTemplate('ajax')->willReturn('ajax.html');
+        $templateRegistry->getTemplate('dashboard')->willReturn('dashboard.html');
+        $templateRegistry->getTemplate('layout')->willReturn('layout.html');
+
         $pool = new Pool($container, 'title', 'logo.png');
-        $pool->setTemplates([
-            'ajax' => 'ajax.html',
-            'dashboard' => 'dashboard.html',
-        ]);
+        $pool->setTemplateRegistry($templateRegistry->reveal());
 
         $templating = $this->createMock(EngineInterface::class);
         $request = new Request();
@@ -46,6 +49,7 @@ class CoreControllerTest extends TestCase
             'sonata.admin.pool' => $pool,
             'templating' => $templating,
             'request_stack' => $requestStack,
+            'sonata.admin.global_template_registry' => $templateRegistry->reveal(),
         ];
 
         $container->expects($this->any())->method('get')->will($this->returnCallback(function ($id) use ($values) {
@@ -87,11 +91,13 @@ class CoreControllerTest extends TestCase
     {
         $container = $this->createMock(ContainerInterface::class);
 
+        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
+        $templateRegistry->getTemplate('ajax')->willReturn('ajax.html');
+        $templateRegistry->getTemplate('dashboard')->willReturn('dashboard.html');
+        $templateRegistry->getTemplate('layout')->willReturn('layout.html');
+
         $pool = new Pool($container, 'title', 'logo.png');
-        $pool->setTemplates([
-            'ajax' => 'ajax.html',
-            'dashboard' => 'dashboard.html',
-        ]);
+        $pool->setTemplateRegistry($templateRegistry->reveal());
 
         $templating = $this->createMock(EngineInterface::class);
         $request = new Request();
@@ -104,6 +110,7 @@ class CoreControllerTest extends TestCase
             'sonata.admin.pool' => $pool,
             'templating' => $templating,
             'request_stack' => $requestStack,
+            'sonata.admin.global_template_registry' => $templateRegistry->reveal(),
         ];
 
         $container->expects($this->any())->method('get')->will($this->returnCallback(function ($id) use ($values) {

--- a/tests/Templating/TemplateRegistryTest.php
+++ b/tests/Templating/TemplateRegistryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Templating;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Templating\TemplateRegistry;
+
+class TemplateRegistryTest extends TestCase
+{
+    /**
+     * @var TemplateRegistry
+     */
+    private $templateRegistry;
+
+    protected function setUp()
+    {
+        $this->templateRegistry = new TemplateRegistry();
+    }
+
+    public function testGetTemplates()
+    {
+        $this->assertSame([], $this->templateRegistry->getTemplates());
+
+        $templates = [
+            'list' => '@FooAdmin/CRUD/list.html.twig',
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
+        ];
+
+        $this->templateRegistry->setTemplates($templates);
+        $this->assertSame($templates, $this->templateRegistry->getTemplates());
+    }
+
+    public function testGetTemplate1()
+    {
+        $this->assertNull($this->templateRegistry->getTemplate('edit'));
+
+        $this->templateRegistry->setTemplate('edit', '@FooAdmin/CRUD/edit.html.twig');
+        $this->templateRegistry->setTemplate('show', '@FooAdmin/CRUD/show.html.twig');
+
+        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $this->templateRegistry->getTemplate('edit'));
+        $this->assertSame('@FooAdmin/CRUD/show.html.twig', $this->templateRegistry->getTemplate('show'));
+    }
+
+    public function testGetTemplate2()
+    {
+        $this->assertNull($this->templateRegistry->getTemplate('edit'));
+
+        $templates = [
+            'list' => '@FooAdmin/CRUD/list.html.twig',
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
+        ];
+
+        $this->templateRegistry->setTemplates($templates);
+
+        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $this->templateRegistry->getTemplate('edit'));
+        $this->assertSame('@FooAdmin/CRUD/show.html.twig', $this->templateRegistry->getTemplate('show'));
+    }
+}

--- a/tests/Twig/Extension/FakeTemplateRegistryExtension.php
+++ b/tests/Twig/Extension/FakeTemplateRegistryExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class FakeTemplateRegistryExtension extends AbstractExtension
+{
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('get_admin_template', [$this, 'getAdminTemplate']),
+        ];
+    }
+
+    public function getAdminTemplate($name, $adminCode)
+    {
+        $templates = [
+            'base_list_field' => '@SonataAdmin/CRUD/base_list_field.html.twig',
+        ];
+
+        if (isset($templates[$name])) {
+            return $templates[$name];
+        }
+
+        throw new \Exception(sprintf(
+            'Template "%s" of Admin "%s" not found in FakeTemplateRegistry',
+            $name,
+            $adminCode
+        ));
+    }
+}


### PR DESCRIPTION
I am targeting this branch, because these changes are backwards compatible.

Related to #3947

## Changelog

```markdown
### Added
- Added `TemplateRegistry`, `TemplateRegistryInterface` and `MutableTemplateRegistryInterface` to handle all template registration related functionality from both `AbstractAdmin` and `Pool`.

### Deprecated
- Deprecated `AbstractAdmin` methods `getTemplate` and `getTemplates`.
- Deprecated `AbstractAdmin` attribute `$templates`.
- Deprecated `Pool` methods `getTemplate`, `setTemplates` and `getTemplates`.
- Deprecated `Pool` attribute `$templates`.
- Deprecated Twig function `get_pool_template`.
```

## To do

- [X] Update the tests
- [x] Update the documentation
- [X] Add an upgrade note
- [x] Fix BC in `Pool`
- [x] Add `@author` tags
- [x] Fix `@deprecated` tags (prefix with "since 3.x, will be dropped in 4.0.")

## Subject

This PR is part of a series of PRs to eventually move all admin template related functionality to a separate component.

This PR itself moves all template registration functionality from `AbstractAdmin` and `Pool` and moves it into the class `TemplateRegistry` and separate services (one per admin and a general one).

## Next steps

- After this PR, a follow-up PR should be made to use a separate Service Locator instead of the general container to find the correct admin template registries. This needs to have the dependency on Symfony DependencyInjection to be set to 3.3 or higher (currently `^2.8 || ^3.2 || ^4.0`). I will also look at other places where a Service Locator could be used instead of the general container.
- After that, a way to set admin templates through the configuration should be added (to replace the `setTemplate` and `setTemplates` method calls defined within the Admin service definition) and deprecate the `AbstractAdmin::setTemplate()` and `AbstractAdmin::setTemplates()` methods.