### PR TITLE
Calls to AbstractAdmin::getTemplate put back

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2556,7 +2556,9 @@ EOT;
             && $this->hasRoute('create')
         ) {
             $list['create'] = [
-                'template' => $this->getTemplateRegistry()->getTemplate('button_create'),
+                // NEXT_MAJOR: Remove this line and use commented line below it instead
+                'template' => $this->getTemplate('button_create'),
+//                'template' => $this->getTemplateRegistry()->getTemplate('button_create'),
             ];
         }
 
@@ -2565,7 +2567,9 @@ EOT;
             && $this->hasRoute('edit')
         ) {
             $list['edit'] = [
-                'template' => $this->getTemplateRegistry()->getTemplate('button_edit'),
+                // NEXT_MAJOR: Remove this line and use commented line below it instead
+                'template' => $this->getTemplate('button_edit'),
+                //'template' => $this->getTemplateRegistry()->getTemplate('button_edit'),
             ];
         }
 
@@ -2574,7 +2578,9 @@ EOT;
             && $this->hasRoute('history')
         ) {
             $list['history'] = [
-                'template' => $this->getTemplateRegistry()->getTemplate('button_history'),
+                // NEXT_MAJOR: Remove this line and use commented line below it instead
+                'template' => $this->getTemplate('button_history'),
+                // 'template' => $this->getTemplateRegistry()->getTemplate('button_history'),
             ];
         }
 
@@ -2584,7 +2590,9 @@ EOT;
             && $this->hasRoute('acl')
         ) {
             $list['acl'] = [
-                'template' => $this->getTemplateRegistry()->getTemplate('button_acl'),
+                // NEXT_MAJOR: Remove this line and use commented line below it instead
+                'template' => $this->getTemplate('button_acl'),
+                // 'template' => $this->getTemplateRegistry()->getTemplate('button_acl'),
             ];
         }
 
@@ -2594,7 +2602,9 @@ EOT;
             && $this->hasRoute('show')
         ) {
             $list['show'] = [
-                'template' => $this->getTemplateRegistry()->getTemplate('button_show'),
+                // NEXT_MAJOR: Remove this line and use commented line below it instead
+                'template' => $this->getTemplate('button_show'),
+                // 'template' => $this->getTemplateRegistry()->getTemplate('button_show'),
             ];
         }
 
@@ -2603,7 +2613,9 @@ EOT;
             && $this->hasRoute('list')
         ) {
             $list['list'] = [
-                'template' => $this->getTemplateRegistry()->getTemplate('button_list'),
+                // NEXT_MAJOR: Remove this line and use commented line below it instead
+                'template' => $this->getTemplate('button_list'),
+                // 'template' => $this->getTemplateRegistry()->getTemplate('button_list'),
             ];
         }
 
@@ -2643,7 +2655,9 @@ EOT;
             $actions['create'] = [
                 'label' => 'link_add',
                 'translation_domain' => 'SonataAdminBundle',
-                'template' => $this->getTemplateRegistry()->getTemplate('action_create'),
+                // NEXT_MAJOR: Remove this line and use commented line below it instead
+                'template' => $this->getTemplate('action_create'),
+                // 'template' => $this->getTemplateRegistry()->getTemplate('action_create'),
                 'url' => $this->generateUrl('create'),
                 'icon' => 'plus-circle',
             ];
@@ -2851,7 +2865,9 @@ EOT;
             );
 
             $fieldDescription->setAdmin($this);
-            $fieldDescription->setTemplate($this->getTemplateRegistry()->getTemplate('batch'));
+            // NEXT_MAJOR: Remove this line and use commented line below it instead
+            $fieldDescription->setTemplate($this->getTemplate('batch'));
+            // $fieldDescription->setTemplate($this->getTemplateRegistry()->getTemplate('batch'));
 
             $mapper->add($fieldDescription, 'batch');
         }
@@ -2875,7 +2891,9 @@ EOT;
             );
 
             $fieldDescription->setAdmin($this);
-            $fieldDescription->setTemplate($this->getTemplateRegistry()->getTemplate('select'));
+            // NEXT_MAJOR: Remove this line and use commented line below it instead
+            $fieldDescription->setTemplate($this->getTemplate('select'));
+            // $fieldDescription->setTemplate($this->getTemplateRegistry()->getTemplate('select'));
 
             $mapper->add($fieldDescription, 'select');
         }

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -461,6 +461,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     /**
      * Returns template.
      *
+     * @deprecated since 3.x. To be removed in 4.0. Use TemplateRegistry services instead
+     *
      * @param string $name
      *
      * @return null|string

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -167,7 +167,11 @@ class CRUDController implements ContainerAwareInterface
         // set the theme for the current Admin Form
         $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-        return $this->renderWithExtraParams($this->templateRegistry->getTemplate('list'), [
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        $template = $this->admin->getTemplate('list');
+        // $template = $this->templateRegistry->getTemplate('list');
+
+        return $this->renderWithExtraParams($template, [
             'action' => 'list',
             'form' => $formView,
             'datagrid' => $datagrid,
@@ -276,7 +280,11 @@ class CRUDController implements ContainerAwareInterface
             return $this->redirectTo($object);
         }
 
-        return $this->renderWithExtraParams($this->templateRegistry->getTemplate('delete'), [
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        $template = $this->admin->getTemplate('delete');
+        // $template = $this->templateRegistry->getTemplate('delete');
+
+        return $this->renderWithExtraParams($template, [
             'object' => $object,
             'action' => 'delete',
             'csrf_token' => $this->getCsrfToken('sonata.delete'),
@@ -387,7 +395,11 @@ class CRUDController implements ContainerAwareInterface
         // set the theme for the current Admin Form
         $this->setFormTheme($formView, $this->admin->getFormTheme());
 
-        return $this->renderWithExtraParams($this->templateRegistry->getTemplate($templateKey), [
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        $template = $this->admin->getTemplate($templateKey);
+        // $template = $this->templateRegistry->getTemplate($templateKey);
+
+        return $this->renderWithExtraParams($template, [
             'action' => 'edit',
             'form' => $formView,
             'object' => $existingObject,
@@ -486,7 +498,11 @@ class CRUDController implements ContainerAwareInterface
             $formView = $datagrid->getForm()->createView();
             $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-            return $this->renderWithExtraParams($this->templateRegistry->getTemplate('batch_confirmation'), [
+            // NEXT_MAJOR: Remove this line and use commented line below it instead
+            $template = $this->admin->getTemplate('batch_confirmation');
+            // $template = $this->templateRegistry->getTemplate('batch_confirmation');
+
+            return $this->renderWithExtraParams($template, [
                 'action' => 'list',
                 'action_label' => $actionLabel,
                 'batch_translation_domain' => $batchTranslationDomain,
@@ -627,7 +643,11 @@ class CRUDController implements ContainerAwareInterface
         // set the theme for the current Admin Form
         $this->setFormTheme($formView, $this->admin->getFormTheme());
 
-        return $this->renderWithExtraParams($this->templateRegistry->getTemplate($templateKey), [
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        $template = $this->admin->getTemplate($templateKey);
+        // $template = $this->templateRegistry->getTemplate($templateKey);
+
+        return $this->renderWithExtraParams($template, [
             'action' => 'create',
             'form' => $formView,
             'object' => $newObject,
@@ -665,7 +685,11 @@ class CRUDController implements ContainerAwareInterface
 
         $this->admin->setSubject($object);
 
-        return $this->renderWithExtraParams($this->templateRegistry->getTemplate('show'), [
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        $template = $this->admin->getTemplate('show');
+        //$template = $this->templateRegistry->getTemplate('show');
+
+        return $this->renderWithExtraParams($template, [
             'action' => 'show',
             'object' => $object,
             'elements' => $this->admin->getShow(),
@@ -710,7 +734,11 @@ class CRUDController implements ContainerAwareInterface
 
         $revisions = $reader->findRevisions($this->admin->getClass(), $id);
 
-        return $this->renderWithExtraParams($this->templateRegistry->getTemplate('history'), [
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        $template = $this->admin->getTemplate('history');
+        // $template = $this->templateRegistry->getTemplate('history');
+
+        return $this->renderWithExtraParams($template, [
             'action' => 'history',
             'object' => $object,
             'revisions' => $revisions,
@@ -771,7 +799,11 @@ class CRUDController implements ContainerAwareInterface
 
         $this->admin->setSubject($object);
 
-        return $this->renderWithExtraParams($this->templateRegistry->getTemplate('show'), [
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        $template = $this->admin->getTemplate('show');
+        // $template = $this->templateRegistry->getTemplate('show');
+
+        return $this->renderWithExtraParams($template, [
             'action' => 'show',
             'object' => $object,
             'elements' => $this->admin->getShow(),
@@ -845,7 +877,11 @@ class CRUDController implements ContainerAwareInterface
 
         $this->admin->setSubject($base_object);
 
-        return $this->renderWithExtraParams($this->templateRegistry->getTemplate('show_compare'), [
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        $template = $this->admin->getTemplate('show_compare');
+        // $template = $this->templateRegistry->getTemplate('show_compare');
+
+        return $this->renderWithExtraParams($template, [
             'action' => 'show',
             'object' => $base_object,
             'object_compare' => $compare_object,
@@ -977,7 +1013,11 @@ class CRUDController implements ContainerAwareInterface
             }
         }
 
-        return $this->renderWithExtraParams($this->templateRegistry->getTemplate('acl'), [
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        $template = $this->admin->getTemplate('acl');
+        // $template = $this->templateRegistry->getTemplate('acl');
+
+        return $this->renderWithExtraParams($template, [
             'action' => 'acl',
             'permissions' => $adminObjectAclData->getUserPermissions(),
             'object' => $object,
@@ -1124,10 +1164,14 @@ class CRUDController implements ContainerAwareInterface
     protected function getBaseTemplate()
     {
         if ($this->isXmlHttpRequest()) {
-            return $this->templateRegistry->getTemplate('ajax');
+            // NEXT_MAJOR: Remove this line and use commented line below it instead
+            return $this->admin->getTemplate('ajax');
+            // return $this->templateRegistry->getTemplate('ajax');
         }
 
-        return $this->templateRegistry->getTemplate('layout');
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        return $this->admin->getTemplate('layout');
+        // return $this->templateRegistry->getTemplate('layout');
     }
 
     /**

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -154,7 +154,9 @@ class SonataAdminExtension extends AbstractExtension
     ) {
         $template = $this->getTemplate(
             $fieldDescription,
-            $this->getTemplateRegistry($fieldDescription->getAdmin()->getCode())->getTemplate('base_list_field'),
+            // NEXT_MAJOR: Remove this line and use commented line below instead
+            $fieldDescription->getAdmin()->getTemplate('base_list_field'),
+            //$this->getTemplateRegistry($fieldDescription->getAdmin()->getCode())->getTemplate('base_list_field'),
             $environment
         );
 

--- a/src/Twig/Extension/TemplateRegistryExtension.php
+++ b/src/Twig/Extension/TemplateRegistryExtension.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Twig\Extension;
 
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
@@ -58,7 +59,9 @@ final class TemplateRegistryExtension extends AbstractExtension
      */
     public function getAdminTemplate($name, $adminCode)
     {
-        return $this->getTemplateRegistry($adminCode)->getTemplate($name);
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        return $this->getAdmin($adminCode)->getTemplate($name);
+        // return $this->getTemplateRegistry($adminCode)->getTemplate($name);
     }
 
     /**
@@ -100,5 +103,25 @@ final class TemplateRegistryExtension extends AbstractExtension
         }
 
         throw new ServiceNotFoundException($serviceId);
+    }
+
+    /**
+     * @deprecated since 3.x, will be dropped in 4.0. Use TemplateRegistry services instead
+     *
+     * @param string $adminCode
+     *
+     * @throws ServiceNotFoundException
+     * @throws ServiceCircularReferenceException
+     *
+     * @return AdminInterface
+     */
+    private function getAdmin($adminCode)
+    {
+        $admin = $this->container->get($adminCode);
+        if ($admin instanceof AdminInterface) {
+            return $admin;
+        }
+
+        throw new ServiceNotFoundException($adminCode);
     }
 }

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -352,6 +352,24 @@ class CRUDControllerTest extends TestCase
         $this->templateRegistry->getTemplate('batch')->willReturn('@SonataAdmin/CRUD/list__batch.html.twig');
         $this->templateRegistry->getTemplate('batch_confirmation')->willReturn('@SonataAdmin/CRUD/batch_confirmation.html.twig');
 
+        // NEXT_MAJOR: Remove this call
+        $this->admin->method('getTemplate')->willReturnMap([
+            ['ajax', '@SonataAdmin/ajax_layout.html.twig'],
+            ['layout', '@SonataAdmin/standard_layout.html.twig'],
+            ['show', '@SonataAdmin/CRUD/show.html.twig'],
+            ['show_compare', '@SonataAdmin/CRUD/show_compare.html.twig'],
+            ['edit', '@SonataAdmin/CRUD/edit.html.twig'],
+            ['dashboard', '@SonataAdmin/Core/dashboard.html.twig'],
+            ['search', '@SonataAdmin/Core/search.html.twig'],
+            ['list', '@SonataAdmin/CRUD/list.html.twig'],
+            ['preview', '@SonataAdmin/CRUD/preview.html.twig'],
+            ['history', '@SonataAdmin/CRUD/history.html.twig'],
+            ['acl', '@SonataAdmin/CRUD/acl.html.twig'],
+            ['delete', '@SonataAdmin/CRUD/delete.html.twig'],
+            ['batch', '@SonataAdmin/CRUD/list__batch.html.twig'],
+            ['batch_confirmation', '@SonataAdmin/CRUD/batch_confirmation.html.twig'],
+        ]);
+
         $this->admin->expects($this->any())
             ->method('getIdParameter')
             ->will($this->returnValue('id'));

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -242,6 +242,8 @@ class HelperControllerTest extends TestCase
         $this->admin->hasAccess('edit', $object)->willReturn(true);
         $this->admin->getListFieldDescription('enabled')->willReturn($fieldDescription->reveal());
         $this->admin->update($object)->shouldBeCalled();
+        // NEXT_MAJOR: Remove this line
+        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
         $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
         $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
         $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
@@ -289,6 +291,8 @@ class HelperControllerTest extends TestCase
         $this->admin->getClass()->willReturn(get_class($object));
         $this->admin->update($object)->shouldBeCalled();
         $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
+        // NEXT_MAJOR: Remove this line
+        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
         $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
         $this->admin->getModelManager()->willReturn($modelManager->reveal());
         $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -260,6 +260,12 @@ class SonataAdminExtensionTest extends TestCase
             ->method('hasAccess')
             ->will($this->returnValue(true));
 
+        // NEXT_MAJOR: Remove this line
+        $this->admin->expects($this->any())
+            ->method('getTemplate')
+            ->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+
         $this->templateRegistry->getTemplate('base_list_field')->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
         $this->fieldDescription->expects($this->any())
@@ -337,6 +343,12 @@ class SonataAdminExtensionTest extends TestCase
         $this->admin->expects($this->any())
             ->method('hasAccess')
             ->will($this->returnValue(true));
+
+        // NEXT_MAJOR: Remove this line
+        $this->admin->expects($this->any())
+            ->method('getTemplate')
+            ->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
         $this->templateRegistry->getTemplate('base_list_field')->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
@@ -1300,6 +1312,11 @@ EOT
      */
     public function testRenderListElementNonExistentTemplate()
     {
+        // NEXT_MAJOR: Remove this line
+        $this->admin->method('getTemplate')
+            ->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+
         $this->templateRegistry->getTemplate('base_list_field')->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
         $this->fieldDescription->expects($this->once())
@@ -1338,6 +1355,11 @@ EOT
     {
         $this->expectException(\Twig_Error_Loader::class);
         $this->expectExceptionMessage('Unable to find template "@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig"');
+
+        // NEXT_MAJOR: Remove this line
+        $this->admin->method('getTemplate')
+            ->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig');
 
         $this->templateRegistry->getTemplate('base_list_field')->willReturn('@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig');
 

--- a/tests/Twig/Extension/TemplateRegistryExtensionTest.php
+++ b/tests/Twig/Extension/TemplateRegistryExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\AdminBundle\Twig\Extension\TemplateRegistryExtension;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -38,12 +39,23 @@ class TemplateRegistryExtensionTest extends TestCase
      */
     private $container;
 
+    /**
+     * NEXT_MAJOR: Remove this attribute.
+     *
+     * @var AdminInterface
+     */
     private $admin;
 
     protected function setUp()
     {
         $this->templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
         $this->container = $this->prophesize(ContainerInterface::class);
+
+        // NEXT_MAJOR: Remove this line
+        $this->admin = $this->prophesize(AdminInterface::class);
+
+        // NEXT_MAJOR: Remove this line
+        $this->admin->getTemplate('edit')->willReturn('@SonataAdmin/CRUD/edit.html.twig');
 
         $this->templateRegistry->getTemplate('edit')->willReturn('@SonataAdmin/CRUD/edit.html.twig');
 
@@ -68,7 +80,10 @@ class TemplateRegistryExtensionTest extends TestCase
 
     public function testGetAdminTemplate()
     {
-        $this->container->get('admin.post.template_registry')->willReturn($this->templateRegistry);
+        // NEXT_MAJOR: Remove this line
+        $this->container->get('admin.post')->willReturn($this->admin->reveal());
+
+        $this->container->get('admin.post.template_registry')->willReturn($this->templateRegistry->reveal());
 
         $this->assertEquals(
             '@SonataAdmin/CRUD/edit.html.twig',
@@ -78,10 +93,15 @@ class TemplateRegistryExtensionTest extends TestCase
 
     public function testGetAdminTemplateFailure()
     {
+        // NEXT_MAJOR: Remove this line
+        $this->container->get('admin.post')->willReturn(null);
         $this->container->get('admin.post.template_registry')->willReturn(null);
 
         $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage('You have requested a non-existent service "admin.post.template_registry"');
+
+        // NEXT_MAJOR: Remove this line and use the commented line below instead
+        $this->expectExceptionMessage('You have requested a non-existent service "admin.post"');
+        // $this->expectExceptionMessage('You have requested a non-existent service "admin.post.template_registry"');
 
         $this->assertEquals(
             '@SonataAdmin/CRUD/edit.html.twig',


### PR DESCRIPTION
I am targeting this branch, because this is a fix to a BC breaking change.

Closes #5065

## Changelog

```markdown
### Fixed
- Fixed a BC break where an overwritten `getTemplate()` method in an `Admin`
was no longer called by Sonata.
```

## Subject

Changes in PR #4980 introduced a BC break: the `AbstractAdmin` method `getTemplate()` was no longer called (all calls to that method were replaced with calls to the `TemplateRegistry::getTemplate()` method).

As @FabienPapet pointed out, people may override the `AbstractAdmin::getTemplate()` method to use different templates than the defaults.
Because that method is no longer called, the system reverts back to using the default templates. This is a BC break.

I replaced all admin-specific calls to `TemplateRegistry::getTemplate()` with calls to `AbstractAdmin::getTemplate()`. The original calls are commented out, so they may be re-used at the next major update.