### PR TITLE
[Dashboard] Don't iterate over blocks if wanted condition is already reached

### DIFF
--- a/src/Resources/views/Core/dashboard.html.twig
+++ b/src/Resources/views/Core/dashboard.html.twig
@@ -16,35 +16,35 @@ file that was distributed with this source code.
 {% block content %}
 
     {% set has_left = false %}
-    {% for block in blocks.left %}
+    {% for block in blocks.left if not has_left %}
         {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
             {% set has_left = true %}
         {% endif %}
     {% endfor %}
 
     {% set has_center = false %}
-    {% for block in blocks.center %}
+    {% for block in blocks.center if not has_center %}
         {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
             {% set has_center = true %}
         {% endif %}
     {% endfor %}
 
     {% set has_right = false %}
-    {% for block in blocks.right %}
+    {% for block in blocks.right if not has_right %}
         {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
             {% set has_right = true %}
         {% endif %}
     {% endfor %}
 
     {% set has_top = false %}
-    {% for block in blocks.top %}
+    {% for block in blocks.top if not has_top %}
         {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
             {% set has_top = true %}
         {% endif %}
     {% endfor %}
 
     {% set has_bottom = false %}
-    {% for block in blocks.bottom %}
+    {% for block in blocks.bottom if not has_bottom %}
         {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
             {% set has_bottom = true %}
         {% endif %}


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is a minor improvement.

## Changelog

```markdown
### Changed

- Changed `dashboard.html.twig` in order to avoid unnecessary iterations on block loops.
```

