### PR TITLE
Make CoreController actions CaaSes

### DIFF
--- a/src/Action/DashboardAction.php
+++ b/src/Action/DashboardAction.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Action;
+
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+
+final class DashboardAction extends Controller
+{
+    /**
+     * @var array
+     */
+    private $dashboardBlocks;
+
+    /**
+     * @var BreadcrumbsBuilderInterface
+     */
+    private $breadcrumbsBuilder;
+
+    /**
+     * @var TemplateRegistryInterface
+     */
+    private $templateRegistry;
+
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    public function __construct(
+        array $dashboardBlocks,
+        BreadcrumbsBuilderInterface $breadcrumbsBuilder,
+        TemplateRegistryInterface $templateRegistry,
+        Pool $pool
+    ) {
+        $this->dashboardBlocks = $dashboardBlocks;
+        $this->breadcrumbsBuilder = $breadcrumbsBuilder;
+        $this->templateRegistry = $templateRegistry;
+        $this->pool = $pool;
+    }
+
+    public function __invoke(Request $request)
+    {
+        $blocks = [
+            'top' => [],
+            'left' => [],
+            'center' => [],
+            'right' => [],
+            'bottom' => [],
+        ];
+
+        foreach ($this->dashboardBlocks as $block) {
+            $blocks[$block['position']][] = $block;
+        }
+
+        $parameters = [
+            'base_template' => $request->isXmlHttpRequest() ?
+                $this->templateRegistry->getTemplate('ajax') :
+                $this->templateRegistry->getTemplate('layout'),
+            'admin_pool' => $this->pool,
+            'blocks' => $blocks,
+        ];
+
+        if (!$request->isXmlHttpRequest()) {
+            $parameters['breadcrumbs_builder'] = $this->breadcrumbsBuilder;
+        }
+
+        return $this->render($this->templateRegistry->getTemplate('dashboard'), $parameters);
+    }
+}

--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Action;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Search\SearchHandler;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SearchAction extends Controller
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var SearchHandler
+     */
+    private $searchHandler;
+
+    /**
+     * @var TemplateRegistryInterface
+     */
+    private $templateRegistry;
+
+    /**
+     * @var BreadcrumbsBuilderInterface
+     */
+    private $breadcrumbsBuilder;
+
+    public function __construct(
+        Pool $pool,
+        SearchHandler $searchHandler,
+        TemplateRegistryInterface $templateRegistry,
+        BreadcrumbsBuilderInterface $breadcrumbsBuilder
+    ) {
+        $this->pool = $pool;
+        $this->searchHandler = $searchHandler;
+        $this->templateRegistry = $templateRegistry;
+        $this->breadcrumbsBuilder = $breadcrumbsBuilder;
+    }
+
+    /**
+     * The search action first render an empty page, if the query is set, then the template generates
+     * some ajax request to retrieve results for each admin. The Ajax query returns a JSON response.
+     *
+     * @throws \RuntimeException
+     *
+     * @return JsonResponse|Response
+     */
+    public function __invoke(Request $request)
+    {
+        if (!$request->get('admin') || !$request->isXmlHttpRequest()) {
+            return $this->render($this->templateRegistry->getTemplate('search'), [
+                'base_template' => $request->isXmlHttpRequest() ?
+                    $this->templateRegistry->getTemplate('ajax') :
+                    $this->templateRegistry->getTemplate('layout'),
+                'breadcrumbs_builder' => $this->breadcrumbsBuilder,
+                'admin_pool' => $this->pool,
+                'query' => $request->get('q'),
+                'groups' => $this->pool->getDashboardGroups(),
+            ]);
+        }
+
+        try {
+            $admin = $this->pool->getAdminByAdminCode($request->get('admin'));
+        } catch (ServiceNotFoundException $e) {
+            throw new \RuntimeException('Unable to find the Admin instance', $e->getCode(), $e);
+        }
+
+        if (!$admin instanceof AdminInterface) {
+            throw new \RuntimeException('The requested service is not an Admin instance');
+        }
+
+        $results = [];
+
+        $page = false;
+        $total = false;
+        if ($pager = $this->searchHandler->search(
+            $admin,
+            $request->get('q'),
+            $request->get('page'),
+            $request->get('offset')
+        )) {
+            foreach ($pager->getResults() as $result) {
+                $results[] = [
+                    'label' => $admin->toString($result),
+                    'link' => $admin->generateObjectUrl('edit', $result),
+                    'id' => $admin->id($result),
+                ];
+            }
+            $page = (int) $pager->getPage();
+            $total = (int) $pager->getNbResults();
+        }
+
+        $response = new JsonResponse([
+            'results' => $results,
+            'page' => $page,
+            'total' => $total,
+        ]);
+        $response->setPrivate();
+
+        return $response;
+    }
+}

--- a/src/Controller/CoreController.php
+++ b/src/Controller/CoreController.php
@@ -11,12 +11,20 @@
 
 namespace Sonata\AdminBundle\Controller;
 
-use Sonata\AdminBundle\Admin\AdminInterface;
+// NEXT_MAJOR: remove this file
+
+@trigger_error(
+    'The '.__NAMESPACE__.'\CoreController class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use '.__NAMESPACE__.'\SearchAction or '.__NAMESPACE__.'\DashboardAction instead.',
+    E_USER_DEPRECATED
+);
+
+use Sonata\AdminBundle\Action\DashboardAction;
+use Sonata\AdminBundle\Action\SearchAction;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Search\SearchHandler;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -31,29 +39,9 @@ class CoreController extends Controller
      */
     public function dashboardAction()
     {
-        $blocks = [
-            'top' => [],
-            'left' => [],
-            'center' => [],
-            'right' => [],
-            'bottom' => [],
-        ];
+        $dashboardAction = $this->container->get(DashboardAction::class);
 
-        foreach ($this->container->getParameter('sonata.admin.configuration.dashboard_blocks') as $block) {
-            $blocks[$block['position']][] = $block;
-        }
-
-        $parameters = [
-            'base_template' => $this->getBaseTemplate(),
-            'admin_pool' => $this->container->get('sonata.admin.pool'),
-            'blocks' => $blocks,
-        ];
-
-        if (!$this->getCurrentRequest()->isXmlHttpRequest()) {
-            $parameters['breadcrumbs_builder'] = $this->get('sonata.admin.breadcrumbs_builder');
-        }
-
-        return $this->render($this->getTemplateRegistry()->getTemplate('dashboard'), $parameters);
+        return $dashboardAction($this->getCurrentRequest());
     }
 
     /**
@@ -66,48 +54,9 @@ class CoreController extends Controller
      */
     public function searchAction(Request $request)
     {
-        if ($request->get('admin') && $request->isXmlHttpRequest()) {
-            try {
-                $admin = $this->getAdminPool()->getAdminByAdminCode($request->get('admin'));
-            } catch (ServiceNotFoundException $e) {
-                throw new \RuntimeException('Unable to find the Admin instance', $e->getCode(), $e);
-            }
+        $searchAction = $this->container->get(SearchAction::class);
 
-            if (!$admin instanceof AdminInterface) {
-                throw new \RuntimeException('The requested service is not an Admin instance');
-            }
-
-            $handler = $this->getSearchHandler();
-
-            $results = [];
-
-            if ($pager = $handler->search($admin, $request->get('q'), $request->get('page'), $request->get('offset'))) {
-                foreach ($pager->getResults() as $result) {
-                    $results[] = [
-                        'label' => $admin->toString($result),
-                        'link' => $admin->generateObjectUrl('edit', $result),
-                        'id' => $admin->id($result),
-                    ];
-                }
-            }
-
-            $response = new JsonResponse([
-                'results' => $results,
-                'page' => $pager ? (int) $pager->getPage() : false,
-                'total' => $pager ? (int) $pager->getNbResults() : false,
-            ]);
-            $response->setPrivate();
-
-            return $response;
-        }
-
-        return $this->render($this->getTemplateRegistry()->getTemplate('search'), [
-            'base_template' => $this->getBaseTemplate(),
-            'breadcrumbs_builder' => $this->get('sonata.admin.breadcrumbs_builder'),
-            'admin_pool' => $this->container->get('sonata.admin.pool'),
-            'query' => $request->get('q'),
-            'groups' => $this->getAdminPool()->getDashboardGroups(),
-        ]);
+        return $searchAction($request);
     }
 
     /**

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -141,6 +141,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $loader->load('block.xml');
         $loader->load('menu.xml');
         $loader->load('commands.xml');
+        $loader->load('actions.xml');
 
         if (isset($bundles['SonataExporterBundle'])) {
             $loader->load('exporter.xml');

--- a/src/Resources/config/actions.xml
+++ b/src/Resources/config/actions.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <!-- NEXT_MAJOR: remove the "class" and "public" attributes -->
+        <service id="Sonata\AdminBundle\Action\DashboardAction" class="Sonata\AdminBundle\Action\DashboardAction" public="true">
+            <argument>%sonata.admin.configuration.dashboard_blocks%</argument>
+            <argument type="service" id="sonata.admin.breadcrumbs_builder"/>
+            <argument type="service" id="sonata.admin.global_template_registry"/>
+            <argument type="service" id="sonata.admin.pool"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+        <service id="Sonata\AdminBundle\Action\SearchAction" class="Sonata\AdminBundle\Action\SearchAction" public="true">
+            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="sonata.admin.search.handler"/>
+            <argument type="service" id="sonata.admin.global_template_registry"/>
+            <argument type="service" id="sonata.admin.breadcrumbs_builder"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/routing/sonata_admin.xml
+++ b/src/Resources/config/routing/sonata_admin.xml
@@ -6,7 +6,7 @@
         <default key="permanent">true</default>
     </route>
     <route id="sonata_admin_dashboard" path="/dashboard">
-        <default key="_controller">SonataAdminBundle:Core:dashboard</default>
+        <default key="_controller">Sonata\AdminBundle\Action\DashboardAction</default>
     </route>
     <route id="sonata_admin_retrieve_form_element" path="/core/get-form-field-element">
         <default key="_controller">sonata.admin.controller.admin:retrieveFormFieldElementAction</default>
@@ -23,7 +23,7 @@
         <default key="_controller">sonata.admin.controller.admin:setObjectFieldValueAction</default>
     </route>
     <route id="sonata_admin_search" path="/search">
-        <default key="_controller">SonataAdminBundle:Core:search</default>
+        <default key="_controller">Sonata\AdminBundle\Action\SearchAction</default>
     </route>
     <route id="sonata_admin_retrieve_autocomplete_items" path="/core/get-autocomplete-items">
         <default key="_controller">sonata.admin.controller.admin:retrieveAutocompleteItemsAction</default>

--- a/tests/Action/DashboardActionTest.php
+++ b/tests/Action/DashboardActionTest.php
@@ -9,13 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\AdminBundle\Tests\Controller;
+namespace Sonata\AdminBundle\Tests\Action;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\DashboardAction;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Pool;
-use Sonata\AdminBundle\Controller\CoreController;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -23,11 +22,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-class CoreControllerTest extends TestCase
+class DashboardActionTest extends TestCase
 {
-    /**
-     * @group legacy
-     */
     public function testdashboardActionStandardRequest()
     {
         $container = $this->createMock(ContainerInterface::class);
@@ -48,13 +44,13 @@ class CoreControllerTest extends TestCase
 
         $breadcrumbsBuilder = $this->getMockForAbstractClass(BreadcrumbsBuilderInterface::class);
 
+        $dashboardAction = new DashboardAction(
+            [],
+            $breadcrumbsBuilder,
+            $templateRegistry->reveal(),
+            $pool
+        );
         $values = [
-            DashboardAction::class => $dashboardAction = new DashboardAction(
-                [],
-                $breadcrumbsBuilder,
-                $templateRegistry->reveal(),
-                $pool
-            ),
             'templating' => $templating,
             'request_stack' => $requestStack,
         ];
@@ -70,16 +66,10 @@ class CoreControllerTest extends TestCase
                 return 'templating' === $id;
             }));
 
-        $controller = new CoreController();
-        $controller->setContainer($container);
-
-        $this->isInstanceOf(Response::class, $controller->dashboardAction());
+        $this->isInstanceOf(Response::class, $dashboardAction($request));
     }
 
-    /**
-     * @group legacy
-     */
-    public function testdashboardActionAjaxLayout()
+    public function testDashboardActionAjaxLayout()
     {
         $container = $this->createMock(ContainerInterface::class);
 
@@ -99,13 +89,14 @@ class CoreControllerTest extends TestCase
         $requestStack = new RequestStack();
         $requestStack->push($request);
 
+        $dashboardAction = new DashboardAction(
+            [],
+            $breadcrumbsBuilder,
+            $templateRegistry->reveal(),
+            $pool
+        );
+        $dashboardAction->setContainer($container);
         $values = [
-            DashboardAction::class => $dashboardAction = new DashboardAction(
-                [],
-                $breadcrumbsBuilder,
-                $templateRegistry->reveal(),
-                $pool
-            ),
             'templating' => $templating,
             'request_stack' => $requestStack,
         ];
@@ -121,11 +112,6 @@ class CoreControllerTest extends TestCase
                 return 'templating' === $id;
             }));
 
-        $controller = new CoreController();
-        $controller->setContainer($container);
-
-        $response = $controller->dashboardAction($request);
-
-        $this->isInstanceOf(Response::class, $response);
+        $this->isInstanceOf(Response::class, $dashboardAction($request));
     }
 }

--- a/tests/Action/SearchActionTest.php
+++ b/tests/Action/SearchActionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Action;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Action\SearchAction;
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Search\SearchHandler;
+use Sonata\AdminBundle\Templating\TemplateRegistry;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\CleanAdmin;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SearchActionTest extends TestCase
+{
+    private $container;
+    private $pool;
+    private $action;
+    private $templating;
+    private $breadcrumbsBuilder;
+
+    protected function setUp()
+    {
+        $this->container = new Container();
+
+        $this->pool = new Pool($this->container, 'title', 'logo.png');
+        $templateRegistry = new TemplateRegistry([
+            'search' => 'search.html.twig',
+            'layout' => 'layout.html.twig',
+        ]);
+
+        $this->breadcrumbsBuilder = $this->createMock(BreadcrumbsBuilderInterface::class);
+        $this->searchHandler = $this->createMock(SearchHandler::class);
+
+        $this->action = new SearchAction(
+            $this->pool,
+            $this->searchHandler,
+            $templateRegistry,
+            $this->breadcrumbsBuilder
+        );
+        $this->action->setContainer($this->container);
+        $this->templating = $this->prophesize(EngineInterface::class);
+        $this->container->set('templating', $this->templating->reveal());
+    }
+
+    public function testGlobalPage()
+    {
+        $request = new Request(['q' => 'some search']);
+        $this->templating->render('search.html.twig', [
+            'base_template' => 'layout.html.twig',
+            'breadcrumbs_builder' => $this->breadcrumbsBuilder,
+            'admin_pool' => $this->pool,
+            'query' => 'some search',
+            'groups' => [],
+        ])->willReturn(new Response());
+        $this->templating->renderResponse('search.html.twig', [
+            'base_template' => 'layout.html.twig',
+            'breadcrumbs_builder' => $this->breadcrumbsBuilder,
+            'admin_pool' => $this->pool,
+            'query' => 'some search',
+            'groups' => [],
+        ], null)->willReturn(new Response());
+
+        // NEXT_MAJOR: simplify this when dropping php 5
+        $action = $this->action;
+        $this->assertInstanceOf(Response::class, $action($request));
+    }
+
+    public function testAjaxCall()
+    {
+        $admin = new CleanAdmin('code', 'class', 'controller');
+        $this->container->set('foo', $admin);
+        $this->pool->setAdminServiceIds(['foo']);
+        $request = new Request(['admin' => 'foo']);
+        $request->headers->set('X-Requested-With', 'XMLHttpRequest');
+
+        // NEXT_MAJOR: simplify this when dropping php 5
+        $action = $this->action;
+        $this->assertInstanceOf(JsonResponse::class, $action($request));
+    }
+}


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Changed
- `Controller\CoreController` is now deprecated in favor of `Action\{Search,Dasbhoard}Action`
```

## Todo
- [x] unit test search action
- [x] add `NEXT_MAJOR` comments
- [x] move to `Action` namespace
- [x] fix the build
- [x] rebase on #5122
- [x] test this on an actual project

## Subject

Using invokable CaaSes vs one big controller achieves several things:
1. it discourages piling on more actions in controllers with vague names (SRP)
2. it leads to easier to unit test actions and visible deps (DIP)
3. it will allow us to make more services private
