### PR TITLE
[WIP] Segregate AdminExtensionInterface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,14 @@
 UPGRADE 3.x
 ===========
 
+`Sonata\AdminBundle\Admin\AdminExtensionInterface` has been deprecated and segregated into single
+method interfaces, they can be found under the `Sonata\AdminBundle\Admin\Extension` namespace.
+
+`Sonata\AdminBundle\Admin\AbstractAdminExtension` has been deprecated without alternative.
+
+`Sonata\AdminBundle\Admin\AbstractAdmin::addExtension` has been deprecated, use
+`Sonata\AdminBundle\Admin\AbstractAdmin::addAdminExtension` instead.
+
 ## Deprecated `SonataAdminBundle\Controller\HelperController` in favor of actions
 
 If you extended that controller, you should split your extended controller and

--- a/docs/reference/extensions.rst
+++ b/docs/reference/extensions.rst
@@ -2,11 +2,11 @@ Extensions
 ==========
 
 Admin extensions allow you to add or change features of one or more Admin
-instances. To create an extension your class
-must implement the interface ``Sonata\AdminBundle\Admin\AdminExtensionInterface``
-and be registered as a service. The interface defines a number of functions which
-you can use to customize the edit form, list view, form validation, alter newly
-created objects and other admin features.
+instances. To create an extension your class must implement one or more interfaces
+in the ``Sonata\AdminBundle\Admin\Extension`` namespace and be registered as a service.
+The interface defines a number of functions which you can use to customize the
+edit form, list view, form validation, alter newly created objects and other admin
+features.
 
 .. note::
     This article assumes you are using Symfony 4. Using Symfony 2.8 or 3
@@ -15,11 +15,11 @@ created objects and other admin features.
 
 .. code-block:: php
 
-    use Sonata\AdminBundle\Admin\AbstractAdminExtension;
+    use Sonata\AdminBundle\Admin\Extension\ConfigureFormFieldsInterface;
     use Sonata\AdminBundle\Form\FormMapper;
     use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
-    class PublishStatusAdminExtension extends AbstractAdminExtension
+    class PublishStatusAdminExtension implements ConfigureFormFieldsInterface
     {
         public function configureFormFields(FormMapper $formMapper)
         {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -15,6 +15,30 @@ use Doctrine\Common\Util\ClassUtils;
 use Knp\Menu\FactoryInterface as MenuFactoryInterface;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\ItemInterface as MenuItemInterface;
+use Sonata\AdminBundle\Admin\AdminExtensionInterface as OldAdminExtensionInterface;
+use Sonata\AdminBundle\Admin\Extension\AdminExtensionInterface as NewAdminExtensionInterface;
+use Sonata\AdminBundle\Admin\Extension\AlterNewInstanceInterface;
+use Sonata\AdminBundle\Admin\Extension\AlterObjectInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureActionButtonsInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureBatchActionsInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureDatagridFieldsInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureDefaultFilterValuesInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureExportFieldsInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureFormFieldsInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureListFieldsInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureQueryInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureRoutesInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureShowFieldsInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureTabMenuInterface;
+use Sonata\AdminBundle\Admin\Extension\GetAccessMappingInterface;
+use Sonata\AdminBundle\Admin\Extension\GetPersistentParametersInterface;
+use Sonata\AdminBundle\Admin\Extension\PostPersistInterface;
+use Sonata\AdminBundle\Admin\Extension\PostRemoveInterface;
+use Sonata\AdminBundle\Admin\Extension\PostUpdateInterface;
+use Sonata\AdminBundle\Admin\Extension\PrePersistInterface;
+use Sonata\AdminBundle\Admin\Extension\PreRemoveInterface;
+use Sonata\AdminBundle\Admin\Extension\PreUpdateInterface;
+use Sonata\AdminBundle\Admin\Extension\ValidateInterface;
 use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
@@ -410,7 +434,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     protected $templates = [];
 
     /**
-     * @var AdminExtensionInterface[]
+     * @var OldAdminExtensionInterface|NewAdminExtensionInterface[]
      */
     protected $extensions = [];
 
@@ -599,8 +623,17 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         $fields = $this->getModelManager()->getExportFields($this->getClass());
 
         foreach ($this->getExtensions() as $extension) {
+            // NEXT_MAJOR: check if extension implements ConfigureExportFieldsInterface before calling the method
             if (method_exists($extension, 'configureExportFields')) {
                 $fields = $extension->configureExportFields($this, $fields);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof ConfigureExportFieldsInterface) {
+                $this->triggerExtensionDeprecationMessage(
+                    'configureExportFields',
+                    ConfigureExportFieldsInterface::class
+                );
             }
         }
 
@@ -657,7 +690,15 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     {
         $this->preUpdate($object);
         foreach ($this->extensions as $extension) {
-            $extension->preUpdate($this, $object);
+            // NEXT_MAJOR: check if extension implements PreUpdateInterface before calling the method
+            if (method_exists($extension, 'preUpdate')) {
+                $extension->preUpdate($this, $object);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof PreUpdateInterface) {
+                $this->triggerExtensionDeprecationMessage('preUpdate', PreUpdateInterface::class);
+            }
         }
 
         $result = $this->getModelManager()->update($object);
@@ -668,7 +709,15 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
         $this->postUpdate($object);
         foreach ($this->extensions as $extension) {
-            $extension->postUpdate($this, $object);
+            // NEXT_MAJOR: check if extension implements PostUpdateInterface before calling the method
+            if (method_exists($extension, 'postUpdate')) {
+                $extension->postUpdate($this, $object);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof PostUpdateInterface) {
+                $this->triggerExtensionDeprecationMessage('postUpdate', PostUpdateInterface::class);
+            }
         }
 
         return $object;
@@ -678,7 +727,15 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     {
         $this->prePersist($object);
         foreach ($this->extensions as $extension) {
-            $extension->prePersist($this, $object);
+            // NEXT_MAJOR: check if extension implements PrePersistInterface before calling the method
+            if (method_exists($extension, 'prePersist')) {
+                $extension->prePersist($this, $object);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof PrePersistInterface) {
+                $this->triggerExtensionDeprecationMessage('prePersist', PrePersistInterface::class);
+            }
         }
 
         $result = $this->getModelManager()->create($object);
@@ -689,7 +746,15 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
         $this->postPersist($object);
         foreach ($this->extensions as $extension) {
-            $extension->postPersist($this, $object);
+            // NEXT_MAJOR: check if extension implements PostPersistInterface before calling the method
+            if (method_exists($extension, 'postPersist')) {
+                $extension->postPersist($this, $object);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof PostPersistInterface) {
+                $this->triggerExtensionDeprecationMessage('postPersist', PostPersistInterface::class);
+            }
         }
 
         $this->createObjectSecurity($object);
@@ -701,7 +766,15 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     {
         $this->preRemove($object);
         foreach ($this->extensions as $extension) {
-            $extension->preRemove($this, $object);
+            // NEXT_MAJOR: check if extension implements PreRemoveInterface before calling the method
+            if (method_exists($extension, 'preRemove')) {
+                $extension->preRemove($this, $object);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof PreRemoveInterface) {
+                $this->triggerExtensionDeprecationMessage('preRemove', PreRemoveInterface::class);
+            }
         }
 
         $this->getSecurityHandler()->deleteObjectSecurity($this, $object);
@@ -709,7 +782,15 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
         $this->postRemove($object);
         foreach ($this->extensions as $extension) {
-            $extension->postRemove($this, $object);
+            // NEXT_MAJOR: check if extension implements PostRemoveInterface before calling the method
+            if (method_exists($extension, 'postRemove')) {
+                $extension->postRemove($this, $object);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof PostRemoveInterface) {
+                $this->triggerExtensionDeprecationMessage('postRemove', PostRemoveInterface::class);
+            }
         }
     }
 
@@ -840,7 +921,18 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         }
 
         foreach ($this->getExtensions() as $extension) {
-            $extension->configureDatagridFilters($mapper);
+            // NEXT_MAJOR: check if extension implements ConfigureDatagridFieldsInterface before calling the method
+            if (method_exists($extension, 'configureDatagridFilters')) {
+                $extension->configureDatagridFilters($mapper);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof ConfigureDatagridFieldsInterface) {
+                $this->triggerExtensionDeprecationMessage(
+                    'configureDatagridFilters',
+                    ConfigureDatagridFieldsInterface::class
+                );
+            }
         }
     }
 
@@ -1088,9 +1180,17 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         $actions = $this->configureBatchActions($actions);
 
         foreach ($this->getExtensions() as $extension) {
-            // TODO: remove method check in next major release
+            // NEXT_MAJOR: check if extension implements ConfigureBatchActionsInterface before calling the method
             if (method_exists($extension, 'configureBatchActions')) {
                 $actions = $extension->configureBatchActions($this, $actions);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof ConfigureBatchActionsInterface) {
+                $this->triggerExtensionDeprecationMessage(
+                    'configureBatchActions',
+                    ConfigureBatchActionsInterface::class
+                );
             }
         }
 
@@ -1229,7 +1329,18 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     {
         $object = $this->getModelManager()->getModelInstance($this->getClass());
         foreach ($this->getExtensions() as $extension) {
-            $extension->alterNewInstance($this, $object);
+            // NEXT_MAJOR: check if extension implements AlterNewInstanceInterface before calling the method
+            if (method_exists($extension, 'alterNewInstance')) {
+                $extension->alterNewInstance($this, $object);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof AlterNewInstanceInterface) {
+                $this->triggerExtensionDeprecationMessage(
+                    'alterNewInstance',
+                    AlterNewInstanceInterface::class
+                );
+            }
         }
 
         return $object;
@@ -1260,7 +1371,18 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         $this->configureFormFields($mapper);
 
         foreach ($this->getExtensions() as $extension) {
-            $extension->configureFormFields($mapper);
+            // NEXT_MAJOR: check if extension implements ConfigureFormFieldsInterface before calling the method
+            if (method_exists($extension, 'configureFormFields')) {
+                $extension->configureFormFields($mapper);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof ConfigureFormFieldsInterface) {
+                $this->triggerExtensionDeprecationMessage(
+                    'configureFormFields',
+                    ConfigureFormFieldsInterface::class
+                );
+            }
         }
 
         $this->attachInlineValidator();
@@ -1293,7 +1415,18 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     {
         $object = $this->getModelManager()->find($this->getClass(), $id);
         foreach ($this->getExtensions() as $extension) {
-            $extension->alterObject($this, $object);
+            // NEXT_MAJOR: check if extension implements AlterObjectInterface before calling the method
+            if (method_exists($extension, 'alterObject')) {
+                $extension->alterObject($this, $object);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof AlterObjectInterface) {
+                $this->triggerExtensionDeprecationMessage(
+                    'alterObject',
+                    AlterObjectInterface::class
+                );
+            }
         }
 
         return $object;
@@ -1324,7 +1457,15 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         $query = $this->getModelManager()->createQuery($this->getClass());
 
         foreach ($this->extensions as $extension) {
-            $extension->configureQuery($this, $query, $context);
+            // NEXT_MAJOR: check if extension implements ConfigureQueryInterface before calling the method
+            if (method_exists($extension, 'configureQuery')) {
+                $extension->configureQuery($this, $query, $context);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof ConfigureQueryInterface) {
+                $this->triggerExtensionDeprecationMessage('configureQuery', ConfigureQueryInterface::class);
+            }
         }
 
         return $query;
@@ -1357,7 +1498,18 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         $this->configureTabMenu($menu, $action, $childAdmin);
 
         foreach ($this->getExtensions() as $extension) {
-            $extension->configureTabMenu($this, $menu, $action, $childAdmin);
+            // NEXT_MAJOR: check if extension implements ConfigureTabMenuInterface before calling the method
+            if (method_exists($extension, 'configureTabMenu')) {
+                $extension->configureTabMenu($this, $menu, $action, $childAdmin);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof ConfigureTabMenuInterface) {
+                $this->triggerExtensionDeprecationMessage(
+                    'configureTabMenu',
+                    ConfigureTabMenuInterface::class
+                );
+            }
         }
 
         $this->menu = $menu;
@@ -1887,7 +2039,20 @@ EOT;
         $parameters = [];
 
         foreach ($this->getExtensions() as $extension) {
-            $params = $extension->getPersistentParameters($this);
+            $params = [];
+
+            // NEXT_MAJOR: check if extension implements GetPersistentParametersInterface before calling the method
+            if (method_exists($extension, 'getPersistentParameters')) {
+                $params = $extension->getPersistentParameters($this);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof GetPersistentParametersInterface) {
+                $this->triggerExtensionDeprecationMessage(
+                    'getPersistentParameters',
+                    GetPersistentParametersInterface::class
+                );
+            }
 
             if (!is_array($params)) {
                 throw new \RuntimeException(sprintf('The %s::getPersistentParameters must return an array', get_class($extension)));
@@ -2391,8 +2556,35 @@ EOT;
         return $this->filterTheme;
     }
 
-    public function addExtension(AdminExtensionInterface $extension)
+    public function addExtension(OldAdminExtensionInterface $extension)
     {
+        @trigger_error(
+            'Method "addExtension" is deprecated. Check "addAdminExtension".',
+            E_USER_DEPRECATED
+        );
+
+        $this->extensions[] = $extension;
+    }
+
+    /**
+     * NEXT_MAJOR: remove whole if and add only NewAdminExtensionInterface typehint.
+     *
+     * @param NewAdminExtensionInterface|OldAdminExtensionInterface $extension
+     */
+    public function addAdminExtension($extension)
+    {
+        if ($extension instanceof OldAdminExtensionInterface) {
+            @trigger_error(sprintf(
+                'Extensions implementing "%s" are deprecated since 3.x and will be removed in 4.0.'
+                .' Implement single-method interfaces from "Sonata\AdminBundle\Admin\Extension" namespace.',
+                OldAdminExtensionInterface::class
+            ), E_USER_DEPRECATED);
+        } elseif (!$extension instanceof NewAdminExtensionInterface) {
+            throw new \InvalidArgumentException(
+                'Extension has to implement one of the interfaces in "Sonata\AdminBundle\Admin\Extension" namespace.'
+            );
+        }
+
         $this->extensions[] = $extension;
     }
 
@@ -2675,9 +2867,17 @@ EOT;
         $list = $this->configureActionButtons($action, $object);
 
         foreach ($this->getExtensions() as $extension) {
-            // TODO: remove method check in next major release
+            // NEXT_MAJOR: check if extension implements ConfigureActionButtonsInterface before calling the method
             if (method_exists($extension, 'configureActionButtons')) {
                 $list = $extension->configureActionButtons($this, $list, $action, $object);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof ConfigureActionButtonsInterface) {
+                $this->triggerExtensionDeprecationMessage(
+                    'configureActionButtons',
+                    ConfigureActionButtonsInterface::class
+                );
             }
         }
 
@@ -2796,9 +2996,17 @@ EOT;
         $this->configureDefaultFilterValues($defaultFilterValues);
 
         foreach ($this->getExtensions() as $extension) {
-            // NEXT_MAJOR: remove method check in next major release
+            // NEXT_MAJOR: check if extension implements ConfigureDefaultFilterValuesInterface before calling the method
             if (method_exists($extension, 'configureDefaultFilterValues')) {
                 $extension->configureDefaultFilterValues($this, $defaultFilterValues);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof ConfigureDefaultFilterValuesInterface) {
+                $this->triggerExtensionDeprecationMessage(
+                    'configureDefaultFilterValues',
+                    ConfigureDefaultFilterValuesInterface::class
+                );
             }
         }
 
@@ -2877,7 +3085,18 @@ EOT;
         $this->configureShowFields($mapper);
 
         foreach ($this->getExtensions() as $extension) {
-            $extension->configureShowFields($mapper);
+            // NEXT_MAJOR: check if extension implements ConfigureShowFieldsInterface before calling the method
+            if (method_exists($extension, 'configureShowFields')) {
+                $extension->configureShowFields($mapper);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof ConfigureShowFieldsInterface) {
+                $this->triggerExtensionDeprecationMessage(
+                    'configureShowFields',
+                    ConfigureShowFieldsInterface::class
+                );
+            }
         }
     }
 
@@ -2917,7 +3136,18 @@ EOT;
         $this->configureListFields($mapper);
 
         foreach ($this->getExtensions() as $extension) {
-            $extension->configureListFields($mapper);
+            // NEXT_MAJOR: check if extension implements ConfigureListFieldsInterface before calling the method
+            if (method_exists($extension, 'configureListFields')) {
+                $extension->configureListFields($mapper);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof ConfigureListFieldsInterface) {
+                $this->triggerExtensionDeprecationMessage(
+                    'configureListFields',
+                    ConfigureListFieldsInterface::class
+                );
+            }
         }
 
         if ($this->hasRequest() && $this->getRequest()->isXmlHttpRequest()) {
@@ -3022,7 +3252,18 @@ EOT;
                 $admin->validate($errorElement, $object);
 
                 foreach ($admin->getExtensions() as $extension) {
-                    $extension->validate($admin, $errorElement, $object);
+                    // NEXT_MAJOR: check if extension implements ValidateInterface before calling the method
+                    if (method_exists($extension, 'validate')) {
+                        $extension->validate($admin, $errorElement, $object);
+                    }
+
+                    // NEXT_MAJOR: remove this conditional
+                    if (!$extension instanceof ValidateInterface) {
+                        $this->triggerExtensionDeprecationMessage(
+                            'validate',
+                            ValidateInterface::class
+                        );
+                    }
                 }
             },
             'serializingWarning' => true,
@@ -3061,9 +3302,14 @@ EOT;
         ], $this->getAccessMapping());
 
         foreach ($this->extensions as $extension) {
-            // TODO: remove method check in next major release
+            // NEXT_MAJOR: check if extension implements GetAccessMappingInterface before calling the method
             if (method_exists($extension, 'getAccessMapping')) {
                 $access = array_merge($access, $extension->getAccessMapping($this));
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof GetAccessMappingInterface) {
+                $this->triggerExtensionDeprecationMessage('getAccessMapping', GetAccessMappingInterface::class);
             }
         }
 
@@ -3075,6 +3321,21 @@ EOT;
      */
     protected function configureDefaultFilterValues(array &$filterValues)
     {
+    }
+
+    /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @param string $method
+     * @param string $class
+     */
+    private function triggerExtensionDeprecationMessage($method, $class)
+    {
+        @trigger_error(sprintf(
+            'Calling "%s" without implementing "%s" in your extension is deprecated.',
+            $method,
+            $class
+        ), E_USER_DEPRECATED);
     }
 
     /**
@@ -3100,7 +3361,18 @@ EOT;
         $this->configureRoutes($this->routes);
 
         foreach ($this->getExtensions() as $extension) {
-            $extension->configureRoutes($this, $this->routes);
+            // NEXT_MAJOR: check if extension implements ConfigureRoutesInterface before calling the method
+            if (method_exists($extension, 'configureRoutes')) {
+                $extension->configureRoutes($this, $this->routes);
+            }
+
+            // NEXT_MAJOR: remove this conditional
+            if (!$extension instanceof ConfigureRoutesInterface) {
+                $this->triggerExtensionDeprecationMessage(
+                    'configureRoutes',
+                    ConfigureRoutesInterface::class
+                );
+            }
         }
     }
 }

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -20,6 +20,11 @@ use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\CoreBundle\Validator\ErrorElement;
 
+@trigger_error(sprintf(
+    '"%s" is deprecated since 3.x and will be removed in 4.0.',
+    AbstractAdminExtension::class
+), E_USER_DEPRECATED);
+
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -12,29 +12,34 @@
 namespace Sonata\AdminBundle\Admin;
 
 use Knp\Menu\ItemInterface as MenuItemInterface;
-use Sonata\AdminBundle\Datagrid\DatagridMapper;
-use Sonata\AdminBundle\Datagrid\ListMapper;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Route\RouteCollection;
-use Sonata\AdminBundle\Show\ShowMapper;
-use Sonata\CoreBundle\Validator\ErrorElement;
+use Sonata\AdminBundle\Admin\Extension\AlterNewInstanceInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureDatagridFieldsInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureFormFieldsInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureListFieldsInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureQueryInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureRoutesInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureShowFieldsInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureTabMenuInterface;
+use Sonata\AdminBundle\Admin\Extension\GetPersistentParametersInterface;
+use Sonata\AdminBundle\Admin\Extension\PostPersistInterface;
+use Sonata\AdminBundle\Admin\Extension\PostRemoveInterface;
+use Sonata\AdminBundle\Admin\Extension\PostUpdateInterface;
+use Sonata\AdminBundle\Admin\Extension\PrePersistInterface;
+use Sonata\AdminBundle\Admin\Extension\PreRemoveInterface;
+use Sonata\AdminBundle\Admin\Extension\PreUpdateInterface;
+use Sonata\AdminBundle\Admin\Extension\ValidateInterface;
+
+@trigger_error(sprintf(
+    '"%s" is deprecated since 3.x and will be removed in 4.0.'
+    .' Implement single interfaces from "Sonata\AdminBundle\Admin\Extension" namespace.',
+    AdminExtensionInterface::class
+), E_USER_DEPRECATED);
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-interface AdminExtensionInterface
+interface AdminExtensionInterface extends ConfigureFormFieldsInterface, ConfigureListFieldsInterface, ConfigureDatagridFieldsInterface, ConfigureShowFieldsInterface, ConfigureRoutesInterface, ConfigureTabMenuInterface, ValidateInterface, ConfigureQueryInterface, AlterNewInstanceInterface, GetPersistentParametersInterface, PreUpdateInterface, PostUpdateInterface, PrePersistInterface, PostPersistInterface, PreRemoveInterface, PostRemoveInterface
 {
-    public function configureFormFields(FormMapper $formMapper);
-
-    public function configureListFields(ListMapper $listMapper);
-
-    public function configureDatagridFilters(DatagridMapper $datagridMapper);
-
-    public function configureShowFields(ShowMapper $showMapper);
-
-    public function configureRoutes(AdminInterface $admin, RouteCollection $collection);
-
     /**
      * DEPRECATED: Use configureTabMenu instead.
      *
@@ -51,50 +56,7 @@ interface AdminExtensionInterface
         AdminInterface $childAdmin = null
     );
 
-    /**
-     * Builds the tab menu.
-     *
-     * @param string $action
-     */
-    public function configureTabMenu(
-        AdminInterface $admin,
-        MenuItemInterface $menu,
-        $action,
-        AdminInterface $childAdmin = null
-    );
-
-    /**
-     * @param mixed $object
-     */
-    public function validate(AdminInterface $admin, ErrorElement $errorElement, $object);
-
-    /**
-     * @param string $context
-     */
-    public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list');
-
-    /**
-     * Get a chance to modify a newly created instance.
-     *
-     * @param mixed $object
-     */
-    public function alterNewInstance(AdminInterface $admin, $object);
-
-    /**
-     * Get a chance to modify object instance.
-     *
-     * @param mixed $object
-     */
-    public function alterObject(AdminInterface $admin, $object);
-
-    /**
-     * Get a chance to add persistent parameters.
-     *
-     * @return array
-     */
-    public function getPersistentParameters(AdminInterface $admin);
-
-    /**
+    /*
      * Return the controller access mapping.
      *
      * @return array
@@ -102,7 +64,7 @@ interface AdminExtensionInterface
     // TODO: Uncomment in next major release
     // public function getAccessMapping(AdminInterface $admin);
 
-    /**
+    /*
      * Returns the list of batch actions.
      *
      * @param array $actions
@@ -112,7 +74,7 @@ interface AdminExtensionInterface
     // TODO: Uncomment in next major release
     // public function configureBatchActions(AdminInterface $admin, array $actions);
 
-    /**
+    /*
      * Get a chance to modify export fields.
      *
      * @param string[] $fields
@@ -121,36 +83,6 @@ interface AdminExtensionInterface
      */
     // TODO: Uncomment in next major release
     // public function configureExportFields(AdminInterface $admin, array $fields);
-
-    /**
-     * @param mixed $object
-     */
-    public function preUpdate(AdminInterface $admin, $object);
-
-    /**
-     * @param mixed $object
-     */
-    public function postUpdate(AdminInterface $admin, $object);
-
-    /**
-     * @param mixed $object
-     */
-    public function prePersist(AdminInterface $admin, $object);
-
-    /**
-     * @param mixed $object
-     */
-    public function postPersist(AdminInterface $admin, $object);
-
-    /**
-     * @param mixed $object
-     */
-    public function preRemove(AdminInterface $admin, $object);
-
-    /**
-     * @param mixed $object
-     */
-    public function postRemove(AdminInterface $admin, $object);
 
     /*
      * Get all action buttons for an action

--- a/src/Admin/Extension/AdminExtensionInterface.php
+++ b/src/Admin/Extension/AdminExtensionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface AdminExtensionInterface
+{
+}

--- a/src/Admin/Extension/AlterNewInstanceInterface.php
+++ b/src/Admin/Extension/AlterNewInstanceInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface AlterNewInstanceInterface extends AdminExtensionInterface
+{
+    /**
+     * Get a chance to modify a newly created instance.
+     *
+     * @param mixed $object
+     */
+    public function alterNewInstance(AdminInterface $admin, $object);
+}

--- a/src/Admin/Extension/AlterObjectInterface.php
+++ b/src/Admin/Extension/AlterObjectInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface AlterObjectInterface extends AdminExtensionInterface
+{
+    /**
+     * Get a chance to modify object instance.
+     *
+     * @param mixed $object
+     */
+    public function alterObject(AdminInterface $admin, $object);
+}

--- a/src/Admin/Extension/ConfigureActionButtonsInterface.php
+++ b/src/Admin/Extension/ConfigureActionButtonsInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureActionButtonsInterface extends AdminExtensionInterface
+{
+    /*
+     * Get all action buttons for an action
+     *
+     * @param string $action
+     * @param mixed $object
+     *
+     * @return array
+     */
+    public function configureActionButtons(AdminInterface $admin, array $list, $action, $object);
+}

--- a/src/Admin/Extension/ConfigureBatchActionsInterface.php
+++ b/src/Admin/Extension/ConfigureBatchActionsInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureBatchActionsInterface extends AdminExtensionInterface
+{
+    /**
+     * Returns the list of batch actions.
+     *
+     * @return array
+     */
+    public function configureBatchActions(AdminInterface $admin, array $actions);
+}

--- a/src/Admin/Extension/ConfigureDatagridFieldsInterface.php
+++ b/src/Admin/Extension/ConfigureDatagridFieldsInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureDatagridFieldsInterface extends AdminExtensionInterface
+{
+    public function configureDatagridFilters(DatagridMapper $datagridMapper);
+}

--- a/src/Admin/Extension/ConfigureDefaultFilterValuesInterface.php
+++ b/src/Admin/Extension/ConfigureDefaultFilterValuesInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureDefaultFilterValuesInterface extends AdminExtensionInterface
+{
+    /**
+     * Returns a list of default filters.
+     */
+    public function configureDefaultFilterValues(AdminInterface $admin, array &$filterValues);
+}

--- a/src/Admin/Extension/ConfigureExportFieldsInterface.php
+++ b/src/Admin/Extension/ConfigureExportFieldsInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureExportFieldsInterface extends AdminExtensionInterface
+{
+    /**
+     * Get a chance to modify export fields.
+     *
+     * @param string[] $fields
+     *
+     * @return string[]
+     */
+    public function configureExportFields(AdminInterface $admin, array $fields);
+}

--- a/src/Admin/Extension/ConfigureFormFieldsInterface.php
+++ b/src/Admin/Extension/ConfigureFormFieldsInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Form\FormMapper;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureFormFieldsInterface extends AdminExtensionInterface
+{
+    public function configureFormFields(FormMapper $formMapper);
+}

--- a/src/Admin/Extension/ConfigureListFieldsInterface.php
+++ b/src/Admin/Extension/ConfigureListFieldsInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Datagrid\ListMapper;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureListFieldsInterface extends AdminExtensionInterface
+{
+    public function configureListFields(ListMapper $listMapper);
+}

--- a/src/Admin/Extension/ConfigureQueryInterface.php
+++ b/src/Admin/Extension/ConfigureQueryInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureQueryInterface extends AdminExtensionInterface
+{
+    /**
+     * @param string $context
+     */
+    public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list');
+}

--- a/src/Admin/Extension/ConfigureRoutesInterface.php
+++ b/src/Admin/Extension/ConfigureRoutesInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Route\RouteCollection;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureRoutesInterface extends AdminExtensionInterface
+{
+    public function configureRoutes(AdminInterface $admin, RouteCollection $collection);
+}

--- a/src/Admin/Extension/ConfigureShowFieldsInterface.php
+++ b/src/Admin/Extension/ConfigureShowFieldsInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Show\ShowMapper;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureShowFieldsInterface extends AdminExtensionInterface
+{
+    public function configureShowFields(ShowMapper $showMapper);
+}

--- a/src/Admin/Extension/ConfigureTabMenuInterface.php
+++ b/src/Admin/Extension/ConfigureTabMenuInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Knp\Menu\ItemInterface as MenuItemInterface;
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureTabMenuInterface extends AdminExtensionInterface
+{
+    /**
+     * Builds the tab menu.
+     *
+     * @param string $action
+     */
+    public function configureTabMenu(
+        AdminInterface $admin,
+        MenuItemInterface $menu,
+        $action,
+        AdminInterface $childAdmin = null
+    );
+}

--- a/src/Admin/Extension/GetAccessMappingInterface.php
+++ b/src/Admin/Extension/GetAccessMappingInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface GetAccessMappingInterface extends AdminExtensionInterface
+{
+    /**
+     * Return the controller access mapping.
+     *
+     * @return array
+     */
+    public function getAccessMapping(AdminInterface $admin);
+}

--- a/src/Admin/Extension/GetPersistentParametersInterface.php
+++ b/src/Admin/Extension/GetPersistentParametersInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface GetPersistentParametersInterface extends AdminExtensionInterface
+{
+    /**
+     * Get a chance to add persistent parameters.
+     *
+     * @return array
+     */
+    public function getPersistentParameters(AdminInterface $admin);
+}

--- a/src/Admin/Extension/LockExtension.php
+++ b/src/Admin/Extension/LockExtension.php
@@ -20,9 +20,11 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
 /**
+ * NEXT_MAJOR: Remove extending of AbstractAdminExtension.
+ *
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
  */
-class LockExtension extends AbstractAdminExtension
+class LockExtension extends AbstractAdminExtension implements ConfigureFormFieldsInterface, PreUpdateInterface
 {
     /**
      * @var string

--- a/src/Admin/Extension/PostPersistInterface.php
+++ b/src/Admin/Extension/PostPersistInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface PostPersistInterface extends AdminExtensionInterface
+{
+    /**
+     * @param mixed $object
+     */
+    public function postPersist(AdminInterface $admin, $object);
+}

--- a/src/Admin/Extension/PostRemoveInterface.php
+++ b/src/Admin/Extension/PostRemoveInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface PostRemoveInterface extends AdminExtensionInterface
+{
+    /**
+     * @param mixed $object
+     */
+    public function postRemove(AdminInterface $admin, $object);
+}

--- a/src/Admin/Extension/PostUpdateInterface.php
+++ b/src/Admin/Extension/PostUpdateInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface PostUpdateInterface extends AdminExtensionInterface
+{
+    /**
+     * @param mixed $object
+     */
+    public function postUpdate(AdminInterface $admin, $object);
+}

--- a/src/Admin/Extension/PrePersistInterface.php
+++ b/src/Admin/Extension/PrePersistInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface PrePersistInterface extends AdminExtensionInterface
+{
+    /**
+     * @param mixed $object
+     */
+    public function prePersist(AdminInterface $admin, $object);
+}

--- a/src/Admin/Extension/PreRemoveInterface.php
+++ b/src/Admin/Extension/PreRemoveInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface PreRemoveInterface extends AdminExtensionInterface
+{
+    /**
+     * @param mixed $object
+     */
+    public function preRemove(AdminInterface $admin, $object);
+}

--- a/src/Admin/Extension/PreUpdateInterface.php
+++ b/src/Admin/Extension/PreUpdateInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface PreUpdateInterface extends AdminExtensionInterface
+{
+    /**
+     * @param mixed $object
+     */
+    public function preUpdate(AdminInterface $admin, $object);
+}

--- a/src/Admin/Extension/ValidateInterface.php
+++ b/src/Admin/Extension/ValidateInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\CoreBundle\Validator\ErrorElement;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ValidateInterface extends AdminExtensionInterface
+{
+    /**
+     * @param mixed $object
+     */
+    public function validate(AdminInterface $admin, ErrorElement $errorElement, $object);
+}

--- a/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -79,7 +79,7 @@ class ExtensionCompilerPass implements CompilerPassInterface
             $admin = $container->getDefinition($target);
 
             foreach (array_values($extensions) as $extension) {
-                $admin->addMethodCall('addExtension', [$extension]);
+                $admin->addMethodCall('addAdminExtension', [$extension]);
             }
         }
     }

--- a/tests/Action/AppendFormFieldElementActionTest.php
+++ b/tests/Action/AppendFormFieldElementActionTest.php
@@ -63,6 +63,9 @@ final class AppendFormFieldElementActionTest extends TestCase
      */
     private $helper;
 
+    /**
+     * @group legacy
+     */
     protected function setUp()
     {
         $this->twig = $this->prophesize(Environment::class);

--- a/tests/Admin/Extension/LockExtensionTest.php
+++ b/tests/Admin/Extension/LockExtensionTest.php
@@ -59,6 +59,10 @@ class LockExtensionTest extends TestCase
      */
     private $request;
 
+    /**
+     * @group legacy
+     * @expectedDeprecation "Sonata\AdminBundle\Admin\AbstractAdminExtension" is deprecated since 3.x and will be removed in 4.0.
+     */
     protected function setUp()
     {
         $this->modelManager = $this->prophesize(LockInterface::class);

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -16,7 +16,7 @@ use Knp\Menu\Matcher\MatcherInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
-use Sonata\AdminBundle\Admin\AdminExtensionInterface;
+use Sonata\AdminBundle\Admin\Extension\AdminExtensionInterface;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
 use Sonata\AdminBundle\Tests\Fixtures\DependencyInjection\TimestampableTrait;
@@ -232,6 +232,8 @@ class ExtensionCompilerPassTest extends TestCase
     }
 
     /**
+     * @group legacy
+     * @expectedDeprecation Extensions implementing "Sonata\AdminBundle\Admin\AdminExtensionInterface" are deprecated since 3.x and will be removed in 4.0. Implement single-method interfaces from "Sonata\AdminBundle\Admin\Extension" namespace.
      * @covers \Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass::process
      */
     public function testProcess()

--- a/tests/Fixtures/Admin/Extension/DummyExtension.php
+++ b/tests/Fixtures/Admin/Extension/DummyExtension.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\Extension\AdminExtensionInterface;
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+class DummyExtension implements AdminExtensionInterface
+{
+    public function configureBatchActions(AdminInterface $admin, array $actions)
+    {
+        return [];
+    }
+
+    public function configureActionButtons(AdminInterface $admin, $list, $action, $object)
+    {
+        return [];
+    }
+
+    public function configureDefaultFilterValues(AdminInterface $admin, array &$filterValues)
+    {
+        return [];
+    }
+}

--- a/tests/Menu/Matcher/Voter/AdminVoterTest.php
+++ b/tests/Menu/Matcher/Voter/AdminVoterTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class AdminVoterTest extends AbstractVoterTest
 {
     /**
-     * {@inheritdoc}
+     * @group legacy
      */
     public function provideData()
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Separated Sonata\AdminBundle\Admin\AdminExtensionInterface into single method
interfaces inside of Sonata\AdminBundle\Admin\Extension namespace

### Deprecated
- Sonata\AdminBundle\Admin\AdminExtensionInterface
- Sonata\AdminBundle\Admin\AbstractAdminExtension
- Sonata\AdminBundle\Admin\AbstractAdmin::addExtension
- Sonata\AdminBundle\Admin\AbstractAdmin:: addAdminExtension with old interface
- Using any of the extension methods without implementing its interface
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
 -->

 ## To do
    
- [x] Update the tests
- [x] Update the documentation
- [x] Update the changelog
- [x] Add an upgrade note

## Subject

Before I continue with this, just confirm to me that this is the right way?