### PR TITLE
Force top: 0 on navbar positioning on mobile

### DIFF
--- a/src/Resources/public/css/layout.css
+++ b/src/Resources/public/css/layout.css
@@ -374,7 +374,7 @@ body.fixed .content-header .navbar.stuck {
     body.fixed .right-side {
         padding-top: 0;
     }
-    body.fixed .content-header .navbar.stuck {
+    body.fixed .content-header nav.navbar.stuck {
         top: 0;
         position: relative;
         margin: 0;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4850 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Navbar positioning on mobile is no longer altered like in desktop
```

## Subject

<!-- Describe your Pull Request content here -->
I don't like to use importants, but on this case, the good solution would be BC break probably, because the perfect scenario would be to not have the fixed class on the body if the header is not fixed.