### PR TITLE
Deprecate Admin\Datagrid\PagerInterface in favor of DatagridBundle\Pager\PagerInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "knplabs/knp-menu-bundle": "^2.2",
         "sonata-project/block-bundle": "^3.11",
         "sonata-project/core-bundle": "^3.9",
+        "sonata-project/datagrid-bundle": "^2.3",
         "sonata-project/exporter": "^1.8",
         "symfony/asset": "^2.8 || ^3.2 || ^4.0",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",

--- a/src/Datagrid/PagerInterface.php
+++ b/src/Datagrid/PagerInterface.php
@@ -13,49 +13,11 @@ namespace Sonata\AdminBundle\Datagrid;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @deprecated since 3.x, to be removed in 4.0
  */
-interface PagerInterface
+interface PagerInterface extends \Sonata\DatagridBundle\Pager\PagerInterface
 {
-    /**
-     * Initialize the Pager.
-     */
-    public function init();
-
-    /**
-     * Returns the maximum number of results per page.
-     *
-     * @return int
-     */
-    public function getMaxPerPage();
-
-    /**
-     * Sets the maximum number of results per page.
-     *
-     * @param int $max
-     */
-    public function setMaxPerPage($max);
-
-    /**
-     * Sets the current page.
-     *
-     * @param int $page
-     */
-    public function setPage($page);
-
-    /**
-     * Set query.
-     *
-     * @param ProxyQueryInterface $query
-     */
-    public function setQuery($query);
-
-    /**
-     * Returns an array of results on the given page.
-     *
-     * @return array
-     */
-    public function getResults();
-
     /**
      * Sets the maximum number of page numbers.
      *


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate `Admin\Datagrid\PagerInterface` in favor of `DatagridBundle\Pager\PagerInterface`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

There already exists a defintion for a `PagerInterface`. The AdminBundle shouldn't create an own definition.
