### PR TITLE
Call the method directly instead of invoking `__call()` at `BaseFieldDescription::getFieldValue()`

### DIFF
--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -304,7 +304,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         if (method_exists($object, '__call')) {
             $this->cacheFieldGetter($object, $fieldName, 'call');
 
-            return $object->__call($fieldName, $parameters);
+            return $object->$fieldName(...$parameters);
         }
 
         if (isset($object->{$fieldName})) {


### PR DESCRIPTION
## Subject
Call the method directly instead of invoking `__call()` at `BaseFieldDescription::getFieldValue()`

I am targeting this branch, because this is a minor improvement without any important impact on oldest branches.

See https://github.com/sonata-project/SonataAdminBundle/pull/5459#pullrequestreview-198791912.