### PR TITLE
Allow adding header attributes to collection's inline table

### DIFF
--- a/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -70,6 +70,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             $sonataAdmin['inline'] = $fieldDescription->getOption('inline', 'natural');
             $sonataAdmin['block_name'] = $fieldDescription->getOption('block_name', false);
             $sonataAdmin['class'] = $this->getClass($builder);
+            $sonataAdmin['header_attr'] = $fieldDescription->getOption('header_attr', []);
 
             $builder->setAttribute('sonata_admin_enabled', true);
         }

--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
@@ -8,6 +8,8 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
+{% use 'form_div_layout.html.twig' %}
+
 <table class="table table-bordered">
     <thead>
         <tr>
@@ -16,12 +18,15 @@ file that was distributed with this source code.
                     <th>{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}</th>
                 {% else %}
                     <th
-                        {% if nested_field.vars['required']|default(false) %}
-                            class="required"
-                        {% endif %}
-                        {% if nested_field.vars['attr']['hidden']|default(false) %}
-                            style="display:none;"
-                        {% endif %}
+                        {% with {attr: sonata_admin.header_attr[field_name]|default([])} %}
+                            {% if nested_field.vars['required']|default(false) %}
+                                {% set attr = attr|merge({class: (attr.class|default('') ~ ' required')|trim}) %}
+                            {% endif %}
+                            {% if nested_field.vars['attr']['hidden']|default(false) %}
+                                {% set attr = attr|merge({style: (attr.style|default('') ~ ' display:none;')|trim}) %}
+                            {% endif %}
+                            {{ block('attributes') }}
+                        {% endwith %}
                     >
                         {{ nested_field.vars.label|trans({}, nested_field.vars['sonata_admin'].admin.translationDomain
                             |default(nested_field.vars.translation_domain)


### PR DESCRIPTION
I am targeting this branch, because this feature is backwards compatible.

## Changelog

```markdown
### Added
- Added possibility to pass attributes (e. g. for styling) to collection table headers.
```

## To do
- [ ] Add tests
- [ ] Update the documentation

## Subject

A simple feature to pass attributes to collection table headers. The main purpose I use it for is to override column width in some cases, like translations column (any column where most of the content editing occurs).
In many cases auto width is not OK, because some simple checkboxes/dropdowns take up more screen space that they should shrinking down important columns.

In the example below if Product has `translations` property/column, this column will have 50% width.
Config works similar to normal `attr` form option.

If maintainers are interested in this feature, I can update docs, add tests etc.
If you have ideas of better implementation, I can change it.

```
    $formMapper
        ->add(
                    'products',
                    CollectionType::class,
                    [
                        'by_reference' => false,
                    ],
                    [
                        'edit' => 'inline',
                        'inline' => 'table',
                        'sortable' => 'position',
                        'header_attr' => [  // new feature usage example
                            'translations' => ['style' => 'width:50%;'],
                        ],
                    ]
                )
```