### PR TITLE
[WIP] Use "<time>" html tag when displaying fields of type date and datetime

### DIFF
--- a/src/Resources/views/CRUD/display_date.html.twig
+++ b/src/Resources/views/CRUD/display_date.html.twig
@@ -1,0 +1,21 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{%- spaceless %}
+    {%- if value is empty -%}
+        &nbsp;
+    {%- else -%}
+        {% set options = field_description.options %}
+        <time datetime="{{ value|date('Y-m-d', 'UTC') }}" title="{{ value|date('Y-m-d', 'UTC') }}">
+            {{ value|date(options.format|default('F j, Y'), options.timezone|default(null)) }}
+        </time>
+    {%- endif -%}
+{% endspaceless -%}

--- a/src/Resources/views/CRUD/display_datetime.html.twig
+++ b/src/Resources/views/CRUD/display_datetime.html.twig
@@ -1,0 +1,21 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{%- spaceless %}
+    {%- if value is empty -%}
+        &nbsp;
+    {%- else -%}
+        {% set options = field_description.options %}
+        <time datetime="{{ value|date('c', 'UTC') }}" title="{{ value|date('c', 'UTC') }}">
+            {{ value|date(options.format|default(null), options.timezone|default(null)) }}
+        </time>
+    {%- endif -%}
+{% endspaceless -%}

--- a/src/Resources/views/CRUD/display_time.html.twig
+++ b/src/Resources/views/CRUD/display_time.html.twig
@@ -1,0 +1,20 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{%- spaceless %}
+    {%- if value is empty -%}
+        &nbsp;
+    {%- else -%}
+        <time datetime="{{ value|date('H:i:sP', 'UTC') }}" title="{{ value|date('H:i:sP', 'UTC') }}">
+            {{ value|date('H:i:s', field_description.options.timezone|default(null)) }}
+        </time>
+    {%- endif -%}
+{% endspaceless -%}

--- a/src/Resources/views/CRUD/list_date.html.twig
+++ b/src/Resources/views/CRUD/list_date.html.twig
@@ -11,12 +11,6 @@ file that was distributed with this source code.
 
 {% extends get_admin_template('base_list_field', admin.code) %}
 
-{% block field%}
-    {%- if value is empty -%}
-        &nbsp;
-    {%- elseif field_description.options.format is defined -%}
-        {{ value|date(field_description.options.format) }}
-    {%- else -%}
-        {{ value|date('F j, Y') }}
-    {%- endif -%}
+{% block field %}
+    {%- include '@SonataAdmin/CRUD/display_date.html.twig' -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_datetime.html.twig
+++ b/src/Resources/views/CRUD/list_datetime.html.twig
@@ -12,9 +12,5 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {%- if value is empty -%}
-        &nbsp;
-    {%- else -%}
-        {{ value|date(field_description.options.format|default(null), field_description.options.timezone|default(null)) }}
-    {%- endif -%}
+    {%- include '@SonataAdmin/CRUD/display_datetime.html.twig' -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_time.html.twig
+++ b/src/Resources/views/CRUD/list_time.html.twig
@@ -12,9 +12,5 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {%- if value is empty -%}
-        &nbsp;
-    {%- else -%}
-        {{ value|date('H:i:s', field_description.options.timezone|default(null)) }}
-    {%- endif -%}
+    {%- include '@SonataAdmin/CRUD/display_time.html.twig' -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_date.html.twig
+++ b/src/Resources/views/CRUD/show_date.html.twig
@@ -11,12 +11,6 @@ file that was distributed with this source code.
 
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
-{% block field%}
-    {%- if value is empty -%}
-        &nbsp;
-    {%- elseif field_description.options.format is defined -%}
-        {{ value|date(field_description.options.format) }}
-    {%- else -%}
-        {{ value|date('F j, Y') }}
-    {%- endif -%}
+{% block field %}
+    {%- include '@SonataAdmin/CRUD/display_date.html.twig' -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_datetime.html.twig
+++ b/src/Resources/views/CRUD/show_datetime.html.twig
@@ -12,9 +12,5 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- if value is empty -%}
-        &nbsp;
-    {%- else -%}
-        {{ value|date(field_description.options.format|default(null), field_description.options.timezone|default(null)) }}
-    {%- endif -%}
+    {%- include '@SonataAdmin/CRUD/display_datetime.html.twig' -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_time.html.twig
+++ b/src/Resources/views/CRUD/show_time.html.twig
@@ -12,9 +12,5 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- if value is empty -%}
-        &nbsp;
-    {%- else -%}
-        {{ value|date('H:i:s', field_description.options.timezone|default(null)) }}
-    {%- endif -%}
+    {%- include '@SonataAdmin/CRUD/display_time.html.twig' -%}
 {% endblock %}

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -458,7 +458,9 @@ class SonataAdminExtensionTest extends TestCase
             ],
             'datetime field' => [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-datetime" objectId="12345">
-                    December 24, 2013 10:11
+                    <time datetime="2013-12-24T10:11:12+00:00" title="2013-12-24T10:11:12+00:00">
+                        December 24, 2013 10:11
+                    </time>
                 </td>',
                 'datetime',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
@@ -466,7 +468,9 @@ class SonataAdminExtensionTest extends TestCase
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-datetime" objectId="12345">
-                    December 24, 2013 18:11
+                    <time datetime="2013-12-24T10:11:12+00:00" title="2013-12-24T10:11:12+00:00">
+                        December 24, 2013 18:11
+                    </time>
                 </td>',
                 'datetime',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('UTC')),
@@ -480,7 +484,9 @@ class SonataAdminExtensionTest extends TestCase
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-datetime" objectId="12345">
-                    24.12.2013 10:11:12
+                    <time datetime="2013-12-24T10:11:12+00:00" title="2013-12-24T10:11:12+00:00">
+                        24.12.2013 10:11:12
+                    </time>
                 </td>',
                 'datetime',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
@@ -494,7 +500,9 @@ class SonataAdminExtensionTest extends TestCase
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-datetime" objectId="12345">
-                    24.12.2013 18:11:12
+                    <time datetime="2013-12-24T10:11:12+00:00" title="2013-12-24T10:11:12+00:00">
+                        24.12.2013 18:11:12
+                    </time>
                 </td>',
                 'datetime',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('UTC')),
@@ -507,7 +515,11 @@ class SonataAdminExtensionTest extends TestCase
                 ['format' => 'd.m.Y H:i:s', 'timezone' => 'Asia/Hong_Kong'],
             ],
             [
-                '<td class="sonata-ba-list-field sonata-ba-list-field-date" objectId="12345"> December 24, 2013 </td>',
+                '<td class="sonata-ba-list-field sonata-ba-list-field-date" objectId="12345">
+                    <time datetime="2013-12-24" title="2013-12-24">
+                        December 24, 2013
+                    </time>
+                </td>',
                 'date',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 [],
@@ -519,7 +531,11 @@ class SonataAdminExtensionTest extends TestCase
                 [],
             ],
             [
-                '<td class="sonata-ba-list-field sonata-ba-list-field-date" objectId="12345"> 24.12.2013 </td>',
+                '<td class="sonata-ba-list-field sonata-ba-list-field-date" objectId="12345">
+                    <time datetime="2013-12-24" title="2013-12-24">
+                        24.12.2013
+                    </time>
+                </td>',
                 'date',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 ['format' => 'd.m.Y'],
@@ -531,13 +547,21 @@ class SonataAdminExtensionTest extends TestCase
                 ['format' => 'd.m.Y'],
             ],
             [
-                '<td class="sonata-ba-list-field sonata-ba-list-field-time" objectId="12345"> 10:11:12 </td>',
+                '<td class="sonata-ba-list-field sonata-ba-list-field-time" objectId="12345">
+                    <time datetime="10:11:12+00:00" title="10:11:12+00:00">
+                        10:11:12
+                    </time>
+                </td>',
                 'time',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 [],
             ],
             [
-                '<td class="sonata-ba-list-field sonata-ba-list-field-time" objectId="12345"> 18:11:12 </td>',
+                '<td class="sonata-ba-list-field sonata-ba-list-field-time" objectId="12345">
+                    <time datetime="10:11:12+00:00" title="10:11:12+00:00">
+                        18:11:12
+                    </time>
+                </td>',
                 'time',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('UTC')),
                 ['timezone' => 'Asia/Hong_Kong'],
@@ -1474,42 +1498,42 @@ EOT
             ['<th>Data</th> <td>Example</td>', 'text', 'Example', ['safe' => false]],
             ['<th>Data</th> <td>Example</td>', 'textarea', 'Example', ['safe' => false]],
             [
-                '<th>Data</th> <td>December 24, 2013 10:11</td>',
+                '<th>Data</th> <td><time datetime="2013-12-24T10:11:12+00:00" title="2013-12-24T10:11:12+00:00"> December 24, 2013 10:11 </time></td>',
                 'datetime',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')), [],
             ],
             [
-                '<th>Data</th> <td>24.12.2013 10:11:12</td>',
+                '<th>Data</th> <td><time datetime="2013-12-24T10:11:12+00:00" title="2013-12-24T10:11:12+00:00"> 24.12.2013 10:11:12 </time></td>',
                 'datetime',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 ['format' => 'd.m.Y H:i:s'],
             ],
             [
-                '<th>Data</th> <td>December 24, 2013 18:11</td>',
+                '<th>Data</th> <td><time datetime="2013-12-24T10:11:12+00:00" title="2013-12-24T10:11:12+00:00"> December 24, 2013 18:11 </time></td>',
                 'datetime',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('UTC')),
                 ['timezone' => 'Asia/Hong_Kong'],
             ],
             [
-                '<th>Data</th> <td>December 24, 2013</td>',
+                '<th>Data</th> <td><time datetime="2013-12-24" title="2013-12-24"> December 24, 2013 </time></td>',
                 'date',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 [],
             ],
             [
-                '<th>Data</th> <td>24.12.2013</td>',
+                '<th>Data</th> <td><time datetime="2013-12-24" title="2013-12-24"> 24.12.2013 </time></td>',
                 'date',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 ['format' => 'd.m.Y'],
             ],
             [
-                '<th>Data</th> <td>10:11:12</td>',
+                '<th>Data</th> <td><time datetime="10:11:12+00:00" title="10:11:12+00:00"> 10:11:12 </time></td>',
                 'time',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 [],
             ],
             [
-                '<th>Data</th> <td>18:11:12</td>',
+                '<th>Data</th> <td><time datetime="10:11:12+00:00" title="10:11:12+00:00"> 18:11:12 </time></td>',
                 'time',
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('UTC')),
                 ['timezone' => 'Asia/Hong_Kong'],


### PR DESCRIPTION
## Subject

Use `<time>` html tag when displaying fields of type date and datetime. This allows to print the UTC dates using the "datetime" and "title" attributes.

I am targeting this branch, because these changes respect BC.

## Changelog

```markdown

### Changed
- Changed the rendering for date, datetime and time properties in order to use `<time>` tags, which print the dates in UTC using `datetime` and `title` attributes, allowing to view the UTC date with the default browser tooltip.
```

Example of UTC date 2017-04-06T00:11:38+00:00 printed with `America/Argentina/Buenos_Aires` (UTC -3) timezone:
```
<time datetime="2017-04-06T00:11:38+00:00" title="2017-04-06T00:11:38+00:00">
    05/04/2017 21:11:38
</time>
```
![datetime](https://user-images.githubusercontent.com/1231441/54076868-15805800-428f-11e9-9852-7087db8bc556.png)