### PR TITLE
Delete sonata website on sidebar footer

### DIFF
--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -251,7 +251,6 @@ file that was distributed with this source code.
                             {% block side_bar_after_nav %}
                                 <p class="text-center small" style="border-top: 1px solid #444444; padding-top: 10px">
                                     {% block side_bar_after_nav_content %}
-                                        <a href="https://sonata-project.org" rel="noreferrer" target="_blank">sonata project</a>
                                     {% endblock %}
                                 </p>
                             {% endblock %}


### PR DESCRIPTION
As discussed on slack, maybe we can remove this line to avoid overriding it.

##  Changelog
```markdown
### Changed
- `side_bar_after_nav_content` block is now empty by default
```