### PR TITLE
fixed display top nav menu when user does not have rights for first or last module

### DIFF
--- a/src/Resources/views/Core/add_block.html.twig
+++ b/src/Resources/views/Core/add_block.html.twig
@@ -36,7 +36,7 @@
                         {% set render_first_element = false %}
                     {% else %}
                         </ul>
-                    {%  endif %}
+                    {% endif %}
                     <ul class="dropdown-menu{% if column_count > 1 %} col-md-{{ (12/column_count)|round }}{% endif %}">
                 {% endif %}
                 {% if loop.index0 % items_per_column != 0 %}

--- a/src/Resources/views/Core/add_block.html.twig
+++ b/src/Resources/views/Core/add_block.html.twig
@@ -16,27 +16,29 @@
     {% set column_count = (groups|length / items_per_column)|round(0, 'ceil') %}
 
     <div class="dropdown-menu multi-column dropdown-add"
-        {% if column_count > 1 %}style="width: {{ column_count*140 }}px;"{% endif %}
-            >
+         {% if column_count > 1 %}style="width: {{ column_count*140 }}px;"{% endif %}
+    >
         {% for group in groups|reverse %}
             {% set display = (group.roles is empty or is_granted(sonata_admin.adminPool.getOption('role_admin')) ) %}
             {% for role in group.roles if not display %}
                 {% set display = is_granted(role) %}
             {% endfor %}
 
-            {% if display %}
+            {% if loop.first %}
+                {% set render_first_element = true %}
+            {% endif %}
 
-                {% if loop.first or loop.index0 % items_per_column == 0 %}
-                    {% if loop.first %}
+            {% if display %}
+                {% if render_first_element or loop.index0 % items_per_column == 0 %}
+                    {% if render_first_element %}
                         <div class="container-fluid">
                             <div class="row">
+                        {% set render_first_element = false %}
                     {% else %}
                         </ul>
-                    {% endif %}
-
+                    {%  endif %}
                     <ul class="dropdown-menu{% if column_count > 1 %} col-md-{{ (12/column_count)|round }}{% endif %}">
                 {% endif %}
-
                 {% if loop.index0 % items_per_column != 0 %}
                     <li role="presentation" class="divider"></li>
                 {% endif %}
@@ -60,13 +62,11 @@
                         {% endif %}
                     {% endif %}
                 {% endfor %}
-
-                {% if loop.last %}
-                            </ul>
-                        </div>
+                {% if loop.last and not render_first_element %}
+                    </ul>
+                    </div>
                     </div>
                 {% endif %}
-
             {% endif %}
         {% endfor %}
     </div>

--- a/src/Resources/views/Core/add_block.html.twig
+++ b/src/Resources/views/Core/add_block.html.twig
@@ -16,7 +16,7 @@
     {% set column_count = (groups|length / items_per_column)|round(0, 'ceil') %}
 
     <div class="dropdown-menu multi-column dropdown-add"
-         {% if column_count > 1 %}style="width: {{ column_count*140 }}px;"{% endif %}
+        {% if column_count > 1 %}style="width: {{ column_count*140 }}px;"{% endif %}
     >
         {% for group in groups|reverse %}
             {% set display = (group.roles is empty or is_granted(sonata_admin.adminPool.getOption('role_admin')) ) %}


### PR DESCRIPTION
I am targeting this branch, because  this feature is backwards compatible.

## Changelog
```markdown
### Fixed
- wrong HTML generated (top nav menu), if the user does not have rights for first or last module
```

## Subject
Fixed top menu rendering. When user does not have rights for first or last admin module, wrong HTML was generated whitch breaks top menu and user block
