### PR TITLE
More CRUDController actions CaaSec

### DIFF
--- a/src/Action/ListObjectsAction.php
+++ b/src/Action/ListObjectsAction.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Action;
+
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Bridge\Exporter\AdminExporter;
+use Sonata\AdminBundle\Twig\AdminEnvironment;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+final class ListObjectsAction
+{
+    /**
+     * @var AdminEnvironment
+     */
+    private $environment;
+
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var CsrfTokenManagerInterface|null
+     */
+    private $tokenManager;
+
+    /**
+     * @var AdminExporter|null
+     */
+    private $exporter;
+
+    public function __construct(
+        AdminEnvironment $environment,
+        Pool $pool,
+        CsrfTokenManagerInterface $tokenManager = null,
+        AdminExporter $exporter = null
+    ) {
+        $this->environment = $environment;
+        $this->pool = $pool;
+        $this->tokenManager = $tokenManager;
+        $this->exporter = $exporter;
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $admin = $this->environment->getAdmin();
+
+        $admin->checkAccess('list');
+
+        if ($listMode = $request->get('_list_mode')) {
+            $admin->setListMode($listMode);
+        }
+
+        $datagrid = $admin->getDatagrid();
+        $formView = $datagrid->getForm()->createView();
+
+        // set the theme for the current Admin Form
+        $this->environment->setFormTheme($formView, $admin->getFilterTheme());
+
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        $template = $admin->getTemplate('list');
+        // $template = $this->templateRegistry->getTemplate('list');
+
+        return $this->environment->render($template, [
+            'action' => 'list',
+            'form' => $formView,
+            'datagrid' => $datagrid,
+            'csrf_token' => $this->getCsrfToken('sonata.batch'),
+            'export_formats' => $this->exporter ?
+                $this->exporter->getAvailableFormats($admin) :
+                $admin->getExportFormats(),
+        ]);
+    }
+
+    /**
+     * Get CSRF token.
+     *
+     * @param string $intention
+     *
+     * @return string|false
+     */
+    private function getCsrfToken(string $intention)
+    {
+        if ($this->tokenManager) {
+            return $this->tokenManager->getToken($intention)->getValue();
+        }
+
+        return false;
+    }
+}

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Controller;
 use Doctrine\Common\Inflector\Inflector;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Sonata\AdminBundle\Action\ListObjectsAction;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
@@ -149,29 +150,9 @@ class CRUDController implements ContainerAwareInterface
             return $preResponse;
         }
 
-        if ($listMode = $request->get('_list_mode')) {
-            $this->admin->setListMode($listMode);
-        }
+        $action = $this->container->get(ListObjectsAction::class);
 
-        $datagrid = $this->admin->getDatagrid();
-        $formView = $datagrid->getForm()->createView();
-
-        // set the theme for the current Admin Form
-        $this->setFormTheme($formView, $this->admin->getFilterTheme());
-
-        // NEXT_MAJOR: Remove this line and use commented line below it instead
-        $template = $this->admin->getTemplate('list');
-        // $template = $this->templateRegistry->getTemplate('list');
-
-        return $this->renderWithExtraParams($template, [
-            'action' => 'list',
-            'form' => $formView,
-            'datagrid' => $datagrid,
-            'csrf_token' => $this->getCsrfToken('sonata.batch'),
-            'export_formats' => $this->has('sonata.admin.admin_exporter') ?
-                $this->get('sonata.admin.admin_exporter')->getAvailableFormats($this->admin) :
-                $this->admin->getExportFormats(),
-        ], null);
+        return $action();
     }
 
     /**

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -22,6 +22,7 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Exception\LockException;
 use Sonata\AdminBundle\Exception\ModelManagerException;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Sonata\AdminBundle\Twig\AdminEnvironment;
 use Sonata\AdminBundle\Util\AdminObjectAclData;
 use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
 use Symfony\Bridge\Twig\AppVariable;
@@ -127,19 +128,7 @@ class CRUDController implements ContainerAwareInterface
      */
     public function renderWithExtraParams($view, array $parameters = [], Response $response = null)
     {
-        if (!$this->isXmlHttpRequest()) {
-            $parameters['breadcrumbs_builder'] = $this->get('sonata.admin.breadcrumbs_builder');
-        }
-        $parameters['admin'] = $parameters['admin'] ??
-            $this->admin;
-
-        $parameters['base_template'] = $parameters['base_template'] ??
-            $this->getBaseTemplate();
-
-        $parameters['admin_pool'] = $this->get('sonata.admin.pool');
-
-        //NEXT_MAJOR: Remove method alias and use $this->render() directly.
-        return $this->originalRender($view, $parameters, $response);
+        return $this->get(AdminEnvironment::class)->render($view, $parameters, $response);
     }
 
     /**

--- a/src/Resources/config/actions.xml
+++ b/src/Resources/config/actions.xml
@@ -42,5 +42,11 @@
         <service id="sonata.admin.action.retrieve_autocomplete_items" class="Sonata\AdminBundle\Action\RetrieveAutocompleteItemsAction" public="true">
             <argument type="service" id="sonata.admin.pool"/>
         </service>
+        <service id="Sonata\AdminBundle\Action\ListObjectsAction" class="Sonata\AdminBundle\Action\ListObjectsAction" public="true">
+            <argument type="service" id="Sonata\AdminBundle\Twig\AdminEnvironment"/>
+            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="security.csrf.token_manager" on-invalid="null"/>
+            <argument type="service" id="sonata.admin.admin_exporter" on-invalid="null"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/twig.xml
+++ b/src/Resources/config/twig.xml
@@ -36,5 +36,13 @@
             <argument type="service" id="sonata.admin.global_template_registry"/>
             <argument type="service" id="service_container"/>
         </service>
+        <service id="Sonata\AdminBundle\Twig\AdminEnvironment" class="Sonata\AdminBundle\Twig\AdminEnvironment" public="true">
+            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="sonata.admin.global_template_registry"/>
+            <argument type="service" id="sonata.admin.breadcrumbs_builder"/>
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="twig"/>
+            <argument type="service" id="templating" on-invalid="null"/>
+        </service>
     </services>
 </container>

--- a/src/Twig/AdminEnvironment.php
+++ b/src/Twig/AdminEnvironment.php
@@ -133,24 +133,6 @@ final class AdminEnvironment
     }
 
     /**
-     * Returns the base template name.
-     *
-     * @return string The template name
-     */
-    private function getBaseTemplate(): string
-    {
-        if ($this->isXmlHttpRequest()) {
-            // NEXT_MAJOR: Remove this line and use commented line below it instead
-            return $this->admin->getTemplate('ajax');
-            // return $this->templateRegistry->getTemplate('ajax');
-        }
-
-        // NEXT_MAJOR: Remove this line and use commented line below it instead
-        return $this->admin->getTemplate('layout');
-        // return $this->templateRegistry->getTemplate('layout');
-    }
-
-    /**
      * @return AdminInterface
      */
     public function getAdmin(): AdminInterface
@@ -183,6 +165,24 @@ final class AdminEnvironment
         $admin->setRequest($request);
 
         return $admin;
+    }
+
+    /**
+     * Returns the base template name.
+     *
+     * @return string The template name
+     */
+    private function getBaseTemplate(): string
+    {
+        if ($this->isXmlHttpRequest()) {
+            // NEXT_MAJOR: Remove this line and use commented line below it instead
+            return $this->admin->getTemplate('ajax');
+            // return $this->templateRegistry->getTemplate('ajax');
+        }
+
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        return $this->admin->getTemplate('layout');
+        // return $this->templateRegistry->getTemplate('layout');
     }
 
     /**

--- a/src/Twig/AdminEnvironment.php
+++ b/src/Twig/AdminEnvironment.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig;
+
+use InvalidArgumentException;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\FormRenderer;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
+
+final class AdminEnvironment
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var TemplateRegistryInterface
+     */
+    private $templateRegistry;
+
+    /**
+     * @var BreadcrumbsBuilderInterface
+     */
+    private $breadcrumbBuilder;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * @var EngineInterface|null
+     */
+    private $templating;
+
+    public function __construct(Pool $pool, TemplateRegistryInterface $templateRegistry, BreadcrumbsBuilderInterface $breadcrumbBuilder, RequestStack $requestStack, Environment $twig, EngineInterface $templating = null)
+    {
+        $this->pool = $pool;
+        $this->templateRegistry = $templateRegistry;
+        $this->breadcrumbBuilder = $breadcrumbBuilder;
+        $this->requestStack = $requestStack;
+        $this->twig = $twig;
+        // NEXT_MAJOR: Remove templating
+        $this->templating = $templating;
+    }
+
+    /**
+     * Renders a view while passing mandatory parameters on to the template.
+     *
+     * @param string $view The view name
+     *
+     * @return Response A Response instance
+     */
+    public function render($view, array $parameters = [], Response $response = null): Response
+    {
+        $admin = $this->getAdmin();
+
+        if (!$this->isXmlHttpRequest()) {
+            $parameters['breadcrumbs_builder'] = $this->breadcrumbBuilder;
+        }
+
+        $parameters['admin'] = $parameters['admin'] ?? $admin;
+
+        if (!isset($parameters['base_template'])) {
+            $parameters['base_template'] = $this->getBaseTemplate();
+        }
+
+        $parameters['admin_pool'] = $this->pool;
+
+        if (null !== $this->templating) {
+            $content = $this->templating->render($view, $parameters);
+        } else {
+            $content = $this->twig->render($view, $parameters);
+        }
+
+        if (null === $response) {
+            $response = new Response();
+        }
+
+        $response->setContent($content);
+
+        return $response;
+    }
+
+    /**
+     * Sets the admin form theme to form view. Used for compatibility between Symfony versions.
+     */
+    public function setFormTheme(FormView $formView, array $theme = null): void
+    {
+        // BC for Symfony < 3.2 where this runtime does not exists
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $this->twig->getExtension(FormExtension::class)->renderer->setTheme($formView, $theme);
+
+            return;
+        }
+
+        // BC for Symfony < 3.4 where runtime should be TwigRenderer
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $this->twig->getRuntime(TwigRenderer::class)->setTheme($formView, $theme);
+
+            return;
+        }
+
+        $this->twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
+    }
+
+    /**
+     * Returns the base template name.
+     *
+     * @return string The template name
+     */
+    private function getBaseTemplate(): string
+    {
+        if ($this->isXmlHttpRequest()) {
+            // NEXT_MAJOR: Remove this line and use commented line below it instead
+            return $this->admin->getTemplate('ajax');
+            // return $this->templateRegistry->getTemplate('ajax');
+        }
+
+        // NEXT_MAJOR: Remove this line and use commented line below it instead
+        return $this->admin->getTemplate('layout');
+        // return $this->templateRegistry->getTemplate('layout');
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin(): AdminInterface
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (null === $request) {
+            throw new InvalidArgumentException('No request found to detect parent admin');
+        }
+
+        $adminCode = $request->get('code');
+
+        if (!$adminCode) {
+            throw new \RuntimeException(sprintf(
+                'There is no `_sonata_admin` defined for the controller `%s` and the current route `%s`',
+                \get_class($this),
+                $request->get('_route')
+            ));
+        }
+
+        $admin = $this->pool->getInstance($adminCode);
+
+        if (!$admin) {
+            throw new \RuntimeException(sprintf(
+                'Unable to find the admin class related to the current controller (%s)',
+                \get_class($this)
+            ));
+        }
+
+        $admin->setRequest($request);
+
+        return $admin;
+    }
+
+    /**
+     * Returns true if the request is a XMLHttpRequest.
+     *
+     * @return bool True if the request is an XMLHttpRequest, false otherwise
+     */
+    private function isXmlHttpRequest(): bool
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        return null !== $request && ($request->isXmlHttpRequest() || $request->get('_xml_http_request'));
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this feature is BC. Refs #5120

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- `CRUDController::listAction` is now deprecated in favor of `ListObjectsAction`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject
This is another step to reduce the logic of the big `CRUDController` in favor of simple action classes.

