### PR TITLE
Unify menu item generation

### DIFF
--- a/src/Menu/Provider/GroupMenuProvider.php
+++ b/src/Menu/Provider/GroupMenuProvider.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Menu\Provider;
 
 use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -80,51 +81,13 @@ class GroupMenuProvider implements MenuProviderInterface
     {
         $group = $options['group'];
 
-        $menuItem = $this->menuFactory->createItem(
-            $options['name'],
-            [
-                'label' => $group['label'],
-            ]
-        );
+        $menuItem = $this->menuFactory->createItem($options['name']);
 
-        if (empty($group['on_top'])) {
+        if (empty($group['on_top']) || false === $group['on_top']) {
             foreach ($group['items'] as $item) {
-                if (isset($item['admin']) && !empty($item['admin'])) {
-                    $admin = $this->pool->getInstance($item['admin']);
-
-                    // skip menu item if no `list` url is available or user doesn't have the LIST access rights
-                    if (!$admin->hasRoute('list') || !$admin->hasAccess('list')) {
-                        continue;
-                    }
-
-                    $label = $admin->getLabel();
-                    $options = $admin->generateMenuUrl('list', [], $item['route_absolute']);
-                    $options['extras'] = [
-                        'label_catalogue' => $admin->getTranslationDomain(),
-                        'admin' => $admin,
-                    ];
-                } else {
-                    //NEXT_MAJOR: Remove if statement of null checker.
-                    if (null !== $this->checker) {
-                        if ((!empty($item['roles']) && !$this->checker->isGranted($item['roles']))
-                            || (!empty($group['roles']) && !$this->checker->isGranted($group['roles'], $item['route']))
-                        ) {
-                            continue;
-                        }
-                    }
-
-                    $label = $item['label'];
-                    $options = [
-                        'route' => $item['route'],
-                        'routeParameters' => $item['route_params'],
-                        'routeAbsolute' => $item['route_absolute'],
-                        'extras' => [
-                            'label_catalogue' => $group['label_catalogue'],
-                        ],
-                    ];
+                if ($this->canGenerateMenuItem($item, $group)) {
+                    $menuItem->addChild($this->generateMenuItem($item, $group));
                 }
-
-                $menuItem->addChild($label, $options);
             }
 
             if (false === $menuItem->hasChildren()) {
@@ -133,28 +96,15 @@ class GroupMenuProvider implements MenuProviderInterface
                 $menuItem->setAttribute('class', 'keep-open');
                 $menuItem->setExtra('keep_open', $group['keep_open']);
             }
-        } else {
-            foreach ($group['items'] as $item) {
-                if (isset($item['admin']) && !empty($item['admin'])) {
-                    $admin = $this->pool->getInstance($item['admin']);
-
-                    // Do not display group if no `list` url is available or user doesn't have the LIST access rights
-                    if (!$admin->hasRoute('list') || !$admin->hasAccess('list')) {
-                        $menuItem->setDisplay(false);
-
-                        continue;
-                    }
-
-                    $options = $admin->generateUrl('list');
-                    $menuItem->setExtra('route', $admin->getBaseRouteName().'_list');
-                    $menuItem->setExtra('on_top', $group['on_top']);
-                    $menuItem->setUri($options);
-                } else {
-                    $router = $this->pool->getContainer()->get('router');
-                    $menuItem->setUri($router->generate($item['route']));
-                }
+        } elseif (1 === count($group['items'])) {
+            if ($this->canGenerateMenuItem($group['items'][0], $group)) {
+                $menuItem = $this->generateMenuItem($group['items'][0], $group);
+                $menuItem->setExtra('on_top', $group['on_top']);
+            } else {
+                $menuItem->setDisplay(false);
             }
         }
+        $menuItem->setLabel($group['label']);
 
         return $menuItem;
     }
@@ -169,5 +119,51 @@ class GroupMenuProvider implements MenuProviderInterface
     public function has($name, array $options = [])
     {
         return 'sonata_group_menu' === $name;
+    }
+
+    /**
+     * @return bool
+     */
+    private function canGenerateMenuItem(array $item, array $group)
+    {
+        if (isset($item['admin']) && !empty($item['admin'])) {
+            $admin = $this->pool->getInstance($item['admin']);
+
+            // skip menu item if no `list` url is available or user doesn't have the LIST access rights
+            return $admin->hasRoute('list') && $admin->hasAccess('list');
+        }
+
+        //NEXT_MAJOR: Remove if statement of null checker.
+        return null === $this->checker || (
+            (empty($item['roles']) || $this->checker->isGranted($item['roles'])) &&
+            (empty($group['roles']) || $this->checker->isGranted($group['roles']))
+        );
+    }
+
+    /**
+     * @return ItemInterface
+     */
+    private function generateMenuItem(array $item, array $group)
+    {
+        if (isset($item['admin']) && !empty($item['admin'])) {
+            $admin = $this->pool->getInstance($item['admin']);
+
+            $options = $admin->generateMenuUrl('list', [], $item['route_absolute']);
+            $options['extras'] = [
+                'label_catalogue' => $admin->getTranslationDomain(),
+                'admin' => $admin,
+            ];
+
+            return $this->menuFactory->createItem($admin->getLabel(), $options);
+        }
+
+        return $this->menuFactory->createItem($item['label'], [
+            'route' => $item['route'],
+            'routeParameters' => $item['route_params'],
+            'routeAbsolute' => $item['route_absolute'],
+            'extras' => [
+                'label_catalogue' => $group['label_catalogue'],
+            ],
+        ]);
     }
 }

--- a/tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/tests/Menu/Provider/GroupMenuProviderTest.php
@@ -75,7 +75,7 @@ class GroupMenuProviderTest extends TestCase
     {
         $provider = new GroupMenuProvider($this->factory, $this->pool);
 
-        $this->pool->expects($this->once())
+        $this->pool->expects($this->any())
             ->method('getInstance')
             ->with($this->equalTo('sonata_admin_foo_service'))
             ->will($this->returnValue($this->getAdminMock()));
@@ -115,7 +115,7 @@ class GroupMenuProviderTest extends TestCase
      */
     public function testGetMenuProviderWithCheckerGrantedGroupRoles(array $adminGroups)
     {
-        $this->pool->expects($this->once())
+        $this->pool->expects($this->any())
             ->method('getInstance')
             ->with($this->equalTo('sonata_admin_foo_service'))
             ->will($this->returnValue($this->getAdminMock()));
@@ -155,7 +155,7 @@ class GroupMenuProviderTest extends TestCase
      */
     public function testGetMenuProviderWithAdmin(array $adminGroups)
     {
-        $this->pool->expects($this->once())
+        $this->pool->expects($this->any())
             ->method('getInstance')
             ->with($this->equalTo('sonata_admin_foo_service'))
             ->will($this->returnValue($this->getAdminMock()));
@@ -199,7 +199,7 @@ class GroupMenuProviderTest extends TestCase
      */
     public function testGetKnpMenuWithListRoute(array $adminGroups)
     {
-        $this->pool->expects($this->once())
+        $this->pool->expects($this->any())
             ->method('getInstance')
             ->with($this->equalTo('sonata_admin_foo_service'))
             ->will($this->returnValue($this->getAdminMock(false)));
@@ -229,7 +229,7 @@ class GroupMenuProviderTest extends TestCase
      */
     public function testGetKnpMenuWithGrantedList(array $adminGroups)
     {
-        $this->pool->expects($this->once())
+        $this->pool->expects($this->any())
             ->method('getInstance')
             ->with($this->equalTo('sonata_admin_foo_service'))
             ->will($this->returnValue($this->getAdminMock(true, false)));
@@ -259,7 +259,7 @@ class GroupMenuProviderTest extends TestCase
      */
     public function testGetMenuProviderOnTopOptions(array $adminGroupsOnTopOption)
     {
-        $this->pool->expects($this->once())
+        $this->pool->expects($this->any())
             ->method('getInstance')
             ->with($this->equalTo('sonata_admin_foo_service'))
             ->will($this->returnValue($this->getAdminMock(true, false)));
@@ -283,7 +283,7 @@ class GroupMenuProviderTest extends TestCase
      */
     public function testGetMenuProviderKeepOpenOption(array $adminGroups)
     {
-        $this->pool->expects($this->once())
+        $this->pool->expects($this->any())
             ->method('getInstance')
             ->with($this->equalTo('sonata_admin_foo_service'))
             ->will($this->returnValue($this->getAdminMock()));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4576
Closes #4518
Closes #4413

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed route generation with parameter for on_top menu items
- Fixed custom group permission for menu items
```

## Subject

<!-- Describe your Pull Request content here -->
This is a little refactor of the GroupMenuProvider, to generate the menu items in a unique way.