### PR TITLE
Do not build the pager when not necessary

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -480,7 +480,6 @@ class CRUDController implements ContainerAwareInterface
         }
 
         $datagrid = $this->admin->getDatagrid();
-        $datagrid->buildPager();
 
         if (true !== $nonRelevantMessage) {
             $this->addFlash(
@@ -500,6 +499,8 @@ class CRUDController implements ContainerAwareInterface
             $batchTranslationDomain = isset($batchActions[$action]['translation_domain']) ?
                 $batchActions[$action]['translation_domain'] :
                 $this->admin->getTranslationDomain();
+
+            $datagrid->buildPager();
 
             $formView = $datagrid->getForm()->createView();
             $this->setFormTheme($formView, $this->admin->getFilterTheme());


### PR DESCRIPTION
I am targeting this branch, because this should be a backward compatible change. It should be just a performance optimization.

## Changelog


```markdown
### Changed
- Do not load the pager when performing a batch action without confirmation
```
## Subject

When performing a batch action and having `$idx` defined, currently sonata still does a query to calculate the pagination information (to be able to set the min/max results per page). 
Later that result gets discarded as the batch query runs on the elements specified by `$idx` or `$allElements` variables.

The query to calculate the total results might be very expensive, slowing down batch actions even if they update a single element via `$idx`. 

In my setup, ~90% of time is spent on calculating the total count of rows in the table and ~5% to do the batch action.
