### PR TITLE
Fix timezone usage for datetime/time list and show template

### DIFF
--- a/src/Resources/views/CRUD/list_datetime.html.twig
+++ b/src/Resources/views/CRUD/list_datetime.html.twig
@@ -14,12 +14,7 @@ file that was distributed with this source code.
 {% block field %}
     {%- if value is empty -%}
         &nbsp;
-    {%- elseif field_description.options.format is defined -%}
-        {% set timezone = field_description.options.timezone is defined ? field_description.options.timezone : null %}
-        {{ value|date(field_description.options.format, timezone) }}
-    {%- elseif field_description.options.timezone is defined -%}
-        {{ value|date(null, field_description.options.timezone) }}
     {%- else -%}
-        {{ value|date }}
+        {{ value|date(field_description.options.format|default(null), field_description.options.timezone|default(null)) }}
     {%- endif -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_time.html.twig
+++ b/src/Resources/views/CRUD/list_time.html.twig
@@ -15,6 +15,6 @@ file that was distributed with this source code.
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}
-        {{ value|date('H:i:s') }}
+        {{ value|date('H:i:s', field_description.options.timezone|default(null)) }}
     {%- endif -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_datetime.html.twig
+++ b/src/Resources/views/CRUD/show_datetime.html.twig
@@ -14,9 +14,7 @@ file that was distributed with this source code.
 {% block field %}
     {%- if value is empty -%}
         &nbsp;
-    {%- elseif field_description.options.format is defined -%}
-        {{ value|date(field_description.options.format) }}
     {%- else -%}
-        {{ value|date }}
+        {{ value|date(field_description.options.format|default(null), field_description.options.timezone|default(null)) }}
     {%- endif -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_time.html.twig
+++ b/src/Resources/views/CRUD/show_time.html.twig
@@ -15,6 +15,6 @@ file that was distributed with this source code.
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}
-        {{ value|date('H:i:s') }}
+        {{ value|date('H:i:s', field_description.options.timezone|default(null)) }}
     {%- endif -%}
 {% endblock %}

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -522,6 +522,12 @@ class SonataAdminExtensionTest extends TestCase
                 [],
             ],
             [
+                '<td class="sonata-ba-list-field sonata-ba-list-field-time" objectId="12345"> 18:11:12 </td>',
+                'time',
+                new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('UTC')),
+                ['timezone' => 'Asia/Hong_Kong'],
+            ],
+            [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-time" objectId="12345"> &nbsp; </td>',
                 'time',
                 null,
@@ -1464,6 +1470,12 @@ EOT
                 ['format' => 'd.m.Y H:i:s'],
             ],
             [
+                '<th>Data</th> <td>December 24, 2013 18:11</td>',
+                'datetime',
+                new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('UTC')),
+                ['timezone' => 'Asia/Hong_Kong'],
+            ],
+            [
                 '<th>Data</th> <td>December 24, 2013</td>',
                 'date',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
@@ -1480,6 +1492,12 @@ EOT
                 'time',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 [],
+            ],
+            [
+                '<th>Data</th> <td>18:11:12</td>',
+                'time',
+                new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('UTC')),
+                ['timezone' => 'Asia/Hong_Kong'],
             ],
             ['<th>Data</th> <td>10.746135</td>', 'number', 10.746135, ['safe' => false]],
             ['<th>Data</th> <td>5678</td>', 'integer', 5678, ['safe' => false]],


### PR DESCRIPTION
I am targeting this branch (3.x), because Templating for `show_datetime`, `show_time` and `list_time` doesn't use TimeZone option to display date.

Closes #5156 

## Changelog
```markdown
### Changed
- Enable TimeZone for datetime and time templating
```

## Subject

As mentionned in issue #5156, the timezone is only set on `list_datetime` template. However the same behavior is expected for `list_time`, `show_datetime` and `show_time`. That's the goal of this PR