### PR TITLE
set type int to _page and _per_page from request

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -759,6 +759,12 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         // build the values array
         if ($this->hasRequest()) {
             $filters = $this->request->query->get('filter', []);
+            if (isset($filters['_page'])) {
+                $filters['_page'] = (int) $filters['_page'];
+            }
+            if (isset($filters['_per_page'])) {
+                $filters['_per_page'] = (int) $filters['_per_page'];
+            }
 
             // if filter persistence is configured
             // NEXT_MAJOR: remove `$this->persistFilters !== false` from the condition

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1692,7 +1692,13 @@ class AdminTest extends TestCase
         $query = $this->createMock(ParameterBag::class, ['get']);
         $query->expects($this->any())
             ->method('get')
-            ->will($this->returnValue([]));
+            ->will($this->returnValue([
+                'filter' => [
+                    '_page' => '1',
+                    '_per_page' => '32',
+                ],
+            ]));
+
         $request->query = $query;
         $request->expects($this->any())
             ->method('get')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Variables `_page` and `_per_page` get from request was a string. It was a problem with check it in `determinedPerPageValue`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
Closes #5484

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- type int for _page and _per_page from request 
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
