### PR TITLE
Remove -20px margin for radio and checkbox buttons

### DIFF
--- a/src/Resources/public/css/styles.css
+++ b/src/Resources/public/css/styles.css
@@ -367,7 +367,6 @@ td.sonata-ba-list-field .editable-empty:not(.editable-open) {
 .checkbox label,
 .radio label {
     font-weight: 700;
-    margin-left: -20px;
 }
 
 /**


### PR DESCRIPTION
## Subject
The bootstrap css from sonatacore already has a -20px margin for radio and checkbox inputs, this results in a -40px margin, which displays the delete checkbox for example in a CollectionType outside the table.

Bootsrap css in bundles/sonatacore/vendor/bootstrap/dist/css/less/forms.less:
```
.checkbox input[type=checkbox], .checkbox-inline input[type=checkbox], .radio input[type=radio], .radio-inline input[type=radio] {
    position: absolute;
    margin-top: 4px\9;
    margin-left: -20px;
}
```
## Changelog
```
### Fixed
- Removed -20px margin for radio and checkbox buttons, wich caused delete checkboxes for CollectionType to display outside of the table.
```