### PR TITLE
Add required option to editable list choice

### DIFF
--- a/docs/reference/field_types.rst
+++ b/docs/reference/field_types.rst
@@ -65,6 +65,15 @@ related documentations.
 Choice
 ^^^^^^
 
+You can use the following parameters:
+
+======================================  ==================================================================
+Parameter                               Description
+======================================  ==================================================================
+**choices**                             Array of choices
+**required**                            Whether the field is required or not (default true) when the ``editable`` option is set to ``true``. If false, an empty placeholder will be added.
+======================================  ==================================================================
+
 .. code-block:: php
 
     public function configureListFields(ListMapper $listMapper)

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -411,6 +411,15 @@ class SonataAdminExtension extends AbstractExtension
             }
         }
 
+        if (false === $fieldDescription->getOption('required', true)
+            && false === $fieldDescription->getOption('multiple', false)
+        ) {
+            $xEditableChoices = array_merge([[
+                'value' => '',
+                'text' => '',
+            ]], $xEditableChoices);
+        }
+
         return $xEditableChoices;
     }
 

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -2313,38 +2313,69 @@ EOT
     public function xEditableChoicesProvider()
     {
         return [
-            'needs processing' => [['Status1' => 'Alias1', 'Status2' => 'Alias2']],
-            'already processed' => [[
-                ['value' => 'Status1', 'text' => 'Alias1'],
-                ['value' => 'Status2', 'text' => 'Alias2'],
-            ]],
+            'needs processing' => [
+                ['choices' => ['Status1' => 'Alias1', 'Status2' => 'Alias2']],
+                [
+                    ['value' => 'Status1', 'text' => 'Alias1'],
+                    ['value' => 'Status2', 'text' => 'Alias2'],
+                ],
+            ],
+            'already processed' => [
+                ['choices' => [
+                    ['value' => 'Status1', 'text' => 'Alias1'],
+                    ['value' => 'Status2', 'text' => 'Alias2'],
+                ]],
+                [
+                    ['value' => 'Status1', 'text' => 'Alias1'],
+                    ['value' => 'Status2', 'text' => 'Alias2'],
+                ],
+            ],
+            'not required' => [
+                [
+                    'required' => false,
+                    'choices' => ['' => '', 'Status1' => 'Alias1', 'Status2' => 'Alias2'],
+                ],
+                [
+                    ['value' => '', 'text' => ''],
+                    ['value' => 'Status1', 'text' => 'Alias1'],
+                    ['value' => 'Status2', 'text' => 'Alias2'],
+                ],
+            ],
+            'not required multiple' => [
+                [
+                    'required' => false,
+                    'multiple' => true,
+                    'choices' => ['Status1' => 'Alias1', 'Status2' => 'Alias2'],
+                ],
+                [
+                    ['value' => 'Status1', 'text' => 'Alias1'],
+                    ['value' => 'Status2', 'text' => 'Alias2'],
+                ],
+            ],
         ];
     }
 
     /**
      * @dataProvider xEditablechoicesProvider
      */
-    public function testGetXEditableChoicesIsIdempotent(array $input)
+    public function testGetXEditableChoicesIsIdempotent(array $options, $expectedChoices)
     {
         $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
-        $fieldDescription->expects($this->exactly(2))
+        $fieldDescription->expects($this->any())
             ->method('getOption')
             ->withConsecutive(
                 ['choices', []],
-                ['catalogue']
+                ['catalogue'],
+                ['required'],
+                ['multiple']
             )
             ->will($this->onConsecutiveCalls(
-                $input,
-                'MyCatalogue'
+                $options['choices'],
+                'MyCatalogue',
+                isset($options['multiple']) ? $options['multiple'] : null
             ));
 
-        $this->assertSame(
-            [
-                ['value' => 'Status1', 'text' => 'Alias1'],
-                ['value' => 'Status2', 'text' => 'Alias2'],
-            ],
-            $this->twigExtension->getXEditableChoices($fieldDescription)
-        );
+        $this->assertSame($expectedChoices, $this->twigExtension->getXEditableChoices($fieldDescription));
     }
 
     public function select2LocalesProvider()


### PR DESCRIPTION
I am targeting this branch, because it's a small BC improvement.

```markdown
### Added
- Added `required` option to editable list `choice`
```
- [x] Update the tests
- [x] Update the documentation

## Subject

This PR adds a `required` option to editable list `choice`. If set to `false`, it will add an empty placeholder to the select input.

```
$listMapper->add('status', 'choice', [
    'choices' => [
        'prep' => 'Prepared',
        'prog' => 'In progress',
        'done' => 'Done'
    ],
    'editable' => true,
    'required' => false,
]);
```
![capture](https://user-images.githubusercontent.com/663607/37351958-7f77bb74-26dc-11e8-8d7f-098c5a396c7a.JPG)
