### PR TITLE
Document another way to add dashboard action

### DIFF
--- a/docs/cookbook/recipe_custom_action.rst
+++ b/docs/cookbook/recipe_custom_action.rst
@@ -326,15 +326,34 @@ Create a template for that button:
     </li>
 
 You can also add this action to your dashboard actions, you have to overwrite
-the ``getDashboardActions`` method in your admin class::
+the ``getDashboardActions`` method in your admin class and there are two
+ways you can add action::
 
+    public function getDashboardActions()
+    {
+        $actions = parent::getDashboardActions();
+
+        $actions['import']['template'] = 'import_dashboard_button.html.twig';
+
+        return $actions;
+    }
+
+Create a template for that button:
+
+.. code-block:: html+jinja
+
+    <a class="btn btn-link btn-flat" href="{{ admin.generateUrl('import') }}">
+        <i class="fa fa-level-up"></i>{{ 'import_action'|trans({}, 'SonataAdminBundle') }}
+    </a>
+
+Or you can just pass values as array::
 
     public function getDashboardActions()
     {
         $actions = parent::getDashboardActions();
 
         $actions['import'] = [
-            'label' => 'action_import',
+            'label' => 'import_action',
             'translation_domain' => 'SonataAdminBundle',
             'url' => $this->generateUrl('import'),
             'icon' => 'level-up',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because docs

## Subject

Just found out that you can create a template instead of forwarding an array, that looks like a cleaner solution to me so here is an update.
