### PR TITLE
Automatically add new media to the autocomplete field after create

### DIFF
--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -86,6 +86,7 @@ class ModelAutocompleteType extends AbstractType
             'btn_catalogue',
             // allow HTML
             'safe_label',
+            'property',
         ] as $passthroughOption) {
             $view->vars[$passthroughOption] = $options[$passthroughOption];
         }

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -273,6 +273,41 @@ file that was distributed with this source code.
                 $(usedInputRef).remove();
                 return true;
             });
+
+            {% set create_url = sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) %}
+
+            $(document).ajaxSuccess(function(event, xhr, settings) {
+              if(typeof xhr.responseJSON != 'undefined') {
+                  if ('{{ create_url }}'.indexOf(settings.url) !== -1 && typeof xhr.responseJSON != 'string' && xhr.responseJSON.result == 'ok') {
+                    var form = JSON.parse('{"' + decodeURI(settings.data).replace('+', ' ').replace(/"/g, '\\"').replace(/&/g, '","').replace(/=/g,'":"') + '"}');
+                    var item = new Option(
+                      form['{{ sonata_admin.field_description.associationadmin.uniqid }}[{{ form.vars.property }}]'],
+                      xhr.responseJSON.objectId,
+                      true, true
+                      );
+
+                    {%- if multiple -%}
+                      var data = autocompleteInput.select2('data');
+                      data.push(item);
+                    {%- else -%}
+                      var data = item;
+                    {%- endif -%}
+
+                    $('#{{ id }}_hidden_inputs_wrap').html('<input type="hidden" name="{{ full_name }}" value="'+xhr.responseJSON.objectId+'" />');
+
+                    // append to Select2
+                    autocompleteInput.select2('data', data).append(data).trigger('change');
+
+                    // manually trigger the `select2:select` event
+                    autocompleteInput.select2('data', data).trigger({
+                        type: 'select2:select',
+                        params: {
+                            data: data
+                        }
+                    });
+                  }
+              }
+            });
         });
         {% endautoescape %}
     </script>


### PR DESCRIPTION
I am targeting this branch, because this is the main branch.

Closes #4802 

```markdown
### Fixed
Newly created media is not autoselected
```

## Subject

Automatically add new media to the autocomplete field after create

Thanks to @lushc

My code is [its code](https://gist.github.com/npotier/a7b2b34f0daae7205f86#gistcomment-1754374) with some adaptations, especially on the part concerning the label of the form field which was hard coded.

I need the property option to get this data. I can't find it in the FormView object. 
Maybe someone has a trick to get this data from the FormView object.