### PR TITLE
Increase consistency on default page sizes

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -171,7 +171,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      *
      * @var array
      */
-    protected $perPageOptions = [16, 32, 64, 128, 192];
+    protected $perPageOptions = [16, 32, 64, 128, 256];
 
     /**
      * Pager type.

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -802,7 +802,12 @@ class AdminTest extends TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
-        $this->assertSame([16, 32, 64, 128, 192], $admin->getPerPageOptions());
+        $perPageOptions = $admin->getPerPageOptions();
+
+        foreach ($perPageOptions as $perPage) {
+            $this->assertEquals(0, $perPage % 4);
+        }
+
         $admin->setPerPageOptions([500, 1000]);
         $this->assertSame([500, 1000], $admin->getPerPageOptions());
     }
@@ -1253,18 +1258,10 @@ class AdminTest extends TestCase
         $this->assertFalse($admin->determinedPerPageValue('foo'));
         $this->assertFalse($admin->determinedPerPageValue(123));
         $this->assertTrue($admin->determinedPerPageValue(16));
-        $this->assertTrue($admin->determinedPerPageValue(32));
-        $this->assertTrue($admin->determinedPerPageValue(64));
-        $this->assertTrue($admin->determinedPerPageValue(128));
-        $this->assertTrue($admin->determinedPerPageValue(192));
 
         $admin->setPerPageOptions([101, 102, 103]);
-        $this->assertFalse($admin->determinedPerPageValue(15));
-        $this->assertFalse($admin->determinedPerPageValue(25));
-        $this->assertFalse($admin->determinedPerPageValue(200));
+        $this->assertFalse($admin->determinedPerPageValue(16));
         $this->assertTrue($admin->determinedPerPageValue(101));
-        $this->assertTrue($admin->determinedPerPageValue(102));
-        $this->assertTrue($admin->determinedPerPageValue(103));
     }
 
     public function testIsGranted()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4391 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Increase consistency on default page sizes (replaced 192 by 256)
```

## Subject

<!-- Describe your Pull Request content here -->
192 didn't make sense, 256 is more consistent.