### PR TITLE
Added a link to the next chapter

### DIFF
--- a/docs/getting_started/creating_an_admin.rst
+++ b/docs/getting_started/creating_an_admin.rst
@@ -213,3 +213,5 @@ entity and learn more about this class.
     "link_add", you should make sure that you've `enabled the translator`_.
 
 .. _`enabled the translator`: http://symfony.com/doc/current/book/translation.html#configuration
+
+In the :doc:`next chapter <the_form_view>`, you're going to look at the form view.


### PR DESCRIPTION
The link to the next chapter was missing at the end of the page so I added it

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->