### PR TITLE
Fix strict comparison is last page in Pager.

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -579,7 +579,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      */
     protected function setLastPage($page)
     {
-        $this->lastPage = $page;
+        $this->lastPage = (int) $page;
 
         if ($this->getPage() > $page) {
             $this->setPage($page);


### PR DESCRIPTION
## Subject
Variable `lastPage` can be float. It was a problem with identical comparision `(===)`.

I am targeting this branch, because it is a patch.

## Changelog
```markdown
### Fixed
- Cast float to int when last page in Pager is assigned
```