### PR TITLE
[Documentation] Added SonataAdminBundle link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ Admin Bundle
 
 **SonataAdminBundle is split into 4 bundles:**
 
-* SonataAdminBundle: contains core libraries and services
+* `SonataAdminBundle <https://github.com/sonata-project/SonataAdminBundle>`_: contains core libraries and services
 * `SonataDoctrineORMAdminBundle <https://github.com/sonata-project/SonataDoctrineORMAdminBundle>`_: integrates Doctrine ORM project with the core admin bundle
 * `SonataDoctrineMongoDBAdminBundle <https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle>`_: integrates MongoDB with the core admin bundle
 * `SonataDoctrinePhpcrAdminBundle <https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle>`_: integrates PHPCR with the core admin bundle


### PR DESCRIPTION
I am targeting this branch, because it's just a little deal to add a link on the documentation index in an exisiting text.

## Subject
Just a little PR to add the SonataAdminBundle link on the documentation index page :
![sonataadminbundle-link-docs](https://user-images.githubusercontent.com/6014143/40880607-6e843352-66b4-11e8-818f-e705304aeed7.png)
