### PR TITLE
Throw Deprecation if the child does not belong to a parent

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -23,6 +23,10 @@ Instead of a simple boolean var (whether to persist or not filters) you can now 
 that will be responsible for doing the job (see `FilterPersisterInterface`).
 An implementation was added, which falls back to the previous behavior : `SessionFilterPersister`.
 
+## Deprecated editing of a child admin that does not belong to a given parent
+
+This is not allowed anymore and will throw a 404 error.
+
 UPGRADE FROM 3.32 to 3.33
 =========================
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -23,9 +23,9 @@ Instead of a simple boolean var (whether to persist or not filters) you can now 
 that will be responsible for doing the job (see `FilterPersisterInterface`).
 An implementation was added, which falls back to the previous behavior : `SessionFilterPersister`.
 
-## Deprecated editing of a child admin that does not belong to a given parent
+## Deprecated edit/show/delete of a child admin that does not belong to a given parent
 
-This is not allowed anymore and will throw a 404 error.
+This is not allowed anymore and will throw a 404 error in the future.
 
 UPGRADE FROM 3.32 to 3.33
 =========================

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -230,6 +230,23 @@ class CRUDController implements ContainerAwareInterface
             throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
         }
 
+        if ($parentAdmin = $this->admin->getParent()) {
+            $parentId = $request->get($parentAdmin->getIdParameter());
+
+            $propertyAccessor = PropertyAccess::createPropertyAccessor();
+            $propertyPath = new PropertyPath($this->admin->getParentAssociationMapping());
+
+            $parent = $propertyAccessor->getValue($object, $propertyPath);
+
+            if ($parentAdmin->getObject($parentId) !== $parent) {
+                // NEXT_MAJOR: make this exception
+                @trigger_error("Deleting a child that isn't connected to a given parent is deprecated since 3.x"
+                    ." and won't be allowed in 4.0.",
+                    E_USER_DEPRECATED
+                );
+            }
+        }
+
         $this->admin->checkAccess('delete', $object);
 
         $preResponse = $this->preDelete($request, $object);
@@ -317,6 +334,7 @@ class CRUDController implements ContainerAwareInterface
             $parent = $propertyAccessor->getValue($existingObject, $propertyPath);
 
             if ($parentAdmin->getObject($parentId) !== $parent) {
+                // NEXT_MAJOR: make this exception
                 @trigger_error("Editing a child that isn't connected to a given parent is deprecated since 3.x"
                     ." and won't be allowed in 4.0.",
                     E_USER_DEPRECATED
@@ -672,6 +690,23 @@ class CRUDController implements ContainerAwareInterface
 
         if (!$object) {
             throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
+        }
+
+        if ($parentAdmin = $this->admin->getParent()) {
+            $parentId = $request->get($parentAdmin->getIdParameter());
+
+            $propertyAccessor = PropertyAccess::createPropertyAccessor();
+            $propertyPath = new PropertyPath($this->admin->getParentAssociationMapping());
+
+            $parent = $propertyAccessor->getValue($object, $propertyPath);
+
+            if ($parentAdmin->getObject($parentId) !== $parent) {
+                // NEXT_MAJOR: make this exception
+                @trigger_error("Viewing a child that isn't connected to a given parent is deprecated since 3.x"
+                    ." and won't be allowed in 4.0.",
+                    E_USER_DEPRECATED
+                );
+            }
         }
 
         $this->admin->checkAccess('show', $object);

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1458,6 +1458,11 @@ class CRUDController implements ContainerAwareInterface
             return;
         }
 
+        // NEXT_MAJOR: remove this check
+        if (!$this->admin->getParentAssociationMapping()) {
+            return;
+        }
+
         $parentId = $request->get($parentAdmin->getIdParameter());
 
         $propertyAccessor = PropertyAccess::createPropertyAccessor();

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -314,11 +314,11 @@ class CRUDController implements ContainerAwareInterface
             $propertyAccessor = PropertyAccess::createPropertyAccessor();
             $propertyPath = new PropertyPath($this->admin->getParentAssociationMapping());
 
-            $value = $propertyAccessor->getValue($existingObject, $propertyPath);
+            $parent = $propertyAccessor->getValue($existingObject, $propertyPath);
 
-            if ($parentAdmin->getObject($parentId) !== $value) {
+            if ($parentAdmin->getObject($parentId) !== $parent) {
                 @trigger_error("Editing a child that isn't connected to a given parent is deprecated since 3.x"
-                    ." and won't be allowed in 4.x.",
+                    ." and won't be allowed in 4.0.",
                     E_USER_DEPRECATED
                 );
             }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4556

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Editing child admin that does not belong to a given parent
```

## Subject

First of all, I am not sure if this is a BC break?
Second, is this a good way? What if they don't have a getter or named it differently? Would it even work with forms? Any suggestions?