### PR TITLE
fixed bug with complex properties in ModelAutocompleteType

### DIFF
--- a/src/Controller/HelperController.php
+++ b/src/Controller/HelperController.php
@@ -416,7 +416,7 @@ class HelperController
                     $filter = $datagrid->getFilter($prop);
                     $filter->setCondition(FilterInterface::CONDITION_OR);
 
-                    $datagrid->setValue($prop, null, $searchText);
+                    $datagrid->setValue($filter->getFormName(), null, $searchText);
                 }
             } else {
                 if (!$datagrid->hasFilter($property)) {
@@ -428,7 +428,7 @@ class HelperController
                     ));
                 }
 
-                $datagrid->setValue($property, null, $searchText);
+                $datagrid->setValue($datagrid->getFilter($property)->getFormName(), null, $searchText);
             }
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this PR fix existing bug.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- fixed bug with complex properties in `ModelAutocompleteType`
```
## Subject

<!-- Describe your Pull Request content here -->

Right now code like 
```php
->add('childEntity', ModelAutocompleteType::class, [
    'class'     => Entity::class,
    'property'  => 'parent.title',
])
```
doesnt work, because wrong filter names are generated in `$datagrid->values`:

`parent.title instead of `parent__title`. This PR fix this bug.