### PR TITLE
Add round for scrollTop + height for Windows

### DIFF
--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -632,7 +632,7 @@ var Admin = {
 
         jQuery(window).scroll(
             Admin.debounce(function() {
-                if (footer.length && jQuery(window).scrollTop() + jQuery(window).height() == jQuery(document).height()) {
+                if (footer.length && Math.round(jQuery(window).scrollTop() + jQuery(window).height()) >= jQuery(document).height()) {
                     jQuery(footer).removeClass('stuck');
                 }
 


### PR DESCRIPTION
I am targeting this branch, because this is the main branch...

## Changelog

```markdown
### Changed
- Fix in edit page, the footer with actions buttons will be stuck for Windows users and the last field will no longer be hidden
```

## Subject

The class `stuck` is not removed on Windows (I tried with Chrome) when the page is at the end. The div `sonata-ba-form-actions` hides the last field. 
The cause for this problem is Windows` jQuery(window).scrollTop() + jQuery(window).height()` does not return an integer but a float...