### PR TITLE
Fix fatal error in strict mode: strlen() expects parameter 1 to be string, null given

### DIFF
--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -395,8 +395,9 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         foreach ($defaultArguments as $index => $value) {
             $declaredInParent = $parentDefinition && array_key_exists($index, $parentArguments);
+            $argumentValue = $declaredInParent ? $parentArguments[$index] : $arguments[$index];
 
-            if (0 == strlen($declaredInParent ? $parentArguments[$index] : $arguments[$index])) {
+            if (null === $argumentValue || 0 === strlen($argumentValue)) {
                 $arguments[$declaredInParent ? sprintf('index_%s', $index) : $index] = $value;
             }
         }


### PR DESCRIPTION
## Changelog
```markdown
### Fixed
- Fatal error in strict mode
```

## Subject
Fix a bug with strlen on null value:

```
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: strlen() expects parameter 1 to be string, null given in /var/www/vendor/sonata-project/admin-bundle/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php:402
Stack trace:
#0 /var/www/vendor/sonata-project/admin-bundle/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php(402): strlen(NULL)
#1 /var/www/vendor/sonata-project/admin-bundle/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php(67): Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass->replaceDefaultArguments(Array, Object(Symfony\Component\DependencyInjection\Definition), NULL)
#2 /var/www/vendor/symfony/dependency-injection/Compiler/Compiler.php(95): Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass->process(Object(Symfony\Component\DependencyInjection\ContainerBuilder))
#3 /var/www/vendor/symfony/dependency-injection/ContainerBuilder.php(711): Symfony\Component\DependencyInj in /var/www/vendor/sonata-project/admin-bundle/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php on line 402

```
