### PR TITLE
Trigger event manually when iCheck input has changed

### DIFF
--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -101,10 +101,16 @@ var Admin = {
         if (window.SONATA_CONFIG && window.SONATA_CONFIG.USE_ICHECK) {
             Admin.log('[core|setup_icheck] configure iCheck on', subject);
 
-            jQuery("input[type='checkbox']:not('label.btn>input'), input[type='radio']:not('label.btn>input')", subject).iCheck({
-                checkboxClass: 'icheckbox_square-blue',
-                radioClass: 'iradio_square-blue'
-            });
+            jQuery("input[type='checkbox']:not('label.btn>input'), input[type='radio']:not('label.btn>input')", subject)
+                .iCheck({
+                    checkboxClass: 'icheckbox_square-blue',
+                    radioClass: 'iradio_square-blue'
+                })
+                // See https://github.com/fronteed/iCheck/issues/244
+                .on('ifToggled', function (e) {
+                    $(e.target).trigger('change');
+                })
+            ;
         }
     },
     /**


### PR DESCRIPTION
I am targeting this branch, because it's a bugfix.

## Changelog

```markdown
### Fixed
- Fixed iCheck inputs not triggering change event
```
## Subject

Currently, the iCheck lib does not trigger the change event, despite an old issue / PR (see https://github.com/fronteed/iCheck/issues/244). This PR fixes it until it's fixed.