### PR TITLE
Moving ifTrue and ifFalse from BaseGroupedMapper to BaseMapper

### DIFF
--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -55,6 +55,10 @@ class DatagridMapper extends BaseMapper
         $fieldOptions = null,
         array $fieldDescriptionOptions = []
     ) {
+        if (null !== $this->apply && !$this->apply) {
+            return $this;
+        }
+
         if (is_array($fieldOptions)) {
             $filterOptions['field_options'] = $fieldOptions;
         }

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -70,6 +70,10 @@ class ListMapper extends BaseMapper
      */
     public function add($name, $type = null, array $fieldDescriptionOptions = [])
     {
+        if (null !== $this->apply && !$this->apply) {
+            return $this;
+        }
+
         // Change deprecated inline action "view" to "show"
         if ('_action' == $name && 'actions' == $type) {
             if (isset($fieldDescriptionOptions['actions']['view'])) {

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -31,11 +31,6 @@ abstract class BaseGroupedMapper extends BaseMapper
     protected $currentTab;
 
     /**
-     * @var bool|null
-     */
-    protected $apply;
-
-    /**
      * Add new group or tab (if parameter "tab=true" is available in options).
      *
      * @param string $name
@@ -148,56 +143,6 @@ abstract class BaseGroupedMapper extends BaseMapper
         }
 
         $this->setTabs($tabs);
-
-        return $this;
-    }
-
-    /**
-     * Only nested add if the condition match true.
-     *
-     * @param bool $bool
-     *
-     * @throws \RuntimeException
-     *
-     * @return $this
-     */
-    public function ifTrue($bool)
-    {
-        if (null !== $this->apply) {
-            throw new \RuntimeException('Cannot nest ifTrue or ifFalse call');
-        }
-
-        $this->apply = (true === $bool);
-
-        return $this;
-    }
-
-    /**
-     * Only nested add if the condition match false.
-     *
-     * @param bool $bool
-     *
-     * @throws \RuntimeException
-     *
-     * @return $this
-     */
-    public function ifFalse($bool)
-    {
-        if (null !== $this->apply) {
-            throw new \RuntimeException('Cannot nest ifTrue or ifFalse call');
-        }
-
-        $this->apply = (false === $bool);
-
-        return $this;
-    }
-
-    /**
-     * @return $this
-     */
-    public function ifEnd()
-    {
-        $this->apply = null;
 
         return $this;
     }

--- a/src/Mapper/BaseMapper.php
+++ b/src/Mapper/BaseMapper.php
@@ -31,6 +31,11 @@ abstract class BaseMapper
      */
     protected $builder;
 
+    /**
+     * @var bool|null
+     */
+    protected $apply;
+
     public function __construct(BuilderInterface $builder, AdminInterface $admin)
     {
         $this->builder = $builder;
@@ -80,4 +85,54 @@ abstract class BaseMapper
      * @return $this
      */
     abstract public function reorder(array $keys);
+
+    /**
+     * Only nested add if the condition match true.
+     *
+     * @param bool $bool
+     *
+     * @throws \RuntimeException
+     *
+     * @return $this
+     */
+    public function ifTrue($bool)
+    {
+        if (null !== $this->apply) {
+            throw new \RuntimeException('Cannot nest ifTrue or ifFalse call');
+        }
+
+        $this->apply = (true === $bool);
+
+        return $this;
+    }
+
+    /**
+     * Only nested add if the condition match false.
+     *
+     * @param bool $bool
+     *
+     * @throws \RuntimeException
+     *
+     * @return $this
+     */
+    public function ifFalse($bool)
+    {
+        if (null !== $this->apply) {
+            throw new \RuntimeException('Cannot nest ifTrue or ifFalse call');
+        }
+
+        $this->apply = (false === $bool);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function ifEnd()
+    {
+        $this->apply = null;
+
+        return $this;
+    }
 }

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -261,6 +261,130 @@ class DatagridMapperTest extends TestCase
         ], array_keys($this->datagrid->getFilters()));
     }
 
+    public function testIfTrueApply()
+    {
+        $this->datagridMapper
+            ->ifTrue(true)
+            ->add('foo', 'bar')
+            ->ifEnd()
+        ;
+
+        $this->assertTrue($this->datagridMapper->has('foo'));
+    }
+
+    public function testIfTrueNotApply()
+    {
+        $this->datagridMapper
+            ->ifTrue(false)
+            ->add('foo', 'bar')
+            ->ifEnd()
+        ;
+
+        $this->assertFalse($this->datagridMapper->has('foo'));
+    }
+
+    public function testIfTrueCombination()
+    {
+        $this->datagridMapper
+            ->ifTrue(false)
+            ->add('foo', 'bar')
+            ->ifEnd()
+            ->add('baz', 'foobaz')
+        ;
+
+        $this->assertFalse($this->datagridMapper->has('foo'));
+        $this->assertTrue($this->datagridMapper->has('baz'));
+    }
+
+    public function testIfFalseApply()
+    {
+        $this->datagridMapper
+            ->ifFalse(false)
+            ->add('foo', 'bar')
+            ->ifEnd()
+        ;
+
+        $this->assertTrue($this->datagridMapper->has('foo'));
+    }
+
+    public function testIfFalseNotApply()
+    {
+        $this->datagridMapper
+            ->ifFalse(true)
+            ->add('foo', 'bar')
+            ->ifEnd()
+        ;
+
+        $this->assertFalse($this->datagridMapper->has('foo'));
+    }
+
+    public function testIfFalseCombination()
+    {
+        $this->datagridMapper
+            ->ifFalse(true)
+            ->add('foo', 'bar')
+            ->ifEnd()
+            ->add('baz', 'foobaz')
+        ;
+
+        $this->assertFalse($this->datagridMapper->has('foo'));
+        $this->assertTrue($this->datagridMapper->has('baz'));
+    }
+
+    public function testIfTrueNested()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+
+        $this->datagridMapper->ifTrue(true);
+        $this->datagridMapper->ifTrue(true);
+    }
+
+    public function testIfFalseNested()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+
+        $this->datagridMapper->ifFalse(false);
+        $this->datagridMapper->ifFalse(false);
+    }
+
+    public function testIfCombinationNested()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+
+        $this->datagridMapper->ifTrue(true);
+        $this->datagridMapper->ifFalse(false);
+    }
+
+    public function testIfFalseCombinationNested2()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+
+        $this->datagridMapper->ifFalse(false);
+        $this->datagridMapper->ifTrue(true);
+    }
+
+    public function testIfFalseCombinationNested3()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+
+        $this->datagridMapper->ifFalse(true);
+        $this->datagridMapper->ifTrue(false);
+    }
+
+    public function testIfFalseCombinationNested4()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+
+        $this->datagridMapper->ifTrue(false);
+        $this->datagridMapper->ifFalse(true);
+    }
+
     private function getFieldDescriptionMock($name = null, $label = null)
     {
         $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class);

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -252,6 +252,130 @@ class ListMapperTest extends TestCase
         ], true), print_r($this->fieldDescriptionCollection->getElements(), true));
     }
 
+    public function testIfTrueApply()
+    {
+        $this->listMapper
+            ->ifTrue(true)
+            ->add('foo', 'bar')
+            ->ifEnd()
+        ;
+
+        $this->assertTrue($this->listMapper->has('foo'));
+    }
+
+    public function testIfTrueNotApply()
+    {
+        $this->listMapper
+            ->ifTrue(false)
+            ->add('foo', 'bar')
+            ->ifEnd()
+        ;
+
+        $this->assertFalse($this->listMapper->has('foo'));
+    }
+
+    public function testIfTrueCombination()
+    {
+        $this->listMapper
+            ->ifTrue(false)
+            ->add('foo', 'bar')
+            ->ifEnd()
+            ->add('baz', 'foobaz')
+        ;
+
+        $this->assertFalse($this->listMapper->has('foo'));
+        $this->assertTrue($this->listMapper->has('baz'));
+    }
+
+    public function testIfFalseApply()
+    {
+        $this->listMapper
+            ->ifFalse(false)
+            ->add('foo', 'bar')
+            ->ifEnd()
+        ;
+
+        $this->assertTrue($this->listMapper->has('foo'));
+    }
+
+    public function testIfFalseNotApply()
+    {
+        $this->listMapper
+            ->ifFalse(true)
+            ->add('foo', 'bar')
+            ->ifEnd()
+        ;
+
+        $this->assertFalse($this->listMapper->has('foo'));
+    }
+
+    public function testIfFalseCombination()
+    {
+        $this->listMapper
+            ->ifFalse(true)
+            ->add('foo', 'bar')
+            ->ifEnd()
+            ->add('baz', 'foobaz')
+        ;
+
+        $this->assertFalse($this->listMapper->has('foo'));
+        $this->assertTrue($this->listMapper->has('baz'));
+    }
+
+    public function testIfTrueNested()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+
+        $this->listMapper->ifTrue(true);
+        $this->listMapper->ifTrue(true);
+    }
+
+    public function testIfFalseNested()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+
+        $this->listMapper->ifFalse(false);
+        $this->listMapper->ifFalse(false);
+    }
+
+    public function testIfCombinationNested()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+
+        $this->listMapper->ifTrue(true);
+        $this->listMapper->ifFalse(false);
+    }
+
+    public function testIfFalseCombinationNested2()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+
+        $this->listMapper->ifFalse(false);
+        $this->listMapper->ifTrue(true);
+    }
+
+    public function testIfFalseCombinationNested3()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+
+        $this->listMapper->ifFalse(true);
+        $this->listMapper->ifTrue(false);
+    }
+
+    public function testIfFalseCombinationNested4()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+
+        $this->listMapper->ifTrue(false);
+        $this->listMapper->ifFalse(true);
+    }
+
     private function getFieldDescriptionMock($name = null, $label = null)
     {
         $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because making minor feature.

## Changelog

Moving ifTrue and ifFalse from BaseGroupedMapper to BaseMapper for be able to use them in datagridMapper and listMapper

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Moving
- moving `BaseGroupedMapper::$apply` to BaseMapper::$apply
- moving `BaseGroupedMapper::ifTrue` to BaseMapper::ifTrue
- moving `BaseGroupedMapper::ifFalse` to BaseMapper::ifFalse
- moving `BaseGroupedMapper::ifEnd` to BaseMapper::ifEnd
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

Moving ifTrue and ifFalse from BaseGroupedMapper to BaseMapper for use it with databuilderMapper and listMapper
