### PR TITLE
fixing negative result getNbResults, if there are not results

### DIFF
--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -119,7 +119,7 @@ class SimplePager extends Pager
             $this->initializeIterator();
 
             $t = (int) ceil($this->thresholdCount / $this->getMaxPerPage()) + $this->getPage() - 1;
-            $this->setLastPage($t);
+            $this->setLastPage(\max(1, $t));
         }
     }
 

--- a/tests/Datagrid/SimplePagerTest.php
+++ b/tests/Datagrid/SimplePagerTest.php
@@ -112,7 +112,8 @@ class SimplePagerTest extends TestCase
 
         $this->pager->setQuery($this->proxyQuery);
         $this->pager->init();
-        $this->AssertEquals(0, $this->pager->getLastPage());
+        $this->assertEquals(1, $this->pager->getLastPage());
+        $this->assertEquals(0, $this->pager->getNbResults());
     }
 
     public function testInitNoQuery()


### PR DESCRIPTION
I am targeting this branch, because it's a patch.

## Changelog
<!-- REMOVE EMPTY SECTIONS -->
```markdown
## Fixed
- Fixed issue with `getNbResults` return negative result, if there where no results
```

## Subject

Using `SimplePager`, if there are no items `getNbResults` is returning negative number because `init` was setting `setLastPage` to `0` (which is not right, because there can't be 0-page, it's always first page) and when `getNbResults` was called following code is executed `$n = ceil(($this->getLastPage() - 1) * $this->getMaxPerPage());` and we are getting -32 (if 32 is per page)
