### PR TITLE
check `sonata_admin.field_description`, somewhere is null;

### DIFF
--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
         {% endif -%}
     </div>
 
-    {% if sonata_admin.field_description.hasAssociationAdmin is defined %}
+    {% if sonata_admin.field_description and sonata_admin.field_description.hasAssociationAdmin %}
         <div id="field_actions_{{ id }}" class="field-actions">
             {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') 
                                      and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
         {% endif -%}
     </div>
 
-    {% if sonata_admin.field_description.hasAssociationAdmin %}
+    {% if sonata_admin.field_description.hasAssociationAdmin is defined %}
         <div id="field_actions_{{ id }}" class="field-actions">
             {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') 
                                      and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}


### PR DESCRIPTION
Closes #4997

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- FieldDescription null check missing in ModelAutocompleteFilter
```

## Subject
fix "Impossible to access an attribute ("hasAssociationAdmin") on a null variable",
when using `ModelAutocompleteFilter` on configureDatagridFilters;