### PR TITLE
[Docs] fix config file paths, use .yaml instead of .yml and stop talking about admin.yml

### DIFF
--- a/docs/cookbook/recipe_custom_action.rst
+++ b/docs/cookbook/recipe_custom_action.rst
@@ -52,7 +52,7 @@ Either by using XML:
 
 .. code-block:: xml
 
-        <!-- src/Resources/config/admin.xml -->
+        <!-- config/services.xml -->
 
         <service id="app.admin.car" class="App\Admin\CarAdmin">
             <tag name="sonata.admin" manager_type="orm" group="Demo" label="Car" />
@@ -61,11 +61,11 @@ Either by using XML:
             <argument>App\Controller\CarAdminController</argument>
         </service>
 
-or by adding it to your ``admin.yml``:
+or by adding it to your ``services.yaml``:
 
 .. code-block:: yaml
 
-    # src/Resources/config/admin.yml
+    # config/services.yaml
 
     services:
         app.admin.car:

--- a/docs/cookbook/recipe_custom_view.rst
+++ b/docs/cookbook/recipe_custom_view.rst
@@ -96,7 +96,7 @@ that we do not specify the Entity, we leave it as ``null``.
 .. note::
 
     If you are not using Symfony Flex, this service should be registered
-    in ``app/config/services.yml``.
+    in ``app/config/services.yaml``.
 
 For more information about service configuration please refer to Step 3
 of :doc:`../getting_started/creating_an_admin`

--- a/docs/cookbook/recipe_improve_performance_large_datasets.rst
+++ b/docs/cookbook/recipe_improve_performance_large_datasets.rst
@@ -19,7 +19,7 @@ To use `SimplePager` in your admin just define ``pager_type`` inside the service
 
     .. code-block:: xml
 
-        <!-- src/Resources/config/admin.xml -->
+        <!-- config/services.xml -->
 
         <service id="app.admin.post" class="App\Admin\PostAdmin">
             <argument />

--- a/docs/cookbook/recipe_persisting_filters.rst
+++ b/docs/cookbook/recipe_persisting_filters.rst
@@ -16,7 +16,7 @@ You can enable it in your ``sonata_admin`` configuration :
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # config/packages/sonata_admin.yaml
 
         sonata_admin:
             persist_filters: true
@@ -44,7 +44,7 @@ Globally :
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # config/packages/sonata_admin.yaml
 
         sonata_admin:
             persist_filters: true
@@ -56,7 +56,7 @@ Per Admin :
 
     .. code-block:: xml
 
-        <!-- src/AppBundle/Resources/config/admin.xml -->
+        <!-- config/services.xml -->
 
         <service id="app.admin.user" class="AppBundle\Admin\UserAdmin">
             <argument />
@@ -71,7 +71,7 @@ Per Admin :
 
     .. code-block:: yaml
 
-        # src/AppBundle/Resources/config/admin.yml
+        # config/services.yaml
 
         services:
             app.admin.user:
@@ -100,7 +100,7 @@ You can disable it per Admin if you want.
 
     .. code-block:: xml
 
-        <!-- src/AppBundle/Resources/config/admin.xml -->
+        <!-- config/services.xml -->
 
         <service id="app.admin.user" class="AppBundle\Admin\UserAdmin">
             <argument />
@@ -111,7 +111,7 @@ You can disable it per Admin if you want.
 
     .. code-block:: yaml
 
-        # src/AppBundle/Resources/config/admin.yml
+        # config/services.yaml
 
         services:
             app.admin.user:

--- a/docs/cookbook/recipe_sortable_listing.rst
+++ b/docs/cookbook/recipe_sortable_listing.rst
@@ -105,7 +105,7 @@ In order to add new routes for these actions we are also adding the following me
         $collection->add('move', $this->getRouterIdParameter().'/move/{position}');
     }
 
-Now you can update your ``services.yaml`` to use the handler provider by the ``pixSortableBehaviorBundle``
+Now you can update your ``services.yaml`` to use the handler provided by the ``pixSortableBehaviorBundle``
 
 .. code-block:: yaml
 

--- a/docs/cookbook/recipe_sortable_listing.rst
+++ b/docs/cookbook/recipe_sortable_listing.rst
@@ -105,7 +105,7 @@ In order to add new routes for these actions we are also adding the following me
         $collection->add('move', $this->getRouterIdParameter().'/move/{position}');
     }
 
-Now you can update your ``services.yml`` to use the handler provider by the ``pixSortableBehaviorBundle``
+Now you can update your ``services.yaml`` to use the handler provider by the ``pixSortableBehaviorBundle``
 
 .. code-block:: yaml
 

--- a/docs/cookbook/recipe_workflow_integration.rst
+++ b/docs/cookbook/recipe_workflow_integration.rst
@@ -57,7 +57,7 @@ You can use the provided extension to take care of your entity admin.
 
 .. code-block:: yaml
 
-   # config/services.yaml
+   # config/packages/sonata_admin.yaml
    services:
        admin.blog_post:
            class: App\Admin\BlogPostAdmin

--- a/docs/getting_started/the_form_view.rst
+++ b/docs/getting_started/the_form_view.rst
@@ -44,7 +44,7 @@ The same applies to the service definition:
 
 .. code-block:: yaml
 
-    # app/config/services.yml
+    # config/services.yaml
 
     services:
         # ...

--- a/docs/reference/child_admin.rst
+++ b/docs/reference/child_admin.rst
@@ -21,14 +21,16 @@ its parent:
 
     .. code-block:: yaml
 
-        # app/config/services.yml
+        # config/services.yaml
+
         App\Admin\PlaylistAdmin:
             calls:
                 - [addChild, ['@App\Admin\VideoAdmin', 'playlist']]
 
     .. code-block:: xml
 
-        <!-- app/config/services.xml -->
+        <!-- config/services.xml -->
+
         <service id="App\Admin\PlaylistAdmin">
             <!-- ... -->
 

--- a/docs/reference/console.rst
+++ b/docs/reference/console.rst
@@ -77,7 +77,7 @@ Options           Description
  **admin**        the admin class basename (by default this adds "Admin" to the model class name, e.g. "BarAdmin")
  **controller**   the controller class basename (by default this adds "AdminController" to the model class name, e.g. "BarAdminController")
  **manager**      the model manager type (by default this is the first registered model manager type, e.g. "orm")
- **services**     the services YAML file (the default value is "services.yml" or "admin.yml" if it already exist)
+ **services**     the services YAML file (the default value is "services.yaml" or "admin.yml" if it already exist)
  **id**           the admin service ID (the default value is combination of the bundle name and admin class basename like "your_ns_foo.admin.bar")
 ===============   ===============================================================================================================================
 

--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -558,10 +558,6 @@ that looks like this:
                 tags:
                     - { name: sonata.admin, manager_type: orm, label: "Image" }
 
-.. note::
-
-    Refer to `Getting started documentation`_ to see how to define your ``admin.yml`` file.
-
 To embed ``ImageAdmin`` within ``PageAdmin`` we just need to change the reference
 for the ``image1`` field to ``sonata_type_admin`` in our ``PageAdmin`` class:
 
@@ -864,7 +860,6 @@ General
 .. _`Symfony field types`: http://symfony.com/doc/current/book/forms.html#built-in-field-types
 .. _`Symfony choice Field Type docs`: http://symfony.com/doc/current/reference/forms/types/choice.html
 .. _`Symfony PropertyPath`: http://api.symfony.com/2.0/Symfony/Component/Form/Util/PropertyPath.html
-.. _`Getting started documentation`: https://sonata-project.org/bundles/admin/master/doc/reference/getting_started.html#importing-it-in-the-main-config-yml
 .. _`ORM`: https://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/form_field_definition.html
 .. _`PHPCR`: https://sonata-project.org/bundles/doctrine-phpcr-admin/master/doc/reference/form_field_definition.html
 .. _`MongoDB`: https://sonata-project.org/bundles/mongo-admin/master/doc/reference/form_field_definition.html

--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -537,14 +537,14 @@ creation (and editing) of new Images instead of just selecting an existing Image
 from a list.
 
 First we need to create an ``ImageAdmin`` class and register it as an admin class
-for managing ``Image`` objects. In our ``admin.yml`` we have an entry for ``ImageAdmin``
+for managing ``Image`` objects. In our ``services.yaml`` we have an entry for ``ImageAdmin``
 that looks like this:
 
 .. configuration-block::
 
     .. code-block:: yaml
 
-        # src/Resources/config/admin.yml
+        # config/services.yaml
 
         services:
             app.admin.image:
@@ -585,7 +585,7 @@ for the ``image1`` field to ``sonata_type_admin`` in our ``PageAdmin`` class:
     }
 
 We do not need to define any options since Sonata calculates that the linked class
-is of type ``Image`` and the service definition (in ``admin.yml``) defines that ``Image``
+is of type ``Image`` and the service definition (in ``services.yaml``) defines that ``Image``
 objects are managed by the ``ImageAdmin`` class.
 
 The available options (which can be passed as a third parameter to ``FormMapper::add()``) are:

--- a/docs/reference/routing.rst
+++ b/docs/reference/routing.rst
@@ -192,8 +192,7 @@ Other steps needed to create your new action
 
 In addition to defining the route for your new action you also need to create a
 handler for it in your Controller. By default Admin classes use ``Sonata\AdminBundle\Controller\CRUDController``
-as their controller, but this can be changed by altering the third argument when defining
-your Admin service (in your admin.yml file).
+as their controller, but this can be changed by altering the third argument when defining your Admin service.
 
 For example, lets change the Controller for our MediaAdmin class to ``App\Controller\MediaCRUDController``:
 
@@ -201,7 +200,7 @@ For example, lets change the Controller for our MediaAdmin class to ``App\Contro
 
     .. code-block:: yaml
 
-        # src/Resources/config/admin.yml
+        # config/services.yaml
 
         app.admin.media:
             class: App\Admin\MediaAdmin

--- a/docs/reference/security.rst
+++ b/docs/reference/security.rst
@@ -605,7 +605,7 @@ because for example you want to restrict access using extra rules:
 
     .. code-block:: xml
 
-        <!-- src/Resources/config/services.xml -->
+        <!-- config/services.xml -->
 
         <!-- <service id="security.acl.user_permission.map" class="App\Security\Acl\Permission\UserAdminPermissionMap" public="false"></service> -->
 


### PR DESCRIPTION
We should not promote `admin.yaml` anymore and use/promote `config/services.yaml` 