### PR TITLE
Generate routing in docs typo params to array

### DIFF
--- a/docs/reference/routing.rst
+++ b/docs/reference/routing.rst
@@ -129,7 +129,7 @@ the admin variable's ``generateUrl()`` command:
 
 .. code-block:: html+jinja
 
-    <a href="{{ admin.generateUrl('list', params|merge('page': 1)) }}">List</a>
+    <a href="{{ admin.generateUrl('list', params|merge({'page': 1})) }}">List</a>
 
 Note that you do not need to provide the Admin's route prefix (``baseRouteName``) to
 generate a URL for the current Admin, only the action name is needed.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because according to https://twig.symfony.com/doc/2.x/filters/merge.html `merge` has typo, should be 
```twig
...|merge({'page': 1})
``` 
not 
```twig
...|merge('page': 1)
```


<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->


<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
