### PR TITLE
Trigger autoload to ensure BC

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -3113,3 +3113,5 @@ EOT;
         }
     }
 }
+
+class_exists(\Sonata\Form\Validator\ErrorElement::class);

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -130,3 +130,5 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     {
     }
 }
+
+class_exists(\Sonata\Form\Validator\ErrorElement::class);

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -175,3 +175,5 @@ interface AdminExtensionInterface
      */
     // public function configureDefaultFilterValues(AdminInterface $admin, array &$filterValues);
 }
+
+class_exists(\Sonata\Form\Validator\ErrorElement::class);

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -703,3 +703,5 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 //    NEXT_MAJOR: uncomment this method in 4.0
     // public function isDefaultFilter($name);
 }
+
+class_exists(\Sonata\Form\Validator\ErrorElement::class);


### PR DESCRIPTION
## Subject

A class that extends one of ours, or implements one of our interface
but still uses legacy types in the signature of the methods it overrides
or implements will cause a crash at compile time: type hints in
signature do not cause autoloading, and thus the class alias will not be
created. To fix this, we trigger the autoload of the new type, so that
no deprecation is thrown when it in turns autoloads the old type.

That issue was reported here:
https://github.com/sonata-project/SonataAdminBundle/pull/5418#issuecomment-454128691

I guess I will need to update [my blog post](https://dev.to/greg0ire/how-to-deprecate-a-type-in-php-48cf).

I am targeting this branch, because this is BC.


## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Crash about incompatible signatures involving `ErrorElement`
```

@dmaicher please review