### PR TITLE
Fix sonata_type_collection fields delete row on new row add

### DIFF
--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -98,15 +98,34 @@ class AdminHelper
      */
     public function appendFormFieldElement(AdminInterface $admin, $subject, $elementId)
     {
+        // child rows marked as toDelete
+        $toDelete = [];
         // retrieve the subject
         $formBuilder = $admin->getFormBuilder();
+
+        // get the field element
+        $childFormBuilder = $this->getChildFormBuilder($formBuilder, $elementId);
+
+        if ($childFormBuilder) {
+            $formData = $admin->getRequest()->get($formBuilder->getName(), []);
+            if (array_key_exists($childFormBuilder->getName(), $formData)) {
+                $formData = $admin->getRequest()->get($formBuilder->getName(), []);
+                $i = 0;
+                foreach ($formData[$childFormBuilder->getName()] as $name => &$field) {
+                    $toDelete[$i] = false;
+                    if (array_key_exists('_delete', $field)) {
+                        $toDelete[$i] = true;
+                        unset($field['_delete']);
+                    }
+                    ++$i;
+                }
+            }
+            $admin->getRequest()->request->set($formBuilder->getName(), $formData);
+        }
 
         $form = $formBuilder->getForm();
         $form->setData($subject);
         $form->handleRequest($admin->getRequest());
-
-        // get the field element
-        $childFormBuilder = $this->getChildFormBuilder($formBuilder, $elementId);
 
         //Child form not found (probably nested one)
         //if childFormBuilder was not found resulted in fatal error getName() method call on non object
@@ -174,6 +193,15 @@ class AdminHelper
 
         // bind the data
         $finalForm->setData($form->getData());
+
+        // back up delete field
+        if (\count($toDelete) > 0) {
+            $i = 0;
+            foreach ($finalForm->get($childFormBuilder->getName()) as $childField) {
+                $childField->get('_delete')->setData(isset($toDelete[$i]) && $toDelete[$i]);
+                ++$i;
+            }
+        }
 
         return [$fieldDescription, $finalForm];
     }


### PR DESCRIPTION
I am targeting this branch, because bug fixes with BC.

Closes #1304 #1628

## Changelog

```markdown
### Fixed
- `sonata_type_collection` fields no longer deletes row when adding a new row
```

## Subject
When we add new row the submit action is executed with PreSubmit and PostSubmit events, so the `Sonata\CoreBundle\Form\EventListener` is executed and remove rows where delete is checked.
To fix it, i save the 'delete' marked rows name in array, and unset the `_delete` fields in the request, before handleRequest and submit action, and backup the `_delete` fields value after setting collection
