### PR TITLE
Change exception type caught in AdminType

### DIFF
--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -24,7 +24,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
+use Symfony\Component\PropertyAccess\Exception\AccessException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 /**
@@ -67,7 +67,7 @@ class AdminType extends AbstractType
                     $subject = $p->getValue($parentSubject, $path);
                     $builder->setData($subject);
                 }
-            } catch (NoSuchIndexException $e) {
+            } catch (AccessException $e) {
                 // no object here
             }
         }


### PR DESCRIPTION
## Subject

Modify `src/Form/Type/AdminType.php` in order to solve #5463 issue.

Replace `NoSuchIndexException` by its parent `AccessException` to also catch `NoSuchPropertyException` when trying to access parent subject descendant data using PropertyAccessor.

I am targeting this branch, because it is a small BC fix.

## Changelog

```markdown
### Fixed
- Crash when submitting a form with a collection of grandchildren entities.
```

## To do
- [ ] Update the tests
