### PR TITLE
Simplify template based on inline standard

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
@@ -35,30 +35,20 @@ file that was distributed with this source code.
         {% for nested_group_field_name, nested_group_field in form.children %}
             <tr>
                 {% for field_name, nested_field in nested_group_field.children %}
-                    <td class="
-                        sonata-ba-td-{{ id }}-{{ field_name  }}
-                        control-group
-                        {% if nested_field.vars.errors|length > 0 %} error sonata-ba-field-error{% endif %}
-                        "
+                    <td class="sonata-ba-td-{{ id }}-{{ field_name }} control-group"
                         {% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %}
                             style="display:none;"
                         {% endif %}
                     >
-                        {% if sonata_admin.field_description.associationadmin.formfielddescriptions[field_name] is defined %}
-                            {{ form_widget(nested_field) }}
-
+                        {% if associationAdmin.formfielddescriptions[field_name] is defined %}
+                            {{ form_row(nested_field, {
+                                'inline': 'table',
+                                'edit': 'inline',
+                                'label': false
+                            }) }}
                             {% set dummy = nested_group_field.setrendered %}
                         {% else %}
-                            {% if field_name == '_delete' %}
-                                {{ form_widget(nested_field, { label: false }) }}
-                            {% else %}
-                                {{ form_widget(nested_field) }}
-                            {% endif %}
-                        {% endif %}
-                        {% if nested_field.vars.errors|length > 0 %}
-                            <div class="help-inline sonata-ba-field-error-messages">
-                                {{ form_errors(nested_field) }}
-                            </div>
+                            {{ form_row(nested_field, { label: false }) }}
                         {% endif %}
                     </td>
                 {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4911 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `ChoiceFieldMaskType` now works on inline table collections
```

## Subject

<!-- Describe your Pull Request content here -->
Trying to fix the issue #4911 I ended up comparing those 2 templates:

https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig

The first one don't work as expected (the choiceFieldMaskType) and it is used when creating a collectionType with edit inline table.

The second one actually works (the choiceFieldMaskType), and it is used when creating a collectionType with edit inline standard

The solution and the issue is that the table visualization is not using the form_row (that prints a div with an id referencing the field).

Using form_row makes things easier with validation because it has it inside, but forces us to hide the label, because it is only printed on the table header.

Please @lukepass can you test this one? I already did a few tests and everything works good, but having two real tests (or more) is even great.
