### PR TITLE
#5137 handle ArrayCollection from PHPCR in SimplePager

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -68,3 +68,6 @@ The `buildBreacrumbs` method has been removed from the interface.
 ## SonataAdminExtension
 The Twig filters that come with the bundle will no longer load a default template when used with a missing template.
 The `sonata_admin` twig extension is now final. You may no longer extend it.
+
+## SimplePager
+Method `SimplePager::getResults` is always returning an array

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Datagrid;
 
+use Doctrine\Common\Collections\ArrayCollection;
+
 /**
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  * @author Sjoerd Peters <sjoerd.peters@gmail.com>
@@ -74,6 +76,10 @@ class SimplePager extends Pager
         $this->thresholdCount = count($this->results);
         if (count($this->results) > $this->getMaxPerPage()) {
             $this->haveToPaginate = true;
+            // doctrine/phpcr-odm returns ArrayCollection
+            if ($this->results instanceof ArrayCollection) {
+                $this->results = $this->results->toArray();
+            }
             $this->results = \array_slice($this->results, 0, $this->getMaxPerPage());
         } else {
             $this->haveToPaginate = false;

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Datagrid;
 
-use Doctrine\Common\Collections\ArrayCollection;
-
 /**
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  * @author Sjoerd Peters <sjoerd.peters@gmail.com>
@@ -76,12 +74,7 @@ class SimplePager extends Pager
         $this->thresholdCount = count($this->results);
         if (count($this->results) > $this->getMaxPerPage()) {
             $this->haveToPaginate = true;
-
-            if ($this->results instanceof ArrayCollection) {
-                $this->results = new ArrayCollection($this->results->slice(0, $this->getMaxPerPage()));
-            } else {
-                $this->results = new ArrayCollection(array_slice($this->results, 0, $this->getMaxPerPage()));
-            }
+            $this->results = \array_slice($this->results, 0, $this->getMaxPerPage());
         } else {
             $this->haveToPaginate = false;
         }

--- a/tests/Datagrid/SimplePagerTest.php
+++ b/tests/Datagrid/SimplePagerTest.php
@@ -40,7 +40,7 @@ class SimplePagerTest extends TestCase
         $this->proxyQuery->expects($this->once())
                 ->method('execute')
                 ->with([], null)
-                ->will($this->returnValue(new ArrayCollection(range(0, 12))));
+                ->will($this->returnValue(range(0, 12)));
 
         $this->proxyQuery->expects($this->once())
             ->method('setMaxResults')
@@ -61,7 +61,7 @@ class SimplePagerTest extends TestCase
         $this->proxyQuery->expects($this->once())
             ->method('execute')
             ->with([], null)
-            ->will($this->returnValue(new ArrayCollection(range(0, 12))));
+            ->will($this->returnValue(range(0, 12)));
 
         $this->proxyQuery->expects($this->once())
             ->method('setMaxResults')
@@ -121,5 +121,20 @@ class SimplePagerTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $this->pager->init();
+    }
+
+    public function testGetResultsAlwaysReturnsAnArray(): void
+    {
+        // phpcr odm returns ArrayCollection
+
+        $this->proxyQuery->expects($this->once())
+            ->method('execute')
+            ->with([], null)
+            ->will($this->returnValue(new ArrayCollection(\range(0, 12))));
+
+        $this->pager->setQuery($this->proxyQuery);
+        $this->pager->setMaxPerPage(2);
+
+        $this->assertSame(\range(0, 1), $this->pager->getResults());
     }
 }


### PR DESCRIPTION
I am targeting this branch, because BC-break.

Closes #5137
Related to #5138

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed inconsistent return-type of `SimplePager::getResults`, now it is always returning `array`
```

## Subject
- [x] Removed deprecated behavior of SimplePager
- [x] Investigate PHPCR
- [x] Adjust and add unit tests
- [x] Added note to UPGRADE-4.0.md