### PR TITLE
#5140 fix count(null) for php 7.2+

### DIFF
--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -148,7 +148,7 @@ class AdminHelper
                 $data[$childFormBuilder->getName()] = [];
             }
 
-            $objectCount = count($value);
+            $objectCount = null === $value ? 0 : count($value);
             $postCount = count($data[$childFormBuilder->getName()]);
 
             $fields = array_keys($fieldDescription->getAssociationAdmin()->getFormFieldDescriptions());


### PR DESCRIPTION
I am targeting this branch, because bug.

Closes #5140

## Changelog


```markdown
### Fixed

Worning "Parameter must be an array or an object that implements Countable" for count(null) in php 7.2
```