### PR TITLE
Revert "Simplify template based on inline standard"

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
@@ -35,20 +35,30 @@ file that was distributed with this source code.
         {% for nested_group_field_name, nested_group_field in form.children %}
             <tr>
                 {% for field_name, nested_field in nested_group_field.children %}
-                    <td class="sonata-ba-td-{{ id }}-{{ field_name }} control-group"
+                    <td class="
+                        sonata-ba-td-{{ id }}-{{ field_name  }}
+                        control-group
+                        {% if nested_field.vars.errors|length > 0 %} error sonata-ba-field-error{% endif %}
+                        "
                         {% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %}
                             style="display:none;"
                         {% endif %}
                     >
-                        {% if associationAdmin.formfielddescriptions[field_name] is defined %}
-                            {{ form_row(nested_field, {
-                                'inline': 'table',
-                                'edit': 'inline',
-                                'label': false
-                            }) }}
+                        {% if sonata_admin.field_description.associationadmin.formfielddescriptions[field_name] is defined %}
+                            {{ form_widget(nested_field) }}
+
                             {% set dummy = nested_group_field.setrendered %}
                         {% else %}
-                            {{ form_row(nested_field, { label: false }) }}
+                            {% if field_name == '_delete' %}
+                                {{ form_widget(nested_field, { label: false }) }}
+                            {% else %}
+                                {{ form_widget(nested_field) }}
+                            {% endif %}
+                        {% endif %}
+                        {% if nested_field.vars.errors|length > 0 %}
+                            <div class="help-inline sonata-ba-field-error-messages">
+                                {{ form_errors(nested_field) }}
+                            </div>
                         {% endif %}
                     </td>
                 {% endfor %}


### PR DESCRIPTION
This reverts commit fdc7ea1756aeec0d6a9cf232e288e1a2d6779b8e.

I am targeting this branch, because it's a regression fix.

Fixes #5067 

## Changelog

```markdown
### Fixed
- Regression for child form type rendering
```
