### PR TITLE
Toggle edit button after operations add/list/remove

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -479,7 +479,12 @@ This code manages the many-to-[one|many] association field popup
                     associationadmin.generateUrl('edit', {'id' : 'OBJECT_ID'})
                 }}'.replace('OBJECT_ID', jQuery(this).val());
 
-                jQuery('#field_actions_{{ id }} a.btn-warning').attr('href', edit_button_url);
+                var edit_button_node = jQuery('#field_actions_{{ id }} a.btn-warning');
+                if (jQuery(this).val()) {
+                    edit_button_node.removeClass('hidden').attr('href', edit_button_url);
+                } else {
+                    edit_button_node.addClass('hidden');
+                }
             {% endif %}
         });
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Toggle edit button `sonata_type_model_list_widget` after operations add/list/remove
```


   
## To do
    
- [x] Need merge [SonataDoctrineORMAdminBundle#865](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/865)

## Subject

After adding the value, sometimes you need to edit, but the edit button is available only after updating the object.

Example how this works:
![hf4rkv4nr1](https://user-images.githubusercontent.com/3332033/49433181-2bcfd100-f7d3-11e8-9076-4104496d2da8.gif)


