### PR TITLE
Add runtime exception

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -336,7 +336,7 @@ class CRUDController implements ContainerAwareInterface
         /** @var $form Form */
         $form = $this->admin->getForm();
 
-        if (!is_array($fields = $form->all()) || 0 === count($fields)) {
+        if (!\is_array($fields = $form->all()) || 0 === count($fields)) {
             throw new \RuntimeException(
                 'No editable field defined. Did you forget to implement the "configureFormFields" method?'
             );
@@ -597,7 +597,7 @@ class CRUDController implements ContainerAwareInterface
         /** @var $form Form */
         $form = $this->admin->getForm();
 
-        if (!is_array($fields = $form->all()) || 0 === count($fields)) {
+        if (!\is_array($fields = $form->all()) || 0 === count($fields)) {
             throw new \RuntimeException(
                 'No editable field defined. Did you forget to implement the "configureFormFields" method?'
             );
@@ -715,7 +715,7 @@ class CRUDController implements ContainerAwareInterface
         $fields = $this->admin->getShow();
 
         // NEXT_MAJOR: replace deprecation with exception
-        if (!is_array($fields->getElements()) || 0 === $fields->count()) {
+        if (!\is_array($fields->getElements()) || 0 === $fields->count()) {
             @trigger_error(
                 'Calling this method without implementing "configureShowFields"'
                 .' is not supported since 3.x'

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -711,8 +711,8 @@ class CRUDController implements ContainerAwareInterface
 
         $this->admin->setSubject($object);
 
-        /** @var $fields FieldDescriptionCollection */
         $fields = $this->admin->getShow();
+        \assert($fields instanceof FieldDescriptionCollection);
 
         // NEXT_MAJOR: replace deprecation with exception
         if (!\is_array($fields->getElements()) || 0 === $fields->count()) {

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -717,8 +717,10 @@ class CRUDController implements ContainerAwareInterface
         // NEXT_MAJOR: remove this check
         if (!is_array($fields->getElements()) || 0 === $fields->count()) {
             @trigger_error(
-                'Calling this method without implementing "configureShowFields" is not supported since 3.x'
-                .' and will no longer be possible in 4.0', E_USER_DEPRECATED
+                'Calling this method without implementing "configureShowFields"'
+                .' is not supported since 3.x'
+                .' and will no longer be possible in 4.0',
+                E_USER_DEPRECATED
             );
         }
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -332,13 +332,15 @@ class CRUDController implements ContainerAwareInterface
         $this->admin->setSubject($existingObject);
         $objectId = $this->admin->getNormalizedIdentifier($existingObject);
 
-        if (!\is_array($fields = $this->admin->getForm()->all()) || 0 === \count($fields)) {
+        /** @var $form Form */
+        $form = $this->admin->getForm();
+
+        if (!is_array($fields = $form->all()) || 0 === count($fields)) {
             throw new \RuntimeException(
                 'No editable field defined. Did you forget to implement the "configureFormFields" method?'
             );
         }
 
-        $form = $this->admin->getForm();
         $form->setData($existingObject);
         $form->handleRequest($request);
 
@@ -591,6 +593,7 @@ class CRUDController implements ContainerAwareInterface
 
         $this->admin->setSubject($newObject);
 
+        /** @var $form Form */
         $form = $this->admin->getForm();
         $form->setData($newObject);
         $form->handleRequest($request);

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -714,7 +714,7 @@ class CRUDController implements ContainerAwareInterface
         /** @var $fields FieldDescriptionCollection */
         $fields = $this->admin->getShow();
 
-        // NEXT_MAJOR: remove this check
+        // NEXT_MAJOR: replace deprecation with exception
         if (!is_array($fields->getElements()) || 0 === $fields->count()) {
             @trigger_error(
                 'Calling this method without implementing "configureShowFields"'

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -560,6 +560,7 @@ class CRUDController implements ContainerAwareInterface
      * Create action.
      *
      * @throws AccessDeniedException If access is not granted
+     * @throws \RuntimeException     If no editable field is defined
      *
      * @return Response
      */
@@ -685,7 +686,6 @@ class CRUDController implements ContainerAwareInterface
      *
      * @throws NotFoundHttpException If the object does not exist
      * @throws AccessDeniedException If access is not granted
-     * @throws \RuntimeException     If no field to show is defined
      *
      * @return Response
      */

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -333,8 +333,8 @@ class CRUDController implements ContainerAwareInterface
         $this->admin->setSubject($existingObject);
         $objectId = $this->admin->getNormalizedIdentifier($existingObject);
 
-        /** @var $form Form */
         $form = $this->admin->getForm();
+        \assert($form instanceof Form);
 
         if (!\is_array($fields = $form->all()) || 0 === \count($fields)) {
             throw new \RuntimeException(
@@ -595,8 +595,8 @@ class CRUDController implements ContainerAwareInterface
 
         $this->admin->setSubject($newObject);
 
-        /** @var $form Form */
         $form = $this->admin->getForm();
+        \assert($form instanceof Form);
 
         if (!\is_array($fields = $form->all()) || 0 === \count($fields)) {
             throw new \RuntimeException(

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -717,8 +717,8 @@ class CRUDController implements ContainerAwareInterface
         // NEXT_MAJOR: remove this check
         if (!is_array($fields->getElements()) || 0 === $fields->count()) {
             @trigger_error(
-                'Calling this method without implementing "configureShowFields" is not supported since 3.x and will no longer be possible in 4.0',
-                E_USER_DEPRECATED
+                'Calling this method without implementing "configureShowFields" is not supported since 3.x'
+                .' and will no longer be possible in 4.0', E_USER_DEPRECATED
             );
         }
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -714,9 +714,11 @@ class CRUDController implements ContainerAwareInterface
         /** @var $fields FieldDescriptionCollection */
         $fields = $this->admin->getShow();
 
+        // NEXT_MAJOR: remove this check
         if (!is_array($fields->getElements()) || 0 === $fields->count()) {
-            throw new \RuntimeException(
-                'No field to show. Did you forget to implement the "configureShowFields" method?'
+            @trigger_error(
+                'Calling this method without implementing "configureShowFields" is not supported since 3.x and will no longer be possible in 4.0',
+                E_USER_DEPRECATED
             );
         }
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -336,7 +336,7 @@ class CRUDController implements ContainerAwareInterface
         /** @var $form Form */
         $form = $this->admin->getForm();
 
-        if (!\is_array($fields = $form->all()) || 0 === count($fields)) {
+        if (!\is_array($fields = $form->all()) || 0 === \count($fields)) {
             throw new \RuntimeException(
                 'No editable field defined. Did you forget to implement the "configureFormFields" method?'
             );
@@ -597,7 +597,7 @@ class CRUDController implements ContainerAwareInterface
         /** @var $form Form */
         $form = $this->admin->getForm();
 
-        if (!\is_array($fields = $form->all()) || 0 === count($fields)) {
+        if (!\is_array($fields = $form->all()) || 0 === \count($fields)) {
             throw new \RuntimeException(
                 'No editable field defined. Did you forget to implement the "configureFormFields" method?'
             );

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -833,6 +833,37 @@ class CRUDControllerTest extends TestCase
         $this->controller->showAction(null, $this->request);
     }
 
+    public function testShowActionRuntimeException()
+    {
+        $this->expectException(\RuntimeException::class);
+        $object = new \stdClass();
+
+        $this->admin->expects($this->once())
+            ->method('getObject')
+            ->will($this->returnValue($object));
+
+        $this->admin->expects($this->once())
+            ->method('checkAccess')
+            ->with($this->equalTo('show'))
+            ->will($this->returnValue(true));
+
+        $show = $this->createMock(FieldDescriptionCollection::class);
+
+        $this->admin->expects($this->once())
+            ->method('getShow')
+            ->will($this->returnValue($show));
+
+        $show->expects($this->once())
+            ->method('getElements')
+            ->willReturn([]);
+
+        $show->expects($this->once())
+            ->method('count')
+            ->willReturn(0);
+
+        $this->controller->showAction(null, $this->request);
+    }
+
     public function testPreShow()
     {
         $object = new \stdClass();
@@ -873,6 +904,10 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getShow')
             ->will($this->returnValue($show));
+
+        $show->expects($this->once())
+            ->method('getElements')
+            ->willReturn(['field' => 'fielddata']);
 
         $this->assertInstanceOf(Response::class, $this->controller->showAction(null, $this->request));
 
@@ -1985,6 +2020,36 @@ class CRUDControllerTest extends TestCase
         $this->controller->createAction($this->request);
     }
 
+    public function testCreateActionRuntimeException()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $this->admin->expects($this->once())
+            ->method('checkAccess')
+            ->with($this->equalTo('create'))
+            ->will($this->returnValue(true));
+
+        $this->admin->expects($this->any())
+            ->method('getClass')
+            ->will($this->returnValue('stdClass'));
+
+        $this->admin->expects($this->once())
+            ->method('getNewInstance')
+            ->will($this->returnValue(new \stdClass()));
+
+        $form = $this->createMock(Form::class);
+
+        $this->admin->expects($this->once())
+            ->method('getForm')
+            ->will($this->returnValue($form));
+
+        $form->expects($this->once())
+            ->method('all')
+            ->willReturn([]);
+
+        $this->controller->createAction($this->request);
+    }
+
     public function testPreCreate()
     {
         $object = new \stdClass();
@@ -2033,6 +2098,10 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
+
+        $form->expects($this->once())
+            ->method('all')
+            ->willReturn(['field' => 'fielddata']);
 
         $formView = $this->createMock(FormView::class);
 
@@ -2108,6 +2177,10 @@ class CRUDControllerTest extends TestCase
             ->will($this->returnValue($form));
 
         $form->expects($this->once())
+            ->method('all')
+            ->willReturn(['field' => 'fielddata']);
+
+        $form->expects($this->once())
             ->method('isSubmitted')
             ->will($this->returnValue(true));
 
@@ -2169,6 +2242,10 @@ class CRUDControllerTest extends TestCase
             ->will($this->returnValue($form));
 
         $form->expects($this->once())
+            ->method('all')
+            ->willReturn(['field' => 'fielddata']);
+
+        $form->expects($this->once())
             ->method('isSubmitted')
             ->will($this->returnValue(true));
 
@@ -2210,6 +2287,10 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
+
+        $form->expects($this->once())
+            ->method('all')
+            ->willReturn(['field' => 'fielddata']);
 
         $form->expects($this->once())
             ->method('isSubmitted')
@@ -2273,6 +2354,10 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
+
+        $form->expects($this->once())
+            ->method('all')
+            ->willReturn(['field' => 'fielddata']);
 
         $form->expects($this->once())
             ->method('isValid')
@@ -2350,6 +2435,10 @@ class CRUDControllerTest extends TestCase
             ->will($this->returnValue($form));
 
         $form->expects($this->once())
+            ->method('all')
+            ->willReturn(['field' => 'fielddata']);
+
+        $form->expects($this->once())
             ->method('isSubmitted')
             ->will($this->returnValue(true));
 
@@ -2404,6 +2493,10 @@ class CRUDControllerTest extends TestCase
             ->will($this->returnValue($form));
 
         $form->expects($this->once())
+            ->method('all')
+            ->willReturn(['field' => 'fielddata']);
+
+        $form->expects($this->once())
             ->method('isSubmitted')
             ->will($this->returnValue(true));
 
@@ -2456,6 +2549,10 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
+
+        $form->expects($this->once())
+            ->method('all')
+            ->willReturn(['field' => 'fielddata']);
 
         $this->admin->expects($this->once())
             ->method('supportsPreviewMode')

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -833,6 +833,40 @@ class CRUDControllerTest extends TestCase
         $this->controller->showAction(null, $this->request);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Calling this method without implementing "configureShowFields" is not supported since 3.x and will no longer be possible in 4.0
+     */
+    public function testShowActionDeprecation()
+    {
+        $object = new \stdClass();
+
+        $this->admin->expects($this->once())
+            ->method('getObject')
+            ->will($this->returnValue($object));
+
+        $this->admin->expects($this->once())
+            ->method('checkAccess')
+            ->with($this->equalTo('show'))
+            ->will($this->returnValue(true));
+
+        $show = $this->createMock(FieldDescriptionCollection::class);
+
+        $this->admin->expects($this->once())
+            ->method('getShow')
+            ->will($this->returnValue($show));
+
+        $show->expects($this->once())
+            ->method('getElements')
+            ->willReturn([]);
+
+        $show->expects($this->once())
+            ->method('count')
+            ->willReturn(0);
+
+        $this->controller->showAction(null, $this->request);
+    }
+
     public function testPreShow()
     {
         $object = new \stdClass();

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -1510,7 +1510,7 @@ class CRUDControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
 
-        $this->admin->expects($this->exactly(2))
+        $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
 
@@ -1572,7 +1572,7 @@ class CRUDControllerTest extends TestCase
             ->method('getData')
             ->will($this->returnValue($object));
 
-        $this->admin->expects($this->exactly(2))
+        $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
 
@@ -1622,7 +1622,7 @@ class CRUDControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
 
-        $this->admin->expects($this->exactly(2))
+        $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
 
@@ -1686,7 +1686,7 @@ class CRUDControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
 
-        $this->admin->expects($this->exactly(2))
+        $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
 
@@ -1740,7 +1740,7 @@ class CRUDControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
 
-        $this->admin->expects($this->exactly(2))
+        $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
 
@@ -1801,7 +1801,7 @@ class CRUDControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
 
-        $this->admin->expects($this->exactly(2))
+        $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
 
@@ -1865,7 +1865,7 @@ class CRUDControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
 
-        $this->admin->expects($this->exactly(2))
+        $this->admin->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($form));
 

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -833,37 +833,6 @@ class CRUDControllerTest extends TestCase
         $this->controller->showAction(null, $this->request);
     }
 
-    public function testShowActionRuntimeException()
-    {
-        $this->expectException(\RuntimeException::class);
-        $object = new \stdClass();
-
-        $this->admin->expects($this->once())
-            ->method('getObject')
-            ->will($this->returnValue($object));
-
-        $this->admin->expects($this->once())
-            ->method('checkAccess')
-            ->with($this->equalTo('show'))
-            ->will($this->returnValue(true));
-
-        $show = $this->createMock(FieldDescriptionCollection::class);
-
-        $this->admin->expects($this->once())
-            ->method('getShow')
-            ->will($this->returnValue($show));
-
-        $show->expects($this->once())
-            ->method('getElements')
-            ->willReturn([]);
-
-        $show->expects($this->once())
-            ->method('count')
-            ->willReturn(0);
-
-        $this->controller->showAction(null, $this->request);
-    }
-
     public function testPreShow()
     {
         $object = new \stdClass();


### PR DESCRIPTION
## Subject

(Following #5195 )
From the `CRUDController` throw runtime exception before rendering the html page if no field is defined on the configureFormFields()  or `configureShowFields()` function

## Changelog

```markdown
### Added
- Added `RuntimeException` message for `Create` and `Show` actions from `CRUDController`
```