### PR TITLE
Fix BC break when baseControllerName uses bundle notation with subfolder

### DIFF
--- a/src/Route/RouteCollection.php
+++ b/src/Route/RouteCollection.php
@@ -84,6 +84,10 @@ class RouteCollection
 
         if (!isset($defaults['_controller'])) {
             $actionJoiner = false === \strpos($this->baseControllerName, '\\') ? ':' : '::';
+            if (false !== \strpos($this->baseControllerName, '\\') && false !== \strpos($this->baseControllerName, ':')) {
+                $actionJoiner = ':';
+            }
+
             $defaults['_controller'] = $this->baseControllerName.$actionJoiner.$this->actionify($code);
         }
 

--- a/src/Route/RouteCollection.php
+++ b/src/Route/RouteCollection.php
@@ -84,7 +84,7 @@ class RouteCollection
 
         if (!isset($defaults['_controller'])) {
             $actionJoiner = false === \strpos($this->baseControllerName, '\\') ? ':' : '::';
-            if (false !== \strpos($this->baseControllerName, '\\') && false !== \strpos($this->baseControllerName, ':')) {
+            if (':' !== $actionJoiner && false !== \strpos($this->baseControllerName, ':')) {
                 $actionJoiner = ':';
             }
 

--- a/tests/Route/RouteCollectionTest.php
+++ b/tests/Route/RouteCollectionTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\AdminBundle\Tests\Route;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Symfony\Component\Routing\Route;
 
@@ -184,5 +185,23 @@ class RouteCollectionTest extends TestCase
         $this->assertSame('baseControllerServiceName:viewAction', $route->getDefault('_controller'));
         $this->assertSame('baseCodeRoute', $route->getDefault('_sonata_admin'));
         $this->assertSame('baseRouteName_view', $route->getDefault('_sonata_name'));
+    }
+
+    public function testControllerWithFQCN()
+    {
+        $routeCollection = new RouteCollection('baseCodeRoute', 'baseRouteName', 'baseRoutePattern', CRUDController::class);
+        $routeCollection->add('view');
+        $route = $routeCollection->get('view');
+
+        $this->assertSame('Sonata\AdminBundle\Controller\CRUDController::viewAction', $route->getDefault('_controller'));
+    }
+
+    public function testControllerWithBundleSubFolder()
+    {
+        $routeCollection = new RouteCollection('baseCodeRoute', 'baseRouteName', 'baseRoutePattern', 'AppBundle\Admin:Test');
+        $routeCollection->add('view');
+        $route = $routeCollection->get('view');
+
+        $this->assertSame('AppBundle\Admin:Test:view', $route->getDefault('_controller'));
     }
 }


### PR DESCRIPTION
I am targeting this branch, because it fixes a BC break when using Bundle notation with Subfolder.

## Changelog

```markdown
### Fixed
- Fixed BC break when baseControllerName uses bundle notation with subfolder
```
## Subject

Related to #5228 
