### PR TITLE
Fix displaying images in media list mosaic view

### DIFF
--- a/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
+++ b/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
@@ -30,9 +30,9 @@ This template can be customized to match your needs. You should only extends the
 
                             <div class="mosaic-inner-box-default">
                                 {% block sonata_mosaic_background %}
-                                    <img src="{{ meta.isImageAvailable is not defined or (meta.isImageAvailable is defined and meta.isImageAvailable) ?
-                                        meta.image :
-                                        sonata_admin.getMosaicBackground() }}" alt="{{ meta.title }}" />
+                                    <img src="{{ meta.isImageAvailable is defined and not meta.isImageAvailable ?
+                                        sonata_admin.getMosaicBackground() :
+                                        meta.image }}" alt="{{ meta.title }}" />
                                 {% endblock %}
                                 {% block sonata_mosaic_default_view %}
                                     <span class="mosaic-box-label label label-primary pull-right">#{{ admin.id(object) }}</span>

--- a/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
+++ b/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
@@ -30,7 +30,7 @@ This template can be customized to match your needs. You should only extends the
 
                             <div class="mosaic-inner-box-default">
                                 {% block sonata_mosaic_background %}
-                                    <img src="{{ meta.isImageAvailable is defined and meta.isImageAvailable ?
+                                    <img src="{{ meta.isImageAvailable is not defined or (meta.isImageAvailable is defined and meta.isImageAvailable) ?
                                         meta.image :
                                         sonata_admin.getMosaicBackground() }}" alt="{{ meta.title }}" />
                                 {% endblock %}


### PR DESCRIPTION
## Fix mosaic view of Media list 

I am targeting this branch, because this is a backwards-compatible regression fix.

This is an additional fix for https://github.com/sonata-project/SonataMediaBundle/issues/1525. That error has been fixed in https://github.com/sonata-project/SonataAdminBundle/pull/5435
However solution is flawed. Since MediaAdmin creates `Sonata\BlockBundle\Meta\Metadata`, which doesn't have `isImageAvailable()` method, new condition always ends up being `false`. Therefore in mosaic view we always get a fallback image instead of real image thumbnail.

Closes https://github.com/sonata-project/SonataMediaBundle/issues/1525

## Changelog

```markdown
### Fixed
- Regression bug which causes SonataMediaBundle's Media list to show fallback image in mosaic view instead of real image preview
```