### PR TITLE
private constants

### DIFF
--- a/src/DependencyInjection/Compiler/AdminMakerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminMakerCompilerPass.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 final class AdminMakerCompilerPass implements CompilerPassInterface
 {
-    const MANAGERS = [
+    private const MANAGERS = [
         'sonata.admin.manager.orm',
         'sonata.admin.manager.doctrine_mongodb',
         'sonata.admin.manager.doctrine_phpcr',

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -39,7 +39,7 @@ use Twig\TwigFunction;
 class SonataAdminExtension extends AbstractExtension
 {
     // @todo: there are more locales which are not supported by moment and they need to be translated/normalized/canonicalized here
-    const MOMENT_UNSUPPORTED_LOCALES = [
+    private const MOMENT_UNSUPPORTED_LOCALES = [
         'es' => ['es', 'es-do'],
         'nl' => ['nl', 'nl-be'],
         'fr' => ['fr', 'fr-ca', 'fr-ch'],


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it was released yesterday.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- visibility of constants
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

Per definition this can be considered as a BC break, but we released it yesterday and it should reduce headaches in the future...