### PR TITLE
Add ability to specify batch action confirmation template per action

### DIFF
--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -26,7 +26,7 @@ Each key represent a batch action and could contain these settings:
 - **ask_confirmation**: defaults to true and means that the user will be asked
   for confirmation before the batch action is processed
 - **template**: Override ``ask_confirmation`` template for this specific action. This allows you
-  to specify different template for each batch action that requires confirmation.
+  to specify different templates for each batch action that requires confirmation.
 
 For example, lets define a new ``merge`` action which takes a number of source items and
 merges them onto a single target item. It should only be available when two conditions are met:

--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -25,6 +25,8 @@ Each key represent a batch action and could contain these settings:
   (default: the translation domain of the admin)
 - **ask_confirmation**: defaults to true and means that the user will be asked
   for confirmation before the batch action is processed
+- **template**: Override ``ask_confirmation`` template for this specific action. This allows you
+  to specify different template for each batch action that requires confirmation.
 
 For example, lets define a new ``merge`` action which takes a number of source items and
 merges them onto a single target item. It should only be available when two conditions are met:

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -514,9 +514,13 @@ class CRUDController implements ContainerAwareInterface
             $formView = $datagrid->getForm()->createView();
             $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-            // NEXT_MAJOR: Remove this line and use commented line below it instead
-            $template = $this->admin->getTemplate('batch_confirmation');
-            // $template = $this->templateRegistry->getTemplate('batch_confirmation');
+            // NEXT_MAJOR: Remove these lines and use commented lines below them instead
+            $template = !empty($batchActions[$action]['template']) ?
+                $batchActions[$action]['template'] :
+                $this->admin->getTemplate('batch_confirmation');
+            // $template = !empty($batchActions[$action]['template']) ?
+            //     $batchActions[$action]['template'] :
+            //     $this->templateRegistry->getTemplate('batch_confirmation');
 
             return $this->renderWithExtraParams($template, [
                 'action' => 'list',

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3712,6 +3712,43 @@ class CRUDControllerTest extends TestCase
         $this->assertSame('list', $result->getTargetUrl());
     }
 
+    public function testBatchActionWithCustomConfirmationTemplate()
+    {
+        $batchActions = ['delete' => ['label' => 'Foo Bar', 'ask_confirmation' => true, 'template' => 'custom_template.html.twig']];
+
+        $this->admin->expects($this->once())
+            ->method('getBatchActions')
+            ->will($this->returnValue($batchActions));
+
+        $data = ['action' => 'delete', 'idx' => ['123', '456'], 'all_elements' => false];
+
+        $this->request->setMethod('POST');
+        $this->request->request->set('data', json_encode($data));
+        $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
+
+        $datagrid = $this->createMock(DatagridInterface::class);
+
+        $this->admin->expects($this->once())
+            ->method('getDatagrid')
+            ->will($this->returnValue($datagrid));
+
+        $form = $this->getMockBuilder(Form::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $form->expects($this->once())
+            ->method('createView')
+            ->will($this->returnValue($this->createMock(FormView::class)));
+
+        $datagrid->expects($this->once())
+            ->method('getForm')
+            ->will($this->returnValue($form));
+
+        $this->controller->batchAction($this->request);
+
+        $this->assertSame('custom_template.html.twig', $this->template);
+    }
+
     /**
      * NEXT_MAJOR: Remove this legacy group.
      *

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3732,9 +3732,7 @@ class CRUDControllerTest extends TestCase
             ->method('getDatagrid')
             ->will($this->returnValue($datagrid));
 
-        $form = $this->getMockBuilder(Form::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $form = $this->createMock(Form::class);
 
         $form->expects($this->once())
             ->method('createView')


### PR DESCRIPTION
## Subject

Add ability to specify batch action confirmation template per action thus making it easier to support multiple batch actions with `ask_confirmation` and custom templates per admin.

I am targeting this branch, because it's backwards compatible feature.

Sort of addresses some simple use-cases for #4105

## Changelog

```markdown
### Added
- Added `template` option to admin `batchActions`
```