### PR TITLE
Fixed trying to access non-existing properties in strict_variables mode

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
@@ -22,7 +22,7 @@ file that was distributed with this source code.
                                             <th>{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}</th>
                                         {% else %}
                                             <th
-                                                {% if (nested_field.vars['required'] is defined) and nested_field.vars['required'] %}
+                                                {% if nested_field.vars['required']|default(false) %}
                                                     class="required"
                                                 {% endif %}
                                             >
@@ -38,7 +38,7 @@ file that was distributed with this source code.
                                         {% for field_name, nested_field in nested_group_field.children %}
                                             <td
                                                 class="sonata-ba-td-{{ id }}-{{ field_name  }} control-group
-                                                {% if (nested_field.vars.errors is defined) and nested_field.vars.errors|length > 0 %} error sonata-ba-field-error{% endif %}"
+                                                {% if nested_field.vars.errors|default(false) %} error sonata-ba-field-error{% endif %}"
                                             >
                                                 {% if sonata_admin.field_description.associationadmin.hasformfielddescriptions(field_name) is defined %}
                                                     {{ form_widget(nested_field) }}
@@ -47,7 +47,7 @@ file that was distributed with this source code.
                                                 {% else %}
                                                     {{ form_widget(nested_field) }}
                                                 {% endif %}
-                                                {% if (nested_field.vars.errors is defined) and nested_field.vars.errors|length > 0 %}
+                                                {% if nested_field.vars.errors|default(false) %}
                                                     <div class="help-inline sonata-ba-field-error-messages">
                                                         {{ form_errors(nested_field) }}
                                                     </div>

--- a/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
@@ -21,7 +21,11 @@ file that was distributed with this source code.
                                         {% if field_name == '_delete' %}
                                             <th>{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}</th>
                                         {% else %}
-                                            <th {{ nested_field.vars['required']  ? 'class="required"' : '' }}>
+                                            <th
+                                                {% if (nested_field.vars['required'] is defined) and nested_field.vars['required'] %}
+                                                    class="required"
+                                                {% endif %}
+                                            >
                                                 {{ nested_field.vars['sonata_admin'].admin.trans(nested_field.vars.label) }}
                                             </th>
                                         {% endif %}
@@ -32,7 +36,10 @@ file that was distributed with this source code.
                                 {% for nested_group_field_name, nested_group_field in form.children %}
                                     <tr>
                                         {% for field_name, nested_field in nested_group_field.children %}
-                                            <td class="sonata-ba-td-{{ id }}-{{ field_name  }} control-group{% if nested_field.vars.errors|length > 0 %} error sonata-ba-field-error{% endif %}">
+                                            <td
+                                                class="sonata-ba-td-{{ id }}-{{ field_name  }} control-group
+                                                {% if (nested_field.vars.errors is defined) and nested_field.vars.errors|length > 0 %} error sonata-ba-field-error{% endif %}"
+                                            >
                                                 {% if sonata_admin.field_description.associationadmin.hasformfielddescriptions(field_name) is defined %}
                                                     {{ form_widget(nested_field) }}
 
@@ -40,7 +47,7 @@ file that was distributed with this source code.
                                                 {% else %}
                                                     {{ form_widget(nested_field) }}
                                                 {% endif %}
-                                                {% if nested_field.vars.errors|length > 0 %}
+                                                {% if (nested_field.vars.errors is defined) and nested_field.vars.errors|length > 0 %}
                                                     <div class="help-inline sonata-ba-field-error-messages">
                                                         {{ form_errors(nested_field) }}
                                                     </div>

--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
@@ -16,10 +16,10 @@ file that was distributed with this source code.
                     <th>{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}</th>
                 {% else %}
                     <th
-                        {% if (nested_field.vars['required'] is defined) and nested_field.vars['required'] %}
+                        {% if nested_field.vars['required']|default(false) %}
                             class="required"
                         {% endif %}
-                        {% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %}
+                        {% if nested_field.vars['attr']['hidden']|default(false) %}
                             style="display:none;"
                         {% endif %}
                     >
@@ -38,9 +38,9 @@ file that was distributed with this source code.
                     <td class="
                         sonata-ba-td-{{ id }}-{{ field_name  }}
                         control-group
-                        {% if (nested_field.vars.errors is defined) and nested_field.vars.errors|length > 0 %} error sonata-ba-field-error{% endif %}
+                        {% if nested_field.vars.errors|default(false) %} error sonata-ba-field-error{% endif %}
                         "
-                        {% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %}
+                        {% if nested_field.vars['attr']['hidden']|default(false) %}
                             style="display:none;"
                         {% endif %}
                     >
@@ -53,9 +53,9 @@ file that was distributed with this source code.
                                 {{ form_widget(nested_field, { label: false }) }}
                             {% else %}
                                 {{ form_widget(nested_field) }}
-                            {% endif %}
+                            {% endif %}e
                         {% endif %}
-                        {% if  (nested_field.vars.errors is defined) and nested_field.vars.errors|length > 0 %}
+                        {% if nested_field.vars.errors|default(false) %}
                             <div class="help-inline sonata-ba-field-error-messages">
                                 {{ form_errors(nested_field) }}
                             </div>

--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
                     <th>{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}</th>
                 {% else %}
                     <th
-                        {% if nested_field.vars['required'] %}
+                        {% if (nested_field.vars['required'] is defined) and nested_field.vars['required'] %}
                             class="required"
                         {% endif %}
                         {% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %}
@@ -38,7 +38,7 @@ file that was distributed with this source code.
                     <td class="
                         sonata-ba-td-{{ id }}-{{ field_name  }}
                         control-group
-                        {% if nested_field.vars.errors|length > 0 %} error sonata-ba-field-error{% endif %}
+                        {% if (nested_field.vars.errors is defined) and nested_field.vars.errors|length > 0 %} error sonata-ba-field-error{% endif %}
                         "
                         {% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %}
                             style="display:none;"
@@ -55,7 +55,7 @@ file that was distributed with this source code.
                                 {{ form_widget(nested_field) }}
                             {% endif %}
                         {% endif %}
-                        {% if nested_field.vars.errors|length > 0 %}
+                        {% if  (nested_field.vars.errors is defined) and nested_field.vars.errors|length > 0 %}
                             <div class="help-inline sonata-ba-field-error-messages">
                                 {{ form_errors(nested_field) }}
                             </div>


### PR DESCRIPTION
I am targeting this branch, because this is a backwards-compatible bug fix

## Changelog

```markdown
### Fixed
- Error on some fields in collection table when `strict_variables` mode is enabled
```

## Subject
When `strict_variables` mode is enabled, trying to access non-existing array key from a template results in exception.
```
                        {% if nested_field.vars['required'] %}
                            class="required"
                        {% endif %}
```

`nested_field.vars['required']` and `nested_field.vars.errors` can be missing if collection form contains some a not mapped field with field type defined.

## Example
FooAdmin
```
    protected function configureFormFields(FormMapper $formMapper): void
    {
        $formMapper
            ->add(
                'bars',
                CollectionType::class,
                ['by_reference' => false],
                ['edit' => 'inline', 'inline' => 'table']
            )
            ->end();
    }
```
BarAdmin
```
    protected function configureFormFields(FormMapper $formMapper): void
    {
        $formMapper
            ->add('assetName')
            ->add(
                'button',
                ButtonType::class,
                [
                    'href' => $asset->getUrl(),
                    'hideOnDisabled' => true,
                    'enabled' => (bool) $asset->getUrl(),
                    'label' => "Play",
                ]
            )
            ->end();
    }
```
In this case `button` FormView will not have those properties because in `Symfony\Component\Form\FormBuilder::create()`
```
    public function create($name, $type = null, array $options = array())
    {
        // [... not relevant code]

        // This is going to be true
        if (null !== $type) {
            // This method doesn't run 'required' guesser and doesn't add 'required' option
            return $this->getFormFactory()->createNamedBuilder($name, $type, null, $options);
        }

        return $this->getFormFactory()->createBuilderForProperty($this->getDataClass(), $name, null, $options);
    }
```

## Solution
Handle check of potentially missing property using `is defined` Twig construct, same as it's done for `nested_field.vars['attr']['hidden']`