### PR TITLE
Fix bad link target in doc

### DIFF
--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -648,4 +648,4 @@ Checkbox range selection
 
 .. _`issues on GitHub`: https://github.com/sonata-project/SonataAdminBundle/issues/1519
 .. _`SonataDoctrineORMAdminBundle Documentation`: https://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/list_field_definition.html
-.. _`here`: https://github.com/sonata-project/SonataCoreBundle/tree/master/Form/Type
+.. _`here`: https://github.com/sonata-project/SonataCoreBundle/tree/master/src/Form/Type


### PR DESCRIPTION
I am targeting this branch, because the target linked to the master branch.

## Changelog

```markdown

### Fixed
 - Fixed bad link target in doc.
```