### PR TITLE
Add missing data-widget attribute for sidebar menu

### DIFF
--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -1,7 +1,7 @@
 {% extends 'knp_menu.html.twig' %}
 
 {% block root %}
-    {%- set listAttributes = item.childrenAttributes|merge({'class': 'sidebar-menu'}) %}
+    {%- set listAttributes = item.childrenAttributes|merge({'class': 'sidebar-menu', 'data-widget': 'tree'}) %}
     {%- set request        = item.extra('request') ?: app.request %}
     {{ block('list') -}}
 {% endblock %}


### PR DESCRIPTION
I am targeting this branch, because it's a bugfix.

Closes #5062 

## Changelog

```markdown
### Fixed
- Not working sidebar menu tree with AdminLTE v2.4
```
