### PR TITLE
Generate code that is more modern

### DIFF
--- a/src/Resources/skeleton/Admin.php.twig
+++ b/src/Resources/skeleton/Admin.php.twig
@@ -6,6 +6,8 @@
     {%- endfor %}
 {% endset %}
 
+declare(strict_types=1);
+
 namespace {{ namespace }};
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;
@@ -16,14 +18,14 @@ use Sonata\AdminBundle\Show\ShowMapper;
 
 class {{ classBasename }} extends AbstractAdmin
 {
-    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
     {
         $datagridMapper
             {{- code }}
         ;
     }
 
-    protected function configureListFields(ListMapper $listMapper)
+    protected function configureListFields(ListMapper $listMapper): void
     {
         $listMapper
             {{- code }}
@@ -37,14 +39,14 @@ class {{ classBasename }} extends AbstractAdmin
         ;
     }
 
-    protected function configureFormFields(FormMapper $formMapper)
+    protected function configureFormFields(FormMapper $formMapper): void
     {
         $formMapper
             {{- code }}
         ;
     }
 
-    protected function configureShowFields(ShowMapper $showMapper)
+    protected function configureShowFields(ShowMapper $showMapper): void
     {
         $showMapper
             {{- code }}

--- a/src/Resources/skeleton/Admin.tpl.php
+++ b/src/Resources/skeleton/Admin.tpl.php
@@ -1,5 +1,7 @@
 <?= "<?php\n" ?>
 
+declare(strict_types=1);
+
 namespace <?= $namespace ?>;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;
@@ -11,13 +13,13 @@ use Sonata\AdminBundle\Show\ShowMapper;
 final class <?= $class_name ?> extends AbstractAdmin
 {
 
-    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
     {
         $datagridMapper
 <?= $fields ?>;
     }
 
-    protected function configureListFields(ListMapper $listMapper)
+    protected function configureListFields(ListMapper $listMapper): void
     {
         $listMapper
 <?= $fields ?>->add('_action', null, [
@@ -29,13 +31,13 @@ final class <?= $class_name ?> extends AbstractAdmin
             ]);
     }
 
-    protected function configureFormFields(FormMapper $formMapper)
+    protected function configureFormFields(FormMapper $formMapper): void
     {
         $formMapper
 <?= $fields ?>;
     }
 
-    protected function configureShowFields(ShowMapper $showMapper)
+    protected function configureShowFields(ShowMapper $showMapper): void
     {
         $showMapper
 <?= $fields ?>;

--- a/src/Resources/skeleton/AdminController.php.twig
+++ b/src/Resources/skeleton/AdminController.php.twig
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace {{ namespace }};
 
 use Sonata\AdminBundle\Controller\CRUDController;

--- a/src/Resources/skeleton/AdminController.tpl.php
+++ b/src/Resources/skeleton/AdminController.tpl.php
@@ -1,5 +1,7 @@
 <?= "<?php\n" ?>
 
+declare(strict_types=1);
+
 namespace <?= $namespace ?>;
 
 use Sonata\AdminBundle\Controller\CRUDController;

--- a/tests/Fixtures/Admin/ModelAdmin.php
+++ b/tests/Fixtures/Admin/ModelAdmin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sonata\AdminBundle\Tests\Fixtures\Admin;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;
@@ -10,7 +12,7 @@ use Sonata\AdminBundle\Show\ShowMapper;
 
 class ModelAdmin extends AbstractAdmin
 {
-    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
     {
         $datagridMapper
             ->add('foo')
@@ -19,7 +21,7 @@ class ModelAdmin extends AbstractAdmin
         ;
     }
 
-    protected function configureListFields(ListMapper $listMapper)
+    protected function configureListFields(ListMapper $listMapper): void
     {
         $listMapper
             ->add('foo')
@@ -35,7 +37,7 @@ class ModelAdmin extends AbstractAdmin
         ;
     }
 
-    protected function configureFormFields(FormMapper $formMapper)
+    protected function configureFormFields(FormMapper $formMapper): void
     {
         $formMapper
             ->add('foo')
@@ -44,7 +46,7 @@ class ModelAdmin extends AbstractAdmin
         ;
     }
 
-    protected function configureShowFields(ShowMapper $showMapper)
+    protected function configureShowFields(ShowMapper $showMapper): void
     {
         $showMapper
             ->add('foo')

--- a/tests/Fixtures/Controller/ModelAdminController.php
+++ b/tests/Fixtures/Controller/ModelAdminController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sonata\AdminBundle\Tests\Fixtures\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController;


### PR DESCRIPTION
## Subject

Now that we dropped php 7, we should generate classes that look like what we recommend in our docs.

I am targeting this branch, because this is BC.


## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- php 7-specific type hints in generated code
- strict_types declaration in generated code
```