### PR TITLE
Fix deprecation notice about FrameworkBundle redirect

### DIFF
--- a/src/Resources/config/routing/sonata_admin.xml
+++ b/src/Resources/config/routing/sonata_admin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="sonata_admin_redirect" path="/">
-        <default key="_controller">FrameworkBundle:Redirect:redirect</default>
+        <default key="_controller">Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction</default>
         <default key="route">sonata_admin_dashboard</default>
         <default key="permanent">true</default>
     </route>


### PR DESCRIPTION
I am targeting this branch, because it's a minor fix.

References #5251.

## Changelog

```markdown
### Fixed
- FrameworkBundle redirect action notation to the current syntax
```

## Subject

Fixes deprecation notice about FrameworkBundle redirect.
