### PR TITLE
Replace extension logic with dispatcher

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,13 @@
 UPGRADE 3.x
 ===========
 
+`Sonata\AdminBundle\Admin\AdminExtensionInterface` has been deprecated and segregated into
+single-method interfaces, they can be found under the `Sonata\AdminBundle\Admin\Extension` namespace.
+
+`Sonata\AdminBundle\Admin\AbstractAdminExtension` has been deprecated without alternative.
+
+`Sonata\AdminBundle\Admin\AbstractAdmin::addExtension` has been deprecated.
+
 ## Deprecated `SonataAdminBundle\Controller\HelperController` in favor of actions
 
 If you extended that controller, you should split your extended controller and

--- a/docs/reference/extensions.rst
+++ b/docs/reference/extensions.rst
@@ -8,14 +8,16 @@ and be registered as a service. The interface defines a number of functions whic
 you can use to customize the edit form, list view, form validation, alter newly
 created objects and other admin features::
 
-    use Sonata\AdminBundle\Admin\AbstractAdminExtension;
-    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Admin\Extension\ConfigureFormFieldsInterface;
+    use Sonata\AdminBundle\Extension\Event\ConfigureFormFieldsMessage;
     use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
     final class PublishStatusAdminExtension extends AbstractAdminExtension
     {
         protected function configureFormFields(FormMapper $formMapper)
         {
+            $formMapper = $event->getMapper();
+
             $formMapper
                 ->add('status', ChoiceType::class, [
                     'choices' => [

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -22,6 +22,11 @@ use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\Form\Validator\ErrorElement;
 
+@trigger_error(sprintf(
+    '"%s" is deprecated since 3.x and will be removed in 4.0.',
+    AbstractAdminExtension::class
+), E_USER_DEPRECATED);
+
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -22,6 +22,12 @@ use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\Form\Validator\ErrorElement;
 
+@trigger_error(sprintf(
+    '"%s" is deprecated since 3.x and will be removed in 4.0.'
+    .' Implement single-method interfaces from "Sonata\AdminBundle\Admin\Extension" namespace.',
+    AdminExtensionInterface::class
+), E_USER_DEPRECATED);
+
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */

--- a/src/Admin/Extension/AdminExtensionInterface.php
+++ b/src/Admin/Extension/AdminExtensionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface AdminExtensionInterface
+{
+}

--- a/src/Admin/Extension/AlterNewInstanceInterface.php
+++ b/src/Admin/Extension/AlterNewInstanceInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\AlterNewInstanceMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface AlterNewInstanceInterface extends AdminExtensionInterface
+{
+    /**
+     * Get a chance to modify a newly created instance.
+     */
+    public function alterNewInstance(AlterNewInstanceMessage $event);
+}

--- a/src/Admin/Extension/AlterObjectInterface.php
+++ b/src/Admin/Extension/AlterObjectInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\AlterObjectMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface AlterObjectInterface extends AdminExtensionInterface
+{
+    /**
+     * Get a chance to modify object instance.
+     */
+    public function alterObject(AlterObjectMessage $event);
+}

--- a/src/Admin/Extension/ConfigureActionButtonsInterface.php
+++ b/src/Admin/Extension/ConfigureActionButtonsInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\ConfigureActionButtonsTask;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureActionButtonsInterface extends AdminExtensionInterface
+{
+    /*
+     * Get all action buttons for an action
+     */
+    public function configureActionButtons(ConfigureActionButtonsTask $event);
+}

--- a/src/Admin/Extension/ConfigureBatchActionsInterface.php
+++ b/src/Admin/Extension/ConfigureBatchActionsInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\ConfigureBatchActionsTask;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureBatchActionsInterface extends AdminExtensionInterface
+{
+    public function configureBatchActions(ConfigureBatchActionsTask $event);
+}

--- a/src/Admin/Extension/ConfigureDatagridFieldsInterface.php
+++ b/src/Admin/Extension/ConfigureDatagridFieldsInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\ConfigureDatagridFiltersMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureDatagridFieldsInterface extends AdminExtensionInterface
+{
+    public function configureDatagridFilters(ConfigureDatagridFiltersMessage $event);
+}

--- a/src/Admin/Extension/ConfigureDefaultFilterValuesInterface.php
+++ b/src/Admin/Extension/ConfigureDefaultFilterValuesInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\ConfigureDefaultFilterValuesMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureDefaultFilterValuesInterface extends AdminExtensionInterface
+{
+    public function configureDefaultFilterValues(ConfigureDefaultFilterValuesMessage $event);
+}

--- a/src/Admin/Extension/ConfigureExportFieldsInterface.php
+++ b/src/Admin/Extension/ConfigureExportFieldsInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\ConfigureExportFieldsTask;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureExportFieldsInterface extends AdminExtensionInterface
+{
+    /**
+     * Get a chance to modify export fields.
+     */
+    public function configureExportFields(ConfigureExportFieldsTask $event);
+}

--- a/src/Admin/Extension/ConfigureFormFieldsInterface.php
+++ b/src/Admin/Extension/ConfigureFormFieldsInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\ConfigureFormFieldsMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureFormFieldsInterface extends AdminExtensionInterface
+{
+    public function configureFormFields(ConfigureFormFieldsMessage $event);
+}

--- a/src/Admin/Extension/ConfigureListFieldsInterface.php
+++ b/src/Admin/Extension/ConfigureListFieldsInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\ConfigureListFieldsMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureListFieldsInterface extends AdminExtensionInterface
+{
+    public function configureListFields(ConfigureListFieldsMessage $event);
+}

--- a/src/Admin/Extension/ConfigureQueryInterface.php
+++ b/src/Admin/Extension/ConfigureQueryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\ConfigureQueryMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureQueryInterface extends AdminExtensionInterface
+{
+    public function configureQuery(ConfigureQueryMessage $event);
+}

--- a/src/Admin/Extension/ConfigureRoutesInterface.php
+++ b/src/Admin/Extension/ConfigureRoutesInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\ConfigureRoutesMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureRoutesInterface extends AdminExtensionInterface
+{
+    public function configureRoutes(ConfigureRoutesMessage $event);
+}

--- a/src/Admin/Extension/ConfigureShowFieldsInterface.php
+++ b/src/Admin/Extension/ConfigureShowFieldsInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\ConfigureShowFieldsMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureShowFieldsInterface extends AdminExtensionInterface
+{
+    public function configureShowFields(ConfigureShowFieldsMessage $event);
+}

--- a/src/Admin/Extension/ConfigureTabMenuInterface.php
+++ b/src/Admin/Extension/ConfigureTabMenuInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\ConfigureTabMenuMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ConfigureTabMenuInterface extends AdminExtensionInterface
+{
+    /**
+     * Builds the tab menu.
+     */
+    public function configureTabMenu(ConfigureTabMenuMessage $event);
+}

--- a/src/Admin/Extension/GetAccessMappingInterface.php
+++ b/src/Admin/Extension/GetAccessMappingInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\GetAccessMappingTask;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface GetAccessMappingInterface extends AdminExtensionInterface
+{
+    public function getAccessMapping(GetAccessMappingTask $event);
+}

--- a/src/Admin/Extension/GetPersistentParametersInterface.php
+++ b/src/Admin/Extension/GetPersistentParametersInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\GetPersistentParametersTask;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface GetPersistentParametersInterface extends AdminExtensionInterface
+{
+    /**
+     * Get a chance to add persistent parameters.
+     */
+    public function getPersistentParameters(GetPersistentParametersTask $event);
+}

--- a/src/Admin/Extension/LockExtension.php
+++ b/src/Admin/Extension/LockExtension.php
@@ -22,6 +22,8 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
 /**
+ * NEXT_MAJOR: Remove extending of AbstractAdminExtension.
+ *
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
  */
 class LockExtension extends AbstractAdminExtension

--- a/src/Admin/Extension/PostPersistInterface.php
+++ b/src/Admin/Extension/PostPersistInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\PostPersistMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface PostPersistInterface extends AdminExtensionInterface
+{
+    public function postPersist(PostPersistMessage $event);
+}

--- a/src/Admin/Extension/PostRemoveInterface.php
+++ b/src/Admin/Extension/PostRemoveInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\PostRemoveMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface PostRemoveInterface extends AdminExtensionInterface
+{
+    public function postRemove(PostRemoveMessage $event);
+}

--- a/src/Admin/Extension/PostUpdateInterface.php
+++ b/src/Admin/Extension/PostUpdateInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\PostUpdateMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface PostUpdateInterface extends AdminExtensionInterface
+{
+    public function postUpdate(PostUpdateMessage $postUpdateMessage);
+}

--- a/src/Admin/Extension/PrePersistInterface.php
+++ b/src/Admin/Extension/PrePersistInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\PrePersistMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface PrePersistInterface extends AdminExtensionInterface
+{
+    public function prePersist(PrePersistMessage $event);
+}

--- a/src/Admin/Extension/PreRemoveInterface.php
+++ b/src/Admin/Extension/PreRemoveInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\PreRemoveMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface PreRemoveInterface extends AdminExtensionInterface
+{
+    public function preRemove(PreRemoveMessage $event);
+}

--- a/src/Admin/Extension/PreUpdateInterface.php
+++ b/src/Admin/Extension/PreUpdateInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\PreUpdateMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface PreUpdateInterface extends AdminExtensionInterface
+{
+    public function preUpdate(PreUpdateMessage $preUpdateMessage);
+}

--- a/src/Admin/Extension/ValidateInterface.php
+++ b/src/Admin/Extension/ValidateInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Extension\Event\ValidateMessage;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface ValidateInterface extends AdminExtensionInterface
+{
+    public function validate(ValidateMessage $event);
+}

--- a/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -13,6 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
+use Sonata\AdminBundle\Admin\AdminExtensionInterface as OldAdminExtensionInterface;
+use Sonata\AdminBundle\Admin\Extension\AdminExtensionInterface as NewAdminExtensionInterface;
+use Sonata\AdminBundle\Extension\ExtensionEmitter;
+use Sonata\AdminBundle\Extension\ExtensionNotifier;
+use Sonata\AdminBundle\Extension\ExtensionProcessor;
+use Sonata\AdminBundle\Extension\ExtensionProvider;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -80,9 +86,31 @@ class ExtensionCompilerPass implements CompilerPassInterface
             krsort($extensions);
             $admin = $container->getDefinition($target);
 
-            foreach (array_values($extensions) as $extension) {
+            list($oldExtensions, $newExtensions) = $this->filterExtensions($container, array_values($extensions));
+
+            foreach ($oldExtensions as $extension) {
                 $admin->addMethodCall('addExtension', [$extension]);
             }
+
+            $extensionProviderDefinition = $container
+                ->register($extensionProviderId = $target.'.extension.provider', ExtensionProvider::class);
+
+            $extensionProviderDefinition->addMethodCall('setExtensions', [$newExtensions]);
+
+            $container
+                ->register($extensionNotifierId = $target.'.extension.notifier', ExtensionNotifier::class)
+                ->addArgument($extensionProviderReference = new Reference($extensionProviderId));
+
+            $container
+                ->register($extensionProcessorId = $target.'.extension.processor', ExtensionProcessor::class)
+                ->addArgument($extensionProviderReference);
+
+            $container
+                ->register($extensionEmitterId = $target.'.extension.emitter', ExtensionEmitter::class)
+                ->addArgument(new Reference($extensionNotifierId))
+                ->addArgument(new Reference($extensionProcessorId));
+
+            $admin->addMethodCall('setExtensionEmitter', [new Reference($extensionEmitterId)]);
         }
     }
 
@@ -227,5 +255,30 @@ class ExtensionCompilerPass implements CompilerPassInterface
 
         $priority = $attributes['priority'] ?? 0;
         $targets[$target]->insert(new Reference($extension), $priority);
+    }
+
+    /**
+     * @param Reference[] $extensions
+     *
+     * @return array
+     */
+    private function filterExtensions(ContainerBuilder $containerBuilder, array $extensions)
+    {
+        $oldExtensions = [];
+        $newExtensions = [];
+
+        foreach ($extensions as $extension) {
+            $extensionDefinition = $containerBuilder->getDefinition((string) $extension);
+
+            if (is_subclass_of($extensionDefinition->getClass(), OldAdminExtensionInterface::class)) {
+                $oldExtensions[] = $extension;
+            }
+
+            if (is_subclass_of($extensionDefinition->getClass(), NewAdminExtensionInterface::class)) {
+                $newExtensions[] = $extension;
+            }
+        }
+
+        return [$oldExtensions, $newExtensions];
     }
 }

--- a/src/Extension/Event/AlterNewInstanceMessage.php
+++ b/src/Extension/Event/AlterNewInstanceMessage.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class AlterNewInstanceMessage implements MessageInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var object
+     */
+    private $object;
+
+    /**
+     * @param object $object
+     */
+    public function __construct(AdminInterface $admin, $object)
+    {
+        $this->admin = $admin;
+        $this->object = $object;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return object
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+}

--- a/src/Extension/Event/AlterObjectMessage.php
+++ b/src/Extension/Event/AlterObjectMessage.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class AlterObjectMessage implements MessageInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var object
+     */
+    private $object;
+
+    /**
+     * @param object $object
+     */
+    public function __construct(AdminInterface $admin, $object)
+    {
+        $this->admin = $admin;
+        $this->object = $object;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return object
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+}

--- a/src/Extension/Event/ConfigureActionButtonsTask.php
+++ b/src/Extension/Event/ConfigureActionButtonsTask.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ConfigureActionButtonsTask implements TaskInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var array
+     */
+    private $list;
+
+    /**
+     * @var string
+     */
+    private $action;
+
+    /**
+     * @var object
+     */
+    private $object;
+
+    /**
+     * @var array
+     */
+    private $result = [];
+
+    /**
+     * @param string $action
+     * @param object $object
+     */
+    public function __construct(AdminInterface $admin, array $list, $action, $object)
+    {
+        $this->admin = $admin;
+        $this->list = $this->result = $list;
+        $this->action = $action;
+        $this->object = $object;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return array
+     */
+    public function getList()
+    {
+        return $this->list;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAction()
+    {
+        return $this->action;
+    }
+
+    /**
+     * @return object
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+
+    /**
+     * @return array
+     */
+    public function result()
+    {
+        return $this->result;
+    }
+
+    public function updateResult(array $result)
+    {
+        $this->result = $result;
+    }
+}

--- a/src/Extension/Event/ConfigureBatchActionsTask.php
+++ b/src/Extension/Event/ConfigureBatchActionsTask.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ConfigureBatchActionsTask implements TaskInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var array
+     */
+    private $actions;
+
+    /**
+     * @var array
+     */
+    private $result = [];
+
+    public function __construct(AdminInterface $admin, array $actions)
+    {
+        $this->admin = $admin;
+        $this->actions = $this->result = $actions;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return array
+     */
+    public function getActions()
+    {
+        return $this->actions;
+    }
+
+    /**
+     * @return array
+     */
+    public function result()
+    {
+        return $this->result;
+    }
+
+    public function updateResult(array $result)
+    {
+        $this->result = $result;
+    }
+}

--- a/src/Extension/Event/ConfigureDatagridFiltersMessage.php
+++ b/src/Extension/Event/ConfigureDatagridFiltersMessage.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ConfigureDatagridFiltersMessage implements MessageInterface
+{
+    /**
+     * @var DatagridMapper
+     */
+    private $mapper;
+
+    public function __construct(DatagridMapper $mapper)
+    {
+        $this->mapper = $mapper;
+    }
+
+    /**
+     * @return DatagridMapper
+     */
+    public function getMapper()
+    {
+        return $this->mapper;
+    }
+}

--- a/src/Extension/Event/ConfigureDefaultFilterValuesMessage.php
+++ b/src/Extension/Event/ConfigureDefaultFilterValuesMessage.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ConfigureDefaultFilterValuesMessage implements MessageInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var array
+     */
+    private $filterValues;
+
+    public function __construct(AdminInterface $admin, array &$filterValues)
+    {
+        $this->admin = $admin;
+        $this->filterValues = $filterValues;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFilterValues()
+    {
+        return $this->filterValues;
+    }
+}

--- a/src/Extension/Event/ConfigureExportFieldsTask.php
+++ b/src/Extension/Event/ConfigureExportFieldsTask.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ConfigureExportFieldsTask implements TaskInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var string[]
+     */
+    private $fields;
+
+    /**
+     * @var string[]
+     */
+    private $result = [];
+
+    public function __construct(AdminInterface $admin, array $fields)
+    {
+        $this->admin = $admin;
+        $this->fields = $this->result = $fields;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFields()
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function result()
+    {
+        return $this->result;
+    }
+
+    public function updateResult(array $result)
+    {
+        $this->result = $result;
+    }
+}

--- a/src/Extension/Event/ConfigureFormFieldsMessage.php
+++ b/src/Extension/Event/ConfigureFormFieldsMessage.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Form\FormMapper;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ConfigureFormFieldsMessage implements MessageInterface
+{
+    /**
+     * @var FormMapper
+     */
+    private $mapper;
+
+    public function __construct(FormMapper $mapper)
+    {
+        $this->mapper = $mapper;
+    }
+
+    /**
+     * @return FormMapper
+     */
+    public function getMapper()
+    {
+        return $this->mapper;
+    }
+}

--- a/src/Extension/Event/ConfigureListFieldsMessage.php
+++ b/src/Extension/Event/ConfigureListFieldsMessage.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Datagrid\ListMapper;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ConfigureListFieldsMessage implements MessageInterface
+{
+    /**
+     * @var ListMapper
+     */
+    private $mapper;
+
+    public function __construct(ListMapper $mapper)
+    {
+        $this->mapper = $mapper;
+    }
+
+    /**
+     * @return ListMapper
+     */
+    public function getMapper()
+    {
+        return $this->mapper;
+    }
+}

--- a/src/Extension/Event/ConfigureQueryMessage.php
+++ b/src/Extension/Event/ConfigureQueryMessage.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ConfigureQueryMessage implements MessageInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var ProxyQueryInterface
+     */
+    private $query;
+
+    /**
+     * @var string
+     */
+    private $context;
+
+    /**
+     * @param string $context
+     */
+    public function __construct(AdminInterface $admin, ProxyQueryInterface $query, $context)
+    {
+        $this->admin = $admin;
+        $this->query = $query;
+        $this->context = $context;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return ProxyQueryInterface
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+}

--- a/src/Extension/Event/ConfigureRoutesMessage.php
+++ b/src/Extension/Event/ConfigureRoutesMessage.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Route\RouteCollection;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ConfigureRoutesMessage implements MessageInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var RouteCollection
+     */
+    private $routeCollection;
+
+    public function __construct(AdminInterface $admin, RouteCollection $routeCollection)
+    {
+        $this->admin = $admin;
+        $this->routeCollection = $routeCollection;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return RouteCollection
+     */
+    public function getRouteCollection()
+    {
+        return $this->routeCollection;
+    }
+}

--- a/src/Extension/Event/ConfigureShowFieldsMessage.php
+++ b/src/Extension/Event/ConfigureShowFieldsMessage.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Show\ShowMapper;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ConfigureShowFieldsMessage implements MessageInterface
+{
+    /**
+     * @var ShowMapper
+     */
+    private $mapper;
+
+    public function __construct(ShowMapper $mapper)
+    {
+        $this->mapper = $mapper;
+    }
+
+    /**
+     * @return ShowMapper
+     */
+    public function getMapper()
+    {
+        return $this->mapper;
+    }
+}

--- a/src/Extension/Event/ConfigureTabMenuMessage.php
+++ b/src/Extension/Event/ConfigureTabMenuMessage.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Knp\Menu\ItemInterface as MenuItemInterface;
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ConfigureTabMenuMessage implements MessageInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var MenuItemInterface
+     */
+    private $menu;
+
+    /**
+     * @var string
+     */
+    private $action;
+
+    /**
+     * @var AdminInterface
+     */
+    private $childAdmin;
+
+    /**
+     * @param string $action
+     */
+    public function __construct(
+        AdminInterface $admin,
+        MenuItemInterface $menu,
+        $action,
+        AdminInterface $childAdmin = null
+    ) {
+        $this->admin = $admin;
+        $this->menu = $menu;
+        $this->action = $action;
+        $this->childAdmin = $childAdmin;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return MenuItemInterface
+     */
+    public function getMenu()
+    {
+        return $this->menu;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAction()
+    {
+        return $this->action;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getChildAdmin()
+    {
+        return $this->childAdmin;
+    }
+}

--- a/src/Extension/Event/EventInterface.php
+++ b/src/Extension/Event/EventInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface EventInterface
+{
+}

--- a/src/Extension/Event/GetAccessMappingTask.php
+++ b/src/Extension/Event/GetAccessMappingTask.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class GetAccessMappingTask implements TaskInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var array
+     */
+    private $result = [];
+
+    public function __construct(AdminInterface $admin)
+    {
+        $this->admin = $admin;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return array
+     */
+    public function result()
+    {
+        return $this->result;
+    }
+
+    public function updateResult(array $result)
+    {
+        $this->result = $result;
+    }
+}

--- a/src/Extension/Event/GetPersistentParametersTask.php
+++ b/src/Extension/Event/GetPersistentParametersTask.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class GetPersistentParametersTask implements TaskInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var array
+     */
+    private $result = [];
+
+    public function __construct(AdminInterface $admin)
+    {
+        $this->admin = $admin;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return array
+     */
+    public function result()
+    {
+        return $this->result;
+    }
+
+    public function updateResult(array $result)
+    {
+        $this->result = $result;
+    }
+}

--- a/src/Extension/Event/MessageInterface.php
+++ b/src/Extension/Event/MessageInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface MessageInterface extends EventInterface
+{
+}

--- a/src/Extension/Event/PostPersistMessage.php
+++ b/src/Extension/Event/PostPersistMessage.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class PostPersistMessage implements MessageInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var object
+     */
+    private $object;
+
+    /**
+     * @param object $object
+     */
+    public function __construct(AdminInterface $admin, $object)
+    {
+        $this->admin = $admin;
+        $this->object = $object;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return object
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+}

--- a/src/Extension/Event/PostRemoveMessage.php
+++ b/src/Extension/Event/PostRemoveMessage.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class PostRemoveMessage implements MessageInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var object
+     */
+    private $object;
+
+    /**
+     * @param object $object
+     */
+    public function __construct(AdminInterface $admin, $object)
+    {
+        $this->admin = $admin;
+        $this->object = $object;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return object
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+}

--- a/src/Extension/Event/PostUpdateMessage.php
+++ b/src/Extension/Event/PostUpdateMessage.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class PostUpdateMessage implements MessageInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var object
+     */
+    private $object;
+
+    /**
+     * @param object $object
+     */
+    public function __construct(AdminInterface $admin, $object)
+    {
+        $this->admin = $admin;
+        $this->object = $object;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return object
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+}

--- a/src/Extension/Event/PrePersistMessage.php
+++ b/src/Extension/Event/PrePersistMessage.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class PrePersistMessage implements MessageInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var object
+     */
+    private $object;
+
+    /**
+     * @param object $object
+     */
+    public function __construct(AdminInterface $admin, $object)
+    {
+        $this->admin = $admin;
+        $this->object = $object;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return object
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+}

--- a/src/Extension/Event/PreRemoveMessage.php
+++ b/src/Extension/Event/PreRemoveMessage.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class PreRemoveMessage implements MessageInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var object
+     */
+    private $object;
+
+    /**
+     * @param object $object
+     */
+    public function __construct(AdminInterface $admin, $object)
+    {
+        $this->admin = $admin;
+        $this->object = $object;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return object
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+}

--- a/src/Extension/Event/PreUpdateMessage.php
+++ b/src/Extension/Event/PreUpdateMessage.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class PreUpdateMessage implements MessageInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var object
+     */
+    private $object;
+
+    /**
+     * @param object $object
+     */
+    public function __construct(AdminInterface $admin, $object)
+    {
+        $this->admin = $admin;
+        $this->object = $object;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return object
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+}

--- a/src/Extension/Event/TaskInterface.php
+++ b/src/Extension/Event/TaskInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+interface TaskInterface extends EventInterface
+{
+}

--- a/src/Extension/Event/ValidateMessage.php
+++ b/src/Extension/Event/ValidateMessage.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\CoreBundle\Validator\ErrorElement;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ValidateMessage implements MessageInterface
+{
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var ErrorElement
+     */
+    private $errorElement;
+
+    /**
+     * @var object
+     */
+    private $object;
+
+    /**
+     * @param object $object
+     */
+    public function __construct(AdminInterface $admin, ErrorElement $errorElement, $object)
+    {
+        $this->admin = $admin;
+        $this->errorElement = $errorElement;
+        $this->object = $object;
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @return ErrorElement
+     */
+    public function getErrorElement()
+    {
+        return $this->errorElement;
+    }
+
+    /**
+     * @return object
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+}

--- a/src/Extension/EventInterfaceMap.php
+++ b/src/Extension/EventInterfaceMap.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension;
+
+use InvalidArgumentException;
+use Sonata\AdminBundle\Admin\Extension;
+use function array_key_exists;
+use function get_class;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class EventInterfaceMap
+{
+    const EVENT_INTERFACE_MAP = [
+        Event\AlterNewInstanceMessage::class => Extension\AlterNewInstanceInterface::class,
+        Event\AlterObjectMessage::class => Extension\AlterObjectInterface::class,
+        Event\ConfigureActionButtonsTask::class => Extension\ConfigureActionButtonsInterface::class,
+        Event\ConfigureBatchActionsTask::class => Extension\ConfigureBatchActionsInterface::class,
+        Event\ConfigureDatagridFiltersMessage::class => Extension\ConfigureDatagridFieldsInterface::class,
+        Event\ConfigureDefaultFilterValuesMessage::class => Extension\ConfigureDefaultFilterValuesInterface::class,
+        Event\ConfigureExportFieldsTask::class => Extension\ConfigureExportFieldsInterface::class,
+        Event\ConfigureFormFieldsMessage::class => Extension\ConfigureFormFieldsInterface::class,
+        Event\ConfigureListFieldsMessage::class => Extension\ConfigureListFieldsInterface::class,
+        Event\ConfigureQueryMessage::class => Extension\ConfigureQueryInterface::class,
+        Event\ConfigureRoutesMessage::class => Extension\ConfigureRoutesInterface::class,
+        Event\ConfigureShowFieldsMessage::class => Extension\ConfigureShowFieldsInterface::class,
+        Event\ConfigureTabMenuMessage::class => Extension\ConfigureTabMenuInterface::class,
+        Event\GetAccessMappingTask::class => Extension\GetAccessMappingInterface::class,
+        Event\GetPersistentParametersTask::class => Extension\GetPersistentParametersInterface::class,
+        Event\PostPersistMessage::class => Extension\PostPersistInterface::class,
+        Event\PostRemoveMessage::class => Extension\PostRemoveInterface::class,
+        Event\PostUpdateMessage::class => Extension\PostUpdateInterface::class,
+        Event\PrePersistMessage::class => Extension\PrePersistInterface::class,
+        Event\PreRemoveMessage::class => Extension\PreRemoveInterface::class,
+        Event\PreUpdateMessage::class => Extension\PreUpdateInterface::class,
+        Event\ValidateMessage::class => Extension\ValidateInterface::class,
+    ];
+
+    /**
+     * @return string
+     */
+    public static function get(Event\EventInterface $event)
+    {
+        $eventClass = get_class($event);
+
+        if (!self::has($event)) {
+            throw new InvalidArgumentException(sprintf(
+                "Interface for event '%s' couldn't be found",
+                $eventClass
+            ));
+        }
+
+        return self::EVENT_INTERFACE_MAP[$eventClass];
+    }
+
+    /**
+     * @return bool
+     */
+    public static function has(Event\EventInterface $event)
+    {
+        return array_key_exists(get_class($event), self::EVENT_INTERFACE_MAP);
+    }
+}

--- a/src/Extension/EventMethodMap.php
+++ b/src/Extension/EventMethodMap.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension;
+
+use InvalidArgumentException;
+use function array_key_exists;
+use function get_class;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class EventMethodMap
+{
+    const EVENT_METHOD_MAP = [
+        Event\AlterNewInstanceMessage::class => 'alterNewInstance',
+        Event\AlterObjectMessage::class => 'alterObject',
+        Event\ConfigureActionButtonsTask::class => 'configureActionButtons',
+        Event\ConfigureBatchActionsTask::class => 'configureBatchActions',
+        Event\ConfigureDatagridFiltersMessage::class => 'configureDatagridFilters',
+        Event\ConfigureDefaultFilterValuesMessage::class => 'configureDefaultFilterValues',
+        Event\ConfigureExportFieldsTask::class => 'configureExportFields',
+        Event\ConfigureFormFieldsMessage::class => 'configureFormFields',
+        Event\ConfigureListFieldsMessage::class => 'configureListFields',
+        Event\ConfigureQueryMessage::class => 'configureQuery',
+        Event\ConfigureRoutesMessage::class => 'configureRoutes',
+        Event\ConfigureShowFieldsMessage::class => 'configureShowFields',
+        Event\ConfigureTabMenuMessage::class => 'configureTabMenu',
+        Event\GetAccessMappingTask::class => 'getAccessMapping',
+        Event\GetPersistentParametersTask::class => 'getPersistentParameters',
+        Event\PostPersistMessage::class => 'postPersist',
+        Event\PostRemoveMessage::class => 'postRemove',
+        Event\PostUpdateMessage::class => 'postUpdate',
+        Event\PrePersistMessage::class => 'prePersist',
+        Event\PreRemoveMessage::class => 'preRemove',
+        Event\PreUpdateMessage::class => 'preUpdate',
+        Event\ValidateMessage::class => 'validate',
+    ];
+
+    /**
+     * @return string
+     */
+    public static function get(Event\EventInterface $event)
+    {
+        $eventClass = get_class($event);
+
+        if (!self::has($event)) {
+            throw new InvalidArgumentException(sprintf(
+                "Method for event '%s' couldn't be found",
+                $eventClass
+            ));
+        }
+
+        return self::EVENT_METHOD_MAP[$eventClass];
+    }
+
+    /**
+     * @return bool
+     */
+    public static function has(Event\EventInterface $event)
+    {
+        return array_key_exists(get_class($event), self::EVENT_METHOD_MAP);
+    }
+}

--- a/src/Extension/ExtensionEmitter.php
+++ b/src/Extension/ExtensionEmitter.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension;
+
+use Sonata\AdminBundle\Extension\Event\EventInterface;
+use Sonata\AdminBundle\Extension\Event\MessageInterface;
+use Sonata\AdminBundle\Extension\Event\TaskInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ExtensionEmitter
+{
+    /**
+     * @var ExtensionNotifier
+     */
+    private $notifier;
+
+    /**
+     * @var ExtensionProcessor
+     */
+    private $processor;
+
+    public function __construct(ExtensionNotifier $notifier, ExtensionProcessor $processor)
+    {
+        $this->notifier = $notifier;
+        $this->processor = $processor;
+    }
+
+    /**
+     * @return TaskInterface|null
+     */
+    public function dispatch(EventInterface $event)
+    {
+        if ($event instanceof TaskInterface) {
+            return $this->processor->process($event);
+        }
+
+        if ($event instanceof MessageInterface) {
+            $this->notifier->notify($event);
+        }
+    }
+}

--- a/src/Extension/ExtensionNotifier.php
+++ b/src/Extension/ExtensionNotifier.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension;
+
+use Sonata\AdminBundle\Extension\Event\MessageInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ExtensionNotifier
+{
+    /**
+     * @var ExtensionProvider
+     */
+    private $provider;
+
+    public function __construct(ExtensionProvider $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    public function notify(MessageInterface $event)
+    {
+        foreach ($this->provider->getListenersForEvent($event) as $extension) {
+            if (EventMethodMap::has($event)) {
+                $extension->{EventMethodMap::get($event)}($event);
+            }
+        }
+    }
+}

--- a/src/Extension/ExtensionProcessor.php
+++ b/src/Extension/ExtensionProcessor.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension;
+
+use Sonata\AdminBundle\Extension\Event\TaskInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ExtensionProcessor
+{
+    /**
+     * @var ExtensionProvider
+     */
+    private $provider;
+
+    public function __construct(ExtensionProvider $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    /**
+     * @return TaskInterface
+     */
+    public function process(TaskInterface $event)
+    {
+        foreach ($this->provider->getListenersForEvent($event) as $extension) {
+            if (EventMethodMap::has($event)) {
+                $extension->{EventMethodMap::get($event)}($event);
+            }
+        }
+
+        return $event;
+    }
+}

--- a/src/Extension/ExtensionProvider.php
+++ b/src/Extension/ExtensionProvider.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Extension;
+
+use Sonata\AdminBundle\Admin\Extension\AdminExtensionInterface;
+use Sonata\AdminBundle\Extension\Event\EventInterface;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ExtensionProvider
+{
+    /**
+     * @var array
+     */
+    private $extensions = [];
+
+    /**
+     * @return iterable
+     */
+    public function getListenersForEvent(EventInterface $event)
+    {
+        $extensionInterface = EventInterfaceMap::get($event);
+
+        $extensions = [];
+
+        foreach ($this->extensions as $extension) {
+            if (is_subclass_of($extension, $extensionInterface)) {
+                $extensions[] = $extension;
+            }
+        }
+
+        return $extensions;
+    }
+
+    public function setExtensions(array $extensions)
+    {
+        $this->extensions = $extensions;
+    }
+
+    public function addExtension(AdminExtensionInterface $extension)
+    {
+        $this->extensions[] = $extension;
+    }
+}

--- a/tests/Admin/SetExtensionEmitterTrait.php
+++ b/tests/Admin/SetExtensionEmitterTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Admin;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Extension\ExtensionEmitter;
+use Sonata\AdminBundle\Extension\ExtensionNotifier;
+use Sonata\AdminBundle\Extension\ExtensionProcessor;
+use Sonata\AdminBundle\Extension\ExtensionProvider;
+
+/**
+ * @internal
+ *
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+trait SetExtensionEmitterTrait
+{
+    private function setExtensionEmitter(AdminInterface $admin, array $extensions = [])
+    {
+        $admin->setExtensionEmitter(
+            new ExtensionEmitter(
+                new ExtensionNotifier($extensionProvider = new ExtensionProvider()),
+                new ExtensionProcessor($extensionProvider)
+            )
+        );
+
+        $extensionProvider->setExtensions($extensions);
+    }
+}

--- a/tests/Extension/EventInterfaceMapTest.php
+++ b/tests/Extension/EventInterfaceMapTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Extension;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Extension\Event\EventInterface;
+use Sonata\AdminBundle\Extension\EventInterfaceMap;
+
+class EventInterfaceMapTest extends TestCase
+{
+    public function testBadEvent()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        EventInterfaceMap::get($this->createMock(EventInterface::class));
+    }
+}

--- a/tests/Extension/EventMethodMapTest.php
+++ b/tests/Extension/EventMethodMapTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Extension;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Extension\Event\EventInterface;
+use Sonata\AdminBundle\Extension\EventMethodMap;
+
+class EventMethodMapTest extends TestCase
+{
+    public function testBadEvent()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        EventMethodMap::get($this->createMock(EventInterface::class));
+    }
+}

--- a/tests/Extension/ExtensionProcessorTest.php
+++ b/tests/Extension/ExtensionProcessorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Extension\Event\ConfigureBatchActionsTask;
+use Sonata\AdminBundle\Extension\ExtensionProcessor;
+use Sonata\AdminBundle\Extension\ExtensionProvider;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\Extension\DummyExtension;
+
+class ExtensionProcessorTest extends TestCase
+{
+    /**
+     * @var ExtensionProvider
+     */
+    private $extensionProvider;
+
+    /**
+     * @var ExtensionProcessor
+     */
+    private $extensionProcessor;
+
+    public function setUp()
+    {
+        $this->extensionProvider = new ExtensionProvider();
+        $this->extensionProvider->addExtension(new DummyExtension());
+
+        $this->extensionProcessor = new ExtensionProcessor($this->extensionProvider);
+    }
+
+    public function testEventExists()
+    {
+        $event = $this->extensionProcessor->process(
+            new ConfigureBatchActionsTask(
+                $this->createMock(AdminInterface::class),
+                $array = ['testing']
+            )
+        );
+
+        $this->assertInstanceOf(ConfigureBatchActionsTask::class, $event);
+        $this->assertSame($array, $event->getActions());
+    }
+}

--- a/tests/Fixtures/Admin/Extension/DummyExtension.php
+++ b/tests/Fixtures/Admin/Extension/DummyExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\Extension\ConfigureActionButtonsInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureBatchActionsInterface;
+use Sonata\AdminBundle\Admin\Extension\ConfigureDefaultFilterValuesInterface;
+use Sonata\AdminBundle\Extension\Event\ConfigureActionButtonsTask;
+use Sonata\AdminBundle\Extension\Event\ConfigureBatchActionsTask;
+use Sonata\AdminBundle\Extension\Event\ConfigureDefaultFilterValuesMessage;
+
+class DummyExtension implements ConfigureActionButtonsInterface, ConfigureDefaultFilterValuesInterface, ConfigureBatchActionsInterface
+{
+    public function configureActionButtons(ConfigureActionButtonsTask $event)
+    {
+    }
+
+    public function configureDefaultFilterValues(ConfigureDefaultFilterValuesMessage $event)
+    {
+    }
+
+    public function configureBatchActions(ConfigureBatchActionsTask $event)
+    {
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5494 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Admin specific `ExtensionEmitter` that will be used to dispatch extension events
- Admin specific `ExtensionNotifier` and `ExtensionProcessor` that will handle events
- Admin specific `ExtensionProvider` that will provide extensions
- Single-method Event Objects per Extension Interface

### Changed
- Separated `Sonata\AdminBundle\Admin\AdminExtensionInterface` into single-method
interfaces, they can be found under the `Sonata\AdminBundle\Admin\Extension` namespace

### Deprecated
- `Sonata\AdminBundle\Admin\AdminExtensionInterface`
- `Sonata\AdminBundle\Admin\AbstractAdminExtension`
- `Sonata\AdminBundle\Admin\AbstractAdmin::addExtension`
```

## To do
    
- [x] Update the tests
- [x] Update the changelog
- [x] Add an upgrade note
- [ ]  Test cherry picking #5199

## Subject

Built on top of #5164, this adds PSR14 compliant (hopefully it won't change much until it is approved) dispatcher for our extension instead of current logic, this will transform:

```php
    public function update($object)
    {
        $this->preUpdate($object);
        foreach ($this->extensions as $extension) {
            $extension->preUpdate($this, $object);
        }
        
        //...

        $this->postUpdate($object);
        foreach ($this->extensions as $extension) {
            $extension->postUpdate($this, $object);
        }
        return $object;
    }
```

into:

```php
public function update($object)
    {
        $this->preUpdate($object);
        $this->extensionEmitter->dispatch(new PreUpdateMessage($this, $object));

        //...

         $this->postUpdate($object);
         $this->extensionEmitter->dispatch(new PostUpdateMessage($this, $object));

         return $object;
    }
```