### PR TITLE
Allow to know which button triggered the submit button

### DIFF
--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -681,7 +681,12 @@ var Admin = {
         Admin.log('[core|setup_form_submit] setup form submit on', subject);
 
         jQuery(subject).find('form').on('submit', function() {
-            jQuery(this).find('button').prop('disabled', true);
+            var form = jQuery(this);
+
+            // this allows to submit forms and know which button was clicked
+            setTimeout(function() {
+                form.find('button').prop('disabled', true);
+            }, 1);
         });
     }
 };


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix regression on #5051: It is possible again to know which button triggered the submit of the form.
```

## Subject

<!-- Describe your Pull Request content here -->
If you disable buttons before submitting the form, it will not
include the submit button name on the variables being submitted.
Using a timeout function we ensure that the forms is sent with
that variable. This allows us to know which button was clicked.

This comes from: https://github.com/sonata-project/SonataAdminBundle/commit/082faff76276fba21c99b1d4949b951b8a4d25d7#commitcomment-28388840