### PR TITLE
Add missing french translation for toggle_navigation

### DIFF
--- a/src/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.fr.xliff
@@ -486,6 +486,10 @@
                 <source>read_less</source>
                 <target>Fermer</target>
             </trans-unit>
+            <trans-unit id="toggle_navigation">
+                <source>toggle_navigation</source>
+                <target>Basculer la navigation</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

```markdown
### Fixed
- Added missing french translation for `Toggle Navigation`
