### PR TITLE
Added missing translation (#5315)

### DIFF
--- a/src/Resources/translations/SonataAdminBundle.es.xliff
+++ b/src/Resources/translations/SonataAdminBundle.es.xliff
@@ -482,6 +482,10 @@
                 <source>read_less</source>
                 <target>Cerrar</target>
             </trans-unit>
+            <trans-unit id="toggle_navigation">
+                <source>toggle_navigation</source>
+                <target>Cambiar modo de navegación</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
I am targeting this branch, because it offer backward compatibility, add a translation will not break the compatibility.

Closes #5315

```markdown
### Added
- New missing translation
```

## Subject

I've add the translation of the key 'toggle_navigation' for the spanish language 
