### PR TITLE
Minor language mistakes in creating_an_admin.rst

### DIFF
--- a/docs/getting_started/creating_an_admin.rst
+++ b/docs/getting_started/creating_an_admin.rst
@@ -102,11 +102,11 @@ Step 1: Create an Admin Class
 
 SonataAdminBundle helps you manage your data using a graphical interface that
 will let you create, update or search your model instances. The bundle relies
-on Admin classes to know which models will be managed and how these actions
+on Admin classes to know which models will be managed and what these actions
 will look like.
 
 An Admin class decides which fields to show on a listing, which fields are used
-to find entries and how the create form will look like. Each model will have
+to find entries and what the create form will look like. Each model will have
 its own Admin class.
 
 Knowing this, let's create an Admin class for the ``Category`` entity. The


### PR DESCRIPTION
Changing "how it looks like" to "what it looks like" in documentation.

I am targeting this branch, because it's the version live on the website.

Closes no issues.

## Subject
Minor corrections on use of English in docs. Found on:
https://symfony.com/doc/master/bundles/SonataAdminBundle/getting_started/creating_an_admin.html