### PR TITLE
Don't display <thead> when in 'mosaic' mode

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -321,6 +321,8 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('outer_list_rows_mosaic')->defaultValue('@SonataAdmin/CRUD/list_outer_rows_mosaic.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('outer_list_rows_list')->defaultValue('@SonataAdmin/CRUD/list_outer_rows_list.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('outer_list_rows_tree')->defaultValue('@SonataAdmin/CRUD/list_outer_rows_tree.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('outer_list_view_mosaic')->defaultValue('@SonataAdmin/CRUD/list_outer_view_mosaic.html.twig')->cannotBeEmpty()->end()
+                        ->scalarNode('outer_list_view_list')->defaultValue('@SonataAdmin/CRUD/list_outer_view_list.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('base_list_field')->defaultValue('@SonataAdmin/CRUD/base_list_field.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('pager_links')->defaultValue('@SonataAdmin/Pager/links.html.twig')->cannotBeEmpty()->end()
                         ->scalarNode('pager_results')->defaultValue('@SonataAdmin/Pager/results.html.twig')->cannotBeEmpty()->end()

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -201,6 +201,8 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
             'outer_list_rows_mosaic' => '@SonataAdmin/CRUD/list_outer_rows_mosaic.html.twig',
             'outer_list_rows_list' => '@SonataAdmin/CRUD/list_outer_rows_list.html.twig',
             'outer_list_rows_tree' => '@SonataAdmin/CRUD/list_outer_rows_tree.html.twig',
+            'outer_list_view_mosaic' => '@SonataAdmin/CRUD/list_outer_view_mosaic.html.twig',
+            'outer_list_view_list' => '@SonataAdmin/CRUD/list_outer_view_list.html.twig',
         ]);
         $container->setParameter('sonata.admin.configuration.admin_services', $config['admin_services']);
         $container->setParameter('sonata.admin.configuration.dashboard_groups', $config['dashboard']['groups']);

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -54,45 +54,48 @@ file that was distributed with this source code.
 
                 {% if admin.datagrid.results|length > 0 %}
                     <table class="table table-bordered table-striped table-hover sonata-ba-list">
-                        {% block table_header %}
-                            <thead>
-                                <tr class="sonata-ba-list-field-header">
-                                    {% for field_description in admin.list.elements %}
-                                        {% if admin.hasRoute('batch') and field_description.getOption('code') == '_batch' and batchactions|length > 0 %}
-                                            <th class="sonata-ba-list-field-header sonata-ba-list-field-header-batch">
-                                              <input type="checkbox" id="list_batch_checkbox">
-                                            </th>
-                                        {% elseif field_description.getOption('code') == '_select' %}
-                                            <th class="sonata-ba-list-field-header sonata-ba-list-field-header-select"></th>
-                                        {% elseif field_description.name == '_action' and app.request.isXmlHttpRequest %}
-                                            {# Action buttons disabled in ajax view! #}
-                                        {% elseif field_description.getOption('ajax_hidden') == true and app.request.isXmlHttpRequest %}
-                                            {# Disable fields with 'ajax_hidden' option set to true #}
-                                        {% else %}
-                                            {% set sortable = false %}
-                                            {% if field_description.options.sortable is defined and field_description.options.sortable %}
-                                                {% set sortable             = true %}
-                                                {% set sort_parameters      = admin.modelmanager.sortparameters(field_description, admin.datagrid) %}
-                                                {% set current              = admin.datagrid.values._sort_by == field_description or admin.datagrid.values._sort_by.name == sort_parameters.filter._sort_by %}
-                                                {% set sort_active_class    = current ? 'sonata-ba-list-field-order-active' : '' %}
-                                                {% set sort_by              = current ? admin.datagrid.values._sort_order : field_description.options._sort_order %}
-                                            {% endif %}
 
-                                            {% spaceless %}
-                                                <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.options.header_class is defined %} {{ field_description.options.header_class }}{% endif %}"{% if field_description.options.header_style is defined %} style="{{ field_description.options.header_style }}"{% endif %}>
-                                                    {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters|merge({_list_mode: admin.getListMode()})) }}">{% endif %}
-                                                    {% if field_description.getOption('label_icon') %}
-                                                        <i class="sonata-ba-list-field-header-label-icon {{ field_description.getOption('label_icon') }}" aria-hidden="true"></i>
-                                                    {% endif %}
-                                                    {{ field_description.label|trans({}, field_description.translationDomain) }}
-                                                    {% if sortable %}</a>{% endif %}
+                        {% if admin.getListMode != 'mosaic' %}
+                            {% block table_header %}
+                                <thead>
+                                    <tr class="sonata-ba-list-field-header">
+                                        {% for field_description in admin.list.elements %}
+                                            {% if admin.hasRoute('batch') and field_description.getOption('code') == '_batch' and batchactions|length > 0 %}
+                                                <th class="sonata-ba-list-field-header sonata-ba-list-field-header-batch">
+                                                <input type="checkbox" id="list_batch_checkbox">
                                                 </th>
-                                            {% endspaceless %}
-                                        {% endif %}
-                                    {% endfor %}
-                                </tr>
-                            </thead>
-                        {% endblock %}
+                                            {% elseif field_description.getOption('code') == '_select' %}
+                                                <th class="sonata-ba-list-field-header sonata-ba-list-field-header-select"></th>
+                                            {% elseif field_description.name == '_action' and app.request.isXmlHttpRequest %}
+                                                {# Action buttons disabled in ajax view! #}
+                                            {% elseif field_description.getOption('ajax_hidden') == true and app.request.isXmlHttpRequest %}
+                                                {# Disable fields with 'ajax_hidden' option set to true #}
+                                            {% else %}
+                                                {% set sortable = false %}
+                                                {% if field_description.options.sortable is defined and field_description.options.sortable %}
+                                                    {% set sortable             = true %}
+                                                    {% set sort_parameters      = admin.modelmanager.sortparameters(field_description, admin.datagrid) %}
+                                                    {% set current              = admin.datagrid.values._sort_by == field_description or admin.datagrid.values._sort_by.name == sort_parameters.filter._sort_by %}
+                                                    {% set sort_active_class    = current ? 'sonata-ba-list-field-order-active' : '' %}
+                                                    {% set sort_by              = current ? admin.datagrid.values._sort_order : field_description.options._sort_order %}
+                                                {% endif %}
+
+                                                {% spaceless %}
+                                                    <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.options.header_class is defined %} {{ field_description.options.header_class }}{% endif %}"{% if field_description.options.header_style is defined %} style="{{ field_description.options.header_style }}"{% endif %}>
+                                                        {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters) }}">{% endif %}
+                                                        {% if field_description.getOption('label_icon') %}
+                                                            <i class="sonata-ba-list-field-header-label-icon {{ field_description.getOption('label_icon') }}" aria-hidden="true"></i>
+                                                        {% endif %}
+                                                        {{ field_description.label|trans({}, field_description.translationDomain) }}
+                                                        {% if sortable %}</a>{% endif %}
+                                                    </th>
+                                                {% endspaceless %}
+                                            {% endif %}
+                                        {% endfor %}
+                                    </tr>
+                                </thead>
+                            {% endblock %}
+                        {% endif %}
 
                         {% block table_body %}
                             <tbody>

--- a/src/Resources/views/CRUD/list_outer_view_list.html.twig
+++ b/src/Resources/views/CRUD/list_outer_view_list.html.twig
@@ -1,0 +1,50 @@
+<table class="table table-bordered table-striped sonata-ba-list">
+    {% block table_header %}
+        <thead>
+            <tr class="sonata-ba-list-field-header">
+                {% for field_description in admin.list.elements %}
+                    {% if admin.hasRoute('batch') and field_description.getOption('code') == '_batch' and batchactions|length > 0 %}
+                        <th class="sonata-ba-list-field-header sonata-ba-list-field-header-batch">
+                            <input type="checkbox" id="list_batch_checkbox">
+                        </th>
+                    {% elseif field_description.getOption('code') == '_select' %}
+                        <th class="sonata-ba-list-field-header sonata-ba-list-field-header-select"></th>
+                    {% elseif field_description.name == '_action' and app.request.isXmlHttpRequest %}
+                        {# Action buttons disabled in ajax view! #}
+                    {% elseif field_description.getOption('ajax_hidden') == true and app.request.isXmlHttpRequest %}
+                        {# Disable fields with 'ajax_hidden' option set to true #}
+                    {% else %}
+                        {% set sortable = false %}
+                        {% if field_description.options.sortable is defined and field_description.options.sortable %}
+                            {% set sortable             = true %}
+                            {% set sort_parameters      = admin.modelmanager.sortparameters(field_description, admin.datagrid) %}
+                            {% set current              = admin.datagrid.values._sort_by == field_description or admin.datagrid.values._sort_by.name == sort_parameters.filter._sort_by %}
+                            {% set sort_active_class    = current ? 'sonata-ba-list-field-order-active' : '' %}
+                            {% set sort_by              = current ? admin.datagrid.values._sort_order : field_description.options._sort_order %}
+                        {% endif %}
+
+                        {% spaceless %}
+                            <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.options.header_class is defined %} {{ field_description.options.header_class }}{% endif %}"{% if field_description.options.header_style is defined %} style="{{ field_description.options.header_style }}"{% endif %}>
+                                {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters) }}">{% endif %}
+                                {% if field_description.getOption('label_icon') %}
+                                    <i class="sonata-ba-list-field-header-label-icon {{ field_description.getOption('label_icon') }}" aria-hidden="true"></i>
+                                {% endif %}
+                                {{ field_description.label|trans({}, field_description.translationDomain) }}
+                                {% if sortable %}</a>{% endif %}
+                            </th>
+                        {% endspaceless %}
+                    {% endif %}
+                {% endfor %}
+            </tr>
+        </thead>
+    {% endblock %}
+
+    {% block table_body %}
+        <tbody>
+            {% include get_admin_template('outer_list_rows_' ~ admin.getListMode(), admin.code) %}
+        </tbody>
+    {% endblock %}
+
+    {% block table_footer %}
+    {% endblock %}
+</table>

--- a/src/Resources/views/CRUD/list_outer_view_mosaic.html.twig
+++ b/src/Resources/views/CRUD/list_outer_view_mosaic.html.twig
@@ -1,0 +1,72 @@
+<ul class="" style="list-style: none;">
+    {% for object in admin.datagrid.results %}
+        {% set meta = admin.getObjectMetadata(object) %}
+        {% set mosaic_content %}
+            <div class="mosaic-box-outter">
+                <div class="mosaic-inner-box">
+                    {#
+                        This box will be display when the mouse is not on the box
+                    #}
+
+                    <div class="mosaic-inner-box-default">
+                        {% block sonata_mosaic_background %}
+                            <img src="{{ meta.image }}" alt="" />
+                        {% endblock %}
+                        {% block sonata_mosaic_default_view %}
+                            <span class="mosaic-box-label label label-primary pull-right">#{{ admin.id(object) }}</span>
+                        {% endblock %}
+                    </div>
+
+                    {#
+                        This box will be display when the mouse is on the box
+                        You can add more description
+                    #}
+                    <div class="mosaic-inner-box-hover">
+                        {% block sonata_mosaic_hover_view %}
+                            <span class="mosaic-box-label label label-primary pull-right">#{{ admin.id(object) }}</span>
+                            {{ meta.description }}
+                        {% endblock %}
+                    </div>
+                </div>
+
+                {# NEXT_MAJOR : remove this assignment #}
+                {% set export_formats = export_formats|default(admin.getExportFormats) %}
+
+                <div class="mosaic-inner-text">
+                    {% if (admin.hasRoute('batch') and batchactions|length > 0) or (admin.hasRoute('export') and admin.hasAccess('export') and export_formats|length) %}
+                        <input type="checkbox" name="idx[]" value="{{ admin.id(object) }}">
+                    {% else %}
+                        &nbsp;
+                    {% endif %}
+
+                    {% block sonata_mosaic_description %}
+                        {{ meta.title|truncate(40) }}
+                    {% endblock %}
+                </div>
+            </div>
+        {% endset %}
+        <li class="col-xs-6 col-sm-3 mosaic-box sonata-ba-list-field-batch sonata-ba-list-field"
+                objectId="{{ admin.id(object) }}">
+            {% if admin.hasAccess('edit', object) and admin.hasRoute('edit') %}
+                <a class="mosaic-inner-link"
+                    href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid(admin) }) }}">
+                    {{ mosaic_content }}
+                </a>
+            {% elseif admin.hasAccess('show', object) and admin.hasRoute('show') %}
+                <a class="mosaic-inner-link"
+                    href="{{ admin.generateUrl('show', {'id' : object|sonata_urlsafeid(admin) }) }}">
+                    {{ mosaic_content }}
+                </a>
+            {% else %}
+                {{ mosaic_content }}
+            {% endif %}
+        </li>
+
+        {% if loop.index % 4 == 0 %}
+            <div class="clearfix hidden-xs"></div>
+        {% endif %}
+        {% if loop.index % 2 == 0 %}
+            <div class="clearfix visible-xs"></div>
+        {% endif %}
+    {% endfor %}
+</ul>


### PR DESCRIPTION
```markdown
### Added

Added check to display or no the table header when in 'mosaic' mode from `src/Resources/views/CRUD/base_list.html.twig`

```

## Subject

The table header no longer becomes coherent when the display mode is in mosaic.

**Table with header**

![table-with-header-](https://user-images.githubusercontent.com/8977909/44738035-9514b980-aaeb-11e8-999d-2d4f160f050a.png)

**Table without header**

![table-without-header](https://user-images.githubusercontent.com/8977909/44738070-aeb60100-aaeb-11e8-91da-d24445b43789.png)

