### PR TITLE
Use consistent admin uniqids

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1866,7 +1866,7 @@ EOT;
     public function getUniqid()
     {
         if (!$this->uniqid) {
-            $this->uniqid = 's'.uniqid();
+            $this->uniqid = 's'.crc32($this->getBaseCodeRoute());
         }
 
         return $this->uniqid;

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -656,7 +656,7 @@ class AdminTest extends TestCase
      * @covers \Sonata\AdminBundle\Admin\AbstractAdmin::setUniqid
      * @covers \Sonata\AdminBundle\Admin\AbstractAdmin::getUniqid
      */
-    public function testUniqid()
+    public function testSetUniqid()
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
@@ -664,6 +664,33 @@ class AdminTest extends TestCase
         $admin->setUniqid($uniqid);
 
         $this->assertSame($uniqid, $admin->getUniqid());
+    }
+
+    public function testUniqidConsistency()
+    {
+        $admin = $this->getMockForAbstractClass(AbstractAdmin::class, [
+            'sonata.abstract.admin',
+            'AbstractBundle\Entity\Foo',
+            'SonataAbstractBundle:FooAdmin',
+        ]);
+        $admin->initialize();
+
+        $uniqid = $admin->getUniqid();
+        $admin->setUniqid(null);
+
+        $this->assertSame($uniqid, $admin->getUniqid());
+
+        $parentAdmin = $this->getMockForAbstractClass(AbstractAdmin::class, [
+            'sonata.abstract.parent.admin',
+            'AbstractBundle\Entity\Bar',
+            'SonataAbstractBundle:BarAdmin',
+        ]);
+        $parentAdmin->initialize();
+
+        $admin->setParent($parentAdmin);
+        $admin->setUniqid(null);
+
+        $this->assertNotSame($uniqid, $admin->getUniqid());
     }
 
     public function testToString()


### PR DESCRIPTION
I am targeting this branch, because it's a BC improvement.

## Changelog

```markdown
### Changed
- Admin uniqids are now more consistent
```
## Subject

Currently, a new admin uniqid will be generated on each page load. With this PR, it will stay the same as it's now generated from the "base code route", which includes the parents codes separated by pipes (ex: `parent.admin.code|child.admin.code`). The crc32 function is used to generate a **short** hash.

I need this because I'm trying to add the [Garlicjs](http://garlicjs.org/) lib to the admin (allow form data persistence on page change), but as fields name contain the admin uniqid, they always change, so it can't work.