### PR TITLE
Moment fr locale

### DIFF
--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -38,6 +38,13 @@ use Twig\TwigFunction;
  */
 class SonataAdminExtension extends AbstractExtension
 {
+    // @todo: there are more locales which are not supported by moment and they need to be translated/normalized/canonicalized here
+    const MOMENT_UNSUPPORTED_LOCALES = [
+        'es' => ['es', 'es-do'],
+        'nl' => ['nl', 'nl-be'],
+        'fr' => ['fr', 'fr-ca', 'fr-ch'],
+    ];
+
     /**
      * @var Pool
      */
@@ -465,18 +472,11 @@ class SonataAdminExtension extends AbstractExtension
             return null;
         }
 
-        if ('es' === $lang && !\in_array($locale, ['es', 'es-do'], true)) {
-            // `moment: ^2.8` only ships "es" and "es-do" locales for "es" language
-            $locale = 'es';
-        } elseif ('nl' === $lang && !\in_array($locale, ['nl', 'nl-be'], true)) {
-            // `moment: ^2.8` only ships "nl" and "nl-be" locales for "nl" language
-            $locale = 'nl';
-        } elseif ('fr' === $lang && !\in_array($locale, ['fr', 'fr-ca', 'fr-ch'], true)) {
-            // `moment: ^2.8` only ships "fr", "fr-ca" and "fr-ch" locales for "fr" language
-            $locale = 'fr';
+        foreach (self::MOMENT_UNSUPPORTED_LOCALES as $language => $locales) {
+            if ($language === $lang && !\in_array($locale, $locales)) {
+                $locale = $language;
+            }
         }
-
-        // @todo: there are more locales which are not supported by moment and they need to be translated/normalized/canonicalized here
 
         return $locale;
     }

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -471,6 +471,9 @@ class SonataAdminExtension extends AbstractExtension
         } elseif ('nl' === $lang && !\in_array($locale, ['nl', 'nl-be'], true)) {
             // `moment: ^2.8` only ships "nl" and "nl-be" locales for "nl" language
             $locale = 'nl';
+        } elseif ('fr' === $lang && !\in_array($locale, ['fr', 'fr-ca', 'fr-ch'], true)) {
+            // `moment: ^2.8` only ships "fr", "fr-ca" and "fr-ch" locales for "fr" language
+            $locale = 'fr';
         }
 
         // @todo: there are more locales which are not supported by moment and they need to be translated/normalized/canonicalized here

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -2542,6 +2542,7 @@ EOT
             ['fo', 'fo'],
             ['fr-ca', 'fr-ca'],
             ['fr-ch', 'fr-ch'],
+            ['fr', 'fr-fr'],
             ['fr', 'fr'],
             ['fy', 'fy'],
             ['gd', 'gd'],


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change is backwards compatible.

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Added support for moment.js French language
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

When loading moment.js localization file in https://github.com/sonata-project/SonataAdminBundle/blob/8fe5cad711ef707668fb4f787bc151e296efbfd3/src/Resources/views/standard_layout.html.twig#L69 when using french language, It attempts to load `fr-fr.js` file which does not exists in moment.js 2.8 and above. 

This PR fixes it by using the same method than `nl` and `es` languages ie. stripping `-fr` from the locale.
