### PR TITLE
Fix HelperController bug: appendFormFieldElementAction and retrieveFormFieldElementAction used wrong object source

### DIFF
--- a/src/Controller/HelperController.php
+++ b/src/Controller/HelperController.php
@@ -93,7 +93,7 @@ class HelperController
             $admin->setUniqid($uniqid);
         }
 
-        $subject = $admin->getModelManager()->find($admin->getClass(), $objectId);
+        $subject = $admin->getObject($objectId);
         if ($objectId && !$subject) {
             throw new NotFoundHttpException();
         }
@@ -136,7 +136,7 @@ class HelperController
         }
 
         if ($objectId) {
-            $subject = $admin->getModelManager()->find($admin->getClass(), $objectId);
+            $subject = $admin->getObject($objectId);
             if (!$subject) {
                 throw new NotFoundHttpException(
                     sprintf('Unable to find the object id: %s, class: %s', $objectId, $admin->getClass())

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -333,7 +333,7 @@ class HelperControllerTest extends TestCase
 
         $renderer = $this->configureFormRenderer();
 
-        $this->admin->getModelManager()->willReturn($modelManager->reveal());
+        $this->admin->getObject(42)->willReturn($object);
         $this->admin->getClass()->willReturn(get_class($object));
         $this->admin->setSubject($object)->shouldBeCalled();
         $this->admin->getFormTheme()->willReturn($formView);
@@ -372,7 +372,7 @@ class HelperControllerTest extends TestCase
 
         $renderer = $this->configureFormRenderer();
 
-        $this->admin->getModelManager()->willReturn($modelManager->reveal());
+        $this->admin->getObject(42)->willReturn($object);
         $this->admin->getClass()->willReturn(get_class($object));
         $this->admin->setSubject($object)->shouldBeCalled();
         $this->admin->getFormTheme()->willReturn($formView);


### PR DESCRIPTION
I am targeting this branch, because I am fixing a bug with wrong method usage for getting object from admin class and it is BC

## Changelog

```markdown
## Fixed
- Fixed issue with `appendFormFieldElementAction` and `retrieveFormFieldElementAction` using ModelManager instead `getObject` admin class method
```
## Subject
I faced this bug, when i create new item with sonata_type_collection. It's totally ignored my admin getObject with custom object source