### PR TITLE
Changing the way of checking the permission

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
@@ -81,7 +81,9 @@ file that was distributed with this source code.
 
         {% if sonata_admin.edit == 'inline' %}
 
-            {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
+            {% if sonata_admin.field_description.associationadmin.hasRoute('create')
+                and sonata_admin.field_description.associationadmin.hasAccess('create')
+                and btn_add %}
                 <span id="field_actions_{{ id }}" >
                     <a
                         href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
@@ -105,7 +107,9 @@ file that was distributed with this source code.
                 </span>
 
                 <span id="field_actions_{{ id }}" class="field-actions">
-                    {% if sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
+                    {% if sonata_admin.field_description.associationadmin.hasRoute('create')
+                        and sonata_admin.field_description.associationadmin.hasAccess('create')
+                        and btn_add %}
                         <a
                             href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
                             onclick="return start_field_dialog_form_add_{{ id }}(this);"

--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -42,8 +42,14 @@ file that was distributed with this source code.
         {% endif %}
 
         <div id="field_actions_{{ id }}" class="field-actions">
-            {% set display_btn_list = sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') and btn_list %}
-            {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
+            {% set display_btn_list = sonata_admin.edit == 'list'
+                and sonata_admin.field_description.associationadmin.hasRoute('list')
+                and sonata_admin.field_description.associationadmin.hasAccess('list')
+                and btn_list %}
+            {% set display_btn_add = sonata_admin.edit != 'admin'
+                and sonata_admin.field_description.associationadmin.hasRoute('create')
+                and sonata_admin.field_description.associationadmin.hasAccess('create')
+                and btn_add %}
             {% if display_btn_list or display_btn_add %}
             <div class="btn-group">
                 {% if display_btn_list %}
@@ -70,7 +76,10 @@ file that was distributed with this source code.
             </div>
             {% endif %}
 
-            {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('delete') and sonata_admin.field_description.associationadmin.isGranted('DELETE') and btn_delete %}
+            {% if sonata_admin.edit == 'list'
+                and sonata_admin.field_description.associationadmin.hasRoute('delete')
+                and sonata_admin.field_description.associationadmin.hasAccess('delete')
+                and btn_delete %}
                 <a  href=""
                     onclick="return remove_selected_element_{{ id }}(this);"
                     class="btn btn-danger btn-sm sonata-ba-action"

--- a/src/Resources/views/CRUD/Association/edit_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many.html.twig
@@ -32,8 +32,8 @@ file that was distributed with this source code.
 
         </span>
 
-        {% set display_create_button = sonata_admin.field_description.associationadmin.hasroute('create')
-            and sonata_admin.field_description.associationadmin.isGranted('CREATE')
+        {% set display_create_button = sonata_admin.field_description.associationadmin.hasRoute('create')
+            and sonata_admin.field_description.associationadmin.hasAccess('create')
             and btn_add
             and (
                 sonata_admin.field_description.options.limit is not defined or

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -42,8 +42,14 @@ file that was distributed with this source code.
         {% endif %}
 
         <div id="field_actions_{{ id }}" class="field-actions">
-            {% set display_btn_list = sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasroute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') and btn_list %}
-            {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
+            {% set display_btn_list = sonata_admin.edit == 'list'
+                and sonata_admin.field_description.associationadmin.hasRoute('list')
+                and sonata_admin.field_description.associationadmin.hasAccess('list')
+                and btn_list %}
+            {% set display_btn_add = sonata_admin.edit != 'admin'
+                and sonata_admin.field_description.associationadmin.hasRoute('create')
+                and sonata_admin.field_description.associationadmin.hasAccess('create')
+                and btn_add %}
             {% if display_btn_list or display_btn_add %}
             <div class="btn-group">
                 {% if display_btn_list %}
@@ -70,7 +76,10 @@ file that was distributed with this source code.
             </div>
             {% endif %}
 
-            {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('delete') and sonata_admin.field_description.associationadmin.isGranted('DELETE') and btn_delete %}
+            {% if sonata_admin.edit == 'list'
+                and sonata_admin.field_description.associationadmin.hasRoute('delete')
+                and sonata_admin.field_description.associationadmin.hasAccess('delete')
+                and btn_delete %}
                 <a  href=""
                     onclick="return remove_selected_element_{{ id }}(this);"
                     class="btn btn-danger btn-sm sonata-ba-action"


### PR DESCRIPTION
I am targeting this branch, because these changes continue the earlier ones.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changing the way of checking the permission
```

## Subject

Everywhere permissions are check by `hasAccess`, but in this files it was still by `isGranted`. 

