### PR TITLE
Check "create" route existence in ModelAutocompleteType form field

### DIFF
--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -13,14 +13,12 @@ file that was distributed with this source code.
     <input type="text" id="{{ id }}_autocomplete_input" value=""
         {%- for attribute,value in attr %} {{attribute}}="{{value}}" {% endfor -%}
         {%- if read_only|default(false) %} readonly="readonly"{% endif -%}    {# NEXT_MAJOR: remove #}
-        {%- if disabled %} disabled="disabled"{% endif -%}
-        {%- if required %} required="required"{% endif %}
+        {%- if disabled %} disabled="disabled"{% endif %}
     />
 
     <select id="{{ id }}_autocomplete_input_v4" data-sonata-select2="false"
         {%- if read_only|default(false) %} readonly="readonly"{% endif -%}
-        {%- if disabled %} disabled="disabled"{% endif -%}
-        {%- if required %} required="required"{% endif %}
+        {%- if disabled %} disabled="disabled"{% endif %}
     >
         {%- for idx, val  in value if idx~'' != '_labels' -%}
             <option value="{{ val }}" selected>{{ value['_labels'][idx] }}</option>
@@ -274,7 +272,13 @@ file that was distributed with this source code.
                 return true;
             });
 
-            {% if sonata_admin.field_description and sonata_admin.field_description.hasAssociationAdmin %}
+            // Automatically select the created record after closing the popup window
+            {% if sonata_admin.field_description 
+                and sonata_admin.field_description.hasAssociationAdmin 
+                and btn_add 
+                and sonata_admin.field_description.associationadmin.hasRoute('create')
+                and sonata_admin.field_description.associationadmin.hasAccess('create') %}
+
                 {% set create_url = sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) %}
     
                 $(document).ajaxSuccess(function(event, xhr, settings) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is affected by this bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5342 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
Fix crash on form pages that use `ModelAutocompleteType` and does not have a create route
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
