### PR TITLE
Don't try to fetch from database if the class is not set

### DIFF
--- a/src/Controller/HelperController.php
+++ b/src/Controller/HelperController.php
@@ -286,6 +286,7 @@ class HelperController
         // Handle entity choice association type, transforming the value into entity
         if ('' !== $value
             && 'choice' == $fieldDescription->getType()
+            && null !== $fieldDescription->getOption('class')
             && $fieldDescription->getOption('class') === $fieldDescription->getTargetEntity()
         ) {
             $value = $admin->getModelManager()->find($fieldDescription->getOption('class'), $value);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Edit on list is fixed for choices not related to an entity
```

## Subject

<!-- Describe your Pull Request content here -->
When using an editable field on listMapper with choices it fails because it will try to fetch from database.

The reason is having both `getOption('class')` and `getTargetEntity()` null.