### PR TITLE
Do not build the pager when not necessary

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Inflector\Inflector;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Exception\LockException;
 use Sonata\AdminBundle\Exception\ModelManagerException;
@@ -480,6 +481,9 @@ class CRUDController implements ContainerAwareInterface
         }
 
         $datagrid = $this->admin->getDatagrid();
+        if (!($datagrid instanceof Datagrid)) {
+            $datagrid->buildPager();
+        }
 
         if (true !== $nonRelevantMessage) {
             $this->addFlash(
@@ -495,12 +499,14 @@ class CRUDController implements ContainerAwareInterface
             true;
 
         if ($askConfirmation && 'ok' != $confirmation) {
+            if ($datagrid instanceof Datagrid) {
+                $datagrid->buildPager();
+            }
+
             $actionLabel = $batchActions[$action]['label'];
             $batchTranslationDomain = isset($batchActions[$action]['translation_domain']) ?
                 $batchActions[$action]['translation_domain'] :
                 $this->admin->getTranslationDomain();
-
-            $datagrid->buildPager();
 
             $formView = $datagrid->getForm()->createView();
             $this->setFormTheme($formView, $this->admin->getFilterTheme());
@@ -518,6 +524,10 @@ class CRUDController implements ContainerAwareInterface
                 'data' => $data,
                 'csrf_token' => $this->getCsrfToken('sonata.batch'),
             ], null);
+        }
+
+        if ($datagrid instanceof Datagrid) {
+            $datagrid->buildFilters();
         }
 
         // execute the action, batchActionXxxxx

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -53,6 +53,11 @@ class Datagrid implements DatagridInterface
     protected $bound = false;
 
     /**
+     * @var bool
+     */
+    private $boundFilters = false;
+
+    /**
      * @var ProxyQueryInterface
      */
     protected $query;
@@ -102,9 +107,9 @@ class Datagrid implements DatagridInterface
         return $this->results;
     }
 
-    public function buildPager()
+    public function buildFilters()
     {
-        if ($this->bound) {
+        if ($this->boundFilters) {
             return;
         }
 
@@ -153,6 +158,17 @@ class Datagrid implements DatagridInterface
                 $this->query->setSortOrder(isset($this->values['_sort_order']) ? $this->values['_sort_order'] : null);
             }
         }
+
+        $this->boundFilters = true;
+    }
+
+    public function buildPager()
+    {
+        if ($this->bound) {
+            return;
+        }
+
+        $this->buildFilters();
 
         $maxPerPage = 25;
         if (isset($this->values['_per_page'])) {


### PR DESCRIPTION
I am targeting this branch, because this should be a backward compatible change. It should be just a performance optimization.

This is an alternative implementation to https://github.com/sonata-project/SonataAdminBundle/pull/5145 that introduced the bug described in https://github.com/sonata-project/SonataAdminBundle/pull/5147



## Changelog


```markdown
### Changed
- Do not load the pager when performing a batch action without confirmation
```
## Subject

When performing a batch action and having `$idx` defined, currently sonata still does a query to calculate the pagination information (to be able to set the min/max results per page). 
Later that result gets discarded as the batch query runs on the elements specified by `$idx` or `$allElements` variables.

The query to calculate the total results might be very expensive, slowing down batch actions even if they update a single element via `$idx`. 

In my setup, ~90% of time is spent on calculating the total count of rows in the table and ~5% to do the batch action.


**My Comments**

I'm not really happy with the current implementation as it relies on `instanceof` but adding a new method to `DatagridInterface` sounds too big BC break... Has anybody suggestions?

The root cause it that `Datagrid::buildPager` builds both the "pager" and the "filters". IMO this are two separate concepts and they should have two separate methods.
I have added `Datagrid::buildFilers` that builds the filters only. But to keep it compatible with possible other implementations, `CRUDController` has some `instanceof`, making the code look pretty ugly.
