### PR TITLE
[Docs] Fixed method visibility and `TYPE_EQUAL` filter constant at docs

### DIFF
--- a/docs/cookbook/recipe_select2.rst
+++ b/docs/cookbook/recipe_select2.rst
@@ -37,7 +37,7 @@ To disable select2 on some ``select`` form element, set data attribute ``data-so
 
     use Sonata\AdminBundle\Form\Type\ModelType;
 
-    public function configureFormFields(FormMapper $formMapper)
+    protected function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
             ->add('category', ModelType::class, [
@@ -65,7 +65,7 @@ to enable ``allowClear`` or ``data-sonata-select2-allow-clear = "false"`` to dis
 
     use Sonata\AdminBundle\Form\Type\ModelType;
 
-    public function configureFormFields(FormMapper $formMapper)
+    protected function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
             ->add('category', ModelType::class, [

--- a/docs/reference/action_create_edit.rst
+++ b/docs/reference/action_create_edit.rst
@@ -161,7 +161,7 @@ To specify options, do as follows::
     {
         // ...
 
-        public function configureFormFields(FormMapper $formMapper): void
+        protected function configureFormFields(FormMapper $formMapper): void
         {
             $formMapper
                 ->tab('General') // the tab call is optional

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -49,7 +49,7 @@ Here is an example:
     <?php
     // ...
 
-    public function configureListFields(ListMapper $listMapper)
+    protected function configureListFields(ListMapper $listMapper)
     {
         $listMapper
             // addIdentifier allows to specify that this column
@@ -361,10 +361,10 @@ given the default type ``is equal`` is used.
 
 .. code-block:: php
 
-    public function configureDefaultFilterValues(array &$filterValues)
+    protected function configureDefaultFilterValues(array &$filterValues)
     {
         $filterValues['foo'] = [
-            'type'  => ChoiceFilter::TYPE_CONTAINS,
+            'type'  => ChoiceType::TYPE_CONTAINS,
             'value' => 'bar',
         ];
     }
@@ -558,7 +558,7 @@ You can:
 
     <?php
 
-    public function configureListFields(ListMapper $list)
+    protected function configureListFields(ListMapper $list)
     {
         $list
             ->add('id', null, [

--- a/docs/reference/action_show.rst
+++ b/docs/reference/action_show.rst
@@ -52,7 +52,7 @@ To specify options, do as follow:
 
     class PersonAdmin extends AbstractAdmin
     {
-        public function configureShowFields(ShowMapper $showMapper)
+        protected function configureShowFields(ShowMapper $showMapper)
         {
             $showMapper
                 ->tab('General') // the tab call is optional
@@ -81,7 +81,7 @@ Here is an example of how to achieve this :
 
     class PersonAdmin extends ParentAdmin
     {
-        public function configureShowFields(ShowMapper $showMapper)
+        protected function configureShowFields(ShowMapper $showMapper)
         {
             parent::configureShowFields($showMapper);
 

--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -37,7 +37,7 @@ merges them onto a single target item. It should only be available when two cond
     <?php
     // in your Admin class
 
-    public function configureBatchActions($actions)
+    protected function configureBatchActions($actions)
     {
         if (
           $this->hasRoute('edit') && $this->hasAccess('edit') &&

--- a/docs/reference/extensions.rst
+++ b/docs/reference/extensions.rst
@@ -21,7 +21,7 @@ created objects and other admin features.
 
     class PublishStatusAdminExtension extends AbstractAdminExtension
     {
-        public function configureFormFields(FormMapper $formMapper)
+        protected function configureFormFields(FormMapper $formMapper)
         {
             $formMapper
                 ->add('status', ChoiceType::class, [

--- a/docs/reference/field_types.rst
+++ b/docs/reference/field_types.rst
@@ -47,7 +47,7 @@ This is currently limited to scalar types (text, integer, url...) and choice typ
 
 .. code-block:: php
 
-    public function configureListFields(ListMapper $listMapper)
+    protected function configureListFields(ListMapper $listMapper)
     {
         $listMapper
 
@@ -76,7 +76,7 @@ Parameter                               Description
 
 .. code-block:: php
 
-    public function configureListFields(ListMapper $listMapper)
+    protected function configureListFields(ListMapper $listMapper)
     {
         // For the value `prog`, the displayed text is `In progress`. The `App` catalogue will be used to translate `In progress` message.
         $listMapper
@@ -95,7 +95,7 @@ The ``choice`` field type also supports multiple values that can be separated by
 
 .. code-block:: php
 
-    public function configureListFields(ListMapper $listMapper)
+    protected function configureListFields(ListMapper $listMapper)
     {
         // For the value `['r', 'b']`, the displayed text ist `red | blue`.
         $listMapper
@@ -136,7 +136,7 @@ Parameter                               Description
 
 .. code-block:: php
 
-    public function configureListFields(ListMapper $listMapper)
+    protected function configureListFields(ListMapper $listMapper)
     {
         $listMapper
             // Output for value `http://example.com`:
@@ -206,7 +206,7 @@ Parameter                   Description
 
 .. code-block:: php
 
-    public function configureListFields(ListMapper $listMapper)
+    protected function configureListFields(ListMapper $listMapper)
     {
         $listMapper
 

--- a/docs/reference/form_help_message.rst
+++ b/docs/reference/form_help_message.rst
@@ -105,7 +105,7 @@ This Extension for example adds a note field to some entities which use a custom
         /**
          * @param DatagridMapper $datagridMapper
          */
-        public function configureDatagridFilters(DatagridMapper $datagridMapper)
+        protected function configureDatagridFilters(DatagridMapper $datagridMapper)
         {
             $datagridMapper
                 ->add('note')
@@ -118,7 +118,7 @@ This Extension for example adds a note field to some entities which use a custom
         /**
          * @param FormMapper $formMapper
          */
-        public function configureFormFields(FormMapper $formMapper)
+        protected function configureFormFields(FormMapper $formMapper)
         {
             $formMapper
                 ->addHelp('note', 'Use this field for an internal note.')
@@ -129,7 +129,7 @@ This Extension for example adds a note field to some entities which use a custom
         /**
          * @param ShowMapper $showMapper
          */
-        public function configureShowFields(ShowMapper $showMapper)
+        protected function configureShowFields(ShowMapper $showMapper)
         {
             $showMapper
                 ->with('Internal')

--- a/docs/reference/routing.rst
+++ b/docs/reference/routing.rst
@@ -392,7 +392,7 @@ list action's links to point to a different action, set the ``route`` option in 
 
     class PostAdmin extends AbstractAdmin
     {
-        public function configureListFields(ListMapper $listMapper)
+        protected function configureListFields(ListMapper $listMapper)
         {
             $listMapper
                 ->addIdentifier('name', null, [

--- a/docs/reference/translation.rst
+++ b/docs/reference/translation.rst
@@ -119,7 +119,7 @@ label can be defined as the third argument of the ``add`` method::
 
     class PageAdmin extends AbstractAdmin
     {
-        public function configureFormFields(FormMapper $formMapper)
+        protected function configureFormFields(FormMapper $formMapper)
         {
             $formMapper
                 ->add('isValid', null, [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are affecting 3.x docs.

## Subject

Fixed methods visibility (`public` => `protected`, mainly overriding `AbstractAdmin::configure*()`) and `TYPE_EQUAL` filter constant at docs.