### PR TITLE
Fix editable relation on list

### DIFF
--- a/src/Controller/HelperController.php
+++ b/src/Controller/HelperController.php
@@ -284,25 +284,15 @@ class HelperController
         }
 
         // Handle entity choice association type, transforming the value into entity
-        if ('' !== $value && 'choice' == $fieldDescription->getType() && $fieldDescription->getOption('class')) {
-            $manager = $this->pool->getContainer()->get($admin->getManagerType())->getManager();
-            $classMetadata = $manager->getClassMetadata($admin->getClass());
-
-            if (!$classMetadata->hasAssociation($field)) {
-                return new JsonResponse(sprintf(
-                    'Unknown association "%s", association does not exist in entity "%s",'
-                    .' available associations are "%s".',
-                    $field,
-                    $admin->getClass(),
-                    implode(', ', $classMetadata->getAssociationNames())
-                ), 404);
-            }
-
-            $value = $manager->find($fieldDescription->getOption('class'), $value);
+        if ('' !== $value
+            && 'choice' == $fieldDescription->getType()
+            && $fieldDescription->getOption('class') === $fieldDescription->getTargetEntity()
+        ) {
+            $value = $admin->getModelManager()->find($fieldDescription->getOption('class'), $value);
 
             if (!$value) {
                 return new JsonResponse(sprintf(
-                    'Edit failed, object with id "%s" not found in association "%s".',
+                    'Edit failed, object with id: %s not found in association: %s.',
                     $originalValue,
                     $field
                 ), 404);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/818

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix edit choice with a relation field on admin list
```

## To do

- [x] Update the tests

## Subject

<!-- Describe your Pull Request content here -->
getManagerType does not return what was expected, also if this method works it is better since it does not rely on container, but on properties that are already loaded.

This is a bugfix from my previous PR: #4930

Please, can you check if this works @mikemix ?
