### PR TITLE
Pool::getInstance checks for valid admin

### DIFF
--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\AdminBundle\Admin;
 
+use InvalidArgumentException;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -165,7 +166,7 @@ class Pool
      *
      * @throws \InvalidArgumentException
      *
-     * @return array
+     * @return AdminInterface[]
      */
     public function getAdminsByGroup($group)
     {
@@ -230,7 +231,7 @@ class Pool
      *
      * @param string $adminCode
      *
-     * @return \Sonata\AdminBundle\Admin\AdminInterface|false|null
+     * @return \Sonata\AdminBundle\Admin\AdminInterface|false
      */
     public function getAdminByAdminCode($adminCode)
     {
@@ -265,7 +266,7 @@ class Pool
      *
      * @throws \InvalidArgumentException
      *
-     * @return AdminInterface|null
+     * @return AdminInterface
      */
     public function getInstance($id)
     {
@@ -297,7 +298,13 @@ class Pool
             throw new \InvalidArgumentException($msg);
         }
 
-        return $this->container->get($id);
+        $admin = $this->container->get($id);
+
+        if (!$admin instanceof AdminInterface) {
+            throw new InvalidArgumentException(sprintf('Found service "%s" is not a valid admin service', $id));
+        }
+
+        return $admin;
     }
 
     /**

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -37,13 +37,9 @@ class PoolTest extends TestCase
             'adminGroup1' => ['sonata.user.admin.group1' => []],
         ]);
 
-        $expectedOutput = [
-            'adminGroup1' => [
-                'sonata.user.admin.group1' => 'sonata_user_admin_group1_AdminClass',
-            ],
-        ];
-
-        $this->assertSame($expectedOutput, $this->pool->getGroups());
+        $result = $this->pool->getGroups();
+        $this->assertArrayHasKey('adminGroup1', $result);
+        $this->assertArrayHasKey('sonata.user.admin.group1', $result['adminGroup1']);
     }
 
     public function testHasGroup()
@@ -129,11 +125,8 @@ class PoolTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals([
-            'sonata_admin1_AdminClass',
-            'sonata_admin2_AdminClass',
-        ], $this->pool->getAdminsByGroup('adminGroup1'));
-        $this->assertEquals(['sonata_admin3_AdminClass'], $this->pool->getAdminsByGroup('adminGroup2'));
+        $this->assertCount(2, $this->pool->getAdminsByGroup('adminGroup1'));
+        $this->assertCount(1, $this->pool->getAdminsByGroup('adminGroup2'));
     }
 
     public function testGetAdminForClassWhenAdminClassIsNotSet()
@@ -173,7 +166,7 @@ class PoolTest extends TestCase
         ]);
 
         $this->assertTrue($this->pool->hasAdminByClass('someclass'));
-        $this->assertSame('sonata_user_admin_group1_AdminClass', $this->pool->getAdminByClass('someclass'));
+        $this->assertInstanceOf(AdminInterface::class, $this->pool->getAdminByClass('someclass'));
     }
 
     public function testGetInstanceWithUndefinedServiceId()
@@ -203,7 +196,7 @@ class PoolTest extends TestCase
     {
         $this->pool->setAdminServiceIds(['sonata.news.admin.post']);
 
-        $this->assertSame('sonata_news_admin_post_AdminClass', $this->pool->getAdminByAdminCode('sonata.news.admin.post'));
+        $this->assertInstanceOf(AdminInterface::class, $this->pool->getAdminByAdminCode('sonata.news.admin.post'));
     }
 
     public function testGetAdminByAdminCodeForChildClass()
@@ -342,8 +335,8 @@ class PoolTest extends TestCase
         $containerMock = $this->createMock(ContainerInterface::class);
         $containerMock->expects($this->any())
             ->method('get')
-            ->will($this->returnCallback(function ($serviceId) {
-                return str_replace('.', '_', $serviceId).'_AdminClass';
+            ->will($this->returnCallback(function () {
+                return $this->createMock(AdminInterface::class);
             }));
 
         return $containerMock;

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -546,9 +546,8 @@ class CRUDControllerTest extends TestCase
     public function testConfigureWithException2()
     {
         $this->expectException(
-            \RuntimeException::class,
-            'Unable to find the admin class related to the current controller '.
-            '(Sonata\AdminBundle\Controller\CRUDController)'
+            \InvalidArgumentException::class,
+            'Found service "nonexistent.admin" is not a valid admin service'
         );
 
         $this->pool->setAdminServiceIds(['nonexistent.admin']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `Pool::getInstance` will always return a valid admin instance
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

According to the PHPDoc, the method will always return an `AdminInterface` (or null). The method never returned null, but a ContainerException if the service did not exist. Now the method checks if this is really an `AdminInterface`.
