### PR TITLE
Fix batch checkbox display when list page is loaded through Ajax

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2914,7 +2914,7 @@ EOT;
 
         $mapper = new ListMapper($this->getListBuilder(), $this->list, $this);
 
-        if (\count($this->getBatchActions()) > 0) {
+        if (\count($this->getBatchActions()) > 0 && !$this->getRequest()->isXmlHttpRequest()) {
             $fieldDescription = $this->getModelManager()->getNewFieldDescriptionInstance(
                 $this->getClass(),
                 'batch',


### PR DESCRIPTION
## Subject

I am targeting this branch, because it fixes the wrong display of batch checkbox field when list page is loaded with Ajax. As you can see in https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Resources/views/CRUD/base_list.html.twig#L133 we just ignore the display of the batch droplist.

## Changelog

```markdown
### Fixed
 - Fixed display of batch checkbox when list page is loaded with Ajax
```