### PR TITLE
Edit wrong example for  command make:sonata:admin

### DIFF
--- a/docs/reference/console.rst
+++ b/docs/reference/console.rst
@@ -53,7 +53,7 @@ Usage example:
 
 .. code-block:: bash
 
-    $ bin/console sonata:admin:generate App/Entity/Foo
+    $ bin/console make:sonata:admin App/Entity/Foo
 
 sonata:admin:generate
 ---------------------


### PR DESCRIPTION
replace wrong command example for "make:sonata:admin" from "$ bin/console sonata:admin:generate App/Entity/Foo" to "$ bin/console make:sonata:admin App/Entity/Foo"
