### PR TITLE
Added default_controller configuration option

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -70,6 +70,7 @@ Full Configuration Options
             title: 'Sonata Admin'
             title_logo: bundles/sonataadmin/logo_title.png
             search: true
+            default_controller: Sonata\AdminBundle\ControllerCRUDController
             options:
                 html5_validate: true
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -70,7 +70,7 @@ Full Configuration Options
             title: 'Sonata Admin'
             title_logo: bundles/sonataadmin/logo_title.png
             search: true
-            default_controller: Sonata\AdminBundle\ControllerCRUDController
+            default_controller: Sonata\AdminBundle\Controller\CRUDController
             options:
                 html5_validate: true
 

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -12,7 +12,6 @@
 namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
 use Doctrine\Common\Inflector\Inflector;
-use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -46,6 +45,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $groupDefaults = $admins = $classes = [];
 
         $pool = $container->getDefinition('sonata.admin.pool');
+        $defaultController = $container->getParameter('sonata.admin.configuration.default_container');
 
         foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $tags) {
             foreach ($tags as $attributes) {
@@ -63,7 +63,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
                 $this->replaceDefaultArguments([
                     0 => $id,
-                    2 => CRUDController::class,
+                    2 => $defaultController,
                 ], $definition, $parentDefinition);
                 $this->applyConfigurationFromAttribute($definition, $attributes);
                 $this->applyDefaults($container, $id, $attributes);

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -45,7 +45,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $groupDefaults = $admins = $classes = [];
 
         $pool = $container->getDefinition('sonata.admin.pool');
-        $defaultController = $container->getParameter('sonata.admin.configuration.default_container');
+        $defaultController = $container->getParameter('sonata.admin.configuration.default_controller');
 
         foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $tags) {
             foreach ($tags as $attributes) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Sonata\AdminBundle\Controller\CRUDController;
 
 /**
  * This class contains the configuration information for the bundle.
@@ -99,6 +100,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
 
+                ->scalarNode('default_controller')->defaultValue(CRUDController::class)->cannotBeEmpty()->end()
                 ->arrayNode('breadcrumbs')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -100,7 +100,12 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
 
-                ->scalarNode('default_controller')->defaultValue(CRUDController::class)->cannotBeEmpty()->end()
+                ->scalarNode('default_controller')
+                    ->defaultValue(CRUDController::class)
+                    ->cannotBeEmpty()
+                    ->info('Name of the controller class to be used as a default in admin definitions')
+                ->end()
+
                 ->arrayNode('breadcrumbs')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -11,9 +11,9 @@
 
 namespace Sonata\AdminBundle\DependencyInjection;
 
+use Sonata\AdminBundle\Controller\CRUDController;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Sonata\AdminBundle\Controller\CRUDController;
 
 /**
  * This class contains the configuration information for the bundle.

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -203,6 +203,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
             'outer_list_rows_tree' => '@SonataAdmin/CRUD/list_outer_rows_tree.html.twig',
         ]);
         $container->setParameter('sonata.admin.configuration.admin_services', $config['admin_services']);
+        $container->setParameter('sonata.admin.configuration.default_controller', $config['default_controller']);
         $container->setParameter('sonata.admin.configuration.dashboard_groups', $config['dashboard']['groups']);
         $container->setParameter('sonata.admin.configuration.dashboard_blocks', $config['dashboard']['blocks']);
         $container->setParameter('sonata.admin.configuration.sort_admins', $config['options']['sort_admins']);


### PR DESCRIPTION
Added default_controller configuration option to allow for mass-replacement of Sonata\AdminBundle\Controller\CRUDController.

I am targeting this branch, because this PR contains no BC.

## Changelog
```markdown
### Added
- Added `default_controller` to the configuration
```
