### PR TITLE
Avoid trying to use non public getters on `BaseFieldDescription`

### DIFF
--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -292,7 +292,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         }
 
         foreach ($getters as $getter) {
-            if (method_exists($object, $getter)) {
+            if (method_exists($object, $getter) && is_callable([$object, $getter])) {
                 $this->cacheFieldGetter($object, $fieldName, 'getter', $getter);
 
                 return call_user_func_array([$object, $getter], $parameters);

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -232,6 +232,22 @@ class BaseFieldDescriptionTest extends TestCase
         $this->assertSame('FOoBar', BaseFieldDescription::camelize('fOo bar'));
     }
 
+    public function testGetInaccessibleValue()
+    {
+        $quux = 'quuX';
+        $foo = new Foo();
+        $foo->setQuux($quux);
+        $ro = new \ReflectionObject($foo);
+        $rm = $ro->getMethod('getQuux');
+        $rm->setAccessible(true);
+        $this->assertSame($quux, $rm->invokeArgs($foo, []));
+
+        $description = new FieldDescription();
+
+        $this->expectException(NoValueException::class);
+        $description->getFieldValue($foo, 'quux');
+    }
+
     public function testGetFieldValue()
     {
         $foo = new Foo();

--- a/tests/Fixtures/Entity/Foo.php
+++ b/tests/Fixtures/Entity/Foo.php
@@ -8,6 +8,8 @@ class Foo
 
     private $baz;
 
+    private $quux;
+
     public $qux;
 
     public function getBar()
@@ -25,9 +27,19 @@ class Foo
         return $this->baz;
     }
 
+    protected function getQuux()
+    {
+        return $this->quux;
+    }
+
     public function setBaz($baz)
     {
         $this->baz = $baz;
+    }
+
+    public function setQuux($quux)
+    {
+        $this->quux = $quux;
     }
 
     public function __toString()


### PR DESCRIPTION
I am targeting this branch, because there is a bug when trying to access non public methods at `BaseFieldDescription`

## Changelog
```Markdown
### Fixed
 - Avoid calling protected/private methods when retrieving values from entities
```
