### PR TITLE
Available default filter type classes link incorrect

### DIFF
--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -648,4 +648,4 @@ Checkbox range selection
 
 .. _`issues on GitHub`: https://github.com/sonata-project/SonataAdminBundle/issues/1519
 .. _`SonataDoctrineORMAdminBundle Documentation`: https://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/list_field_definition.html
-.. _`here`: https://github.com/sonata-project/SonataCoreBundle/tree/master/Form/Type
+.. _`here`: https://github.com/sonata-project/SonataAdminBundle/tree/2.x/Form/Type


### PR DESCRIPTION
NOW :::: `here`: https://github.com/sonata-project/SonataAdminBundle/tree/2.x/Form/Type

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod` to do great stuff

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

<!-- Describe your Pull Request content here -->
