### PR TITLE
add template for history button in list views

### DIFF
--- a/src/Resources/views/CRUD/list__action_history.html.twig
+++ b/src/Resources/views/CRUD/list__action_history.html.twig
@@ -1,0 +1,21 @@
+{#
+
+This file is part of SonataAdminBundle and based on @SonataAdmin\CRUD\list__action_show.html.twig.
+
+(c) Daniel Reiche <d.reiche@gmx.ch>
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+The 'history' routes and actions are already defined by SonataAdmin, they just lack a default list action template.
+We're using the 'link_action_history' message placeholder here, since this is already defined and well translated.
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% if admin.hasAccess('history', object) and admin.hasRoute('history') %}
+    <a href="{{ admin.generateObjectUrl('history', object) }}" class="btn btn-sm btn-default view_link" title="{{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}">
+        <i class="fa fa-history" aria-hidden="true"></i>
+        {{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}
+    </a>
+{% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

adds a default template for a history action button on list views.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this introduces no b/c breaks, merely additions.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5351

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `list__action_history.html.twig` template for list view's history button
```