### PR TITLE
Move body data attributes to a new block

### DIFF
--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -101,6 +101,8 @@ file that was distributed with this source code.
                 {% if app.request.cookies.get('sonata_sidebar_hide') -%}
                     sidebar-collapse
                 {%- endif -%}"
+            {%- endblock -%}
+            {% block body_data_attributes -%}
                 data-sonata-admin='{{ {
                     config: {
                         CONFIRM_EXIT: sonata_admin.adminPool.getOption('confirm_exit'),


### PR DESCRIPTION
I am targeting this branch, because it's a BC fix.

Closes #5256 #5261 #5264.

## Changelog

```markdown
### Changed
- Moved the new body data attribute to a new block.

### Fixed
- BC with standard_layout template body_attributes block overrides
```

## Subject

This is to enable the new way of configuring JS while preserving BC
when the body_attributes block may be overridden by the bundle's user.
