### PR TITLE
Split the helper controller into invokable CaSes

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,11 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated `SonataAdminBundle\Controller\HelperController` in favor of actions
+
+If you extended that controller, you should split your extended controller and
+extend the corresponding classes in `SonataAdminBundle\Action\`.
+
 UPGRADE FROM 3.34 to 3.35
 =========================
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -9,13 +9,13 @@ UPGRADE FROM 3.34 to 3.35
 Admin classes can now have multiple parents, when registering the service
 you should pass a field name:
 
-```
+```xml
 <service id="sonata.admin.playlist" class="App\Admin\PlaylistAdmin">
     <!-- ... -->
 
     <call method="addChild">
         <argument type="service" id="sonata.admin.video" />
-        <argument>playlist</<argument>
+        <argument>playlist</argument>
     </call>
 </service>
 ```

--- a/src/Action/AppendFormFieldElementAction.php
+++ b/src/Action/AppendFormFieldElementAction.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Action;
+
+use Sonata\AdminBundle\Admin\AdminHelper;
+use Sonata\AdminBundle\Admin\Pool;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormRenderer;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment;
+
+final class AppendFormFieldElementAction
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var AdminHelper
+     */
+    private $helper;
+
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    public function __construct(Environment $twig, Pool $pool, AdminHelper $helper)
+    {
+        $this->pool = $pool;
+        $this->helper = $helper;
+        $this->twig = $twig;
+    }
+
+    /**
+     * @throws NotFoundHttpException
+     *
+     * @return Response
+     */
+    public function __invoke(Request $request)
+    {
+        $code = $request->get('code');
+        $elementId = $request->get('elementId');
+        $objectId = $request->get('objectId');
+        $uniqid = $request->get('uniqid');
+
+        $admin = $this->pool->getInstance($code);
+        $admin->setRequest($request);
+
+        if ($uniqid) {
+            $admin->setUniqid($uniqid);
+        }
+
+        $subject = $admin->getObject($objectId);
+        if ($objectId && !$subject) {
+            throw new NotFoundHttpException(sprintf(
+                'Could not find subject for id "%s"',
+                $objectId
+            ));
+        }
+
+        if (!$subject) {
+            $subject = $admin->getNewInstance();
+        }
+
+        $admin->setSubject($subject);
+
+        list(, $form) = $this->helper->appendFormFieldElement($admin, $subject, $elementId);
+
+        assert($form instanceof Form);
+        $view = $this->helper->getChildFormView($form->createView(), $elementId);
+
+        // render the widget
+        $renderer = $this->getFormRenderer();
+        $renderer->setTheme($view, $admin->getFormTheme());
+
+        return new Response($renderer->searchAndRenderBlock($view, 'widget'));
+    }
+
+    /**
+     * @return FormRenderer|TwigRenderer
+     */
+    private function getFormRenderer()
+    {
+        // BC for Symfony < 3.2 where this runtime does not exists
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $extension = $this->twig->getExtension(FormExtension::class);
+            $extension->initRuntime($this->twig);
+
+            return $extension->renderer;
+        }
+
+        // BC for Symfony < 3.4 where runtime should be TwigRenderer
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $runtime = $this->twig->getRuntime(TwigRenderer::class);
+            $runtime->setEnvironment($this->twig);
+
+            return $runtime;
+        }
+
+        return $this->twig->getRuntime(FormRenderer::class);
+    }
+}

--- a/src/Action/GetShortObjectDescriptionAction.php
+++ b/src/Action/GetShortObjectDescriptionAction.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Action;
+
+use Sonata\AdminBundle\Admin\Pool;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment;
+
+final class GetShortObjectDescriptionAction
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    public function __construct(Environment $twig, Pool $pool)
+    {
+        $this->pool = $pool;
+        $this->twig = $twig;
+    }
+
+    /**
+     * @throws NotFoundHttpException
+     *
+     * @return Response
+     */
+    public function __invoke(Request $request)
+    {
+        $code = $request->get('code');
+        $objectId = $request->get('objectId');
+        $uniqid = $request->get('uniqid');
+        $linkParameters = $request->get('linkParameters', []);
+
+        $admin = $this->pool->getInstance($code);
+
+        if (!$admin) {
+            throw new NotFoundHttpException(sprintf(
+                'Could not find admin for code "%s"',
+                $code
+            ));
+        }
+
+        $admin->setRequest($request);
+
+        if ($uniqid) {
+            $admin->setUniqid($uniqid);
+        }
+
+        if (!$objectId) {
+            $objectId = null;
+        }
+
+        $object = $admin->getObject($objectId);
+
+        if (!$object && 'html' == $request->get('_format')) {
+            return new Response();
+        }
+
+        if ('json' == $request->get('_format')) {
+            return new JsonResponse(['result' => [
+                'id' => $admin->id($object),
+                'label' => $admin->toString($object),
+            ]]);
+        } elseif ('html' == $request->get('_format')) {
+            return new Response($this->twig->render($admin->getTemplate('short_object_description'), [
+                'admin' => $admin,
+                'description' => $admin->toString($object),
+                'object' => $object,
+                'link_parameters' => $linkParameters,
+            ]));
+        }
+
+        throw new \RuntimeException('Invalid format');
+    }
+}

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -1,0 +1,226 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Action;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Filter\FilterInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class RetrieveAutocompleteItemsAction
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    public function __construct(Pool $pool)
+    {
+        $this->pool = $pool;
+    }
+
+    /**
+     * Retrieve list of items for autocomplete form field.
+     *
+     * @throws \RuntimeException
+     * @throws AccessDeniedException
+     *
+     * @return JsonResponse
+     */
+    public function __invoke(Request $request)
+    {
+        $admin = $this->pool->getInstance($request->get('admin_code'));
+        $admin->setRequest($request);
+        $context = $request->get('_context', '');
+
+        if ('filter' === $context) {
+            $admin->checkAccess('list');
+        } elseif (!$admin->hasAccess('create') && !$admin->hasAccess('edit')) {
+            throw new AccessDeniedException();
+        }
+
+        // subject will be empty to avoid unnecessary database requests and keep autocomplete function fast
+        $admin->setSubject($admin->getNewInstance());
+
+        if ('filter' === $context) {
+            // filter
+            $fieldDescription = $this->retrieveFilterFieldDescription($admin, $request->get('field'));
+            $filterAutocomplete = $admin->getDatagrid()->getFilter($fieldDescription->getName());
+
+            $property = $filterAutocomplete->getFieldOption('property');
+            $callback = $filterAutocomplete->getFieldOption('callback');
+            $minimumInputLength = $filterAutocomplete->getFieldOption('minimum_input_length', 3);
+            $itemsPerPage = $filterAutocomplete->getFieldOption('items_per_page', 10);
+            $reqParamPageNumber = $filterAutocomplete->getFieldOption('req_param_name_page_number', '_page');
+            $toStringCallback = $filterAutocomplete->getFieldOption('to_string_callback');
+            $targetAdminAccessAction = $filterAutocomplete->getFieldOption('target_admin_access_action', 'list');
+        } else {
+            // create/edit form
+            $fieldDescription = $this->retrieveFormFieldDescription($admin, $request->get('field'));
+            $formAutocomplete = $admin->getForm()->get($fieldDescription->getName());
+
+            $formAutocompleteConfig = $formAutocomplete->getConfig();
+            if ($formAutocompleteConfig->getAttribute('disabled')) {
+                throw new AccessDeniedException(
+                    'Autocomplete list can`t be retrieved because the form element is disabled or read_only.'
+                );
+            }
+
+            $property = $formAutocompleteConfig->getAttribute('property');
+            $callback = $formAutocompleteConfig->getAttribute('callback');
+            $minimumInputLength = $formAutocompleteConfig->getAttribute('minimum_input_length');
+            $itemsPerPage = $formAutocompleteConfig->getAttribute('items_per_page');
+            $reqParamPageNumber = $formAutocompleteConfig->getAttribute('req_param_name_page_number');
+            $toStringCallback = $formAutocompleteConfig->getAttribute('to_string_callback');
+            $targetAdminAccessAction = $formAutocompleteConfig->getAttribute('target_admin_access_action');
+        }
+
+        $searchText = $request->get('q');
+
+        $targetAdmin = $fieldDescription->getAssociationAdmin();
+
+        // check user permission
+        $targetAdmin->checkAccess($targetAdminAccessAction);
+
+        if (mb_strlen($searchText, 'UTF-8') < $minimumInputLength) {
+            return new JsonResponse(['status' => 'KO', 'message' => 'Too short search string.'], 403);
+        }
+
+        $targetAdmin->setFilterPersister(null);
+        $datagrid = $targetAdmin->getDatagrid();
+
+        if (null !== $callback) {
+            if (!is_callable($callback)) {
+                throw new \RuntimeException('Callback does not contain callable function.');
+            }
+
+            call_user_func($callback, $targetAdmin, $property, $searchText);
+        } else {
+            if (is_array($property)) {
+                // multiple properties
+                foreach ($property as $prop) {
+                    if (!$datagrid->hasFilter($prop)) {
+                        throw new \RuntimeException(sprintf(
+                            'To retrieve autocomplete items,'
+                            .' you should add filter "%s" to "%s" in configureDatagridFilters() method.',
+                            $prop, get_class($targetAdmin)
+                        ));
+                    }
+
+                    $filter = $datagrid->getFilter($prop);
+                    $filter->setCondition(FilterInterface::CONDITION_OR);
+
+                    $datagrid->setValue($filter->getFormName(), null, $searchText);
+                }
+            } else {
+                if (!$datagrid->hasFilter($property)) {
+                    throw new \RuntimeException(sprintf(
+                        'To retrieve autocomplete items,'
+                        .' you should add filter "%s" to "%s" in configureDatagridFilters() method.',
+                        $property,
+                        get_class($targetAdmin)
+                    ));
+                }
+
+                $datagrid->setValue($datagrid->getFilter($property)->getFormName(), null, $searchText);
+            }
+        }
+
+        $datagrid->setValue('_per_page', null, $itemsPerPage);
+        $datagrid->setValue('_page', null, $request->query->get($reqParamPageNumber, 1));
+        $datagrid->buildPager();
+
+        $pager = $datagrid->getPager();
+
+        $items = [];
+        $results = $pager->getResults();
+
+        foreach ($results as $entity) {
+            if (null !== $toStringCallback) {
+                if (!is_callable($toStringCallback)) {
+                    throw new \RuntimeException('Option "to_string_callback" does not contain callable function.');
+                }
+
+                $label = call_user_func($toStringCallback, $entity, $property);
+            } else {
+                $resultMetadata = $targetAdmin->getObjectMetadata($entity);
+                $label = $resultMetadata->getTitle();
+            }
+
+            $items[] = [
+                'id' => $admin->id($entity),
+                'label' => $label,
+            ];
+        }
+
+        return new JsonResponse([
+            'status' => 'OK',
+            'more' => !$pager->isLastPage(),
+            'items' => $items,
+        ]);
+    }
+
+    /**
+     * Retrieve the filter field description given by field name.
+     *
+     * @param string $field
+     *
+     * @throws \RuntimeException
+     *
+     * @return \Sonata\AdminBundle\Admin\FieldDescriptionInterface
+     */
+    private function retrieveFilterFieldDescription(AdminInterface $admin, $field)
+    {
+        $admin->getFilterFieldDescriptions();
+
+        $fieldDescription = $admin->getFilterFieldDescription($field);
+
+        if (!$fieldDescription) {
+            throw new \RuntimeException(sprintf('The field "%s" does not exist.', $field));
+        }
+
+        if (null === $fieldDescription->getTargetEntity()) {
+            throw new \RuntimeException(sprintf('No associated entity with field "%s".', $field));
+        }
+
+        return $fieldDescription;
+    }
+
+    /**
+     * Retrieve the form field description given by field name.
+     *
+     * @param string $field
+     *
+     * @throws \RuntimeException
+     *
+     * @return \Sonata\AdminBundle\Admin\FieldDescriptionInterface
+     */
+    private function retrieveFormFieldDescription(AdminInterface $admin, $field)
+    {
+        $admin->getFormFieldDescriptions();
+
+        $fieldDescription = $admin->getFormFieldDescription($field);
+
+        if (!$fieldDescription) {
+            throw new \RuntimeException(sprintf('The field "%s" does not exist.', $field));
+        }
+
+        if (null === $fieldDescription->getTargetEntity()) {
+            throw new \RuntimeException(sprintf('No associated entity with field "%s".', $field));
+        }
+
+        return $fieldDescription;
+    }
+}

--- a/src/Action/RetrieveFormFieldElementAction.php
+++ b/src/Action/RetrieveFormFieldElementAction.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Action;
+
+use Sonata\AdminBundle\Admin\AdminHelper;
+use Sonata\AdminBundle\Admin\Pool;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\FormRenderer;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment;
+
+final class RetrieveFormFieldElementAction
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var AdminHelper
+     */
+    private $helper;
+
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    public function __construct(Environment $twig, Pool $pool, AdminHelper $helper)
+    {
+        $this->pool = $pool;
+        $this->helper = $helper;
+        $this->twig = $twig;
+    }
+
+    /**
+     * @throws NotFoundHttpException
+     *
+     * @return Response
+     */
+    public function __invoke(Request $request)
+    {
+        $code = $request->get('code');
+        $elementId = $request->get('elementId');
+        $objectId = $request->get('objectId');
+        $uniqid = $request->get('uniqid');
+
+        $admin = $this->pool->getInstance($code);
+        $admin->setRequest($request);
+
+        if ($uniqid) {
+            $admin->setUniqid($uniqid);
+        }
+
+        if ($objectId) {
+            $subject = $admin->getObject($objectId);
+            if (!$subject) {
+                throw new NotFoundHttpException(sprintf(
+                    'Unable to find the object id: %s, class: %s',
+                    $objectId,
+                    $admin->getClass()
+                ));
+            }
+        } else {
+            $subject = $admin->getNewInstance();
+        }
+
+        $admin->setSubject($subject);
+
+        $formBuilder = $admin->getFormBuilder();
+
+        $form = $formBuilder->getForm();
+        $form->setData($subject);
+        $form->handleRequest($request);
+
+        $view = $this->helper->getChildFormView($form->createView(), $elementId);
+
+        // render the widget
+        $renderer = $this->getFormRenderer();
+        $renderer->setTheme($view, $admin->getFormTheme());
+
+        return new Response($renderer->searchAndRenderBlock($view, 'widget'));
+    }
+
+    /**
+     * @return FormRenderer|TwigRenderer
+     */
+    private function getFormRenderer()
+    {
+        // BC for Symfony < 3.2 where this runtime does not exists
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $extension = $this->twig->getExtension(FormExtension::class);
+            $extension->initRuntime($this->twig);
+
+            return $extension->renderer;
+        }
+
+        // BC for Symfony < 3.4 where runtime should be TwigRenderer
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $runtime = $this->twig->getRuntime(TwigRenderer::class);
+            $runtime->setEnvironment($this->twig);
+
+            return $runtime;
+        }
+
+        return $this->twig->getRuntime(FormRenderer::class);
+    }
+}

--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Action;
+
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Twig\Environment;
+
+final class SetObjectFieldValueAction
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    public function __construct(Environment $twig, Pool $pool, $validator)
+    {
+        // NEXT_MAJOR: Move ValidatorInterface check to method signature
+        if (!($validator instanceof ValidatorInterface)) {
+            throw new \InvalidArgumentException(
+                'Argument 3 is an instance of '.get_class($validator).', expecting an instance of'
+                .' \Symfony\Component\Validator\Validator\ValidatorInterface'
+            );
+        }
+        $this->pool = $pool;
+        $this->twig = $twig;
+        $this->validator = $validator;
+    }
+
+    /**
+     * @throws NotFoundHttpException
+     *
+     * @return Response
+     */
+    public function __invoke(Request $request)
+    {
+        $field = $request->get('field');
+        $code = $request->get('code');
+        $objectId = $request->get('objectId');
+        $value = $originalValue = $request->get('value');
+        $context = $request->get('context');
+
+        $admin = $this->pool->getInstance($code);
+        $admin->setRequest($request);
+
+        // alter should be done by using a post method
+        if (!$request->isXmlHttpRequest()) {
+            return new JsonResponse('Expected an XmlHttpRequest request header', 405);
+        }
+
+        if ('POST' != $request->getMethod()) {
+            return new JsonResponse('Expected a POST Request', 405);
+        }
+
+        $rootObject = $object = $admin->getObject($objectId);
+
+        if (!$object) {
+            return new JsonResponse('Object does not exist', 404);
+        }
+
+        // check user permission
+        if (false === $admin->hasAccess('edit', $object)) {
+            return new JsonResponse('Invalid permissions', 403);
+        }
+
+        if ('list' == $context) {
+            $fieldDescription = $admin->getListFieldDescription($field);
+        } else {
+            return new JsonResponse('Invalid context', 400);
+        }
+
+        if (!$fieldDescription) {
+            return new JsonResponse('The field does not exist', 400);
+        }
+
+        if (!$fieldDescription->getOption('editable')) {
+            return new JsonResponse('The field cannot be edited, editable option must be set to true', 400);
+        }
+
+        $propertyPath = new PropertyPath($field);
+
+        // If property path has more than 1 element, take the last object in order to validate it
+        if ($propertyPath->getLength() > 1) {
+            $object = $this->pool->getPropertyAccessor()->getValue($object, $propertyPath->getParent());
+
+            $elements = $propertyPath->getElements();
+            $field = end($elements);
+            $propertyPath = new PropertyPath($field);
+        }
+
+        // Handle date type has setter expect a DateTime object
+        if ('' !== $value && 'date' == $fieldDescription->getType()) {
+            $value = new \DateTime($value);
+        }
+
+        // Handle boolean type transforming the value into a boolean
+        if ('' !== $value && 'boolean' == $fieldDescription->getType()) {
+            $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        }
+
+        // Handle entity choice association type, transforming the value into entity
+        if ('' !== $value
+            && 'choice' == $fieldDescription->getType()
+            && null !== $fieldDescription->getOption('class')
+            && $fieldDescription->getOption('class') === $fieldDescription->getTargetEntity()
+        ) {
+            $value = $admin->getModelManager()->find($fieldDescription->getOption('class'), $value);
+
+            if (!$value) {
+                return new JsonResponse(sprintf(
+                    'Edit failed, object with id: %s not found in association: %s.',
+                    $originalValue,
+                    $field
+                ), 404);
+            }
+        }
+
+        $this->pool->getPropertyAccessor()->setValue($object, $propertyPath, '' !== $value ? $value : null);
+
+        $violations = $this->validator->validate($object);
+
+        if (count($violations)) {
+            $messages = [];
+
+            foreach ($violations as $violation) {
+                $messages[] = $violation->getMessage();
+            }
+
+            return new JsonResponse(implode("\n", $messages), 400);
+        }
+
+        $admin->update($object);
+
+        // render the widget
+        // todo : fix this, the twig environment variable is not set inside the extension ...
+        $extension = $this->twig->getExtension(SonataAdminExtension::class);
+
+        $content = $extension->renderListElement($this->twig, $rootObject, $fieldDescription);
+
+        return new JsonResponse($content, 200);
+    }
+}

--- a/src/Controller/HelperController.php
+++ b/src/Controller/HelperController.php
@@ -11,26 +11,32 @@
 
 namespace Sonata\AdminBundle\Controller;
 
+use Sonata\AdminBundle\Action\AppendFormFieldElementAction;
+use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
+use Sonata\AdminBundle\Action\RetrieveAutocompleteItemsAction;
+use Sonata\AdminBundle\Action\RetrieveFormFieldElementAction;
+use Sonata\AdminBundle\Action\SetObjectFieldValueAction;
 use Sonata\AdminBundle\Admin\AdminHelper;
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
-use Sonata\AdminBundle\Filter\FilterInterface;
-use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
-use Symfony\Bridge\Twig\AppVariable;
-use Symfony\Bridge\Twig\Command\DebugCommand;
-use Symfony\Bridge\Twig\Extension\FormExtension;
-use Symfony\Bridge\Twig\Form\TwigRenderer;
-use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Twig\Environment;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\HelperController class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use actions inside Sonata\AdminBundle\Action instead.',
+    E_USER_DEPRECATED
+);
+
 /**
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 3.1, to be removed in 4.0. Use Sonata\AdminBundle\AbstractAdmin instead
+ *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class HelperController
@@ -81,39 +87,9 @@ class HelperController
      */
     public function appendFormFieldElementAction(Request $request)
     {
-        $code = $request->get('code');
-        $elementId = $request->get('elementId');
-        $objectId = $request->get('objectId');
-        $uniqid = $request->get('uniqid');
+        $action = new AppendFormFieldElementAction($this->twig, $this->pool, $this->helper);
 
-        $admin = $this->pool->getInstance($code);
-        $admin->setRequest($request);
-
-        if ($uniqid) {
-            $admin->setUniqid($uniqid);
-        }
-
-        $subject = $admin->getObject($objectId);
-        if ($objectId && !$subject) {
-            throw new NotFoundHttpException();
-        }
-
-        if (!$subject) {
-            $subject = $admin->getNewInstance();
-        }
-
-        $admin->setSubject($subject);
-
-        list(, $form) = $this->helper->appendFormFieldElement($admin, $subject, $elementId);
-
-        /* @var $form \Symfony\Component\Form\Form */
-        $view = $this->helper->getChildFormView($form->createView(), $elementId);
-
-        // render the widget
-        $renderer = $this->getFormRenderer();
-        $renderer->setTheme($view, $admin->getFormTheme());
-
-        return new Response($renderer->searchAndRenderBlock($view, 'widget'));
+        return $action($request);
     }
 
     /**
@@ -123,44 +99,9 @@ class HelperController
      */
     public function retrieveFormFieldElementAction(Request $request)
     {
-        $code = $request->get('code');
-        $elementId = $request->get('elementId');
-        $objectId = $request->get('objectId');
-        $uniqid = $request->get('uniqid');
+        $action = new RetrieveFormFieldElementAction($this->twig, $this->pool, $this->helper);
 
-        $admin = $this->pool->getInstance($code);
-        $admin->setRequest($request);
-
-        if ($uniqid) {
-            $admin->setUniqid($uniqid);
-        }
-
-        if ($objectId) {
-            $subject = $admin->getObject($objectId);
-            if (!$subject) {
-                throw new NotFoundHttpException(
-                    sprintf('Unable to find the object id: %s, class: %s', $objectId, $admin->getClass())
-                );
-            }
-        } else {
-            $subject = $admin->getNewInstance();
-        }
-
-        $admin->setSubject($subject);
-
-        $formBuilder = $admin->getFormBuilder();
-
-        $form = $formBuilder->getForm();
-        $form->setData($subject);
-        $form->handleRequest($request);
-
-        $view = $this->helper->getChildFormView($form->createView(), $elementId);
-
-        // render the widget
-        $renderer = $this->getFormRenderer();
-        $renderer->setTheme($view, $admin->getFormTheme());
-
-        return new Response($renderer->searchAndRenderBlock($view, 'widget'));
+        return $action($request);
     }
 
     /**
@@ -170,48 +111,9 @@ class HelperController
      */
     public function getShortObjectDescriptionAction(Request $request)
     {
-        $code = $request->get('code');
-        $objectId = $request->get('objectId');
-        $uniqid = $request->get('uniqid');
-        $linkParameters = $request->get('linkParameters', []);
+        $action = new GetShortObjectDescriptionAction($this->twig, $this->pool);
 
-        $admin = $this->pool->getInstance($code);
-
-        if (!$admin) {
-            throw new NotFoundHttpException();
-        }
-
-        $admin->setRequest($request);
-
-        if ($uniqid) {
-            $admin->setUniqid($uniqid);
-        }
-
-        if (!$objectId) {
-            $objectId = null;
-        }
-
-        $object = $admin->getObject($objectId);
-
-        if (!$object && 'html' == $request->get('_format')) {
-            return new Response();
-        }
-
-        if ('json' == $request->get('_format')) {
-            return new JsonResponse(['result' => [
-                'id' => $admin->id($object),
-                'label' => $admin->toString($object),
-            ]]);
-        } elseif ('html' == $request->get('_format')) {
-            return new Response($this->twig->render($admin->getTemplate('short_object_description'), [
-                'admin' => $admin,
-                'description' => $admin->toString($object),
-                'object' => $object,
-                'link_parameters' => $linkParameters,
-            ]));
-        }
-
-        throw new \RuntimeException('Invalid format');
+        return $action($request);
     }
 
     /**
@@ -219,110 +121,9 @@ class HelperController
      */
     public function setObjectFieldValueAction(Request $request)
     {
-        $field = $request->get('field');
-        $code = $request->get('code');
-        $objectId = $request->get('objectId');
-        $value = $originalValue = $request->get('value');
-        $context = $request->get('context');
+        $action = new SetObjectFieldValueAction($this->twig, $this->pool, $this->validator);
 
-        $admin = $this->pool->getInstance($code);
-        $admin->setRequest($request);
-
-        // alter should be done by using a post method
-        if (!$request->isXmlHttpRequest()) {
-            return new JsonResponse('Expected an XmlHttpRequest request header', 405);
-        }
-
-        if ('POST' != $request->getMethod()) {
-            return new JsonResponse('Expected a POST Request', 405);
-        }
-
-        $rootObject = $object = $admin->getObject($objectId);
-
-        if (!$object) {
-            return new JsonResponse('Object does not exist', 404);
-        }
-
-        // check user permission
-        if (false === $admin->hasAccess('edit', $object)) {
-            return new JsonResponse('Invalid permissions', 403);
-        }
-
-        if ('list' == $context) {
-            $fieldDescription = $admin->getListFieldDescription($field);
-        } else {
-            return new JsonResponse('Invalid context', 400);
-        }
-
-        if (!$fieldDescription) {
-            return new JsonResponse('The field does not exist', 400);
-        }
-
-        if (!$fieldDescription->getOption('editable')) {
-            return new JsonResponse('The field cannot be edited, editable option must be set to true', 400);
-        }
-
-        $propertyPath = new PropertyPath($field);
-
-        // If property path has more than 1 element, take the last object in order to validate it
-        if ($propertyPath->getLength() > 1) {
-            $object = $this->pool->getPropertyAccessor()->getValue($object, $propertyPath->getParent());
-
-            $elements = $propertyPath->getElements();
-            $field = end($elements);
-            $propertyPath = new PropertyPath($field);
-        }
-
-        // Handle date type has setter expect a DateTime object
-        if ('' !== $value && 'date' == $fieldDescription->getType()) {
-            $value = new \DateTime($value);
-        }
-
-        // Handle boolean type transforming the value into a boolean
-        if ('' !== $value && 'boolean' == $fieldDescription->getType()) {
-            $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
-        }
-
-        // Handle entity choice association type, transforming the value into entity
-        if ('' !== $value
-            && 'choice' == $fieldDescription->getType()
-            && null !== $fieldDescription->getOption('class')
-            && $fieldDescription->getOption('class') === $fieldDescription->getTargetEntity()
-        ) {
-            $value = $admin->getModelManager()->find($fieldDescription->getOption('class'), $value);
-
-            if (!$value) {
-                return new JsonResponse(sprintf(
-                    'Edit failed, object with id: %s not found in association: %s.',
-                    $originalValue,
-                    $field
-                ), 404);
-            }
-        }
-
-        $this->pool->getPropertyAccessor()->setValue($object, $propertyPath, '' !== $value ? $value : null);
-
-        $violations = $this->validator->validate($object);
-
-        if (count($violations)) {
-            $messages = [];
-
-            foreach ($violations as $violation) {
-                $messages[] = $violation->getMessage();
-            }
-
-            return new JsonResponse(implode("\n", $messages), 400);
-        }
-
-        $admin->update($object);
-
-        // render the widget
-        // todo : fix this, the twig environment variable is not set inside the extension ...
-        $extension = $this->twig->getExtension(SonataAdminExtension::class);
-
-        $content = $extension->renderListElement($this->twig, $rootObject, $fieldDescription);
-
-        return new JsonResponse($content, 200);
+        return $action($request);
     }
 
     /**
@@ -335,210 +136,8 @@ class HelperController
      */
     public function retrieveAutocompleteItemsAction(Request $request)
     {
-        $admin = $this->pool->getInstance($request->get('admin_code'));
-        $admin->setRequest($request);
-        $context = $request->get('_context', '');
+        $action = new RetrieveAutocompleteItemsAction($this->pool);
 
-        if ('filter' === $context) {
-            $admin->checkAccess('list');
-        } elseif (!$admin->hasAccess('create') && !$admin->hasAccess('edit')) {
-            throw new AccessDeniedException();
-        }
-
-        // subject will be empty to avoid unnecessary database requests and keep autocomplete function fast
-        $admin->setSubject($admin->getNewInstance());
-
-        if ('filter' === $context) {
-            // filter
-            $fieldDescription = $this->retrieveFilterFieldDescription($admin, $request->get('field'));
-            $filterAutocomplete = $admin->getDatagrid()->getFilter($fieldDescription->getName());
-
-            $property = $filterAutocomplete->getFieldOption('property');
-            $callback = $filterAutocomplete->getFieldOption('callback');
-            $minimumInputLength = $filterAutocomplete->getFieldOption('minimum_input_length', 3);
-            $itemsPerPage = $filterAutocomplete->getFieldOption('items_per_page', 10);
-            $reqParamPageNumber = $filterAutocomplete->getFieldOption('req_param_name_page_number', '_page');
-            $toStringCallback = $filterAutocomplete->getFieldOption('to_string_callback');
-            $targetAdminAccessAction = $filterAutocomplete->getFieldOption('target_admin_access_action', 'list');
-        } else {
-            // create/edit form
-            $fieldDescription = $this->retrieveFormFieldDescription($admin, $request->get('field'));
-            $formAutocomplete = $admin->getForm()->get($fieldDescription->getName());
-
-            $formAutocompleteConfig = $formAutocomplete->getConfig();
-            if ($formAutocompleteConfig->getAttribute('disabled')) {
-                throw new AccessDeniedException(
-                    'Autocomplete list can`t be retrieved because the form element is disabled or read_only.'
-                );
-            }
-
-            $property = $formAutocompleteConfig->getAttribute('property');
-            $callback = $formAutocompleteConfig->getAttribute('callback');
-            $minimumInputLength = $formAutocompleteConfig->getAttribute('minimum_input_length');
-            $itemsPerPage = $formAutocompleteConfig->getAttribute('items_per_page');
-            $reqParamPageNumber = $formAutocompleteConfig->getAttribute('req_param_name_page_number');
-            $toStringCallback = $formAutocompleteConfig->getAttribute('to_string_callback');
-            $targetAdminAccessAction = $formAutocompleteConfig->getAttribute('target_admin_access_action');
-        }
-
-        $searchText = $request->get('q');
-
-        $targetAdmin = $fieldDescription->getAssociationAdmin();
-
-        // check user permission
-        $targetAdmin->checkAccess($targetAdminAccessAction);
-
-        if (mb_strlen($searchText, 'UTF-8') < $minimumInputLength) {
-            return new JsonResponse(['status' => 'KO', 'message' => 'Too short search string.'], 403);
-        }
-
-        $targetAdmin->setFilterPersister(null);
-        $datagrid = $targetAdmin->getDatagrid();
-
-        if (null !== $callback) {
-            if (!is_callable($callback)) {
-                throw new \RuntimeException('Callback does not contain callable function.');
-            }
-
-            call_user_func($callback, $targetAdmin, $property, $searchText);
-        } else {
-            if (is_array($property)) {
-                // multiple properties
-                foreach ($property as $prop) {
-                    if (!$datagrid->hasFilter($prop)) {
-                        throw new \RuntimeException(sprintf(
-                            'To retrieve autocomplete items,'
-                            .' you should add filter "%s" to "%s" in configureDatagridFilters() method.',
-                            $prop, get_class($targetAdmin)
-                        ));
-                    }
-
-                    $filter = $datagrid->getFilter($prop);
-                    $filter->setCondition(FilterInterface::CONDITION_OR);
-
-                    $datagrid->setValue($filter->getFormName(), null, $searchText);
-                }
-            } else {
-                if (!$datagrid->hasFilter($property)) {
-                    throw new \RuntimeException(sprintf(
-                        'To retrieve autocomplete items,'
-                        .' you should add filter "%s" to "%s" in configureDatagridFilters() method.',
-                        $property,
-                        get_class($targetAdmin)
-                    ));
-                }
-
-                $datagrid->setValue($datagrid->getFilter($property)->getFormName(), null, $searchText);
-            }
-        }
-
-        $datagrid->setValue('_per_page', null, $itemsPerPage);
-        $datagrid->setValue('_page', null, $request->query->get($reqParamPageNumber, 1));
-        $datagrid->buildPager();
-
-        $pager = $datagrid->getPager();
-
-        $items = [];
-        $results = $pager->getResults();
-
-        foreach ($results as $entity) {
-            if (null !== $toStringCallback) {
-                if (!is_callable($toStringCallback)) {
-                    throw new \RuntimeException('Option "to_string_callback" does not contain callable function.');
-                }
-
-                $label = call_user_func($toStringCallback, $entity, $property);
-            } else {
-                $resultMetadata = $targetAdmin->getObjectMetadata($entity);
-                $label = $resultMetadata->getTitle();
-            }
-
-            $items[] = [
-                'id' => $admin->id($entity),
-                'label' => $label,
-            ];
-        }
-
-        return new JsonResponse([
-            'status' => 'OK',
-            'more' => !$pager->isLastPage(),
-            'items' => $items,
-        ]);
-    }
-
-    /**
-     * Retrieve the form field description given by field name.
-     *
-     * @param string $field
-     *
-     * @throws \RuntimeException
-     *
-     * @return \Sonata\AdminBundle\Admin\FieldDescriptionInterface
-     */
-    private function retrieveFormFieldDescription(AdminInterface $admin, $field)
-    {
-        $admin->getFormFieldDescriptions();
-
-        $fieldDescription = $admin->getFormFieldDescription($field);
-
-        if (!$fieldDescription) {
-            throw new \RuntimeException(sprintf('The field "%s" does not exist.', $field));
-        }
-
-        if (null === $fieldDescription->getTargetEntity()) {
-            throw new \RuntimeException(sprintf('No associated entity with field "%s".', $field));
-        }
-
-        return $fieldDescription;
-    }
-
-    /**
-     * Retrieve the filter field description given by field name.
-     *
-     * @param string $field
-     *
-     * @throws \RuntimeException
-     *
-     * @return \Sonata\AdminBundle\Admin\FieldDescriptionInterface
-     */
-    private function retrieveFilterFieldDescription(AdminInterface $admin, $field)
-    {
-        $admin->getFilterFieldDescriptions();
-
-        $fieldDescription = $admin->getFilterFieldDescription($field);
-
-        if (!$fieldDescription) {
-            throw new \RuntimeException(sprintf('The field "%s" does not exist.', $field));
-        }
-
-        if (null === $fieldDescription->getTargetEntity()) {
-            throw new \RuntimeException(sprintf('No associated entity with field "%s".', $field));
-        }
-
-        return $fieldDescription;
-    }
-
-    /**
-     * @return FormRenderer|TwigRenderer
-     */
-    private function getFormRenderer()
-    {
-        // BC for Symfony < 3.2 where this runtime does not exists
-        if (!method_exists(AppVariable::class, 'getToken')) {
-            $extension = $this->twig->getExtension(FormExtension::class);
-            $extension->initRuntime($this->twig);
-
-            return $extension->renderer;
-        }
-
-        // BC for Symfony < 3.4 where runtime should be TwigRenderer
-        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
-            $runtime = $this->twig->getRuntime(TwigRenderer::class);
-            $runtime->setEnvironment($this->twig);
-
-            return $runtime;
-        }
-
-        return $this->twig->getRuntime(FormRenderer::class);
+        return $action($request);
     }
 }

--- a/src/Resources/config/actions.xml
+++ b/src/Resources/config/actions.xml
@@ -20,5 +20,27 @@
                 <argument type="service" id="service_container"/>
             </call>
         </service>
+        <service id="sonata.admin.action.append_form_field_element" class="Sonata\AdminBundle\Action\AppendFormFieldElementAction" public="true">
+            <argument type="service" id="twig"/>
+            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="sonata.admin.helper"/>
+        </service>
+        <service id="sonata.admin.action.retrieve_form_field_element" class="Sonata\AdminBundle\Action\RetrieveFormFieldElementAction" public="true">
+            <argument type="service" id="twig"/>
+            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="sonata.admin.helper"/>
+        </service>
+        <service id="sonata.admin.action.get_short_object_description" class="Sonata\AdminBundle\Action\GetShortObjectDescriptionAction" public="true">
+            <argument type="service" id="twig"/>
+            <argument type="service" id="sonata.admin.pool"/>
+        </service>
+        <service id="sonata.admin.action.set_object_field_value" class="Sonata\AdminBundle\Action\SetObjectFieldValueAction" public="true">
+            <argument type="service" id="twig"/>
+            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="validator"/>
+        </service>
+        <service id="sonata.admin.action.retrieve_autocomplete_items" class="Sonata\AdminBundle\Action\RetrieveAutocompleteItemsAction" public="true">
+            <argument type="service" id="sonata.admin.pool"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -45,6 +45,7 @@
         </service>
         <!-- controller as services -->
         <service id="sonata.admin.controller.admin" class="Sonata\AdminBundle\Controller\HelperController" public="true">
+            <deprecated>The controller service "%service_id%" is deprecated in favor of several action services since version 3.x and will be removed in 4.0.</deprecated>
             <argument type="service" id="twig"/>
             <argument type="service" id="sonata.admin.pool"/>
             <argument type="service" id="sonata.admin.helper"/>

--- a/src/Resources/config/routing/sonata_admin.xml
+++ b/src/Resources/config/routing/sonata_admin.xml
@@ -9,23 +9,23 @@
         <default key="_controller">Sonata\AdminBundle\Action\DashboardAction</default>
     </route>
     <route id="sonata_admin_retrieve_form_element" path="/core/get-form-field-element">
-        <default key="_controller">sonata.admin.controller.admin:retrieveFormFieldElementAction</default>
+        <default key="_controller">sonata.admin.action.retrieve_form_field_element</default>
     </route>
     <route id="sonata_admin_append_form_element" path="/core/append-form-field-element">
-        <default key="_controller">sonata.admin.controller.admin:appendFormFieldElementAction</default>
+        <default key="_controller">sonata.admin.action.append_form_field_element</default>
     </route>
     <route id="sonata_admin_short_object_information" path="/core/get-short-object-description.{_format}">
-        <default key="_controller">sonata.admin.controller.admin:getShortObjectDescriptionAction</default>
+        <default key="_controller">sonata.admin.action.get_short_object_description</default>
         <default key="_format">html</default>
         <requirement key="_format">html|json</requirement>
     </route>
     <route id="sonata_admin_set_object_field_value" path="/core/set-object-field-value">
-        <default key="_controller">sonata.admin.controller.admin:setObjectFieldValueAction</default>
+        <default key="_controller">sonata.admin.action.set_object_field_value</default>
     </route>
     <route id="sonata_admin_search" path="/search">
         <default key="_controller">Sonata\AdminBundle\Action\SearchAction</default>
     </route>
     <route id="sonata_admin_retrieve_autocomplete_items" path="/core/get-autocomplete-items">
-        <default key="_controller">sonata.admin.controller.admin:retrieveAutocompleteItemsAction</default>
+        <default key="_controller">sonata.admin.action.retrieve_autocomplete_items</default>
     </route>
 </routes>

--- a/tests/Action/AppendFormFieldElementActionTest.php
+++ b/tests/Action/AppendFormFieldElementActionTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Sonata\AdminBundle\Action\AppendFormFieldElementAction;
+use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminHelper;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormRenderer;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Twig\Environment;
+
+final class AppendFormFieldElementActionTest extends TestCase
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * @var GetShortObjectDescriptionAction
+     */
+    private $action;
+
+    /**
+     * @var AbstractAdmin
+     */
+    private $admin;
+
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    /**
+     * @var AdminHelper
+     */
+    private $helper;
+
+    protected function setUp()
+    {
+        $this->twig = $this->prophesize(Environment::class);
+        $this->pool = $this->prophesize(Pool::class);
+        $this->admin = $this->prophesize(AbstractAdmin::class);
+        $this->pool->getInstance(Argument::any())->willReturn($this->admin->reveal());
+        $this->admin->setRequest(Argument::type(Request::class))->shouldBeCalled();
+        $this->validator = $this->prophesize(ValidatorInterface::class);
+        $this->helper = $this->prophesize(AdminHelper::class);
+        $this->action = new AppendFormFieldElementAction(
+            $this->twig->reveal(),
+            $this->pool->reveal(),
+            $this->helper->reveal()
+        );
+    }
+
+    public function testAppendFormFieldElementAction()
+    {
+        $object = new \stdClass();
+        $request = new Request([
+            'code' => 'sonata.post.admin',
+            'objectId' => 42,
+            'field' => 'enabled',
+            'value' => 1,
+            'context' => 'list',
+        ], [], [], [], [], ['REQUEST_METHOD' => 'POST']);
+
+        $modelManager = $this->prophesize(ModelManagerInterface::class);
+        $formView = new FormView();
+        $form = $this->prophesize(Form::class);
+
+        $renderer = $this->configureFormRenderer();
+
+        $this->admin->getObject(42)->willReturn($object);
+        $this->admin->getClass()->willReturn(get_class($object));
+        $this->admin->setSubject($object)->shouldBeCalled();
+        $this->admin->getFormTheme()->willReturn($formView);
+        $this->helper->appendFormFieldElement($this->admin->reveal(), $object, null)->willReturn([
+            $this->prophesize(FieldDescriptionInterface::class),
+            $form->reveal(),
+        ]);
+        $this->helper->getChildFormView($formView, null)
+            ->willReturn($formView);
+        $modelManager->find(get_class($object), 42)->willReturn($object);
+        $form->createView()->willReturn($formView);
+        $renderer->setTheme($formView, $formView)->shouldBeCalled();
+        $renderer->searchAndRenderBlock($formView, 'widget')->willReturn('block');
+
+        $action = $this->action;
+        $response = $action($request);
+
+        $this->isInstanceOf(Response::class, $response);
+        $this->assertSame($response->getContent(), 'block');
+    }
+
+    private function configureFormRenderer()
+    {
+        $runtime = $this->prophesize(FormRenderer::class);
+
+        // Remove the condition when dropping sf < 3.2
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $extension = $this->prophesize(FormExtension::class);
+
+            $this->twig->getExtension(FormExtension::class)->willReturn($extension->reveal());
+            $extension->initRuntime($this->twig->reveal())->shouldBeCalled();
+            $extension->renderer = $runtime->reveal();
+
+            return $runtime;
+        }
+
+        // Remove the condition when dropping sf < 3.4
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $twigRuntime = $this->prophesize(TwigRenderer::class);
+
+            $this->twig->getRuntime(TwigRenderer::class)->willReturn($twigRuntime->reveal());
+            $twigRuntime->setEnvironment($this->twig->reveal())->shouldBeCalled();
+
+            return $twigRuntime;
+        }
+
+        $this->twig->getRuntime(FormRenderer::class)->willReturn($runtime->reveal());
+
+        return $runtime;
+    }
+}

--- a/tests/Action/GetShortObjectDescriptionActionTest.php
+++ b/tests/Action/GetShortObjectDescriptionActionTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\Pool;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+final class GetShortObjectDescriptionActionTest extends TestCase
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * @var GetShortObjectDescriptionAction
+     */
+    private $action;
+
+    /**
+     * @var AbstractAdmin
+     */
+    private $admin;
+
+    protected function setUp()
+    {
+        $this->twig = new Environment(new ArrayLoader(['template' => 'renderedTemplate']));
+        $this->pool = $this->prophesize(Pool::class);
+        $this->admin = $this->prophesize(AbstractAdmin::class);
+        $this->pool->getInstance(Argument::any())->willReturn($this->admin->reveal());
+        $this->admin->setRequest(Argument::type(Request::class))->shouldBeCalled();
+        $this->action = new GetShortObjectDescriptionAction(
+            $this->twig,
+            $this->pool->reveal()
+        );
+    }
+
+    public function testGetShortObjectDescriptionActionInvalidAdmin()
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $request = new Request([
+            'code' => 'sonata.post.admin',
+            'objectId' => 42,
+            'uniqid' => 'asdasd123',
+        ]);
+
+        $this->pool->getInstance('sonata.post.admin')->willReturn(null);
+        $this->admin->setRequest(Argument::type(Request::class))->shouldNotBeCalled();
+
+        $action = $this->action;
+        $action($request);
+    }
+
+    public function testGetShortObjectDescriptionActionObjectDoesNotExist()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid format');
+
+        $request = new Request([
+            'code' => 'sonata.post.admin',
+            'objectId' => 42,
+            'uniqid' => 'asdasd123',
+        ]);
+
+        $this->admin->setUniqid('asdasd123')->shouldBeCalled();
+        $this->admin->getObject(42)->willReturn(false);
+
+        $action = $this->action;
+        $action($request);
+    }
+
+    public function testGetShortObjectDescriptionActionEmptyObjectId()
+    {
+        $request = new Request([
+            'code' => 'sonata.post.admin',
+            'objectId' => '',
+            'uniqid' => 'asdasd123',
+            '_format' => 'html',
+        ]);
+
+        $this->admin->setUniqid('asdasd123')->shouldBeCalled();
+        $this->admin->getObject(null)->willReturn(false);
+
+        $action = $this->action;
+        $response = $action($request);
+
+        $this->assertInstanceOf(Response::class, $response);
+    }
+
+    public function testGetShortObjectDescriptionActionObject()
+    {
+        $request = new Request([
+            'code' => 'sonata.post.admin',
+            'objectId' => 42,
+            'uniqid' => 'asdasd123',
+            '_format' => 'html',
+        ]);
+        $object = new \stdClass();
+
+        $this->admin->setUniqid('asdasd123')->shouldBeCalled();
+        $this->admin->getObject(42)->willReturn($object);
+        $this->admin->getTemplate('short_object_description')->willReturn('template');
+        $this->admin->toString($object)->willReturn('bar');
+
+        $action = $this->action;
+        $response = $action($request);
+
+        $this->assertSame('renderedTemplate', $response->getContent());
+    }
+}

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -1,0 +1,316 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
+use Sonata\AdminBundle\Action\RetrieveAutocompleteItemsAction;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Datagrid\Pager;
+use Sonata\AdminBundle\Tests\Fixtures\Filter\FooFilter;
+use Sonata\CoreBundle\Model\Metadata;
+use Sonata\DatagridBundle\Datagrid\DatagridInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormConfigInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class RetrieveAutocompleteItemsActionTest extends TestCase
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var GetShortObjectDescriptionAction
+     */
+    private $action;
+
+    /**
+     * @var AbstractAdmin
+     */
+    private $admin;
+
+    protected function setUp()
+    {
+        $this->admin = $this->prophesize(AbstractAdmin::class);
+        $this->admin->setRequest(Argument::type(Request::class))->shouldBeCalled();
+        $this->pool = $this->prophesize(Pool::class);
+        $this->pool->getInstance(Argument::any())->willReturn($this->admin->reveal());
+        $this->action = new RetrieveAutocompleteItemsAction(
+            $this->pool->reveal()
+        );
+    }
+
+    public function testRetrieveAutocompleteItemsActionNotGranted()
+    {
+        $this->expectException(AccessDeniedException::class);
+
+        $request = new Request([
+            'admin_code' => 'foo.admin',
+        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+
+        $this->admin->hasAccess('create')->willReturn(false);
+        $this->admin->hasAccess('edit')->willReturn(false);
+
+        $action = $this->action;
+        $action($request);
+    }
+
+    public function testRetrieveAutocompleteItemsActionDisabledFormelememt()
+    {
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionMessage('Autocomplete list can`t be retrieved because the form element is disabled or read_only.');
+
+        $object = new \stdClass();
+        $request = new Request([
+            'admin_code' => 'foo.admin',
+            'field' => 'barField',
+        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+
+        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
+
+        $this->configureFormConfig('barField', true);
+
+        $this->admin->getNewInstance()->willReturn($object);
+        $this->admin->setSubject($object)->shouldBeCalled();
+        $this->admin->hasAccess('create')->willReturn(true);
+        $this->admin->getFormFieldDescriptions()->willReturn(null);
+        $this->admin->getFormFieldDescription('barField')->willReturn($fieldDescription->reveal());
+
+        $fieldDescription->getTargetEntity()->willReturn(Foo::class);
+        $fieldDescription->getName()->willReturn('barField');
+
+        $action = $this->action;
+        $action($request);
+    }
+
+    public function testRetrieveAutocompleteItemsTooShortSearchString()
+    {
+        $object = new \stdClass();
+        $request = new Request([
+            'admin_code' => 'foo.admin',
+            'field' => 'barField',
+            'q' => 'so',
+        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+
+        $targetAdmin = $this->prophesize(AbstractAdmin::class);
+        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
+
+        $this->configureFormConfig('barField');
+
+        $this->admin->getNewInstance()->willReturn($object);
+        $this->admin->setSubject($object)->shouldBeCalled();
+        $this->admin->hasAccess('create')->willReturn(true);
+        $this->admin->getFormFieldDescription('barField')->willReturn($fieldDescription->reveal());
+        $this->admin->getFormFieldDescriptions()->willReturn(null);
+        $targetAdmin->checkAccess('list')->willReturn(null);
+        $fieldDescription->getTargetEntity()->willReturn(Foo::class);
+        $fieldDescription->getName()->willReturn('barField');
+        $fieldDescription->getAssociationAdmin()->willReturn($targetAdmin->reveal());
+
+        $action = $this->action;
+        $response = $action($request);
+
+        $this->isInstanceOf(Response::class, $response);
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('{"status":"KO","message":"Too short search string."}', $response->getContent());
+    }
+
+    public function testRetrieveAutocompleteItems()
+    {
+        $entity = new \stdClass();
+        $request = new Request([
+            'admin_code' => 'foo.admin',
+            'field' => 'barField',
+            'q' => 'sonata',
+        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+
+        $targetAdmin = $this->prophesize(AbstractAdmin::class);
+        $datagrid = $this->prophesize(DatagridInterface::class);
+        $metadata = $this->prophesize(Metadata::class);
+        $pager = $this->prophesize(Pager::class);
+        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
+
+        $this->configureFormConfig('barField');
+
+        $datagrid = $this->configureAutocompleteItemsDatagrid();
+        $filter = new FooFilter();
+        $filter->initialize('foo');
+
+        $datagrid->hasFilter('foo')->willReturn(true);
+        $datagrid->getFilter('foo')->willReturn($filter);
+        $datagrid->setValue('foo', null, 'sonata')->shouldBeCalled();
+
+        $action = $this->action;
+        $response = $action($request);
+
+        $this->isInstanceOf(Response::class, $response);
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
+    }
+
+    public function testRetrieveAutocompleteItemsComplexPropertyArray()
+    {
+        $request = new Request([
+            'admin_code' => 'foo.admin',
+            'field' => 'barField',
+            'q' => 'sonata',
+        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+
+        $this->configureFormConfigComplexPropertyArray('barField');
+        $datagrid = $this->configureAutocompleteItemsDatagrid();
+
+        $filter = new FooFilter();
+        $filter->initialize('entity.property');
+
+        $datagrid->hasFilter('entity.property')->willReturn(true);
+        $datagrid->getFilter('entity.property')->willReturn($filter);
+        $filter2 = new FooFilter();
+        $filter2->initialize('entity2.property2');
+
+        $datagrid->hasFilter('entity2.property2')->willReturn(true);
+        $datagrid->getFilter('entity2.property2')->willReturn($filter2);
+
+        $datagrid->setValue('entity__property', null, 'sonata')->shouldBeCalled();
+        $datagrid->setValue('entity2__property2', null, 'sonata')->shouldBeCalled();
+
+        $action = $this->action;
+        $response = $action($request);
+
+        $this->isInstanceOf(Response::class, $response);
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
+    }
+
+    public function testRetrieveAutocompleteItemsComplexProperty()
+    {
+        $request = new Request([
+            'admin_code' => 'foo.admin',
+            'field' => 'barField',
+            'q' => 'sonata',
+        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+
+        $this->configureFormConfigComplexProperty('barField');
+        $datagrid = $this->configureAutocompleteItemsDatagrid();
+
+        $filter = new FooFilter();
+        $filter->initialize('entity.property');
+
+        $datagrid->hasFilter('entity.property')->willReturn(true);
+        $datagrid->getFilter('entity.property')->willReturn($filter);
+        $datagrid->setValue('entity__property', null, 'sonata')->shouldBeCalled();
+
+        $action = $this->action;
+        $response = $action($request);
+
+        $this->isInstanceOf(Response::class, $response);
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
+    }
+
+    private function configureAutocompleteItemsDatagrid()
+    {
+        $entity = new \stdClass();
+
+        $targetAdmin = $this->prophesize(AbstractAdmin::class);
+        $datagrid = $this->prophesize(DatagridInterface::class);
+        $metadata = $this->prophesize(Metadata::class);
+        $pager = $this->prophesize(Pager::class);
+        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
+
+        $this->admin->getNewInstance()->willReturn($entity);
+        $this->admin->setSubject($entity)->shouldBeCalled();
+        $this->admin->hasAccess('create')->willReturn(true);
+        $this->admin->getFormFieldDescription('barField')->willReturn($fieldDescription->reveal());
+        $this->admin->getFormFieldDescriptions()->willReturn(null);
+        $this->admin->id($entity)->willReturn(123);
+        $targetAdmin->checkAccess('list')->shouldBeCalled();
+        $targetAdmin->setFilterPersister(null)->shouldBeCalled();
+        $targetAdmin->getDatagrid()->willReturn($datagrid->reveal());
+        $targetAdmin->getObjectMetadata($entity)->willReturn($metadata->reveal());
+        $metadata->getTitle()->willReturn('FOO');
+
+        $datagrid->setValue('_per_page', null, 10)->shouldBeCalled();
+        $datagrid->setValue('_page', null, 1)->shouldBeCalled();
+        $datagrid->buildPager()->willReturn(null);
+        $datagrid->getPager()->willReturn($pager->reveal());
+        $pager->getResults()->willReturn([$entity]);
+        $pager->isLastPage()->willReturn(true);
+        $fieldDescription->getTargetEntity()->willReturn(Foo::class);
+        $fieldDescription->getName()->willReturn('barField');
+        $fieldDescription->getAssociationAdmin()->willReturn($targetAdmin->reveal());
+
+        return $datagrid;
+    }
+
+    private function configureFormConfig($field, $disabled = false)
+    {
+        $form = $this->prophesize(Form::class);
+        $formType = $this->prophesize(Form::class);
+        $formConfig = $this->prophesize(FormConfigInterface::class);
+
+        $this->admin->getForm()->willReturn($form->reveal());
+        $form->get($field)->willReturn($formType->reveal());
+        $formType->getConfig()->willReturn($formConfig->reveal());
+        $formConfig->getAttribute('disabled')->willReturn($disabled);
+        $formConfig->getAttribute('property')->willReturn('foo');
+        $formConfig->getAttribute('callback')->willReturn(null);
+        $formConfig->getAttribute('minimum_input_length')->willReturn(3);
+        $formConfig->getAttribute('items_per_page')->willReturn(10);
+        $formConfig->getAttribute('req_param_name_page_number')->willReturn('_page');
+        $formConfig->getAttribute('to_string_callback')->willReturn(null);
+        $formConfig->getAttribute('target_admin_access_action')->willReturn('list');
+    }
+
+    private function configureFormConfigComplexProperty($field)
+    {
+        $form = $this->prophesize(Form::class);
+        $formType = $this->prophesize(Form::class);
+        $formConfig = $this->prophesize(FormConfigInterface::class);
+
+        $this->admin->getForm()->willReturn($form->reveal());
+        $form->get($field)->willReturn($formType->reveal());
+        $formType->getConfig()->willReturn($formConfig->reveal());
+        $formConfig->getAttribute('disabled')->willReturn(false);
+        $formConfig->getAttribute('property')->willReturn('entity.property');
+        $formConfig->getAttribute('callback')->willReturn(null);
+        $formConfig->getAttribute('minimum_input_length')->willReturn(3);
+        $formConfig->getAttribute('items_per_page')->willReturn(10);
+        $formConfig->getAttribute('req_param_name_page_number')->willReturn('_page');
+        $formConfig->getAttribute('to_string_callback')->willReturn(null);
+        $formConfig->getAttribute('target_admin_access_action')->willReturn('list');
+    }
+
+    private function configureFormConfigComplexPropertyArray($field)
+    {
+        $form = $this->prophesize(Form::class);
+        $formType = $this->prophesize(Form::class);
+        $formConfig = $this->prophesize(FormConfigInterface::class);
+
+        $this->admin->getForm()->willReturn($form->reveal());
+        $form->get($field)->willReturn($formType->reveal());
+        $formType->getConfig()->willReturn($formConfig->reveal());
+        $formConfig->getAttribute('disabled')->willReturn(false);
+        $formConfig->getAttribute('property')->willReturn(['entity.property', 'entity2.property2']);
+        $formConfig->getAttribute('callback')->willReturn(null);
+        $formConfig->getAttribute('minimum_input_length')->willReturn(3);
+        $formConfig->getAttribute('items_per_page')->willReturn(10);
+        $formConfig->getAttribute('req_param_name_page_number')->willReturn('_page');
+        $formConfig->getAttribute('to_string_callback')->willReturn(null);
+        $formConfig->getAttribute('target_admin_access_action')->willReturn('list');
+    }
+}

--- a/tests/Action/RetrieveFormFieldElementActionTest.php
+++ b/tests/Action/RetrieveFormFieldElementActionTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
+use Sonata\AdminBundle\Action\RetrieveFormFieldElementAction;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminHelper;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormRenderer;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\Request;
+use Twig\Environment;
+
+final class RetrieveFormFieldElementActionTest extends TestCase
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var GetShortObjectDescriptionAction
+     */
+    private $action;
+
+    /**
+     * @var AbstractAdmin
+     */
+    private $admin;
+
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * @var AdminHelper
+     */
+    private $helper;
+
+    protected function setUp()
+    {
+        $this->twig = $this->prophesize(Environment::class);
+        $this->admin = $this->prophesize(AbstractAdmin::class);
+        $this->admin->setRequest(Argument::type(Request::class))->shouldBeCalled();
+        $this->pool = $this->prophesize(Pool::class);
+        $this->pool->getInstance(Argument::any())->willReturn($this->admin->reveal());
+        $this->helper = $this->prophesize(AdminHelper::class);
+        $this->action = new RetrieveFormFieldElementAction(
+            $this->twig->reveal(),
+            $this->pool->reveal(),
+            $this->helper->reveal()
+        );
+    }
+
+    public function testRetrieveFormFieldElementAction()
+    {
+        $object = new \stdClass();
+        $request = new Request([
+            'code' => 'sonata.post.admin',
+            'objectId' => 42,
+            'field' => 'enabled',
+            'value' => 1,
+            'context' => 'list',
+        ], [], [], [], [], ['REQUEST_METHOD' => 'POST']);
+
+        $modelManager = $this->prophesize(ModelManagerInterface::class);
+        $formView = new FormView();
+        $form = $this->prophesize(Form::class);
+        $formBuilder = $this->prophesize(FormBuilder::class);
+
+        $renderer = $this->configureFormRenderer();
+
+        $this->admin->getObject(42)->willReturn($object);
+        $this->admin->getClass()->willReturn(get_class($object));
+        $this->admin->setSubject($object)->shouldBeCalled();
+        $this->admin->getFormTheme()->willReturn($formView);
+        $this->admin->getFormBuilder()->willReturn($formBuilder->reveal());
+        $this->helper->getChildFormView($formView, null)
+            ->willReturn($formView);
+        $modelManager->find(get_class($object), 42)->willReturn($object);
+        $form->setData($object)->shouldBeCalled();
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->createView()->willReturn($formView);
+        $formBuilder->getForm()->willReturn($form->reveal());
+        $renderer->setTheme($formView, $formView)->shouldBeCalled();
+        $renderer->searchAndRenderBlock($formView, 'widget')->willReturn('block');
+
+        $action = $this->action;
+        $response = $action($request);
+
+        $this->isInstanceOf(Response::class, $response);
+        $this->assertSame($response->getContent(), 'block');
+    }
+
+    private function configureFormRenderer()
+    {
+        $runtime = $this->prophesize(FormRenderer::class);
+
+        // Remove the condition when dropping sf < 3.2
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $extension = $this->prophesize(FormExtension::class);
+
+            $this->twig->getExtension(FormExtension::class)->willReturn($extension->reveal());
+            $extension->initRuntime($this->twig->reveal())->shouldBeCalled();
+            $extension->renderer = $runtime->reveal();
+
+            return $runtime;
+        }
+
+        // Remove the condition when dropping sf < 3.4
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $twigRuntime = $this->prophesize(TwigRenderer::class);
+
+            $this->twig->getRuntime(TwigRenderer::class)->willReturn($twigRuntime->reveal());
+            $twigRuntime->setEnvironment($this->twig->reveal())->shouldBeCalled();
+
+            return $twigRuntime;
+        }
+
+        $this->twig->getRuntime(FormRenderer::class)->willReturn($runtime->reveal());
+
+        return $runtime;
+    }
+}

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -1,0 +1,294 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
+use Sonata\AdminBundle\Action\SetObjectFieldValueAction;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\FormRenderer;
+use Symfony\Component\Form\FormRendererEngineInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\RuntimeLoader\FactoryRuntimeLoader;
+use Twig\Template;
+
+class Foo
+{
+    public function setEnabled($value)
+    {
+    }
+}
+
+class Bar
+{
+    public function setEnabled($value)
+    {
+    }
+}
+
+class Baz
+{
+    private $bar;
+
+    public function setBar(Bar $bar)
+    {
+        $this->bar = $bar;
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+}
+
+final class SetObjectFieldValueActionTest extends TestCase
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * @var GetShortObjectDescriptionAction
+     */
+    private $action;
+
+    /**
+     * @var AbstractAdmin
+     */
+    private $admin;
+
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    protected function setUp()
+    {
+        $this->twig = new Environment(new ArrayLoader([
+            'admin_template' => 'renderedTemplate',
+            'field_template' => 'renderedTemplate',
+        ]));
+        $this->pool = $this->prophesize(Pool::class);
+        $this->admin = $this->prophesize(AbstractAdmin::class);
+        $this->pool->getInstance(Argument::any())->willReturn($this->admin->reveal());
+        $this->admin->setRequest(Argument::type(Request::class))->shouldBeCalled();
+        $this->validator = $this->prophesize(ValidatorInterface::class);
+        $this->action = new SetObjectFieldValueAction(
+            $this->twig,
+            $this->pool->reveal(),
+            $this->validator->reveal()
+        );
+    }
+
+    public function testSetObjectFieldValueAction()
+    {
+        $object = new Foo();
+        $request = new Request([
+            'code' => 'sonata.post.admin',
+            'objectId' => 42,
+            'field' => 'enabled',
+            'value' => 1,
+            'context' => 'list',
+        ], [], [], [], [], ['REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+
+        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
+        $pool = $this->prophesize(Pool::class);
+        $template = $this->prophesize(Template::class);
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $propertyAccessor = new PropertyAccessor();
+        $templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $this->admin->getObject(42)->willReturn($object);
+        $this->admin->getCode()->willReturn('sonata.post.admin');
+        $this->admin->hasAccess('edit', $object)->willReturn(true);
+        $this->admin->getListFieldDescription('enabled')->willReturn($fieldDescription->reveal());
+        $this->admin->update($object)->shouldBeCalled();
+        // NEXT_MAJOR: Remove this line
+        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
+        $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
+        $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
+        $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
+        $this->twig->addExtension(new SonataAdminExtension(
+            $pool->reveal(),
+            null,
+            $translator->reveal(),
+            $container->reveal()
+        ));
+        $fieldDescription->getOption('editable')->willReturn(true);
+        $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
+        $fieldDescription->getType()->willReturn('boolean');
+        $fieldDescription->getTemplate()->willReturn(false);
+        $fieldDescription->getValue(Argument::cetera())->willReturn('some value');
+
+        $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
+        $action = $this->action;
+        $response = $action($request);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testSetObjectFieldValueActionOnARelationField()
+    {
+        $object = new Baz();
+        $associationObject = new Bar();
+        $request = new Request([
+            'code' => 'sonata.post.admin',
+            'objectId' => 42,
+            'field' => 'bar',
+            'value' => 1,
+            'context' => 'list',
+        ], [], [], [], [], ['REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+
+        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
+        $modelManager = $this->prophesize(ModelManagerInterface::class);
+        $template = $this->prophesize(Template::class);
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $propertyAccessor = new PropertyAccessor();
+        $templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $this->admin->getObject(42)->willReturn($object);
+        $this->admin->getCode()->willReturn('sonata.post.admin');
+        $this->admin->hasAccess('edit', $object)->willReturn(true);
+        $this->admin->getListFieldDescription('bar')->willReturn($fieldDescription->reveal());
+        $this->admin->getClass()->willReturn(get_class($object));
+        $this->admin->update($object)->shouldBeCalled();
+        $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
+        // NEXT_MAJOR: Remove this line
+        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
+        $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
+        $this->admin->getModelManager()->willReturn($modelManager->reveal());
+        $this->twig->addExtension(new SonataAdminExtension(
+            $this->pool->reveal(),
+            null,
+            $translator->reveal(),
+            $container->reveal()
+        ));
+        $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
+        $fieldDescription->getType()->willReturn('choice');
+        $fieldDescription->getOption('editable')->willReturn(true);
+        $fieldDescription->getOption('class')->willReturn(Bar::class);
+        $fieldDescription->getTargetEntity()->willReturn(Bar::class);
+        $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
+        $fieldDescription->getTemplate()->willReturn('field_template');
+        $fieldDescription->getValue(Argument::cetera())->willReturn('some value');
+        $modelManager->find(get_class($associationObject), 1)->willReturn($associationObject);
+
+        $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
+        $action = $this->action;
+        $response = $action($request);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testSetObjectFieldValueActionWithViolations()
+    {
+        $bar = new Bar();
+        $object = new Baz();
+        $object->setBar($bar);
+        $request = new Request([
+            'code' => 'sonata.post.admin',
+            'objectId' => 42,
+            'field' => 'bar.enabled',
+            'value' => 1,
+            'context' => 'list',
+        ], [], [], [], [], ['REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+
+        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
+        $propertyAccessor = new PropertyAccessor();
+
+        $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
+        $this->admin->getObject(42)->willReturn($object);
+        $this->admin->hasAccess('edit', $object)->willReturn(true);
+        $this->admin->getListFieldDescription('bar.enabled')->willReturn($fieldDescription->reveal());
+        $this->validator->validate($bar)->willReturn(new ConstraintViolationList([
+            new ConstraintViolation('error1', null, [], null, 'enabled', null),
+            new ConstraintViolation('error2', null, [], null, 'enabled', null),
+        ]));
+        $fieldDescription->getOption('editable')->willReturn(true);
+        $fieldDescription->getType()->willReturn('boolean');
+
+        $action = $this->action;
+        $response = $action($request);
+
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame(json_encode("error1\nerror2"), $response->getContent());
+    }
+
+    private function configureFormRenderer()
+    {
+        $runtime = new FormRenderer($this->createMock(
+            FormRendererEngineInterface::class,
+            CsrfTokenManagerInterface::class
+        ));
+
+        // Remove the condition when dropping sf < 3.2
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $extension = new FormExtension();
+
+            $this->twig->addExtension($extension);
+            $extension->renderer = $runtime;
+
+            return $runtime;
+        }
+
+        // Remove the condition when dropping sf < 3.4
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $twigRuntime = $this->prophesize(TwigRenderer::class);
+
+            $this->twig->addRuntimeLoader(new FactoryRuntimeLoader(
+                FormRenderer::class,
+                function () use ($runtime) {
+                    return $runtime;
+                }
+            ));
+            $this->twig->getRuntime(TwigRenderer::class)->willReturn($twigRuntime->reveal());
+            $twigRuntime->setEnvironment($this->twig)->shouldBeCalled();
+
+            return $twigRuntime;
+        }
+
+        $this->twig->addRuntimeLoader(new FactoryRuntimeLoader(
+            FormRenderer::class,
+            function () use ($runtime) {
+                return $runtime;
+            }
+        ));
+
+        return $runtime;
+    }
+}

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -89,6 +89,9 @@ class AdminControllerHelper_Bar
     }
 }
 
+/**
+ * @group legacy
+ */
 class HelperControllerTest extends TestCase
 {
     /**


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `SonataAdminBundle\Controller\HelperController` is now deprecated in favor of actions
```

   
## To do
    
- [x] Continue copying/splitting the tests
- [x] Add an upgrade note
- [x] Test this on an actual project

