### PR TITLE
Admin can have multiple parents now

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -3,8 +3,8 @@ UPGRADE 3.x
 
 ## Multiple parents
 
-Admin classes can now have multiple parents, when registering service you
-should pass field name:
+Admin classes can now have multiple parents, when registering the service
+you should pass a field name:
 
 ```
 <service id="sonata.admin.playlist" class="App\Admin\PlaylistAdmin">
@@ -17,7 +17,7 @@ should pass field name:
 </service>
 ```
 
-Overwriting of `$parentAssociationMapping` is discouraged.
+Overwriting `$parentAssociationMapping` is discouraged.
 
 UPGRADE FROM 3.33 to 3.34
 =========================

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -70,6 +70,8 @@ should pass field name:
 Overwriting of `$parentAssociationMapping` is discouraged.
 >>>>>>> 618cfc95... Admin can have multiple parents now
 
+Deprecated calling of `AbstractAdmin::addChild` without second argument.
+
 UPGRADE FROM 3.32 to 3.33
 =========================
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -48,6 +48,8 @@ An implementation was added, which falls back to the previous behavior : `Sessio
 
 This is not allowed anymore and will throw a 404 error in the future.
 
+Deprecated calling of `AbstractAdmin::addChild` without second argument.
+
 UPGRADE FROM 3.32 to 3.33
 =========================
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -19,6 +19,8 @@ you should pass a field name:
 
 Overwriting `$parentAssociationMapping` is discouraged.
 
+Deprecated calling of `AbstractAdmin::addChild` without second argument.
+
 UPGRADE FROM 3.33 to 3.34
 =========================
 
@@ -44,33 +46,9 @@ Instead of a simple boolean var (whether to persist or not filters) you can now 
 that will be responsible for doing the job (see `FilterPersisterInterface`).
 An implementation was added, which falls back to the previous behavior : `SessionFilterPersister`.
 
-<<<<<<< HEAD
 ## Deprecated edit/show/delete of a child admin that does not belong to a given parent
 
 This is not allowed anymore and will throw a 404 error in the future.
-
-Deprecated calling of `AbstractAdmin::addChild` without second argument.
-=======
-## Multiple parents
-
-Admin classes can now have multiple parents, when registering service you
-should pass field name:
-
-```
-<service id="sonata.admin.playlist" class="App\Admin\PlaylistAdmin">
-    <!-- ... -->
-
-    <call method="addChild">
-        <argument type="service" id="sonata.admin.video" />
-        <argument>playlist</<argument>
-    </call>
-</service>
-```
-
-Overwriting of `$parentAssociationMapping` is discouraged.
->>>>>>> 618cfc95... Admin can have multiple parents now
-
-Deprecated calling of `AbstractAdmin::addChild` without second argument.
 
 UPGRADE FROM 3.32 to 3.33
 =========================

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -44,11 +44,31 @@ Instead of a simple boolean var (whether to persist or not filters) you can now 
 that will be responsible for doing the job (see `FilterPersisterInterface`).
 An implementation was added, which falls back to the previous behavior : `SessionFilterPersister`.
 
+<<<<<<< HEAD
 ## Deprecated edit/show/delete of a child admin that does not belong to a given parent
 
 This is not allowed anymore and will throw a 404 error in the future.
 
 Deprecated calling of `AbstractAdmin::addChild` without second argument.
+=======
+## Multiple parents
+
+Admin classes can now have multiple parents, when registering service you
+should pass field name:
+
+```
+<service id="sonata.admin.playlist" class="App\Admin\PlaylistAdmin">
+    <!-- ... -->
+
+    <call method="addChild">
+        <argument type="service" id="sonata.admin.video" />
+        <argument>playlist</<argument>
+    </call>
+</service>
+```
+
+Overwriting of `$parentAssociationMapping` is discouraged.
+>>>>>>> 618cfc95... Admin can have multiple parents now
 
 UPGRADE FROM 3.32 to 3.33
 =========================

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,24 @@
 UPGRADE 3.x
 ===========
 
+## Multiple parents
+
+Admin classes can now have multiple parents, when registering service you
+should pass field name:
+
+```
+<service id="sonata.admin.playlist" class="App\Admin\PlaylistAdmin">
+    <!-- ... -->
+
+    <call method="addChild">
+        <argument type="service" id="sonata.admin.video" />
+        <argument>playlist</<argument>
+    </call>
+</service>
+```
+
+Overwriting of `$parentAssociationMapping` is discouraged.
+
 UPGRADE FROM 3.33 to 3.34
 =========================
 

--- a/docs/reference/child_admin.rst
+++ b/docs/reference/child_admin.rst
@@ -12,7 +12,9 @@ This will create new routes like, for example, ``/playlist/{id}/video/list``,
 where the videos will automatically be filtered by post.
 
 To do this, you first need to call the ``addChild`` method in your ``PlaylistAdmin``
-service configuration:
+service configuration with two arguments, the child admin name (in this case
+``VideoAdmin`` service) and the Entity field that relates our child Entity with
+its parent:
 
 .. configuration-block::
 
@@ -24,30 +26,9 @@ service configuration:
 
             <call method="addChild">
                 <argument type="service" id="sonata.admin.video" />
+                <argument>playlist</argument>
             </call>
         </service>
-
-Then, you have to set the VideoAdmin ``parentAssociationMapping`` attribute to ``playlist`` :
-
-.. code-block:: php
-
-    <?php
-
-    namespace App\Admin;
-
-    // ...
-
-    class VideoAdmin extends AbstractAdmin
-    {
-        protected $parentAssociationMapping = 'playlist';
-
-        // OR
-
-        public function getParentAssociationMapping()
-        {
-            return 'playlist';
-        }
-    }
 
 To display the ``VideoAdmin`` extend the menu in your ``PlaylistAdmin``
 class::

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1764,12 +1764,18 @@ EOT;
 
         $child->setParent($this);
 
-        // TODO: remove $args and add $field parameter to this function on next Major
+        // NEXT_MAJOR: remove $args and add $field parameter to this function on next Major
 
         $args = \func_get_args();
 
         if (isset($args[1])) {
             $child->addParentAssociationMapping($this->getCode(), $args[1]);
+        } else {
+            @trigger_error(
+                'Calling "addChild" without second argument is deprecated since 3.x'
+                .' and will not be allowed in 4.0.',
+                E_USER_DEPRECATED
+            );
         }
     }
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -245,10 +245,9 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     protected $baseCodeRoute = '';
 
     /**
-     * The related parent association, ie if OrderElement has a parent property named order,
-     * then the $parentAssociationMapping must be a string named `order`.
+     * NEXT_MAJOR: should be default array and private.
      *
-     * @var string
+     * @var string|array
      */
     protected $parentAssociationMapping = null;
 
@@ -849,11 +848,38 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      * Returns the name of the parent related field, so the field can be use to set the default
      * value (ie the parent object) or to filter the object.
      *
-     * @return string the name of the parent related field
+     * @throws \InvalidArgumentException
+     *
+     * @return null|string
      */
     public function getParentAssociationMapping()
     {
+        // NEXT_MAJOR: remove array check
+        if (\is_array($this->parentAssociationMapping) && $this->getParent()) {
+            $parent = $this->getParent()->getCode();
+
+            if (array_key_exists($parent, $this->parentAssociationMapping)) {
+                return $this->parentAssociationMapping[$parent];
+            }
+
+            throw new \InvalidArgumentException(sprintf(
+                "There's no association between %s and %s.",
+                $this->getCode(),
+                $this->getParent()->getCode()
+            ));
+        }
+
+        // NEXT_MAJOR: remove this line
         return $this->parentAssociationMapping;
+    }
+
+    /**
+     * @param string $code
+     * @param string $value
+     */
+    final public function addParentAssociationMapping($code, $value)
+    {
+        $this->parentAssociationMapping[$code] = $value;
     }
 
     /**
@@ -1737,6 +1763,14 @@ EOT;
         $this->children[$child->getCode()] = $child;
 
         $child->setParent($this);
+
+        // TODO: remove $args and add $field parameter to this function on next Major
+
+        $args = \func_get_args();
+
+        if (isset($args[1])) {
+            $child->addParentAssociationMapping($this->getCode(), $args[1]);
+        }
     }
 
     public function hasChild($code)

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -261,7 +261,7 @@ class AdminTest extends TestCase
         $this->assertFalse($postAdmin->hasChild('comment'));
 
         $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
-        $postAdmin->addChild($commentAdmin);
+        $postAdmin->addChild($commentAdmin, 'post');
         $this->assertTrue($postAdmin->hasChildren());
         $this->assertTrue($postAdmin->hasChild('sonata.post.admin.comment'));
 
@@ -544,7 +544,7 @@ class AdminTest extends TestCase
         $commentAdmin->setRouteGenerator($routeGenerator);
         $commentAdmin->initialize();
 
-        $postAdmin->addChild($commentAdmin);
+        $postAdmin->addChild($commentAdmin, 'post');
 
         $commentVoteAdmin = new CommentVoteAdmin(
             'sonata.post.admin.comment_vote',

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -262,12 +262,14 @@ class AdminTest extends TestCase
 
         $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
         $postAdmin->addChild($commentAdmin, 'post');
+
         $this->assertTrue($postAdmin->hasChildren());
         $this->assertTrue($postAdmin->hasChild('sonata.post.admin.comment'));
 
         $this->assertSame('sonata.post.admin.comment', $postAdmin->getChild('sonata.post.admin.comment')->getCode());
         $this->assertSame('sonata.post.admin.post|sonata.post.admin.comment', $postAdmin->getChild('sonata.post.admin.comment')->getBaseCodeRoute());
         $this->assertSame($postAdmin, $postAdmin->getChild('sonata.post.admin.comment')->getParent());
+        $this->assertSame('post', $commentAdmin->getParentAssociationMapping());
 
         $this->assertFalse($postAdmin->isChild());
         $this->assertTrue($commentAdmin->isChild());
@@ -513,6 +515,8 @@ class AdminTest extends TestCase
     }
 
     /**
+     * @group legacy
+     * @expectedDeprecation Calling "addChild" without second argument is deprecated since 3.x and will not be allowed in 4.0.
      * @dataProvider provideGetBaseRouteName
      */
     public function testGetBaseRouteNameWithChildAdmin($objFqn, $expected)
@@ -551,6 +555,7 @@ class AdminTest extends TestCase
             'Application\Sonata\NewsBundle\Entity\CommentVote',
             'SonataNewsBundle:CommentVoteAdmin'
         );
+
         $container->set('sonata.post.admin.comment_vote', $commentVoteAdmin);
         $commentVoteAdmin->setConfigurationPool($pool);
         $commentVoteAdmin->setRouteBuilder($pathInfo);
@@ -574,6 +579,7 @@ class AdminTest extends TestCase
         $this->assertTrue($postAdmin->hasRoute('sonata.post.admin.comment|sonata.post.admin.comment_vote.list'));
         $this->assertFalse($postAdmin->hasRoute('sonata.post.admin.post|sonata.post.admin.comment.edit'));
         $this->assertFalse($commentAdmin->hasRoute('edit'));
+        $this->assertSame('post', $commentAdmin->getParentAssociationMapping());
 
         /*
          * Test the route name from request
@@ -2274,8 +2280,8 @@ class AdminTest extends TestCase
             'Application\Sonata\NewsBundle\Entity\Comment',
             'SonataNewsBundle:CommentAdmin'
         );
-        $postAdmin->addChild($commentAdmin);
-        $commentAdmin->addChild($postAdmin);
+        $postAdmin->addChild($commentAdmin, 'post');
+        $commentAdmin->addChild($postAdmin, 'comment');
     }
 
     public function testCircularChildAdminTripleLevel()
@@ -2300,9 +2306,9 @@ class AdminTest extends TestCase
             'Application\Sonata\NewsBundle\Entity\CommentVote',
             'SonataNewsBundle:CommentVoteAdmin'
         );
-        $postAdmin->addChild($commentAdmin);
-        $commentAdmin->addChild($commentVoteAdmin);
-        $commentVoteAdmin->addChild($postAdmin);
+        $postAdmin->addChild($commentAdmin, 'post');
+        $commentAdmin->addChild($commentVoteAdmin, 'comment');
+        $commentVoteAdmin->addChild($postAdmin, 'post');
     }
 
     public function testCircularChildAdminWithItself()
@@ -2342,13 +2348,13 @@ class AdminTest extends TestCase
         $this->assertSame($commentAdmin, $commentAdmin->getRootAncestor());
         $this->assertSame($commentVoteAdmin, $commentVoteAdmin->getRootAncestor());
 
-        $postAdmin->addChild($commentAdmin);
+        $postAdmin->addChild($commentAdmin, 'post');
 
         $this->assertSame($postAdmin, $postAdmin->getRootAncestor());
         $this->assertSame($postAdmin, $commentAdmin->getRootAncestor());
         $this->assertSame($commentVoteAdmin, $commentVoteAdmin->getRootAncestor());
 
-        $commentAdmin->addChild($commentVoteAdmin);
+        $commentAdmin->addChild($commentVoteAdmin, 'comment');
 
         $this->assertSame($postAdmin, $postAdmin->getRootAncestor());
         $this->assertSame($postAdmin, $commentAdmin->getRootAncestor());
@@ -2377,13 +2383,13 @@ class AdminTest extends TestCase
         $this->assertSame(0, $commentAdmin->getChildDepth());
         $this->assertSame(0, $commentVoteAdmin->getChildDepth());
 
-        $postAdmin->addChild($commentAdmin);
+        $postAdmin->addChild($commentAdmin, 'post');
 
         $this->assertSame(0, $postAdmin->getChildDepth());
         $this->assertSame(1, $commentAdmin->getChildDepth());
         $this->assertSame(0, $commentVoteAdmin->getChildDepth());
 
-        $commentAdmin->addChild($commentVoteAdmin);
+        $commentAdmin->addChild($commentVoteAdmin, 'comment');
 
         $this->assertSame(0, $postAdmin->getChildDepth());
         $this->assertSame(1, $commentAdmin->getChildDepth());
@@ -2408,8 +2414,8 @@ class AdminTest extends TestCase
             'SonataNewsBundle:CommentVoteAdmin'
         );
 
-        $postAdmin->addChild($commentAdmin);
-        $commentAdmin->addChild($commentVoteAdmin);
+        $postAdmin->addChild($commentAdmin, 'post');
+        $commentAdmin->addChild($commentVoteAdmin, 'comment');
 
         $this->assertNull($postAdmin->getCurrentLeafChildAdmin());
         $this->assertNull($commentAdmin->getCurrentLeafChildAdmin());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a feature without BC Break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #3339
Continuing #4954

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Admin can now have multiple parents
### Changed
- `AbstractAdmin::addChild` now accepts 2nd parameter with parent name
```

## Subject

Let's finish this once and for all :smile: 