### PR TITLE
Fix display for empty initial value in choice field mask

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -522,7 +522,11 @@ file that was distributed with this source code.
                 }
             }
 
-            choice_field_mask_show('{{ value }}');
+            {% if value is empty %}
+                choice_field_mask_show(showMaskChoiceEl.val());
+            {% else %}
+                choice_field_mask_show('{{ value }}');
+            {% endif %}
         });
 
     </script>


### PR DESCRIPTION
I am targeting this branch, because this is a BC fix.

## Changelog
```markdown
### Fixed
- Fixed choice field mask initial display when field value is empty
```

## Subject
When a `ChoiceFieldMaskType` is used with required set to true, there is no "empty option" added in the select options. The first option of the select is automatically selected by the browser but the field value is empty. In this case, the show/hide js function is triggered for the current field value, an empty value, and does nothing. Finally, we have the first option selected by the browser but the linked fields are not displayed.

The bug seems to have been introduced by this [commit](https://github.com/sonata-project/SonataAdminBundle/commit/9ba0ddcd15652eb0b5e908402a447a05b269501c) and this PR is adding a condition to use previous behavior when field value is empty.