### PR TITLE
Add pool alias

### DIFF
--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -11,6 +11,7 @@
                 <argument type="service" id="sonata.admin.global_template_registry"/>
             </call>
         </service>
+        <service id="Sonata\AdminBundle\Admin\Pool" alias="sonata.admin.pool"/>
         <service id="sonata.admin.route_loader" class="Sonata\AdminBundle\Route\AdminPoolLoader" public="true">
             <argument type="service" id="sonata.admin.pool"/>
             <argument/>


### PR DESCRIPTION
I am targeting this branch, because it fixes a deprecation notice when we want to inject the Pool service and we use autowiring.

## Changelog
```markdown
### Fixed
 - Fixed deprecation notice when Pool is injected in service through autowiring
```
## Subject
it fixes a deprecation notice when we want to inject the Pool service and we use autowiring.