### PR TITLE
Revert "Do not build the pager when not necessary"

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -480,6 +480,7 @@ class CRUDController implements ContainerAwareInterface
         }
 
         $datagrid = $this->admin->getDatagrid();
+        $datagrid->buildPager();
 
         if (true !== $nonRelevantMessage) {
             $this->addFlash(
@@ -499,8 +500,6 @@ class CRUDController implements ContainerAwareInterface
             $batchTranslationDomain = isset($batchActions[$action]['translation_domain']) ?
                 $batchActions[$action]['translation_domain'] :
                 $this->admin->getTranslationDomain();
-
-            $datagrid->buildPager();
 
             $formView = $datagrid->getForm()->createView();
             $this->setFormTheme($formView, $this->admin->getFilterTheme());


### PR DESCRIPTION
Reverts sonata-project/SonataAdminBundle#5145

Reverting this as it introduces a major bug. The pager was also responsible for applying the current filters... so in case you filter the results and use "select all" in a batch action, will ignore the filter and apply the batch on the whole dataset... and this is realllly bad! :cry: 

Will work on it trying to create a better implementation