### PR TITLE
Fix Sonata JS config error when sonata_layout is overrided

### DIFF
--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -31,6 +31,19 @@ file that was distributed with this source code.
             <meta content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' name='viewport'>
         {% endblock %}
 
+        <meta data-sonata-admin='{{ {
+            config: {
+                CONFIRM_EXIT: sonata_admin.adminPool.getOption('confirm_exit'),
+                USE_SELECT2: sonata_admin.adminPool.getOption('use_select2'),
+                USE_ICHECK: sonata_admin.adminPool.getOption('use_icheck'),
+                USE_STICKYFORMS: sonata_admin.adminPool.getOption('use_stickyforms'),
+            },
+            translations: {
+                CONFIRM_EXIT: 'confirm_exit'|trans({}, 'SonataAdminBundle'),
+            },
+        }|json_encode()|raw }}'
+        >
+
         {% block stylesheets %}
             {% for stylesheet in sonata_admin.adminPool.getOption('stylesheets', []) %}
                 <link rel="stylesheet" href="{{ asset(stylesheet) }}">
@@ -101,17 +114,6 @@ file that was distributed with this source code.
                 {% if app.request.cookies.get('sonata_sidebar_hide') -%}
                     sidebar-collapse
                 {%- endif -%}"
-                data-sonata-admin='{{ {
-                    config: {
-                        CONFIRM_EXIT: sonata_admin.adminPool.getOption('confirm_exit'),
-                        USE_SELECT2: sonata_admin.adminPool.getOption('use_select2'),
-                        USE_ICHECK: sonata_admin.adminPool.getOption('use_icheck'),
-                        USE_STICKYFORMS: sonata_admin.adminPool.getOption('use_stickyforms'),
-                    },
-                    translations: {
-                        CONFIRM_EXIT: 'confirm_exit'|trans({}, 'SonataAdminBundle'),
-                    },
-                }|json_encode()|raw }}'
             {%- endblock -%}
     >
 


### PR DESCRIPTION
I am targeting this branch, because it's the branch concerned by this bug

Closes #5261

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added block sonata_js_config after body_attributes block
```

## Subject

Fix JS errors by moving the config values to meta tag [as requested](https://github.com/sonata-project/SonataAdminBundle/pull/5240#issuecomment-429342150) by @core23 
No need to update overrided block in others bundles