### PR TITLE
Escape admin code in autocomplete

### DIFF
--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -113,9 +113,9 @@ file that was distributed with this source code.
                                 // admin
                                 {% if sonata_admin.admin is not null %}
                                     'uniqid': '{{ sonata_admin.admin.uniqid }}',
-                                    'admin_code': '{{ sonata_admin.admin.code }}',
+                                    'admin_code': '{{ sonata_admin.admin.code|e('js') }}',
                                 {% elseif admin_code %}
-                                    'admin_code':  '{{ admin_code }}',
+                                    'admin_code':  '{{ admin_code|e('js') }}',
                                 {% endif %}
 
                                  // subclass


### PR DESCRIPTION
Targeting 3.x as it's a bug fix.

## Changelog

```markdown
### Changed
- Escaped admin code in autocomplete
```

## Subject

When using classes names as service identifiers, the autocompletion fails because the antislash is escaped in javascript:

```
Admin service "AppControllerAdminEventAdmin" not found in admin pool.
```

```
'admin_code': 'App\Controller\Admin\EventAdmin'
=> admin_code=AppControllerAdminEventAdmin in the URL
```

This fixes it.