### PR TITLE
add blank lines after file paths in code examples

### DIFF
--- a/docs/cookbook/recipe_auto_configure_admin_classes.rst
+++ b/docs/cookbook/recipe_auto_configure_admin_classes.rst
@@ -20,6 +20,7 @@ The only thing you need to do is add the configuration for this bundle:
 .. code-block:: yaml
 
     # config/packages/sonata_auto_configure.yaml
+
     sonata_auto_configure:
         admin:
             suffix: Admin

--- a/docs/cookbook/recipe_workflow_integration.rst
+++ b/docs/cookbook/recipe_workflow_integration.rst
@@ -19,6 +19,7 @@ Let's say we have a ``BlogPost`` entity that is under a Symfony workflow:
 .. code-block:: yaml
 
    # config/packages/workflow.yaml
+
    framework:
        workflows:
            blog_post:
@@ -54,6 +55,7 @@ You can use the provided extension to take care of your entity admin.
 .. code-block:: yaml
 
    # config/packages/sonata_admin.yaml
+
    services:
        app.admin.blog_post:
            class: App\Admin\BlogPostAdmin
@@ -77,6 +79,7 @@ You can use the provided extension to take care of your entity admin.
 .. code-block:: yaml
 
    # config/packages/sonata_admin.yaml
+
    sonata_admin:
        extensions:
            admin.extension.workflow.blog_post:

--- a/docs/getting_started/the_form_view.rst
+++ b/docs/getting_started/the_form_view.rst
@@ -13,6 +13,7 @@ Bootstrapping the Admin Class
 The basic class definition will look the same as the ``CategoryAdmin``::
 
     // src/Admin/BlogPostAdmin.php
+
     namespace App\Admin;
 
     use Sonata\AdminBundle\Admin\AbstractAdmin;


### PR DESCRIPTION
to be consistent throughout the docs