### PR TITLE
Fixing the RouteCollection base controller FQCN detection

### DIFF
--- a/src/Route/RouteCollection.php
+++ b/src/Route/RouteCollection.php
@@ -83,7 +83,8 @@ class RouteCollection
         $routeName = $this->baseRouteName.'_'.$name;
 
         if (!isset($defaults['_controller'])) {
-            $actionJoiner = false === \strpos($this->baseControllerName, '\\') ? ':' : '::';
+            $actionJoiner = false !== \strpos($this->baseControllerName, '\\')
+                && false === \strpos($this->baseControllerName, ':') ? '::' : ':';
             if (':' !== $actionJoiner && false !== \strpos($this->baseControllerName, ':')) {
                 $actionJoiner = ':';
             }


### PR DESCRIPTION
## Subject

This is a fix for the `\Sonata\AdminBundle\Route\RouteCollection::add()` base controller FQCN detection. Is is checking if there is a backslash in the base controller string and therefor adding a double colon assuming the base controller to be in the format of an FQCN, but this breaks base controllers in the format of `a:B\b` (to result in a Symfony `a:b:c` colon notation) in which `B\b` means subdir `B` with controller `b` inside of it.

I am targeting this branch, because this is a bugfix of a bug caused by a change introduced in code changes from version 3.39.0 to 3.40.0.

_I am aware of the deprecation that is going on for the `a:b:c` notation in favor of the FQCN notation as already adopted in Symfony 4._

Resolves #5357

## Changelog

```markdown
### Fixed
- Fixing the RouteCollection base controller FQCN detection
```
