### PR TITLE
Fix creating admin docs

### DIFF
--- a/docs/getting_started/creating_an_admin.rst
+++ b/docs/getting_started/creating_an_admin.rst
@@ -208,7 +208,7 @@ routes, you have to make sure the routing loader of the SonataAdminBundle is exe
 
     .. code-block:: yaml
 
-        # config/routing.yaml
+        # config/routes/sonata_admin.yaml
 
         # ...
         _sonata_admin:


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is docs.