### PR TITLE
deprecate header_style

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -6,6 +6,11 @@ UPGRADE 3.x
 If you extended that controller, you should split your extended controller and
 extend the corresponding classes in `SonataAdminBundle\Action\`.
 
+## Deprecated `header_style` option
+
+If you need to style headers prefer to use CSS classes and not in the html DOM.
+In this case please use `header_class` option.
+
 UPGRADE FROM 3.34 to 3.35
 =========================
 

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -120,6 +120,13 @@ class ListMapper extends BaseMapper
             );
         }
 
+        if (isset($fieldDescriptionOptions['header_style'])) {
+            @trigger_error(
+                'The "header_style" option is deprecated, please, use "header_class" option instead.',
+                E_USER_DEPRECATED
+            );
+        }
+
         // add the field with the FormBuilder
         $this->builder->addField($this->list, $type, $fieldDescription, $this->admin);
 


### PR DESCRIPTION
I am targeting this branch, because it's related to the current version and add the trigger for the deprecated option.

Closes #4205

## Changelog
```markdown
### Deprecated
- `header_style` option
```
