### PR TITLE
Added an affirmative twig grant checker

### DIFF
--- a/src/Resources/config/twig.xml
+++ b/src/Resources/config/twig.xml
@@ -26,6 +26,7 @@
             <argument type="service" id="logger" on-invalid="ignore"/>
             <argument type="service" id="translator"/>
             <argument type="service" id="service_container"/>
+            <argument type="service" id="security.authorization_checker"/>
             <call method="setXEditableTypeMapping">
                 <argument>%sonata.admin.twig.extension.x_editable_type_mapping%</argument>
             </call>

--- a/src/Resources/views/Core/dashboard.html.twig
+++ b/src/Resources/views/Core/dashboard.html.twig
@@ -17,35 +17,35 @@ file that was distributed with this source code.
 
     {% set has_left = false %}
     {% for block in blocks.left %}
-        {% if block.roles|length == 0 or is_granted(block.roles) %}
+        {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
             {% set has_left = true %}
         {% endif %}
     {% endfor %}
 
     {% set has_center = false %}
     {% for block in blocks.center %}
-        {% if block.roles|length == 0 or is_granted(block.roles) %}
+        {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
             {% set has_center = true %}
         {% endif %}
     {% endfor %}
 
     {% set has_right = false %}
     {% for block in blocks.right %}
-        {% if block.roles|length == 0 or is_granted(block.roles) %}
+        {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
             {% set has_right = true %}
         {% endif %}
     {% endfor %}
 
     {% set has_top = false %}
     {% for block in blocks.top %}
-        {% if block.roles|length == 0 or is_granted(block.roles) %}
+        {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
             {% set has_top = true %}
         {% endif %}
     {% endfor %}
 
     {% set has_bottom = false %}
     {% for block in blocks.bottom %}
-        {% if block.roles|length == 0 or is_granted(block.roles) %}
+        {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
             {% set has_bottom = true %}
         {% endif %}
     {% endfor %}
@@ -55,7 +55,7 @@ file that was distributed with this source code.
     {% if has_top %}
         <div class="row">
             {% for block in blocks.top %}
-                {% if block.roles|length == 0 or is_granted(block.roles) %}
+                {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
                     <div class="{{ block.class }}">
                         {{ sonata_block_render({ 'type': block.type, 'settings': block.settings}) }}
                     </div>
@@ -84,7 +84,7 @@ file that was distributed with this source code.
         {% if has_left or has_right %}
         <div class="col-md-{{ width_left }}">
             {% for block in blocks.left %}
-                {% if block.roles|length == 0 or is_granted(block.roles) %}
+                {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
                     {{ sonata_block_render({ 'type': block.type, 'settings': block.settings}) }}
                 {% endif %}
             {% endfor %}
@@ -94,7 +94,7 @@ file that was distributed with this source code.
         {% if has_center %}
             <div class="col-md-{{ width_center }}">
                 {% for block in blocks.center %}
-                    {% if block.roles|length == 0 or is_granted(block.roles) %}
+                    {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
                         {{ sonata_block_render({ 'type': block.type, 'settings': block.settings}) }}
                     {% endif %}
                 {% endfor %}
@@ -105,7 +105,7 @@ file that was distributed with this source code.
         {% if has_left or has_right %}
          <div class="col-md-{{ width_right }}">
             {% for block in blocks.right %}
-                {% if block.roles|length == 0 or is_granted(block.roles) %}
+                {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
                     {{ sonata_block_render({ 'type': block.type, 'settings': block.settings}) }}
                 {% endif %}
             {% endfor %}
@@ -116,7 +116,7 @@ file that was distributed with this source code.
     {% if has_bottom %}
         <div class="row">
             {% for block in blocks.bottom %}
-                {% if block.roles|length == 0 or is_granted(block.roles) %}
+                {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
                     <div class="{{ block.class }}">
                         {{ sonata_block_render({ 'type': block.type, 'settings': block.settings}) }}
                     </div>

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -37,6 +37,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * @author Tiago Garcia
@@ -666,6 +667,9 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $container
             ->register('session')
             ->setClass(Session::class);
+        $container
+            ->register('security.authorization_checker')
+            ->setClass(AuthorizationCheckerInterface::class);
         foreach ([
             'doctrine_phpcr' => 'PHPCR',
             'orm' => 'ORM', ] as $key => $bundleSubstring) {

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class ExtensionCompilerPassTest extends TestCase
@@ -389,6 +390,9 @@ class ExtensionCompilerPassTest extends TestCase
         $container
             ->register('session')
             ->setClass(Session::class);
+        $container
+            ->register('security.authorization_checker')
+            ->setClass(AuthorizationCheckerInterface::class);
 
         // Add admin definition's
         $container

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
@@ -31,6 +32,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Translation\DependencyInjection\TranslationDumperPass;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
 use Symfony\Component\Translation\MessageSelector;
@@ -104,6 +106,11 @@ class SonataAdminExtensionTest extends TestCase
      */
     private $templateRegistry;
 
+    /**
+     * @var AuthorizationCheckerInterface
+     */
+    private $securityChecker;
+
     public function setUp()
     {
         date_default_timezone_set('Europe/London');
@@ -152,7 +159,13 @@ class SonataAdminExtensionTest extends TestCase
         $this->container = $this->prophesize(ContainerInterface::class);
         $this->container->get('sonata_admin_foo_service.template_registry')->willReturn($this->templateRegistry->reveal());
 
-        $this->twigExtension = new SonataAdminExtension($this->pool, $this->logger, $this->translator, $this->container->reveal());
+        $this->securityChecker = $this->prophesize(AuthorizationCheckerInterface::class);
+        $this->securityChecker->isGranted(['foo', 'bar'], null)->willReturn(false);
+        $this->securityChecker->isGranted(Argument::type('string'), null)->willReturn(true);
+
+        $this->twigExtension = new SonataAdminExtension(
+            $this->pool, $this->logger, $this->translator, $this->container->reveal(), $this->securityChecker->reveal()
+        );
         $this->twigExtension->setXEditableTypeMapping($this->xEditableTypeMapping);
 
         $request = $this->createMock(Request::class);
@@ -2609,6 +2622,15 @@ EOT
     public function testCanonicalizedLocaleForMoment($expected, $original)
     {
         $this->assertSame($expected, $this->twigExtension->getCanonicalizedLocaleForMoment($this->mockExtensionContext($original)));
+    }
+
+    public function testIsGrantedAffirmative()
+    {
+        $this->assertTrue(
+            $this->twigExtension->isGrantedAffirmative(['foo', 'bar'])
+        );
+        $this->assertTrue($this->twigExtension->isGrantedAffirmative('foo'));
+        $this->assertTrue($this->twigExtension->isGrantedAffirmative('bar'));
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because it's a fix.

Closes #5129

## Changelog

```markdown
### Added
- An affirmative grant checker for Twig

### Fixed
- Dashboard block security was expected to be checked affirmatively rather than unanimously
```
## Subject

Dashboard block security was expected to be checked affirmatively rather than unanimously, fixed it by adding a new checker function to Twig.
