### PR TITLE
Docs: Fix problem in example config

### DIFF
--- a/docs/reference/templates.rst
+++ b/docs/reference/templates.rst
@@ -172,7 +172,7 @@ can specify the templates to use in the ``Admin`` service definition:
             <argument />
             <call method="setTemplate">
                 <argument>edit</argument>
-                <argument>@App/PostAdmin/edit.html.twig</argument>
+                <argument>AppBundle:PostAdmin/edit.html.twig</argument>
             </call>
         </service>
 
@@ -188,7 +188,7 @@ can specify the templates to use in the ``Admin`` service definition:
                     - App\Entity\Post
                     - ~
                 calls:
-                    - [ setTemplate, [edit, "@App/PostAdmin/edit.html.twig"]]
+                    - [ setTemplate, [edit, "AppBundle:PostAdmin/edit.html.twig"]]
                 public: true
 
 .. note::


### PR DESCRIPTION
## Minor documentation fix

The docs at https://symfony.com/doc/3.x/bundles/SonataAdminBundle/reference/templates.html contain bad example config entries.

### Copy of commit message since it explains the problem:
`@App` tries to inject a service, the error you get when trying to use the example config is this (names / paths have been adjusted):

```Fatal error: Uncaught Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: The service "app.admin.frontend_user.template_registry" has a dependency on a non-existent service "App/admin/blocks/customized_edit.html.twig"```

`AppBundle:` actually works as originally intended here.