### PR TITLE
Add missing polish translation

### DIFF
--- a/src/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.pl.xliff
@@ -74,6 +74,10 @@
                 <source>link_add</source>
                 <target>Dodaj</target>
             </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Edytuj</target>
+            </trans-unit>
             <trans-unit id="link_list">
                 <source>link_list</source>
                 <target>Zarządzaj</target>


### PR DESCRIPTION
I am targeting this branch, because it's backwards compatible.

## Changelog

```markdown
### Added
- Added missing polish translation for `link_edit`
```