### PR TITLE
Disable form submit buttons when the form gets submitted

### DIFF
--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -33,6 +33,7 @@ var Admin = {
         Admin.setup_collection_counter(subject);
         Admin.setup_sticky_elements(subject);
         Admin.setup_readmore_elements(subject);
+        Admin.setup_form_submit(subject);
 
 //        Admin.setup_list_modal(subject);
     },
@@ -675,6 +676,13 @@ var Admin = {
     },
     handle_top_navbar_height: function() {
         jQuery('body.fixed .content-wrapper').css('padding-top', jQuery('.navbar-static-top').outerHeight());
+    },
+    setup_form_submit: function(subject) {
+        Admin.log('[core|setup_form_submit] setup form submit on', subject);
+
+        jQuery(subject).find('form').on('submit', function() {
+            jQuery(this).find('button').prop('disabled', true);
+        });
     }
 };
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #3346

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Disable form submit buttons when the form gets submitted
```

## Subject

<!-- Describe your Pull Request content here -->
All forms will get submit buttons disable after the form gets submitted, this way we enforce the form cannot get submitted multiples times.