### PR TITLE
Made the menu checker behave affirmatively even if it's globally unanimous

### DIFF
--- a/src/Menu/Provider/GroupMenuProvider.php
+++ b/src/Menu/Provider/GroupMenuProvider.php
@@ -139,23 +139,31 @@ class GroupMenuProvider implements MenuProviderInterface
         }
 
         // Making the checker behave affirmatively even if it's globally unanimous
-        $roles = null;
-        if (!empty($item['roles'])) {
-            $roles = $item['roles'];
-        } elseif (!empty($group['roles'])) {
-            $roles = $group['roles'];
-        }
-        if (null === $roles) {
-            return true;
-        }
+        // Still must be granted unanimously to group and item
 
-        foreach ($roles as $role) {
-            if ($this->checker->isGranted([$role])) {
-                return true;
+        $isItemGranted = true;
+        if (!empty($item['roles'])) {
+            $isItemGranted = false;
+            foreach ($item['roles'] as $role) {
+                if ($this->checker->isGranted([$role])) {
+                    $isItemGranted = true;
+                    break;
+                }
             }
         }
 
-        return false;
+        $isGroupGranted = true;
+        if (!empty($group['roles'])) {
+            $isGroupGranted = false;
+            foreach ($group['roles'] as $role) {
+                if ($this->checker->isGranted([$role])) {
+                    $isGroupGranted = true;
+                    break;
+                }
+            }
+        }
+
+        return $isItemGranted && $isGroupGranted;
     }
 
     /**

--- a/src/Menu/Provider/GroupMenuProvider.php
+++ b/src/Menu/Provider/GroupMenuProvider.php
@@ -134,10 +134,28 @@ class GroupMenuProvider implements MenuProviderInterface
         }
 
         //NEXT_MAJOR: Remove if statement of null checker.
-        return null === $this->checker || (
-            (empty($item['roles']) || $this->checker->isGranted($item['roles'])) &&
-            (empty($group['roles']) || $this->checker->isGranted($group['roles']))
-        );
+        if (null === $this->checker) {
+            return true;
+        }
+
+        // Making the checker behave affirmatively even if it's globally unanimous
+        $roles = null;
+        if (!empty($item['roles'])) {
+            $roles = $item['roles'];
+        } elseif (!empty($group['roles'])) {
+            $roles = $group['roles'];
+        }
+        if (null === $roles) {
+            return true;
+        }
+
+        foreach ($roles as $role) {
+            if ($this->checker->isGranted([$role])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/tests/Menu/Provider/GroupMenuProviderTest.php
@@ -151,6 +151,43 @@ class GroupMenuProviderTest extends TestCase
     /**
      * @param array $adminGroups
      *
+     * @dataProvider getAdminGroupsMultipleRoles
+     */
+    public function testGetMenuProviderWithCheckerGrantedMultipleGroupRoles(
+        array $adminGroups
+    ) {
+        $this->checker->expects($this->any())
+            ->method('isGranted')
+            ->willReturnCallback(function ($args) {
+                if ($args === ['foo', 'bar']) {
+                    return false;
+                }
+
+                if ($args === ['foo'] || $args === ['bar']) {
+                    return true;
+                }
+
+                return false;
+            });
+
+        $menu = $this->provider->get(
+            'providerFoo',
+            [
+                'name' => 'foo',
+                'group' => $adminGroups,
+            ]
+        );
+
+        $this->assertInstanceOf(ItemInterface::class, $menu);
+
+        $children = $menu->getChildren();
+
+        $this->assertCount(3, $children);
+    }
+
+    /**
+     * @param array $adminGroups
+     *
      * @dataProvider getAdminGroups
      */
     public function testGetMenuProviderWithAdmin(array $adminGroups)
@@ -335,6 +372,49 @@ class GroupMenuProviderTest extends TestCase
                     ],
                     'item_adds' => [],
                     'roles' => ['foo'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getAdminGroupsMultipleRoles()
+    {
+        return [
+            [
+                'bar' => [
+                    'label' => 'foo',
+                    'icon' => '<i class="fa fa-edit"></i>',
+                    'label_catalogue' => 'SonataAdminBundle',
+                    'items' => [
+                        [
+                            'admin' => '',
+                            'label' => 'route_label1',
+                            'route' => 'FooRoute1',
+                            'route_params' => ['foo' => 'bar'],
+                            'route_absolute' => true,
+                            'roles' => ['foo', 'bar'],
+                        ],
+                        [
+                            'admin' => '',
+                            'label' => 'route_label2',
+                            'route' => 'FooRoute2',
+                            'route_params' => ['foo' => 'bar'],
+                            'route_absolute' => true,
+                            'roles' => ['foo'],
+                        ],
+                        [
+                            'admin' => '',
+                            'label' => 'route_label3',
+                            'route' => 'FooRoute3',
+                            'route_params' => ['foo' => 'bar'],
+                            'route_absolute' => true,
+                            'roles' => ['bar'],
+                        ],
+                    ],
+                    'item_adds' => [],
                 ],
             ],
         ];

--- a/tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/tests/Menu/Provider/GroupMenuProviderTest.php
@@ -149,6 +149,24 @@ class GroupMenuProviderTest extends TestCase
     }
 
     /**
+     * @param array $args
+     *
+     * @return bool
+     */
+    public function unanimousGrantCheckerMock($args)
+    {
+        if ($args === ['foo', 'bar']) {
+            return false;
+        }
+
+        if ($args === ['foo'] || $args === ['bar']) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * @param array $adminGroups
      *
      * @dataProvider getAdminGroupsMultipleRoles
@@ -158,17 +176,7 @@ class GroupMenuProviderTest extends TestCase
     ) {
         $this->checker->expects($this->any())
             ->method('isGranted')
-            ->willReturnCallback(function ($args) {
-                if ($args === ['foo', 'bar']) {
-                    return false;
-                }
-
-                if ($args === ['foo'] || $args === ['bar']) {
-                    return true;
-                }
-
-                return false;
-            });
+            ->willReturnCallback([$this, 'unanimousGrantCheckerMock']);
 
         $menu = $this->provider->get(
             'providerFoo',
@@ -183,6 +191,30 @@ class GroupMenuProviderTest extends TestCase
         $children = $menu->getChildren();
 
         $this->assertCount(3, $children);
+    }
+
+    /**
+     * @param array $adminGroups
+     *
+     * @dataProvider getAdminGroupsMultipleRolesOnTop
+     */
+    public function testGetMenuProviderWithCheckerGrantedMultipleGroupRolesOnTop(
+        array $adminGroups
+    ) {
+        $this->checker->expects($this->any())
+            ->method('isGranted')
+            ->willReturnCallback([$this, 'unanimousGrantCheckerMock']);
+
+        $menu = $this->provider->get(
+            'providerFoo',
+            [
+                'name' => 'foo',
+                'group' => $adminGroups,
+            ]
+        );
+        $this->assertInstanceOf(ItemInterface::class, $menu);
+
+        $this->assertTrue($menu->isDisplayed());
     }
 
     /**
@@ -415,6 +447,70 @@ class GroupMenuProviderTest extends TestCase
                         ],
                     ],
                     'item_adds' => [],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getAdminGroupsMultipleRolesOnTop()
+    {
+        return [
+            [
+                [
+                    'label' => 'foo1',
+                    'icon' => '<i class="fa fa-edit"></i>',
+                    'label_catalogue' => 'SonataAdminBundle',
+                    'items' => [
+                        [
+                            'admin' => '',
+                            'label' => 'route_label1',
+                            'route' => 'FooRoute1',
+                            'route_params' => ['foo' => 'bar'],
+                            'route_absolute' => true,
+                        ],
+                    ],
+                    'item_adds' => [],
+                    'roles' => ['foo', 'bar'],
+                    'on_top' => true,
+                ],
+            ], [
+                [
+                    'label' => 'foo2',
+                    'icon' => '<i class="fa fa-edit"></i>',
+                    'label_catalogue' => 'SonataAdminBundle',
+                    'items' => [
+                        [
+                            'admin' => '',
+                            'label' => 'route_label2',
+                            'route' => 'FooRoute2',
+                            'route_params' => ['foo' => 'bar'],
+                            'route_absolute' => true,
+                        ],
+                    ],
+                    'item_adds' => [],
+                    'roles' => ['foo'],
+                    'on_top' => true,
+                ],
+            ], [
+                [
+                    'label' => 'foo3',
+                    'icon' => '<i class="fa fa-edit"></i>',
+                    'label_catalogue' => 'SonataAdminBundle',
+                    'items' => [
+                        [
+                            'admin' => '',
+                            'label' => 'route_label3',
+                            'route' => 'FooRoute3',
+                            'route_params' => ['foo' => 'bar'],
+                            'route_absolute' => true,
+                        ],
+                    ],
+                    'item_adds' => [],
+                    'roles' => ['bar'],
+                    'on_top' => true,
                 ],
             ],
         ];


### PR DESCRIPTION
I am targeting this branch, because it's a fix.

Closes #5128

## Changelog

```markdown
### Fixed
- Menu item security was expected to be checked affirmatively rather than unanimously
```
## Subject

Menu item security was expected to be checked affirmatively rather than unanimously, fixed it.
