### PR TITLE
Make search result page less heavy

### DIFF
--- a/src/Resources/views/Block/block_search_result.html.twig
+++ b/src/Resources/views/Block/block_search_result.html.twig
@@ -19,7 +19,7 @@ file that was distributed with this source code.
     {% endif %}
 
     <div class="col-lg-4 col-md-6 search-box-item {{ visibility_class }}">
-        <div class="box box-solid box-primary {{ visibility_class }}">
+        <div class="box box-solid {{ visibility_class }}">
             <div class="box-header with-border {{ visibility_class }}">
                 {% set icon = settings.icon|default('') %}
                 {{ icon|raw }}
@@ -29,7 +29,7 @@ file that was distributed with this source code.
 
                 <div class="box-tools pull-right">
                     {% if pager and pager.getNbResults() > 0 %}
-                        <span class="badge bg-light-blue">{{ pager.getNbResults() }}</span>
+                        <span class="badge">{{ pager.getNbResults() }}</span>
                     {% elseif admin.hasRoute('create') and admin.hasAccess('create') %}
                         <a href="{{ admin.generateUrl('create') }}" class="btn btn-box-tool">
                             <i class="fa fa-plus" aria-hidden="true"></i>


### PR DESCRIPTION
I am targeting this branch, because BC.

## Changelog

```markdown
### Changed
- Make search result page less heavy
```

## Subject

Currently, when you admin configuration manage a lot of entities, the search result is really heavy:

![image](https://user-images.githubusercontent.com/1698357/36793747-7aae6e3c-1c9e-11e8-8e94-c4bbf87a9329.png)

First of all, the `primary` class is used for primary things. I don't think that dozen of search result panels are primary.

Here is the result of this PR without primary color:

![image](https://user-images.githubusercontent.com/1698357/36793782-970f168a-1c9e-11e8-95f0-4dd63c64896c.png)

With fade option for empty boxes:

![image](https://user-images.githubusercontent.com/1698357/36793794-a152ba48-1c9e-11e8-8fe6-027ea35d52eb.png)

With show option for empty boxes:

![image](https://user-images.githubusercontent.com/1698357/36793806-a7005cca-1c9e-11e8-961b-c26868f04bca.png)

My eyes are not bleeding anymore.