### PR TITLE
[CRUD:Edit] Add exception message

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -300,8 +300,8 @@ class CRUDController implements ContainerAwareInterface
      *
      * @param int|string|null $id
      *
-     * @throws \RuntimeException     If no editable field is defined
      * @throws NotFoundHttpException If the object does not exist
+     * @throws \RuntimeException     If no editable field is defined
      * @throws AccessDeniedException If access is not granted
      *
      * @return Response|RedirectResponse

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -332,8 +332,9 @@ class CRUDController implements ContainerAwareInterface
         $objectId = $this->admin->getNormalizedIdentifier($existingObject);
 
         if (!$this->admin->getFormTabs()) {
-            throw new \RuntimeException('No editable field defined.
-            Did you forget to implement the "configureFormFields" method?');
+            throw new \RuntimeException(
+                'No editable field defined. Did you forget to implement the "configureFormFields" method?'
+            );
         }
 
         /** @var $form Form */

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -300,7 +300,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @param int|string|null $id
      *
-     * @throws \RuntimeException If no editable attribut is defined
+     * @throws \RuntimeException     If no editable attribut is defined
      * @throws NotFoundHttpException If the object does not exist
      * @throws AccessDeniedException If access is not granted
      *

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -332,7 +332,7 @@ class CRUDController implements ContainerAwareInterface
         $objectId = $this->admin->getNormalizedIdentifier($existingObject);
 
         if (!$this->admin->getFormTabs()) {
-            throw new \RuntimeException(sprintf('No editable field defined. Did you forget to implement the "configureFormFields" method?'));
+            throw new \RuntimeException('No editable field defined. Did you forget to implement the "configureFormFields" method?');
         }
 
         /** @var $form Form */

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -300,7 +300,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @param int|string|null $id
      *
-     * @throws \RuntimeException     If no editable attribut is defined
+     * @throws \RuntimeException     If no editable field is defined
      * @throws NotFoundHttpException If the object does not exist
      * @throws AccessDeniedException If access is not granted
      *

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -300,6 +300,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @param int|string|null $id
      *
+     * @throws \RuntimeException If no editable attribut is defined
      * @throws NotFoundHttpException If the object does not exist
      * @throws AccessDeniedException If access is not granted
      *
@@ -329,6 +330,10 @@ class CRUDController implements ContainerAwareInterface
 
         $this->admin->setSubject($existingObject);
         $objectId = $this->admin->getNormalizedIdentifier($existingObject);
+
+        if (!$this->admin->getFormTabs()) {
+            throw new \RuntimeException(sprintf('No editable field defined. Did you forget to implement the "configureFormFields" method?'));
+        }
 
         /** @var $form Form */
         $form = $this->admin->getForm();

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -332,7 +332,8 @@ class CRUDController implements ContainerAwareInterface
         $objectId = $this->admin->getNormalizedIdentifier($existingObject);
 
         if (!$this->admin->getFormTabs()) {
-            throw new \RuntimeException('No editable field defined. Did you forget to implement the "configureFormFields" method?');
+            throw new \RuntimeException('No editable field defined.
+            Did you forget to implement the "configureFormFields" method?');
         }
 
         /** @var $form Form */

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -1482,6 +1482,10 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('edit'))
             ->will($this->returnValue(true));
 
+        $this->admin->expects($this->once())
+            ->method('getFormTabs')
+            ->will($this->returnValue(true));
+
         $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1527,6 +1531,10 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('checkAccess')
             ->with($this->equalTo('edit'));
+
+        $this->admin->expects($this->once())
+            ->method('getFormTabs')
+            ->will($this->returnValue(true));
 
         $this->admin->expects($this->once())
             ->method('hasRoute')
@@ -1588,6 +1596,10 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('checkAccess')
             ->with($this->equalTo('edit'))
+            ->will($this->returnValue(true));
+
+        $this->admin->expects($this->once())
+            ->method('getFormTabs')
             ->will($this->returnValue(true));
 
         $form = $this->getMockBuilder(Form::class)
@@ -1652,6 +1664,10 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('edit'))
             ->will($this->returnValue(true));
 
+        $this->admin->expects($this->once())
+            ->method('getFormTabs')
+            ->will($this->returnValue(true));
+
         $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1702,6 +1718,10 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('checkAccess')
             ->with($this->equalTo('edit'))
+            ->will($this->returnValue(true));
+
+        $this->admin->expects($this->once())
+            ->method('getFormTabs')
             ->will($this->returnValue(true));
 
         $form = $this->getMockBuilder(Form::class)
@@ -1762,6 +1782,10 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->any())
             ->method('getClass')
             ->will($this->returnValue('stdClass'));
+
+        $this->admin->expects($this->once())
+            ->method('getFormTabs')
+            ->will($this->returnValue(true));
 
         $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
@@ -1837,6 +1861,10 @@ class CRUDControllerTest extends TestCase
             ->method('supportsPreviewMode')
             ->will($this->returnValue(true));
 
+        $this->admin->expects($this->once())
+            ->method('getFormTabs')
+            ->will($this->returnValue(true));
+
         $formView = $this->createMock(FormView::class);
 
         $form->expects($this->any())
@@ -1885,6 +1913,10 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->any())
             ->method('getClass')
             ->will($this->returnValue($class));
+
+        $this->admin->expects($this->once())
+            ->method('getFormTabs')
+            ->will($this->returnValue(true));
 
         $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -1431,6 +1431,26 @@ class CRUDControllerTest extends TestCase
         $this->controller->editAction(null, $this->request);
     }
 
+    public function testEditActionRuntimeException()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $this->admin->expects($this->once())
+            ->method('getObject')
+            ->will($this->returnValue(new \stdClass()));
+
+        $this->admin->expects($this->once())
+            ->method('checkAccess')
+            ->with($this->equalTo('edit'))
+            ->will($this->returnValue(true));
+
+        $this->admin->expects($this->once())
+            ->method('getFormTabs')
+            ->will($this->returnValue(false));
+
+        $this->controller->editAction(null, $this->request);
+    }
+
     public function testEditActionAccessDenied()
     {
         $this->expectException(AccessDeniedException::class);


### PR DESCRIPTION
## Subject

From the `CRUDController:editAction()` add an error message before rendering the html page if no field is defined on the  `configureFormFields()` function

## Changelog

```markdown
### Added
- Added exception message if no field is defined on the  `configureFormFields()` function
```
