### PR TITLE
Fix admin type collection tabs ids

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
                     {% for name, form_group in associationAdmin.formgroups %}
                         <li class="{% if loop.first %}active{% endif %}">
                             <a
-                                href="#{{ associationAdmin.uniqid }}_{{ loop.parent.loop.index }}_{{ loop.index }}"
+                                href="#{{ id }}_{{ loop.parent.loop.index }}_{{ loop.index }}"
                                 data-toggle="tab"
                             >
                                 <i class="icon-exclamation-sign has-errors hide"></i>
@@ -30,7 +30,7 @@ file that was distributed with this source code.
                     {% for name, form_group in associationAdmin.formgroups %}
                         <div
                             class="tab-pane {% if loop.first %}active{% endif %}"
-                            id="{{ associationAdmin.uniqid }}_{{ loop.parent.loop.index }}_{{ loop.index }}"
+                            id="{{ id }}_{{ loop.parent.loop.index }}_{{ loop.index }}"
                         >
                             <fieldset>
                                 <div class="sonata-ba-collapsed-fields">


### PR DESCRIPTION
I am targeting this branch, because it's a bugfix.

Closes #5306

## Changelog

```markdown
### Fixed
- Fixed `AdminType` tabs ids when used in collections 
```

## Subject

Embedded tabs now get correct unique ids.

Examples (see #5306) : 
**Before** : `#s652ee50cb4_1_1`
**After** : `#s20ab319f7d_streets_0_buildings_1_1`