### PR TITLE
Close <li>

### DIFF
--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -203,7 +203,7 @@ file that was distributed with this source code.
                                                         <i class="fa fa-arrow-circle-o-down" aria-hidden="true"></i>
                                                         {{ ("export_format_" ~ format)|trans({}, 'SonataAdminBundle') }}
                                                     </a>
-                                                <li>
+                                                </li>
                                                 {% endfor %}
                                             </ul>
                                         </div>


### PR DESCRIPTION
The `/` is missing in `</li>`

### Changelog
```markdown
### Fixed
- invalid html in the export links list
```