### PR TITLE
Unofficially support null

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -642,7 +642,12 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     public function initialize()
     {
         if (!$this->classnameLabel) {
-            $this->classnameLabel = substr($this->getClass(), strrpos($this->getClass(), '\\') + 1);
+            /* NEXT_MAJOR: remove cast to string, null is not supposed to be
+            supported but was documented as such */
+            $this->classnameLabel = substr(
+                (string) $this->getClass(),
+                strrpos((string) $this->getClass(), '\\') + 1
+            );
         }
 
         // NEXT_MAJOR: Remove this line.


### PR DESCRIPTION
## Subject

We documented this as a possibility. For now, let us support it, and let
us decide later if we ask people to move away from it or if we should
embrace it.

I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5421 

## Changelog
<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- crash when using `null` as an admin class name
```