### PR TITLE
Fix missed controllers in documentation

### DIFF
--- a/docs/cookbook/recipe_custom_action.rst
+++ b/docs/cookbook/recipe_custom_action.rst
@@ -269,11 +269,11 @@ The full ``CarAdmin.php`` example looks like this:
 
     If you want to render a custom controller action in a template by using the
     render function in twig you need to add ``_sonata_admin`` as an attribute. For
-    example; ``{{ render(controller('App:XxxxCRUD:comment', {'_sonata_admin':
-    'sonata.admin.xxxx' })) }}``. This has to be done because the moment the
-    rendering should happen the routing, which usually sets the value of this
-    parameter, is not involved at all, and then you will get an error "There is no
-    _sonata_admin defined for the controller
+    example; ``{{ render(controller('App\\Controller\\XxxxCRUDController::comment',
+    {'_sonata_admin': 'sonata.admin.xxxx' })) }}``. This has to be done because the
+    moment the rendering should happen the routing, which usually sets the value of
+    this parameter, is not involved at all, and then you will get an error "There is
+    no _sonata_admin defined for the controller
     App\Controller\XxxxCRUDController and the current route ' '."
 
 Custom Action without Entity

--- a/docs/reference/architecture.rst
+++ b/docs/reference/architecture.rst
@@ -124,7 +124,7 @@ the Dependency Injection Container (DIC).
 This is particularly useful if you decide to extend the ``CRUDController`` to
 add new actions or change the behavior of existing ones. You can specify which controller
 to use when declaring the ``Admin`` service by passing it as the 3rd argument. For example
-to set the controller to ``App:PostAdmin``:
+to set the controller to ``App\Controller\PostAdminController``:
 
 .. configuration-block::
 
@@ -134,7 +134,7 @@ to set the controller to ``App:PostAdmin``:
             <tag name="sonata.admin" manager_type="orm" group="Content" label="Post" />
             <argument />
             <argument>App\Entity\Post</argument>
-            <argument>App:PostAdmin</argument>
+            <argument>App\Controller\PostAdminController</argument>
             <call method="setTranslationDomain">
                 <argument>App</argument>
             </call>

--- a/docs/reference/routing.rst
+++ b/docs/reference/routing.rst
@@ -194,7 +194,7 @@ handler for it in your Controller. By default Admin classes use ``SonataAdminBun
 as their controller, but this can be changed by altering the third argument when defining
 your Admin service (in your admin.yml file).
 
-For example, lets change the Controller for our MediaAdmin class to App:MediaCRUD:
+For example, lets change the Controller for our MediaAdmin class to ``App\Controller\MediaCRUDController``:
 
 .. configuration-block::
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because docs.

## Subject

Missed a few controllers in docs.
