### PR TITLE
Replaced calls to internal Twig Environment loadTemplate method with load

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,11 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated SonataAdminExtension::output()
+
+The `SonataAdminExtension::output()` method is deprecated and should not be
+used anymore.
+
 UPGRADE FROM 3.30 to 3.31
 =========================
 

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -48,6 +48,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Twig\Environment;
 use Twig\Template;
+use Twig\TemplateWrapper;
 
 class AdminControllerHelper_Foo
 {
@@ -91,6 +92,36 @@ class AdminControllerHelper_Bar
 
 class HelperControllerTest extends TestCase
 {
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * @var AdminHelper
+     */
+    private $helper;
+
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    /**
+     * @var AbstractAdmin
+     */
+    private $admin;
+
+    /**
+     * @var HelperController
+     */
+    private $controller;
+
     /**
      * {@inheritdoc}
      */
@@ -215,7 +246,7 @@ class HelperControllerTest extends TestCase
         $this->twig->getExtension(SonataAdminExtension::class)->willReturn(
             new SonataAdminExtension($pool->reveal(), null, $translator->reveal())
         );
-        $this->twig->loadTemplate('admin_template')->willReturn($template->reveal());
+        $this->twig->load('admin_template')->willReturn(new TemplateWrapper($this->twig->reveal(), $template->reveal()));
         $this->twig->isDebug()->willReturn(false);
         $fieldDescription->getOption('editable')->willReturn(true);
         $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
@@ -262,7 +293,7 @@ class HelperControllerTest extends TestCase
         $this->twig->getExtension(SonataAdminExtension::class)->willReturn(
             new SonataAdminExtension($pool->reveal(), null, $translator->reveal())
         );
-        $this->twig->loadTemplate('field_template')->willReturn($template->reveal());
+        $this->twig->load('field_template')->willReturn(new TemplateWrapper($this->twig->reveal(), $template->reveal()));
         $this->twig->isDebug()->willReturn(false);
         $this->pool->getContainer()->willReturn($container->reveal());
         $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -2030,6 +2030,9 @@ EOT
         $this->assertSame('foo', $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
     }
 
+    /**
+     * @group legacy
+     */
     public function testOutput()
     {
         $this->fieldDescription->expects($this->any())
@@ -2075,6 +2078,46 @@ EOT
             ),
             $this->removeExtraWhitespace(
                 $this->twigExtension->output($this->fieldDescription, $template, $parameters, $this->environment)
+            )
+        );
+    }
+
+    public function testRenderWithDebug()
+    {
+        $this->fieldDescription->expects($this->any())
+            ->method('getTemplate')
+            ->will($this->returnValue('@SonataAdmin/CRUD/base_list_field.html.twig'));
+
+        $this->fieldDescription->expects($this->any())
+            ->method('getFieldName')
+            ->will($this->returnValue('fd_name'));
+
+        $this->fieldDescription->expects($this->any())
+            ->method('getValue')
+            ->will($this->returnValue('foo'));
+
+        $parameters = [
+            'admin' => $this->admin,
+            'value' => 'foo',
+            'field_description' => $this->fieldDescription,
+            'object' => $this->object,
+        ];
+
+        $this->environment->enableDebug();
+
+        $this->assertSame(
+            $this->removeExtraWhitespace(<<<'EOT'
+<!-- START
+    fieldName: fd_name
+    template: @SonataAdmin/CRUD/base_list_field.html.twig
+    compiled template: @SonataAdmin/CRUD/base_list_field.html.twig
+-->
+    <td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> foo </td>
+<!-- END - fieldName: fd_name -->
+EOT
+            ),
+            $this->removeExtraWhitespace(
+                $this->twigExtension->renderListElement($this->environment, $this->object, $this->fieldDescription, $parameters)
             )
         );
     }


### PR DESCRIPTION
I am targeting this branch, because it is BC.

## Changelog

```markdown
### Changed
- Replaced calls to Twig internal `Environment::loadTemplate()` method with `Environment::load()` in `SonataAdminExtension`.

### Deprecated
- Deprecated `SonataAdminExtension::output()`. Now using the private `render()` method. Please use the `render*()` methods instead.
```
## Todo
- [x] Reset `output()`, create new method with proper visibility & parameters and deprecate the old one.

## Subject
I noticed that the `Sonata\AdminBundle\Twig\Extension\SonataAdminExtension` class calls an internal Twig method. I replaced these calls with the suggested replacement.