### PR TITLE
Replace string types with FQCN types in docs

### DIFF
--- a/docs/cookbook/recipe_file_uploads.rst
+++ b/docs/cookbook/recipe_file_uploads.rst
@@ -232,18 +232,20 @@ looks like this:
     <?php
     // src/AppBundle/Admin/PostAdmin.php
 
+    use Sonata\AdminBundle\Form\Type\AdminType;
+
     class PostAdmin extends AbstractAdmin
     {
         protected function configureFormFields(FormMapper $formMapper)
         {
             $formMapper
-                ->add('linkedImage1', 'sonata_type_admin', [
+                ->add('linkedImage1', AdminType::class, [
                     'delete' => false
                 ])
-                ->add('linkedImage2', 'sonata_type_admin', [
+                ->add('linkedImage2', AdminType::class, [
                     'delete' => false
                 ])
-                ->add('linkedImage3', 'sonata_type_admin', [
+                ->add('linkedImage3', AdminType::class, [
                     'delete' => false
                 ])
 

--- a/docs/cookbook/recipe_select2.rst
+++ b/docs/cookbook/recipe_select2.rst
@@ -33,10 +33,12 @@ To disable select2 on some ``select`` form element, set data attribute ``data-so
 
 .. code-block:: php
 
+    use Sonata\AdminBundle\Form\Type\ModelType;
+
     public function configureFormFields(FormMapper $formMapper)
     {
-        $formMaper
-            ->add('category', 'sonata_type_model', [
+        $formMapper
+            ->add('category', ModelType::class, [
                 'attr' => [
                     'data-sonata-select2' => 'false'
                 ]
@@ -57,10 +59,12 @@ to enable ``allowClear`` or ``data-sonata-select2-allow-clear = "false"`` to dis
 
 .. code-block:: php
 
+    use Sonata\AdminBundle\Form\Type\ModelType;
+
     public function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
-            ->add('category', 'sonata_type_model', [
+            ->add('category', ModelType::class, [
                 'attr' => [
                     'data-sonata-select2-allow-clear' => 'false'
                 ]

--- a/docs/reference/extensions.rst
+++ b/docs/reference/extensions.rst
@@ -10,13 +10,14 @@ alter newly created objects and other admin features.
 
     use Sonata\AdminBundle\Admin\AbstractAdminExtension;
     use Sonata\AdminBundle\Form\FormMapper;
+    use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
     class PublishStatusAdminExtension extends AbstractAdminExtension
     {
         public function configureFormFields(FormMapper $formMapper)
         {
             $formMapper
-                ->add('status', 'choice', [
+                ->add('status', ChoiceType::class, [
                     'choices' => [
                         'draft' => 'Draft',
                         'published' => 'Published',

--- a/docs/reference/form_help_message.rst
+++ b/docs/reference/form_help_message.rst
@@ -144,18 +144,22 @@ Help messages in a sub-field
     <?php
     // src/AppBundle/Admin/PostAdmin.php
 
+    use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
+    use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+    use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+
     class PostAdmin extends AbstractAdmin
     {
         protected function configureFormFields(FormMapper $formMapper)
         {
             $formMapper
                 ->add('enabled')
-                ->add('settings', 'sonata_type_immutable_array', [
+                ->add('settings', ImmutableArrayType::class, [
                     'keys' => [
-                        ['content', 'textarea', [
+                        ['content', TextareaType::class, [
                             'sonata_help' => 'Set the content'
                         ]],
-                        ['public', 'checkbox', []],
+                        ['public', CheckboxType::class, []],
                     ]
                 ])
             ;

--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -618,7 +618,7 @@ to the underlying forms.
         protected function configureFormFields(FormMapper $formMapper)
         {
             $formMapper
-                ->add('sales', 'sonata_type_collection', [
+                ->add('sales', CollectionType::class, [
                     'type_options' => [
                         // Prevents the "Delete" option from being displayed
                         'delete' => false,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I found some of the documentation was wrong while working.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


<!-- Describe your Pull Request content here -->
I recently updated a project to SF 3.4 and SonataAdminBundle 3.31.1 and ran into some issues with existing code, looking at the docs most of the Form Types used FQCN but not all, so this is just updating some of those I ran into.