### PR TITLE
Added Dutch translation for link_edit

### DIFF
--- a/src/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.nl.xliff
@@ -74,6 +74,10 @@
                 <source>link_add</source>
                 <target>Nieuwe toevoegen</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Bewerken</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Lijst</target>


### PR DESCRIPTION
I am targeting this branch, because this is a bugfix.



<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->


## Subject

I noticed that the translation of edit buttons where incorrect, because the translation for the `link_edit` was missing in the Dutch language file. This PR adds the correct translation.