### PR TITLE
Fix a table cell align

### DIFF
--- a/docs/reference/security.rst
+++ b/docs/reference/security.rst
@@ -144,7 +144,7 @@ The role name will be based on the name of your admin service.
 ========================   ======================================================
 app.admin.foo              ROLE_APP_ADMIN_FOO_{PERMISSION}
 my.blog.admin.foo_bar      ROLE_MY_BLOG_ADMIN_FOO_BAR_{PERMISSION}
-App\Admin\FooAdmin   ROLE_APPBUNDLE\ADMIN\FOOADMIN_{PERMISSION}
+App\Admin\FooAdmin         ROLE_APPBUNDLE\ADMIN\FOOADMIN_{PERMISSION}
 ========================   ======================================================
 
 .. note::


### PR DESCRIPTION
I am targeting this branch, because it's a docs fix.


## Subject

Fix a table cell align for the correct display of the table, because currently it looks like this:

![image](https://user-images.githubusercontent.com/4408379/39294451-76fcbf32-4944-11e8-968c-cc19bca5f6a5.png)

Source - https://symfony.com/doc/current/bundles/SonataAdminBundle/reference/security.html#id1