### PR TITLE
Add sf4 support to explain command

### DIFF
--- a/src/Command/ExplainAdminCommand.php
+++ b/src/Command/ExplainAdminCommand.php
@@ -97,8 +97,7 @@ class ExplainAdminCommand extends ContainerAwareCommand
             ));
         }
 
-        $factory = $this->getContainer()->get('validator.validator_factory');
-        $metadata = $factory->getMetadataFor($admin->getClass());
+        $metadata = $this->getContainer()->get('validator')->getMetadataFor($admin->getClass());
 
         $output->writeln('');
         $output->writeln('<comment>Validation Framework</comment> - http://symfony.com/doc/3.0/book/validation.html');

--- a/tests/Command/ExplainAdminCommandTest.php
+++ b/tests/Command/ExplainAdminCommandTest.php
@@ -153,7 +153,7 @@ class ExplainAdminCommandTest extends TestCase
 
                         return $pool;
 
-                    case 'validator.validator_factory':
+                    case 'validator':
                         return $this->validatorFactory;
 
                     case 'acme.admin.foo':


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5016 
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Explain command compatible with sf4
```
## Subject

This was changed in https://github.com/sonata-project/SonataAdminBundle/pull/4817 and wrong part was saved as `validator.validator_factory` is not the same service in 2.8 and in 3+
