### PR TITLE
Allow `null` values as argument 1 for `FieldDescriptionInterface::getFieldValue()`

### DIFF
--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -263,7 +263,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
 
     public function getFieldValue($object, $fieldName)
     {
-        if ($this->isVirtual()) {
+        if ($this->isVirtual() || null === $object) {
             return;
         }
 

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -271,8 +271,8 @@ interface FieldDescriptionInterface
     public function getSortParentAssociationMapping();
 
     /**
-     * @param object $object
-     * @param string $fieldName
+     * @param object|null $object
+     * @param string      $fieldName
      *
      * @return mixed
      */

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -286,4 +286,11 @@ class BaseFieldDescriptionTest extends TestCase
         // repeating to cover retrieving cached getter
         $this->assertSame(['inexistantMethod', $parameters], $description->getFieldValue($foo, 'inexistantMethod'));
     }
+
+    public function testGetFieldValueWithNullObject()
+    {
+        $foo = null;
+        $description = new FieldDescription();
+        $this->assertNull($description->getFieldValue($foo, 'bar'));
+    }
 }


### PR DESCRIPTION
I am targeting this branch, because this is BC fix.

## Changelog

<!-- - An exception has been thrown during the rendering of a template ("Warning: get_class() expects parameter 1 to be object, null given"). -->

```markdown
### Fixed
- `getFieldValue` from `BaseFieldDescription` can now handle getting a value from null objects.
```

## Subject
As context, I must mention the scenario in which the received subject is `null`.
I have a simple set of geo entities (**City**, **State**, **Country**) which have _many-to-one_ association respectively (a country may have _n_ states, a state may have _n_ cities). I use these entities within others, like **User**. The association between **User** and **City** is _many-to-one_ and is **NULLABLE**. So, in my `UserAdmin::configureShowFields()` I have the following call:
```php
ShowMapper::add('city.state', EntityType::class, ['class' => State::class])
```
then, when there is no city for a user, value passed to `BaseFieldDescription::getFieldValue()` is null.
From #4947, with the described situation, this method throws the mentioned exception, since `get_class()` receives `null` as argument.
___

If you want to contribute with another approach for this fix, please let me know.