### PR TITLE
Fix tab id when it contains backslash

### DIFF
--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -35,7 +35,7 @@
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">
                                 {% for name, form_tab in admin.formtabs %}
-                                    {% set _tab_name = ('tab_'~admin.code~'_'~loop.index)|replace({'.': '_'}) %}
+                                    {% set _tab_name = ('tab_'~admin.code~'_'~loop.index)|replace({'.': '_', '\\': '_'}) %}
                                     <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (app.request.query.get('_tab') == _tab_name) %} class="active"{% endif %}>
                                         <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
                                             <i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i> {{ form_tab.label|trans({}, form_tab.translation_domain ?: admin.translationDomain) }}
@@ -45,7 +45,7 @@
                             </ul>
                             <div class="tab-content">
                                 {% for code, form_tab in admin.formtabs %}
-                                    {% set _tab_name = ('tab_'~admin.code~'_'~loop.index)|replace({'.': '_'}) %}
+                                    {% set _tab_name = ('tab_'~admin.code~'_'~loop.index)|replace({'.': '_', '\\': '_'}) %}
                                     <div class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (app.request.query.get('_tab') == _tab_name) %} in active{% endif %}" id="{{ _tab_name }}">
                                         <div class="box-body  container-fluid">
                                             <div class="sonata-ba-collapsed-fields">

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -41,7 +41,7 @@ file that was distributed with this source code.
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs" role="tablist">
                     {% for name, show_tab in admin.showtabs %}
-                        {% set _tab_name = ('tab_'~admin.code~'_'~loop.index)|replace({'.': '_'}) %}
+                        {% set _tab_name = ('tab_'~admin.code~'_'~loop.index)|replace({'.': '_', '\\': '_'}) %}
                         <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (app.request.query.get('_tab') == _tab_name) %} class="active"{% endif %}>
                             <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
                                 {{ show_tab.label|trans({}, show_tab.translation_domain ?: admin.translationDomain) }}
@@ -52,7 +52,7 @@ file that was distributed with this source code.
 
                 <div class="tab-content">
                     {% for code, show_tab in admin.showtabs %}
-                        {% set _tab_name = ('tab_'~admin.code~'_'~loop.index)|replace({'.': '_'}) %}
+                        {% set _tab_name = ('tab_'~admin.code~'_'~loop.index)|replace({'.': '_', '\\': '_'}) %}
                         <div
                             class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (app.request.query.get('_tab') == _tab_name) %} in active{% endif %}"
                             id="{{ _tab_name }}"


### PR DESCRIPTION
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #5188 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed tab id when the Admin Id contains backslashes
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

<!-- Describe your Pull Request content here -->
If you define your Admin classes with the FQCN, in the edit/show page tab id is something like `tab_App\YourBundle\Admin\PostAdmin_1` and apparently [backslashes do not work properly with jQuery](https://stackoverflow.com/questions/5825948/jquery-selectors-and-backslashes) (you have to escape them). So tabs don't work and it also fails when [it tries to change the hash of the URL](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Resources/public/Admin.js#L709).