### PR TITLE
Fix negative admin unique id on 32 bits platforms

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1873,7 +1873,7 @@ EOT;
     public function getUniqid()
     {
         if (!$this->uniqid) {
-            $this->uniqid = 's'.crc32($this->getBaseCodeRoute());
+            $this->uniqid = 's'.substr(md5($this->getBaseCodeRoute()), 0, 10);
         }
 
         return $this->uniqid;


### PR DESCRIPTION
I am targeting this branch, because it's a bug fix.


## Changelog

```markdown
### Fixed
- Fixed negative admin unique id on 32 bits platforms
```
## Subject

Replaced crc32 with the 10 first characters of a md5 checksum of the `getBaseCodeRoute` method result (no need for more complex hash in this case).

Should fix https://github.com/sonata-project/SonataAdminBundle/issues/5215
