### PR TITLE
Set persistFilters option to true while setting the filter persister

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1430,6 +1430,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     public function setFilterPersister(FilterPersisterInterface $filterPersister = null)
     {
         $this->filterPersister = $filterPersister;
+        // NEXT_MAJOR remove the deprecated property will be removed. Needed for persisted filter condition.
+        $this->persistFilters = true;
     }
 
     /**

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1419,6 +1419,7 @@ class AdminTest extends TestCase
         $this->assertAttributeSame(null, 'filterPersister', $admin);
         $admin->setFilterPersister($filterPersister);
         $this->assertAttributeSame($filterPersister, 'filterPersister', $admin);
+        $this->assertAttributeSame(true, 'persistFilters', $admin);
     }
 
     public function testGetRootCode()


### PR DESCRIPTION
I am targeting this branch, because it's a regression fix.

Closes #5069 

## Changelog

```markdown
### Fixed
- Not working persist_filter option for legacy admin property.
```

## Subject

Even if the property is deprecated, it's still used to check if the filters have to be persisted or not.

As the `setFilterPersister` method is called only if the `persist_filter` configuration key is set to `true`, I set the `persistFilters` deprecated attribute here to avoid resolvable deprecation error with the setter.