### PR TITLE
Fix form types FQCN on Sonata Filters

### DIFF
--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -100,7 +100,7 @@ class ChoiceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'field_type' => 'choice',
+            'field_type' => FormChoiceType::class,
             'field_options' => [],
             'operator_type' => FormChoiceType::class,
             'operator_options' => [],

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
+use Sonata\CoreBundle\Form\Type\DateRangeType as FormDateRangeType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -91,7 +92,7 @@ class DateRangeType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'field_type' => 'sonata_type_date_range',
+            'field_type' => FormDateRangeType::class,
             'field_options' => ['format' => 'yyyy-MM-dd'],
         ]);
     }

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
+use Sonata\CoreBundle\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -94,7 +95,7 @@ class DateTimeRangeType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'field_type' => 'sonata_type_datetime_range',
+            'field_type' => FormDateTimeRangeType::class,
             'field_options' => ['date_format' => 'yyyy-MM-dd'],
         ]);
     }

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType as FormDateTimeType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -110,7 +111,7 @@ class DateTimeType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'field_type' => 'datetime',
+            'field_type' => FormDateTimeType::class,
             'field_options' => ['date_format' => 'yyyy-MM-dd'],
         ]);
     }

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateType as FormDateType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -110,7 +111,7 @@ class DateType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'field_type' => 'date',
+            'field_type' => FormDateType::class,
             'field_options' => ['date_format' => 'yyyy-MM-dd'],
         ]);
     }

--- a/src/Form/Type/Filter/NumberType.php
+++ b/src/Form/Type/Filter/NumberType.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType as FormNumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -104,7 +105,7 @@ class NumberType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'field_type' => 'number',
+            'field_type' => FormNumberType::class,
             'field_options' => [],
         ]);
     }

--- a/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
+++ b/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
+use Sonata\CoreBundle\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -31,7 +32,7 @@ class DateTimeRangeTypeTest extends TypeTestCase
         $options = $optionResolver->resolve();
 
         $expected = [
-            'field_type' => 'sonata_type_datetime_range',
+            'field_type' => FormDateTimeRangeType::class,
             'field_options' => ['date_format' => 'yyyy-MM-dd'],
         ];
         $this->assertSame($expected, $options);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5015 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- form types FQCN are now used in filter. Improves compatibility with SF3/4
```

## Subject

<!-- Describe your Pull Request content here -->
There were a lot of missing Form types FQCN on filter types. Not sure how everything works without this change. But #5015 could be related. Can you check how it works with this PR? @michalwroblewski