### PR TITLE
fix bootstrap js tab toggle not work when click add button more than 2 times

### DIFF
--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -48,7 +48,7 @@
                             </ul>
                             <div class="tab-content">
                                 {% for code, form_tab in admin.formtabs %}
-                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~random_string~'_'~loop.index %}
+                                    {% set _tab_name = tab_prefix ~ loop.index %}
                                     <div class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (tab_query_index == loop.index) %} in active{% endif %}" id="{{ _tab_name }}">
                                         <div class="box-body  container-fluid">
                                             <div class="sonata-ba-collapsed-fields">

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -32,11 +32,11 @@
 
                 <div class="col-md-12">
                     {% if has_tab %}
-                        {% set random = random() %}
+                        {% set random_string = random() %}
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">
                                 {% for name, form_tab in admin.formtabs %}
-                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~random~'_'~loop.index %}
+                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~random_string~'_'~loop.index %}
                                     <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (app.request.query.get('_tab') == _tab_name) %} class="active"{% endif %}>
                                         <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
                                             <i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i> {{ form_tab.label|trans({}, form_tab.translation_domain ?: admin.translationDomain) }}
@@ -46,7 +46,7 @@
                             </ul>
                             <div class="tab-content">
                                 {% for code, form_tab in admin.formtabs %}
-                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~random~'_'~loop.index %}
+                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~random_string~'_'~loop.index %}
                                     <div class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (app.request.query.get('_tab') == _tab_name) %} in active{% endif %}" id="{{ _tab_name }}">
                                         <div class="box-body  container-fluid">
                                             <div class="sonata-ba-collapsed-fields">

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -33,7 +33,7 @@
                 <div class="col-md-12">
                     {% if has_tab %}
                         {% set tab_prefix = 'tab_' ~ admin.uniqid ~ '_' ~ random() %}
-                        {% set tab_query_index = 0 %}
+                        {% set tab_query_index =  app.request.query.get('_tab', 0)|split("_")|last %}
                         {% if app.request.query.has('_tab') %}
                             {% set tab_query_index = app.request.query.get('_tab')|split("_")|last %}
                         {% endif %}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -33,7 +33,7 @@
                 <div class="col-md-12">
                     {% if has_tab %}
                         {% set random_string = random() %}
-                        {% set tab_query_index = -1 %}
+                        {% set tab_query_index = 0 %}
                         {% if app.request.query.has('_tab') %}
                             {% set tab_query_index = app.request.query.get('_tab')|split("_")|last %}
                         {% endif %}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -48,7 +48,10 @@
                             <div class="tab-content">
                                 {% for code, form_tab in admin.formtabs %}
                                     {% set _tab_name = tab_prefix ~ loop.index %}
-                                    <div class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (tab_query_index == loop.index) %} in active{% endif %}" id="{{ _tab_name }}">
+                                    <div
+                                        class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (tab_query_index == loop.index) %} in active{% endif %}"
+                                        id="{{ _tab_name }}"
+                                    >
                                         <div class="box-body  container-fluid">
                                             <div class="sonata-ba-collapsed-fields">
                                                 {% if form_tab.description != false %}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -34,7 +34,6 @@
                     {% if has_tab %}
                         {% set tab_prefix = 'tab_' ~ admin.uniqid ~ '_' ~ random() %}
                         {% set tab_query_index =  app.request.query.get('_tab', 0)|split("_")|last %}
-
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">
                                 {% for name, form_tab in admin.formtabs %}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -32,11 +32,11 @@
 
                 <div class="col-md-12">
                     {% if has_tab %}
-                        {% set random_key = random() %}
+                        {% set random = random() %}
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">
                                 {% for name, form_tab in admin.formtabs %}
-                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~loop.index~'_'~random_key %}
+                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~random~'_'~loop.index %}
                                     <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (app.request.query.get('_tab') == _tab_name) %} class="active"{% endif %}>
                                         <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
                                             <i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i> {{ form_tab.label|trans({}, form_tab.translation_domain ?: admin.translationDomain) }}
@@ -46,7 +46,7 @@
                             </ul>
                             <div class="tab-content">
                                 {% for code, form_tab in admin.formtabs %}
-                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~loop.index~'_'~random_key %}
+                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~random~'_'~loop.index %}
                                     <div class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (app.request.query.get('_tab') == _tab_name) %} in active{% endif %}" id="{{ _tab_name }}">
                                         <div class="box-body  container-fluid">
                                             <div class="sonata-ba-collapsed-fields">

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -32,10 +32,11 @@
 
                 <div class="col-md-12">
                     {% if has_tab %}
+                        {% set random_key = random() %}
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">
                                 {% for name, form_tab in admin.formtabs %}
-                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~loop.index %}
+                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~loop.index~'_'~random_key %}
                                     <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (app.request.query.get('_tab') == _tab_name) %} class="active"{% endif %}>
                                         <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
                                             <i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i> {{ form_tab.label|trans({}, form_tab.translation_domain ?: admin.translationDomain) }}
@@ -45,7 +46,7 @@
                             </ul>
                             <div class="tab-content">
                                 {% for code, form_tab in admin.formtabs %}
-                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~loop.index %}
+                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~loop.index~'_'~random_key %}
                                     <div class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (app.request.query.get('_tab') == _tab_name) %} in active{% endif %}" id="{{ _tab_name }}">
                                         <div class="box-body  container-fluid">
                                             <div class="sonata-ba-collapsed-fields">

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -34,7 +34,6 @@
                     {% if has_tab %}
                         {% set tab_prefix = 'tab_' ~ admin.uniqid ~ '_' ~ random() %}
                         {% set tab_query_index =  app.request.query.get('_tab', 0)|split("_")|last %}
-                        {% endif %}
 
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -32,7 +32,7 @@
 
                 <div class="col-md-12">
                     {% if has_tab %}
-                        {% set random_string = random() %}
+                        {% set tab_prefix = 'tab_' ~ admin.uniqid ~ '_' ~ random() %}
                         {% set tab_query_index = 0 %}
                         {% if app.request.query.has('_tab') %}
                             {% set tab_query_index = app.request.query.get('_tab')|split("_")|last %}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -33,7 +33,7 @@
                 <div class="col-md-12">
                     {% if has_tab %}
                         {% set tab_prefix = 'tab_' ~ admin.uniqid ~ '_' ~ random() %}
-                        {% set tab_query_index =  app.request.query.get('_tab', 0)|split("_")|last %}
+                        {% set tab_query_index = app.request.query.get('_tab', 0)|split("_")|last %}
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">
                                 {% for name, form_tab in admin.formtabs %}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -38,7 +38,7 @@
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">
                                 {% for name, form_tab in admin.formtabs %}
-                                    {% set _tab_name = 'tab_'~admin.uniqid~'_'~random_string~'_'~loop.index %}
+                                    {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                                     <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (tab_query_index == loop.index) %} class="active"{% endif %}>
                                         <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
                                             <i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i> {{ form_tab.label|trans({}, form_tab.translation_domain ?: admin.translationDomain) }}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -34,7 +34,6 @@
                     {% if has_tab %}
                         {% set tab_prefix = 'tab_' ~ admin.uniqid ~ '_' ~ random() %}
                         {% set tab_query_index =  app.request.query.get('_tab', 0)|split("_")|last %}
-                            {% set tab_query_index = app.request.query.get('_tab')|split("_")|last %}
                         {% endif %}
 
                         <div class="nav-tabs-custom">

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -34,7 +34,6 @@
                     {% if has_tab %}
                         {% set tab_prefix = 'tab_' ~ admin.uniqid ~ '_' ~ random() %}
                         {% set tab_query_index =  app.request.query.get('_tab', 0)|split("_")|last %}
-                        {% if app.request.query.has('_tab') %}
                             {% set tab_query_index = app.request.query.get('_tab')|split("_")|last %}
                         {% endif %}
 

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -33,11 +33,16 @@
                 <div class="col-md-12">
                     {% if has_tab %}
                         {% set random_string = random() %}
+                        {% set tab_query_index = -1 %}
+                        {% if app.request.query.has('_tab') %}
+                            {% set tab_query_index = app.request.query.get('_tab')|split("_")|last %}
+                        {% endif %}
+
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">
                                 {% for name, form_tab in admin.formtabs %}
                                     {% set _tab_name = 'tab_'~admin.uniqid~'_'~random_string~'_'~loop.index %}
-                                    <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (app.request.query.get('_tab') == _tab_name) %} class="active"{% endif %}>
+                                    <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (tab_query_index == loop.index) %} class="active"{% endif %}>
                                         <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
                                             <i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i> {{ form_tab.label|trans({}, form_tab.translation_domain ?: admin.translationDomain) }}
                                         </a>
@@ -47,7 +52,7 @@
                             <div class="tab-content">
                                 {% for code, form_tab in admin.formtabs %}
                                     {% set _tab_name = 'tab_'~admin.uniqid~'_'~random_string~'_'~loop.index %}
-                                    <div class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (app.request.query.get('_tab') == _tab_name) %} in active{% endif %}" id="{{ _tab_name }}">
+                                    <div class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (tab_query_index == loop.index) %} in active{% endif %}" id="{{ _tab_name }}">
                                         <div class="box-body  container-fluid">
                                             <div class="sonata-ba-collapsed-fields">
                                                 {% if form_tab.description != false %}

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -39,7 +39,7 @@ file that was distributed with this source code.
 
         {% if has_tab %}
             {% set tab_prefix = 'tab_' ~ admin.uniqid ~ '_' ~ random() %}
-            {% set tab_query_index =  app.request.query.get('_tab', 0)|split("_")|last %}
+            {% set tab_query_index = app.request.query.get('_tab', 0)|split("_")|last %}
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs" role="tablist">
                     {% for name, show_tab in admin.showtabs %}

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -39,11 +39,16 @@ file that was distributed with this source code.
 
         {% if has_tab %}
             {% set random_string = random() %}
+            {% set tab_query_index = -1 %}
+            {% if app.request.query.has('_tab') %}
+                {% set tab_query_index = app.request.query.get('_tab')|split("_")|last %}
+            {% endif %}
+
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs" role="tablist">
                     {% for name, show_tab in admin.showtabs %}
                         {% set _tab_name = 'tab_'~admin.uniqid~'_'~random_string~'_'~loop.index %}
-                        <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (app.request.query.get('_tab') == _tab_name) %} class="active"{% endif %}>
+                        <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (tab_query_index == loop.index) %} class="active"{% endif %}>
                             <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
                                 {{ show_tab.label|trans({}, show_tab.translation_domain ?: admin.translationDomain) }}
                             </a>
@@ -55,7 +60,7 @@ file that was distributed with this source code.
                     {% for code, show_tab in admin.showtabs %}
                         {% set _tab_name = 'tab_'~admin.uniqid~'_'~random_string~'_'~loop.index %}
                         <div
-                            class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (app.request.query.get('_tab') == _tab_name) %} in active{% endif %}"
+                            class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (tab_query_index == loop.index) %} in active{% endif %}"
                             id="{{ _tab_name }}"
                         >
                             <div class="box-body  container-fluid">

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -38,11 +38,11 @@ file that was distributed with this source code.
         {% set has_tab = (admin.showtabs|length == 1 and admin.showtabs|keys[0] != 'default') or admin.showtabs|length > 1 %}
 
         {% if has_tab %}
-            {% set random = random() %}
+            {% set random_string = random() %}
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs" role="tablist">
                     {% for name, show_tab in admin.showtabs %}
-                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~random~'_'~loop.index %}
+                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~random_string~'_'~loop.index %}
                         <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (app.request.query.get('_tab') == _tab_name) %} class="active"{% endif %}>
                             <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
                                 {{ show_tab.label|trans({}, show_tab.translation_domain ?: admin.translationDomain) }}
@@ -53,7 +53,7 @@ file that was distributed with this source code.
 
                 <div class="tab-content">
                     {% for code, show_tab in admin.showtabs %}
-                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~random~'_'~loop.index %}
+                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~random_string~'_'~loop.index %}
                         <div
                             class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (app.request.query.get('_tab') == _tab_name) %} in active{% endif %}"
                             id="{{ _tab_name }}"

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -39,7 +39,7 @@ file that was distributed with this source code.
 
         {% if has_tab %}
             {% set random_string = random() %}
-            {% set tab_query_index = -1 %}
+            {% set tab_query_index = 0 %}
             {% if app.request.query.has('_tab') %}
                 {% set tab_query_index = app.request.query.get('_tab')|split("_")|last %}
             {% endif %}

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -38,16 +38,13 @@ file that was distributed with this source code.
         {% set has_tab = (admin.showtabs|length == 1 and admin.showtabs|keys[0] != 'default') or admin.showtabs|length > 1 %}
 
         {% if has_tab %}
-            {% set random_string = random() %}
-            {% set tab_query_index = 0 %}
-            {% if app.request.query.has('_tab') %}
-                {% set tab_query_index = app.request.query.get('_tab')|split("_")|last %}
-            {% endif %}
+            {% set tab_prefix = 'tab_' ~ admin.uniqid ~ '_' ~ random() %}
+            {% set tab_query_index =  app.request.query.get('_tab', 0)|split("_")|last %}
 
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs" role="tablist">
                     {% for name, show_tab in admin.showtabs %}
-                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~random_string~'_'~loop.index %}
+                        {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                         <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (tab_query_index == loop.index) %} class="active"{% endif %}>
                             <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
                                 {{ show_tab.label|trans({}, show_tab.translation_domain ?: admin.translationDomain) }}
@@ -58,7 +55,7 @@ file that was distributed with this source code.
 
                 <div class="tab-content">
                     {% for code, show_tab in admin.showtabs %}
-                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~random_string~'_'~loop.index %}
+                        {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                         <div
                             class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (tab_query_index == loop.index) %} in active{% endif %}"
                             id="{{ _tab_name }}"

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -40,7 +40,6 @@ file that was distributed with this source code.
         {% if has_tab %}
             {% set tab_prefix = 'tab_' ~ admin.uniqid ~ '_' ~ random() %}
             {% set tab_query_index =  app.request.query.get('_tab', 0)|split("_")|last %}
-
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs" role="tablist">
                     {% for name, show_tab in admin.showtabs %}

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -38,10 +38,11 @@ file that was distributed with this source code.
         {% set has_tab = (admin.showtabs|length == 1 and admin.showtabs|keys[0] != 'default') or admin.showtabs|length > 1 %}
 
         {% if has_tab %}
+            {% set random_key = random() %}
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs" role="tablist">
                     {% for name, show_tab in admin.showtabs %}
-                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~loop.index %}
+                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~loop.index~'_'~random_key %}
                         <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (app.request.query.get('_tab') == _tab_name) %} class="active"{% endif %}>
                             <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
                                 {{ show_tab.label|trans({}, show_tab.translation_domain ?: admin.translationDomain) }}
@@ -52,7 +53,7 @@ file that was distributed with this source code.
 
                 <div class="tab-content">
                     {% for code, show_tab in admin.showtabs %}
-                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~loop.index %}
+                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~loop.index~'_'~random_key %}
                         <div
                             class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (app.request.query.get('_tab') == _tab_name) %} in active{% endif %}"
                             id="{{ _tab_name }}"

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -38,11 +38,11 @@ file that was distributed with this source code.
         {% set has_tab = (admin.showtabs|length == 1 and admin.showtabs|keys[0] != 'default') or admin.showtabs|length > 1 %}
 
         {% if has_tab %}
-            {% set random_key = random() %}
+            {% set random = random() %}
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs" role="tablist">
                     {% for name, show_tab in admin.showtabs %}
-                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~loop.index~'_'~random_key %}
+                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~random~'_'~loop.index %}
                         <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (app.request.query.get('_tab') == _tab_name) %} class="active"{% endif %}>
                             <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
                                 {{ show_tab.label|trans({}, show_tab.translation_domain ?: admin.translationDomain) }}
@@ -53,7 +53,7 @@ file that was distributed with this source code.
 
                 <div class="tab-content">
                     {% for code, show_tab in admin.showtabs %}
-                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~loop.index~'_'~random_key %}
+                        {% set _tab_name = 'tab_'~admin.uniqid~'_'~random~'_'~loop.index %}
                         <div
                             class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (app.request.query.get('_tab') == _tab_name) %} in active{% endif %}"
                             id="{{ _tab_name }}"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targeting this branch, because i find the bootstrap js tab toggle will not work  when click add button more than 2 times.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->


<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Fix bootstrap tab toggle not work when click add button more than 2 times.

```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

<!-- Describe your Pull Request content here -->
fix bootstrap js tab toggle not work when click add button more than 2 times