### PR TITLE
Deprecate admin annotation

### DIFF
--- a/src/Annotation/Admin.php
+++ b/src/Annotation/Admin.php
@@ -19,6 +19,8 @@ use Sonata\AdminBundle\Controller\CRUDController;
 /**
  * Use annotations to define admin classes.
  *
+ * @deprecated since 3.40.2, Use https://github.com/kunicmarko20/SonataAnnotationBundle instead.
+ *
  * @Annotation
  * @Target("CLASS")
  */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because Admin annotation has been deprecated.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5272 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `@Admin` annotation
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [x] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

<!-- Describe your Pull Request content here -->
