### PR TITLE
Implement getExtendedTypes

### DIFF
--- a/src/Form/Extension/ChoiceTypeExtension.php
+++ b/src/Form/Extension/ChoiceTypeExtension.php
@@ -49,4 +49,9 @@ class ChoiceTypeExtension extends AbstractTypeExtension
     {
         return ChoiceType::class;
     }
+
+    public static function getExtendedTypes()
+    {
+        return [ChoiceType::class];
+    }
 }

--- a/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -155,6 +155,11 @@ class FormTypeFieldExtension extends AbstractTypeExtension
         return FormType::class;
     }
 
+    public static function getExtendedTypes()
+    {
+        return [FormType::class];
+    }
+
     /**
      * NEXT_MAJOR: Remove method, when bumping requirements to SF 2.7+.
      *

--- a/src/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
@@ -56,4 +56,9 @@ class MopaCompatibilityTypeFieldExtension extends AbstractTypeExtension
     {
         return FormType::class;
     }
+
+    public static function getExtendedTypes()
+    {
+        return [FormType::class];
+    }
 }

--- a/tests/Form/Extension/ChoiceTypeExtensionTest.php
+++ b/tests/Form/Extension/ChoiceTypeExtensionTest.php
@@ -62,6 +62,11 @@ class ChoiceTypeExtensionTest extends TestCase
             ChoiceType::class,
             $extension->getExtendedType()
         );
+
+        $this->assertSame(
+            [ChoiceType::class],
+            ChoiceTypeExtension::getExtendedTypes()
+        );
     }
 
     public function testDefaultOptionsWithSortable()

--- a/tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
+++ b/tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
@@ -28,6 +28,7 @@ class FormTypeFieldExtensionTest extends TestCase
         $extension = new FormTypeFieldExtension([], []);
 
         $this->assertSame(FormType::class, $extension->getExtendedType());
+        $this->assertSame([FormType::class], FormTypeFieldExtension::getExtendedTypes());
     }
 
     public function testDefaultOptions()


### PR DESCRIPTION
## Subject

It seems that this method is now required.
See BC-break report: https://github.com/symfony/symfony/issues/29426

I am targeting this branch, because this is BC.

Refs #5322 

The bug is in a class that is probably only used in tests, so I believe this is pedantic.