### PR TITLE
Improve hint to exception message

### DIFF
--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -184,6 +184,21 @@ class PoolTest extends TestCase
         $this->pool->getInstance('sonata.news.admin.post');
     }
 
+    public function testGetInstanceWithUndefinedServiceIdAndExistsOther()
+    {
+        $this->pool->setAdminServiceIds([
+            'sonata.news.admin.post',
+            'sonata.news.admin.category',
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Admin service "sonata.news.admin.pos" not found in admin pool. '
+            .'Did you mean "sonata.news.admin.post" '
+            .'or one of those: [sonata.news.admin.category]?');
+
+        $this->pool->getInstance('sonata.news.admin.pos');
+    }
+
     public function testGetAdminByAdminCode()
     {
         $this->pool->setAdminServiceIds(['sonata.news.admin.post']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because is improve.
ref 56b0201c63c50e61e6bb002c78fdd1991924d347 

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `levenshtein` to improve an error message. 
```

## Subject

Now the most-matched phrase is displayed. In addition, a list of all admin services is also displayed.
