### PR TITLE
Fixing checks on menu item display to use the menu context.

### DIFF
--- a/src/Menu/Provider/GroupMenuProvider.php
+++ b/src/Menu/Provider/GroupMenuProvider.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Menu\Provider;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\Pool;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
@@ -130,7 +131,7 @@ class GroupMenuProvider implements MenuProviderInterface
             $admin = $this->pool->getInstance($item['admin']);
 
             // skip menu item if no `list` url is available or user doesn't have the LIST access rights
-            return $admin->hasRoute('list') && $admin->hasAccess('list');
+            return $admin->hasRoute('list') && $admin->hasAccess('list') && $admin->showIn(AbstractAdmin::CONTEXT_MENU);
         }
 
         //NEXT_MAJOR: Remove if statement of null checker.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the changes does not include BC-break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed context checks before displaying side menu items

```



## To do
    
- [ ] Update the tests

## Subject
Fixing the conditions to display the side menu's items to use the context [like in the pool](https://github.com/sonata-project/SonataAdminBundle/blob/2cc7f12fed349c71920d3101f46997219243536e/src/Admin/Pool.php#L142)
