### PR TITLE
fix make:sonata:admin command

### DIFF
--- a/src/Maker/AdminMaker.php
+++ b/src/Maker/AdminMaker.php
@@ -166,7 +166,7 @@ final class AdminMaker extends AbstractMaker
         $adminClassFullName = $adminClassNameDetails->getFullName();
         $this->generateAdmin($io, $generator, $adminClassNameDetails);
 
-        $controllerClassFullName = null;
+        $controllerClassFullName = '';
         if ($this->controllerClassBasename) {
             $controllerClassNameDetails = $generator->createClassNameDetails(
                 $this->controllerClassBasename,
@@ -174,10 +174,11 @@ final class AdminMaker extends AbstractMaker
                 'Controller'
             );
 
+            $this->generateController($input, $io, $generator, $controllerClassNameDetails);
+
             $controllerClassFullName = $controllerClassNameDetails->getFullName();
         }
 
-        $this->generateController($input, $io, $generator, $controllerClassNameDetails);
         $this->generateService($input, $io, $adminClassFullName, $controllerClassFullName);
     }
 
@@ -282,8 +283,8 @@ final class AdminMaker extends AbstractMaker
             $this->controllerClassBasename = Validators::validateControllerClassBasename($this->controllerClassBasename);
         }
 
-        if (!\count($this->availableModelManagers)) {
-            throw new \RuntimeException('There are no model managers registered.');
+        if (0 === \count($this->availableModelManagers)) {
+            throw new \InvalidArgumentException('There are no model managers registered.');
         }
 
         $this->managerType = $input->getOption('manager') ?: array_keys($this->availableModelManagers)[0];

--- a/src/SonataAdminBundle.php
+++ b/src/SonataAdminBundle.php
@@ -45,7 +45,8 @@ class SonataAdminBundle extends Bundle
         $container->addCompilerPass(new ExtensionCompilerPass());
         $container->addCompilerPass(new GlobalVariablesCompilerPass());
 
-        if ($container->has('MakerBundle')) {
+        $bundles = $container->getParameter('kernel.bundles');
+        if (isset($bundles['MakerBundle'])) {
             $container->addCompilerPass(new AdminMakerCompilerPass());
         }
 

--- a/tests/SonataAdminBundleTest.php
+++ b/tests/SonataAdminBundleTest.php
@@ -14,6 +14,7 @@ namespace Sonata\AdminBundle\Tests;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\Compiler\AdminMakerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Sonata\AdminBundle\SonataAdminBundle;
@@ -22,8 +23,6 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Test for SonataAdminBundle.
- *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
 class SonataAdminBundleTest extends TestCase
@@ -31,7 +30,7 @@ class SonataAdminBundleTest extends TestCase
     public function testBuild()
     {
         $containerBuilder = $this->getMockBuilder(ContainerBuilder::class)
-            ->setMethods(['addCompilerPass'])
+            ->setMethods(['addCompilerPass', 'getParameter'])
             ->getMock();
 
         $containerBuilder->expects($this->exactly(4))
@@ -53,8 +52,71 @@ class SonataAdminBundleTest extends TestCase
                     return;
                 }
 
-                $this->fail(sprintf('Compiler pass is not one of the expected types. Expects "Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass", "Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass" or "Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass", but got "%s".', \get_class($pass)));
+                $this->fail(sprintf(
+                    'CompilerPass is not one of the expected types. Expects "%s", "%s", "%s" or "%s", but got "%s".',
+                    AddDependencyCallsCompilerPass::class,
+                    AddFilterTypeCompilerPass::class,
+                    ExtensionCompilerPass::class,
+                    GlobalVariablesCompilerPass::class,
+                    \get_class($pass)
+                ));
             }));
+
+        $containerBuilder
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('kernel.bundles')
+            ->willReturn([]);
+
+        $bundle = new SonataAdminBundle();
+        $bundle->build($containerBuilder);
+    }
+
+    public function testBuildWithMakerBundle()
+    {
+        $containerBuilder = $this->getMockBuilder(ContainerBuilder::class)
+            ->setMethods(['addCompilerPass', 'getParameter'])
+            ->getMock();
+
+        $containerBuilder->expects($this->exactly(5))
+            ->method('addCompilerPass')
+            ->will($this->returnCallback(function (CompilerPassInterface $pass, $type = PassConfig::TYPE_BEFORE_OPTIMIZATION) {
+                if ($pass instanceof AddDependencyCallsCompilerPass) {
+                    return;
+                }
+
+                if ($pass instanceof AddFilterTypeCompilerPass) {
+                    return;
+                }
+
+                if ($pass instanceof ExtensionCompilerPass) {
+                    return;
+                }
+
+                if ($pass instanceof GlobalVariablesCompilerPass) {
+                    return;
+                }
+
+                if ($pass instanceof AdminMakerCompilerPass) {
+                    return;
+                }
+
+                $this->fail(sprintf(
+                    'CompilerPass is not one of the expected types. Expects "%s", "%s", "%s", "%s" or "%s", but got "%s".',
+                    AddDependencyCallsCompilerPass::class,
+                    AddFilterTypeCompilerPass::class,
+                    ExtensionCompilerPass::class,
+                    GlobalVariablesCompilerPass::class,
+                    AdminMakerCompilerPass::class,
+                    \get_class($pass)
+                ));
+            }));
+
+        $containerBuilder
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('kernel.bundles')
+            ->willReturn(['MakerBundle' => 'foo']);
 
         $bundle = new SonataAdminBundle();
         $bundle->build($containerBuilder);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

Rework of #5252 (thank you @volodymyr-nakvasiuk)

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `make:sonata:admin` not working
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

I changed `RuntimeException` to `InvalidArgumentException` which could be considered as a BC break, but imo its better to use it here.

I get this error when using `if (!\count($this->availableManagers))`:
<img width="775" alt="screenshot 2018-10-10 19 34 12" src="https://user-images.githubusercontent.com/995707/46754873-dd66f000-ccc3-11e8-88d1-9c029556a9f8.png">

//cc @indiancomet 