### PR TITLE
adding deprecation notices to SimplePager::getResults

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -123,6 +123,19 @@ extend the corresponding classes in `SonataAdminBundle\Action\`.
 If you need to style headers prefer to use CSS classes and not in the html DOM.
 In this case please use `header_class` option.
 
+## Deprecated returning other type than `Collection` from `SimplePager::getResults()`
+
+When calling `SimplePager::getResults()` on non-empty result which has set `$maxPerPage`, `Collection` would be returned instead of `array` as it is declared in `PagerInterface`. Update usage of `SimplePager::getResults()`, ensure you are transforming `Collection` to `array` and you aren't dealing with any of its methods.
+
+```
+// will return Collection on non-empty result and array on empty result
+$results = $pager->getResults();
+
+if ($results instanceof ArrayCollection) {
+    $results = $results->toArray();
+}
+```
+
 UPGRADE FROM 3.34 to 3.35
 =========================
 

--- a/tests/Datagrid/SimplePagerTest.php
+++ b/tests/Datagrid/SimplePagerTest.php
@@ -123,4 +123,44 @@ class SimplePagerTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->pager->init();
     }
+
+    /**
+     * NEXT_MAJOR: Remove this test along with fixes to SimplePager.
+     */
+    public function testGetResultsReturnTypeArrayCollection(): void
+    {
+        $this->proxyQuery->expects($this->once())
+            ->method('execute')
+            ->with([], null)
+            ->willReturn(['foo', 'bar']);
+
+        $this->pager->setQuery($this->proxyQuery);
+        $this->pager->setMaxPerPage(1);
+
+        $this->assertInstanceOf(ArrayCollection::class, $this->pager->getResults());
+    }
+
+    public function getResultsReturnType(): array
+    {
+        return [
+            [['foo', 'bar'], 2],
+            [[], null],
+        ];
+    }
+
+    /**
+     * @dataProvider getResultsReturnType
+     */
+    public function testGetResultsReturnTypeArray(array $queryReturnValues, ?int $maxPerPage): void
+    {
+        $this->proxyQuery->expects($this->once())
+            ->method('execute')
+            ->with([], null)
+            ->willReturn($queryReturnValues);
+
+        $this->pager->setQuery($this->proxyQuery);
+        $this->pager->setMaxPerPage($maxPerPage);
+
+        $this->assertIsArray($this->pager->getResults());
+    }
 }


### PR DESCRIPTION
I am targeting this branch, because deprecation.

Change already merged into master (4.x) in https://github.com/sonata-project/SonataAdminBundle/commit/1a40728ba8b7524ad34410ce217f236eb90af932

## Changelog

```markdown
### Deprecated
- `SimplePager::getResults` will not return ArrayCollection in next major version (4.0)
```

## Subject
Added deprecation notice to `SimplePager::getResults`