### PR TITLE
Removed new warning produced by PHP7.2 in BaseFieldDescription.php

### DIFF
--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -434,6 +434,9 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         if (!is_string($fieldName)) {
             return null;
         }
+        if (!is_object($object)) {
+            return null;
+        }
         $components = [get_class($object), $fieldName];
         $code = $this->getOption('code');
         if (is_string($code) && '' !== $code) {


### PR DESCRIPTION
I am targeting the 3.x branch, because my changes are made without any BC-break.

```markdown
### Added
- Added a condition in the `getFieldGetterKey` in order remove the new warning produced by PHP7.2.
```

## Subject

As mentioned in this Stack Overflow post (https://stackoverflow.com/a/49752124/2087724) this small PR fixes the new warning produced by the latest release of PHP7.2.

The warning looks like the following: `get_class() expects parameter 1 to be object, null given`

Official php documentation link: http://php.net/manual/en/function.get-class.php

Extract from the documentation:

```
Note: Explicitly passing NULL as the object is no longer allowed as of PHP 7.2.0. The parameter is still optional and calling get_class() without a parameter from inside a class will work, but passing NULL now emits an E_WARNING notice.
```