### PR TITLE
Expose Admin javascript object into window

### DIFF
--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -726,6 +726,8 @@ var Admin = {
     }
 };
 
+window.Admin = Admin;
+
 jQuery(document).ready(function() {
     Admin.handle_top_navbar_height();
 });


### PR DESCRIPTION
I am targeting this branch, because this change is backward compatible.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Admin` object reference to javascript `window` object
```

## Subject
This PR is exposing the `Admin` object to other scripts by adding its reference into the `window` object. In classical use, the `Admin` object can be easily accessed because it is considered as a global. However, this is not the case when this script is used with modules, which are introducing scopes. This change allows the Admin object to be accessed from javascript modules with `window.Admin`.
