### PR TITLE
added option for global search: case_sensitive

### DIFF
--- a/docs/reference/search.rst
+++ b/docs/reference/search.rst
@@ -145,3 +145,31 @@ and it looks like this:
     :align: center
     :alt: Custom view
     :width: 700px
+
+Case sensitive/insensitive
+--------------------------
+
+By default all searches are done case-sensitive.
+
+.. note::
+
+    This will support PostgreSQL out of the box, but unless you change the collation of MySQL, MSSQL or SQLite,
+    it will have no effect! They are case-insensitive by default.
+
+To search case-insensitive use the following option:
+
+.. code-block:: yaml
+
+    # config/packages/sonata_admin.yaml
+
+    sonata_admin:
+        global_search:
+            case_sensitive: false
+
+Using case-insensitivity might lead to performance issues. You can find some more information
+`here <hhttps://use-the-index-luke.com/sql/where-clause/functions/case-insensitive-search>`_.
+
+Instead of searching **all** fields case-insensitive with PostgreSQL, you can use a dedicated
+`CITEXT type <https://www.postgresql.org/docs/9.1/citext.html>`_ via
+`opsway/doctrine-dbal-postgresql <https://github.com/opsway/doctrine-dbal-postgresql/blob/master/src/Doctrine/DBAL/Types/Citext.php>`_
+and keep the `case-sensitive` option with `true`.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -40,6 +40,14 @@ class Configuration implements ConfigurationInterface
             $rootNode = $treeBuilder->getRootNode();
         }
 
+        $caseSensitiveInfo = <<<'CASESENSITIVE'
+Whether the global search should behave case sensitive or not.
+Using case-insensitivity might lead to performance issues.
+
+See https://use-the-index-luke.com/sql/where-clause/functions/case-insensitive-search
+for more information.
+CASESENSITIVE;
+
         $rootNode
             ->fixXmlConfig('option')
             ->fixXmlConfig('admin_service')
@@ -103,6 +111,10 @@ class Configuration implements ConfigurationInterface
                                 })
                                 ->thenInvalid('Configuration value of "global_search.empty_boxes" must be one of show, fade or hide.')
                             ->end()
+                        ->end()
+                        ->booleanNode('case_sensitive')
+                            ->defaultTrue()
+                            ->info($caseSensitiveInfo)
                         ->end()
                     ->end()
                 ->end()

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -172,6 +172,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         }
 
         $container->setParameter('sonata.admin.configuration.global_search.empty_boxes', $config['global_search']['empty_boxes']);
+        $container->setParameter('sonata.admin.configuration.global_search.case_sensitive', $config['global_search']['case_sensitive']);
         $container->setParameter('sonata.admin.configuration.templates', $config['templates'] + [
             'user_block' => '@SonataAdmin/Core/user_block.html.twig',
             'add_block' => '@SonataAdmin/Core/add_block.html.twig',

--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -61,6 +61,7 @@
         </service>
         <service id="sonata.admin.search.handler" class="Sonata\AdminBundle\Search\SearchHandler" public="true">
             <argument type="service" id="sonata.admin.pool"/>
+            <argument>%sonata.admin.configuration.global_search.case_sensitive%</argument>
         </service>
         <!-- event -->
         <service id="sonata.admin.event.extension" class="Sonata\AdminBundle\Event\AdminEventExtension" public="true">

--- a/src/Search/SearchHandler.php
+++ b/src/Search/SearchHandler.php
@@ -28,9 +28,20 @@ class SearchHandler
      */
     protected $pool;
 
-    public function __construct(Pool $pool)
+    /**
+     * @var bool
+     */
+    private $caseSensitive;
+
+    /**
+     * NEXT_MAJOR: remove default true value for $caseSensitive and add bool type hint.
+     *
+     * @param bool $caseSensitive
+     */
+    public function __construct(Pool $pool, $caseSensitive = true)
     {
         $this->pool = $pool;
+        $this->caseSensitive = $caseSensitive;
     }
 
     /**
@@ -50,6 +61,7 @@ class SearchHandler
         foreach ($datagrid->getFilters() as $filter) {
             /** @var $filter FilterInterface */
             if ($filter->getOption('global_search', false)) {
+                $filter->setOption('case_sensitive', $this->caseSensitive);
                 $filter->setCondition(FilterInterface::CONDITION_OR);
                 $datagrid->setValue($filter->getFormName(), null, $term);
                 $found = true;

--- a/tests/Search/SearchHandlerTest.php
+++ b/tests/Search/SearchHandlerTest.php
@@ -48,6 +48,7 @@ class SearchHandlerTest extends TestCase
     {
         $filter = $this->getMockForAbstractClass(FilterInterface::class);
         $filter->expects($this->once())->method('getOption')->will($this->returnValue(false));
+        $filter->expects($this->never())->method('setOption');
 
         $datagrid = $this->getMockForAbstractClass(DatagridInterface::class);
         $datagrid->expects($this->once())->method('getFilters')->will($this->returnValue([$filter]));
@@ -59,10 +60,16 @@ class SearchHandlerTest extends TestCase
         $this->assertFalse($handler->search($admin, 'myservice'));
     }
 
-    public function testBuildPagerWithGlobalSearchField()
+    /**
+     * @test
+     *
+     * @dataProvider buildPagerWithGlobalSearchFieldProvider
+     */
+    public function buildPagerWithGlobalSearchField($caseSensitive)
     {
         $filter = $this->getMockForAbstractClass(FilterInterface::class);
         $filter->expects($this->once())->method('getOption')->will($this->returnValue(true));
+        $filter->expects($this->once())->method('setOption')->with('case_sensitive', $caseSensitive);
 
         $pager = $this->getMockForAbstractClass(PagerInterface::class);
         $pager->expects($this->once())->method('setPage');
@@ -76,7 +83,15 @@ class SearchHandlerTest extends TestCase
         $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->once())->method('getDatagrid')->will($this->returnValue($datagrid));
 
-        $handler = new SearchHandler($this->getPool($admin));
+        $handler = new SearchHandler($this->getPool($admin), $caseSensitive);
         $this->assertInstanceOf(PagerInterface::class, $handler->search($admin, 'myservice'));
+    }
+
+    public function buildPagerWithGlobalSearchFieldProvider()
+    {
+        return [
+            [true],
+            [false],
+        ];
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because this is BC.

Assume you have an Entity Supplier named **Brandid**, you need to search for `Brandid` to find the result. Searching for `brandid` will not bring up results....

With this PR you can search for `Brandid` and `brandid` if `case_sensitive` is set to `false` and get the result.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added possibility to search globally case-sensitive/case-insensitive
```

## To do
    
- [x] Update the tests
- [x] Update the documentation
- [x] [Add PR to DoctrineORMBundle `StringFilter` to support `case_sensitive` option ](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/870)
- [x] add `->info()` node to Configuration