### PR TITLE
Fixed returning types in AbstractAdmin

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1347,7 +1347,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     public function buildTabMenu($action, AdminInterface $childAdmin = null)
     {
         if ($this->loaded['tab_menu']) {
-            return;
+            return $this->menu;
         }
 
         $this->loaded['tab_menu'] = true;
@@ -1368,6 +1368,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         }
 
         $this->menu = $menu;
+
+        return $this->menu;
     }
 
     public function buildSideMenu($action, AdminInterface $childAdmin = null)
@@ -1521,7 +1523,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     }
 
     /**
-     * @param array $group
+     * @param string $group
+     * @param array $keys
      */
     public function reorderFormGroup($group, array $keys)
     {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1524,7 +1524,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     /**
      * @param string $group
-     * @param array $keys
+     * @param array  $keys
      */
     public function reorderFormGroup($group, array $keys)
     {


### PR DESCRIPTION
I am targeting this branch, because it's BC.

## Changelog
Fixed returning types in AbstractAdmin

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - returning types in \Sonata\AdminBundle\Admin\AbstractAdmin
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

<!-- Describe your Pull Request content here -->
Return types in AbstractAdmin not equals same described in interface it implementing