### PR TITLE
Don't merge, proof PR for Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ php:
   - '7.3'
   - nightly
 
-sudo: false
-dist: trusty
+dist: xenial
 
 addons:
   apt:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Admin Bundle
 * `SonataDoctrinePhpcrAdminBundle <https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle>`_: integrates PHPCR with the core admin bundle
 
 The demo website can be found at http://demo.sonata-project.org.
+Dummy change to trigger a full build.
 
 **Usage examples:**
 

--- a/src/SonataAdminBundle.php
+++ b/src/SonataAdminBundle.php
@@ -42,6 +42,7 @@ class SonataAdminBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
+        // dummy change to trigger a full build
         $container->addCompilerPass(new AddDependencyCallsCompilerPass());
         $container->addCompilerPass(new AddFilterTypeCompilerPass());
         $container->addCompilerPass(new ExtensionCompilerPass());


### PR DESCRIPTION
It should be faster for several reasons:
- preinstalled versions of php
- fewer services started

I also removed "sudo: false" because I think it might be the default
now.
See https://docs.travis-ci.com/user/reference/xenial/
