### PR TITLE
different fixes to be consistent

### DIFF
--- a/docs/cookbook/recipe_delete_field_group.rst
+++ b/docs/cookbook/recipe_delete_field_group.rst
@@ -44,6 +44,6 @@ This is optional. However, when not provided, it will be assumed that
 you mean the 'default' tab. If the group is on another tab, it won't be
 removed, when this is not provided. There is a third optional argument
 for the method, which let's you choose, whether or not, tabs are also
-removed, if you happen to remove all groups of a tab. This behaviour
+removed, if you happen to remove all groups of a tab. This behavior
 is disabled by default, but can be enabled, by setting the third
 argument of ``removeGroup`` to ``true``.

--- a/docs/cookbook/recipe_icheck.rst
+++ b/docs/cookbook/recipe_icheck.rst
@@ -25,9 +25,8 @@ If you don't want to use iCheck in your admin, you can disable it in configurati
 Disable iCheck on some form elements
 -------------------------------------
 
-To disable iCheck on some ``checkbox`` or ``radio`` form elements, set data attribute ``data-sonata-icheck = "false"`` to this form element.
-
-.. code-block:: php
+To disable iCheck on some ``checkbox`` or ``radio`` form elements,
+set data attribute ``data-sonata-icheck = "false"`` to this form element::
 
     use Sonata\AdminBundle\Form\FormMapper;
     use Sonata\AdminBundle\Form\Type\ModelType;

--- a/docs/cookbook/recipe_improve_performance_large_datasets.rst
+++ b/docs/cookbook/recipe_improve_performance_large_datasets.rst
@@ -1,4 +1,4 @@
-Improve performance of large datasets
+Improve Performance of Large Datasets
 =====================================
 
 If your database table contains thousands of records, the database queries generated
@@ -17,17 +17,6 @@ To use `SimplePager` in your admin,  define ``pager_type`` in the service defini
 
 .. configuration-block::
 
-    .. code-block:: xml
-
-        <!-- config/services.xml -->
-
-        <service id="app.admin.post" class="App\Admin\PostAdmin">
-            <argument/>
-            <argument>App\Entity\Post</argument>
-            <argument/>
-            <tag name="sonata.admin" manager_type="orm" group="Content" label="Post" pager_type="simple"/>
-        </service>
-
     .. code-block:: yaml
 
         # config/services.yaml
@@ -42,6 +31,18 @@ To use `SimplePager` in your admin,  define ``pager_type`` in the service defini
                 tags:
                     - { name: sonata.admin, manager_type: orm, group: 'Content', label: 'Post', pager_type: 'simple' }
 
+    .. code-block:: xml
+
+        <!-- config/services.xml -->
+
+        <service id="app.admin.post" class="App\Admin\PostAdmin">
+            <argument/>
+            <argument>App\Entity\Post</argument>
+            <argument/>
+            <tag name="sonata.admin" manager_type="orm" group="Content" label="Post" pager_type="simple"/>
+        </service>
+
 .. note::
 
-    The ``pager_results`` template is automatically changed to ``@SonataAdmin/Pager/simple_pager_results.html.twig`` if it's not already overloaded.
+    The ``pager_results`` template is automatically changed to
+    ``@SonataAdmin/Pager/simple_pager_results.html.twig`` if it's not already overloaded.

--- a/docs/cookbook/recipe_persisting_filters.rst
+++ b/docs/cookbook/recipe_persisting_filters.rst
@@ -51,21 +51,6 @@ Per Admin :
 
 .. configuration-block::
 
-    .. code-block:: xml
-
-        <!-- config/services.xml -->
-
-        <service id="app.admin.user" class="App\Admin\UserAdmin">
-            <argument/>
-            <argument>App\Entity\User</argument>
-            <argument/>
-            <tag
-                name="sonata.admin"
-                manager_type="orm"
-                filter_persister="filter_persister_service_id"
-                />
-        </service>
-
     .. code-block:: yaml
 
         # config/services.yaml
@@ -83,6 +68,21 @@ Per Admin :
                         manager_type: orm
                         filter_persister: filter_persister_service_id
 
+    .. code-block:: xml
+
+        <!-- config/services.xml -->
+
+        <service id="app.admin.user" class="App\Admin\UserAdmin">
+            <argument/>
+            <argument>App\Entity\User</argument>
+            <argument/>
+            <tag
+                name="sonata.admin"
+                manager_type="orm"
+                filter_persister="filter_persister_service_id"
+                />
+        </service>
+
 Disable filters persistence for some Admin
 ------------------------------------------
 
@@ -93,17 +93,6 @@ All registered Admins will have the feature enabled.
 You can disable it per Admin if you want.
 
 .. configuration-block::
-
-    .. code-block:: xml
-
-        <!-- config/services.xml -->
-
-        <service id="app.admin.user" class="App\Admin\UserAdmin">
-            <argument/>
-            <argument>App\Entity\User</argument>
-            <argument/>
-            <tag name="sonata.admin" manager_type="orm" persist_filters="false"/>
-        </service>
 
     .. code-block:: yaml
 
@@ -118,6 +107,17 @@ You can disable it per Admin if you want.
                     - ~
                 tags:
                     - { name: sonata.admin, manager_type: orm, persist_filters: false }
+
+    .. code-block:: xml
+
+        <!-- config/services.xml -->
+
+        <service id="app.admin.user" class="App\Admin\UserAdmin">
+            <argument/>
+            <argument>App\Entity\User</argument>
+            <argument/>
+            <tag name="sonata.admin" manager_type="orm" persist_filters="false"/>
+        </service>
 
 .. note::
 

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -38,24 +38,6 @@ With a tag attribute (less verbose)
 
 .. configuration-block::
 
-    .. code-block:: xml
-
-        <!-- config/services.xml -->
-
-        <service id="app.admin.project" class="App\Admin\ProjectAdmin">
-            <argument/>
-            <argument>App\Entity\Project</argument>
-            <argument/>
-            <tag
-                name="sonata.admin"
-                manager_type="orm"
-                group="Project"
-                label="Project"
-                label_translator_strategy="sonata.admin.label.strategy.native"
-                route_builder="sonata.admin.route.path_info"
-                />
-        </service>
-
     .. code-block:: yaml
 
         # config/services.yaml
@@ -75,10 +57,44 @@ With a tag attribute (less verbose)
                     label_translator_strategy: 'sonata.admin.label.strategy.native'
                     route_builder: 'sonata.admin.route.path_info'
 
+    .. code-block:: xml
+
+        <!-- config/services.xml -->
+
+        <service id="app.admin.project" class="App\Admin\ProjectAdmin">
+            <argument/>
+            <argument>App\Entity\Project</argument>
+            <argument/>
+            <tag
+                name="sonata.admin"
+                manager_type="orm"
+                group="Project"
+                label="Project"
+                label_translator_strategy="sonata.admin.label.strategy.native"
+                route_builder="sonata.admin.route.path_info"
+                />
+        </service>
+
 With a method call (more verbose)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+
+        app.admin.project:
+            class: App\Admin\ProjectAdmin
+            arguments:
+                - ~
+                - App\Entity\Project
+                - ~
+            calls:
+                - [setLabelTranslatorStrategy, ['@sonata.admin.label.strategy.native']]
+                - [setRouteBuilder, ['@sonata.admin.route.path_info']]
+            tags:
+                - { name: sonata.admin, manager_type: orm, group: 'Project', label: 'Project' }
 
     .. code-block:: xml
 
@@ -96,22 +112,6 @@ With a method call (more verbose)
             </call>
             <tag name="sonata.admin" manager_type="orm" group="Project" label="Project"/>
         </service>
-
-    .. code-block:: yaml
-
-        # config/services.yaml
-
-        app.admin.project:
-            class: App\Admin\ProjectAdmin
-            arguments:
-                - ~
-                - App\Entity\Project
-                - ~
-            calls:
-                - [setLabelTranslatorStrategy, ['@sonata.admin.label.strategy.native']]
-                - [setRouteBuilder, ['@sonata.admin.route.path_info']]
-            tags:
-                - { name: sonata.admin, manager_type: orm, group: 'Project', label: 'Project' }
 
 If you want to modify the service that is going to be injected, add the following code to your
 application's config file:
@@ -161,14 +161,6 @@ To create your own RouteBuilder create the PHP class and register it as a servic
 
 .. configuration-block::
 
-    .. code-block:: xml
-
-        <!-- config/services.xml -->
-
-        <service id="app.admin.entity_route_builder" class="App\Route\EntityRouterBuilder">
-            <argument type="service" id="sonata.admin.audit.manager"/>
-        </service>
-
     .. code-block:: yaml
 
         # config/services.yaml
@@ -177,7 +169,15 @@ To create your own RouteBuilder create the PHP class and register it as a servic
             app.admin.entity_route_builder:
                 class: App\Route\EntityRouterBuilder
                 arguments:
-                    - "@sonata.admin.audit.manager"
+                    - '@sonata.admin.audit.manager'
+
+    .. code-block:: xml
+
+        <!-- config/services.xml -->
+
+        <service id="app.admin.entity_route_builder" class="App\Route\EntityRouterBuilder">
+            <argument type="service" id="sonata.admin.audit.manager"/>
+        </service>
 
 Inherited classes
 -----------------
@@ -187,23 +187,6 @@ You can manage inherited classes by injecting subclasses using the service confi
 Lets consider a base class named `Person` and its subclasses `Student` and `Teacher`:
 
 .. configuration-block::
-
-    .. code-block:: xml
-
-        <!-- config/services.xml -->
-
-        <service id="app.admin.person" class="App\Admin\PersonAdmin">
-            <argument/>
-            <argument>App\Entity\Person</argument>
-            <argument></argument>
-            <call method="setSubClasses">
-                <argument type="collection">
-                    <argument key="student">App\Entity\Student</argument>
-                    <argument key="teacher">App\Entity\Teacher</argument>
-                </argument>
-            </call>
-            <tag name="sonata.admin" manager_type="orm" group="admin" label="Person"/>
-        </service>
 
     .. code-block:: yaml
 
@@ -223,6 +206,23 @@ Lets consider a base class named `Person` and its subclasses `Student` and `Teac
                         teacher: App\Entity\Teacher
             tags:
                 - { name: sonata.admin, manager_type: orm, group: "admin", label: "Person" }
+
+    .. code-block:: xml
+
+        <!-- config/services.xml -->
+
+        <service id="app.admin.person" class="App\Admin\PersonAdmin">
+            <argument/>
+            <argument>App\Entity\Person</argument>
+            <argument></argument>
+            <call method="setSubClasses">
+                <argument type="collection">
+                    <argument key="student">App\Entity\Student</argument>
+                    <argument key="teacher">App\Entity\Teacher</argument>
+                </argument>
+            </call>
+            <tag name="sonata.admin" manager_type="orm" group="admin" label="Person"/>
+        </service>
 
 You will need to change the way forms are configured in order to
 take into account these new subclasses::

--- a/docs/reference/architecture.rst
+++ b/docs/reference/architecture.rst
@@ -64,18 +64,6 @@ your ``Admin`` services. This is done using a ``call`` to the matching ``setter`
 
 .. configuration-block::
 
-    .. code-block:: xml
-
-        <service id="app.admin.post" class="App\Admin\PostAdmin">
-              <argument/>
-              <argument>App\Entity\Post</argument>
-              <argument/>
-              <call method="setLabelTranslatorStrategy">
-                  <argument type="service" id="sonata.admin.label.strategy.underscore"/>
-              </call>
-              <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
-          </service>
-
     .. code-block:: yaml
 
         services:
@@ -89,6 +77,18 @@ your ``Admin`` services. This is done using a ``call`` to the matching ``setter`
                     - [setLabelTranslatorStrategy, ['@sonata.admin.label.strategy.underscore']]
                 tags:
                     - { name: sonata.admin, manager_type: orm, group: 'Content', label: 'Post' }
+
+    .. code-block:: xml
+
+        <service id="app.admin.post" class="App\Admin\PostAdmin">
+              <argument/>
+              <argument>App\Entity\Post</argument>
+              <argument/>
+              <call method="setLabelTranslatorStrategy">
+                  <argument type="service" id="sonata.admin.label.strategy.underscore"/>
+              </call>
+              <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
+          </service>
 
 Here, we declare the same ``Admin`` service as in the :doc:`../getting_started/creating_an_admin`
 chapter, but using a different label translator strategy, replacing the default one. Notice that
@@ -119,18 +119,6 @@ to set the controller to ``App\Controller\PostAdminController``:
 
 .. configuration-block::
 
-    .. code-block:: xml
-
-        <service id="app.admin.post" class="App\Admin\PostAdmin">
-            <argument/>
-            <argument>App\Entity\Post</argument>
-            <argument>App\Controller\PostAdminController</argument>
-            <call method="setTranslationDomain">
-                <argument>App</argument>
-            </call>
-            <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
-        </service>
-
     .. code-block:: yaml
 
         services:
@@ -144,6 +132,18 @@ to set the controller to ``App\Controller\PostAdminController``:
                     - [setTranslationDomain, ['App']]
                 tags:
                     - { name: sonata.admin, manager_type: orm, group: 'Content', label: 'Post' }
+
+    .. code-block:: xml
+
+        <service id="app.admin.post" class="App\Admin\PostAdmin">
+            <argument/>
+            <argument>App\Entity\Post</argument>
+            <argument>App\Controller\PostAdminController</argument>
+            <call method="setTranslationDomain">
+                <argument>App</argument>
+            </call>
+            <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
+        </service>
 
 When extending ``CRUDController``, remember that the ``Admin`` class already has
 a set of automatically injected dependencies that are useful when implementing several

--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -27,9 +27,7 @@ For example, lets define a new ``merge`` action which takes a number of source i
 merges them onto a single target item. It should only be available when two conditions are met:
 
 - the EDIT and DELETE routes exist for this Admin (have not been disabled)
-- the logged in administrator has EDIT and DELETE permissions
-
-.. code-block:: php
+- the logged in administrator has EDIT and DELETE permissions::
 
     protected function configureBatchActions($actions)
     {
@@ -169,9 +167,7 @@ This method may return three different values:
  - ``false``: Same as above, with the default "action aborted, no model selected" notification message.
  - ``string``: The batch action is not relevant given the current request parameters
    (for example the ``target`` is missing for a ``merge`` action).
-   The returned string is a message displayed to the user.
-
-.. code-block:: php
+   The returned string is a message displayed to the user::
 
     // src/Controller/CRUDController.php
 

--- a/docs/reference/dashboard.rst
+++ b/docs/reference/dashboard.rst
@@ -63,17 +63,6 @@ services:
 
 .. configuration-block::
 
-    .. code-block:: xml
-
-        <!-- config/services.xml -->
-
-        <service id="app.admin.post" class="App\Admin\PostAdmin">
-              <argument/>
-              <argument>App\Entity\Post</argument>
-              <argument/>
-              <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
-          </service>
-
     .. code-block:: yaml
 
         # config/services.yaml
@@ -88,11 +77,6 @@ services:
                 tags:
                     - { name: sonata.admin, manager_type: orm, group: 'Content', label: 'Post' }
 
-In these examples, notice the ``group`` tag, stating that this particular ``Admin``
-service belongs to the ``Content`` group.
-
-.. configuration-block::
-
     .. code-block:: xml
 
         <!-- config/services.xml -->
@@ -101,14 +85,13 @@ service belongs to the ``Content`` group.
               <argument/>
               <argument>App\Entity\Post</argument>
               <argument/>
-              <tag
-                  name="sonata.admin"
-                  manager_type="orm"
-                  group="app.admin.group.content"
-                  label="app.admin.model.post"
-                  label_catalogue="App"
-                  />
+              <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
           </service>
+
+In these examples, notice the ``group`` tag, stating that this particular ``Admin``
+service belongs to the ``Content`` group.
+
+.. configuration-block::
 
     .. code-block:: yaml
 
@@ -127,6 +110,23 @@ service belongs to the ``Content`` group.
                       group: 'app.admin.group.content'
                       label: 'app.admin.model.post'
                       label_catalogue: 'App'
+
+    .. code-block:: xml
+
+        <!-- config/services.xml -->
+
+        <service id="app.admin.post" class="App\Admin\PostAdmin">
+              <argument/>
+              <argument>App\Entity\Post</argument>
+              <argument/>
+              <tag
+                  name="sonata.admin"
+                  manager_type="orm"
+                  group="app.admin.group.content"
+                  label="app.admin.model.post"
+                  label_catalogue="App"
+                  />
+          </service>
 
 In this example, the labels are translated by ``App``, using the given
 ``label_catalogue``. So, you can use the above examples to support multiple languages

--- a/docs/reference/extensions.rst
+++ b/docs/reference/extensions.rst
@@ -77,7 +77,7 @@ The second option is to add it to your config.
                         - app.admin.article
 
 Using ``config/packages/sonata_admin.yaml`` file has some advantages, it allows you to keep your configuration centralized and it provides some
-extra options you can use to wire your extensions in a more dynamic way. This means you can change the behaviour of all
+extra options you can use to wire your extensions in a more dynamic way. This means you can change the behavior of all
 admins that manage a class of a specific type.
 
 admins:

--- a/docs/reference/field_types.rst
+++ b/docs/reference/field_types.rst
@@ -43,21 +43,19 @@ This is currently limited to scalar types (text, integer, url...) and choice typ
     ``date`` filter specification, available at: `http://twig.sensiolabs.org/doc/filters/date.html <http://twig.sensiolabs.org/doc/filters/date.html>`_
     and php timezone list: `https://php.net/manual/en/timezones.php <https://php.net/manual/en/timezones.php>`_
     You can use in lists what `view-timezone <http://symfony.com/doc/current/reference/forms/types/datetime.html#view-timezone>`_ allows on forms,
-    a way to render the date in the user timezone.
+    a way to render the date in the user timezone::
 
-.. code-block:: php
+        protected function configureListFields(ListMapper $listMapper)
+        {
+            $listMapper
 
-    protected function configureListFields(ListMapper $listMapper)
-    {
-        $listMapper
-
-            // store date in UTC but display is in the user timezone
-            ->add('date', null, [
-                'format' => 'Y-m-d H:i',
-                'timezone' => 'America/New_York'
-            ])
-        ;
-    }
+                // store date in UTC but display is in the user timezone
+                ->add('date', null, [
+                    'format' => 'Y-m-d H:i',
+                    'timezone' => 'America/New_York',
+                ])
+            ;
+        }
 
 More types might be provided based on the persistency layer defined. Please refer to their
 related documentations.
@@ -67,12 +65,14 @@ Choice
 
 You can use the following parameters:
 
-======================================  ==================================================================
+======================================  ============================================================
 Parameter                               Description
-======================================  ==================================================================
+======================================  ============================================================
 **choices**                             Array of choices
-**required**                            Whether the field is required or not (default true) when the ``editable`` option is set to ``true``. If false, an empty placeholder will be added.
-======================================  ==================================================================
+**required**                            Whether the field is required or not (default true) when the
+                                        ``editable`` option is set to ``true``. If false, an empty
+                                        placeholder will be added.
+======================================  ============================================================
 
 .. code-block:: php
 
@@ -84,9 +84,9 @@ Parameter                               Description
                 'choices' => [
                     'prep' => 'Prepared',
                     'prog' => 'In progress',
-                    'done' => 'Done'
+                    'done' => 'Done',
                 ],
-                'catalogue' => 'App'
+                'catalogue' => 'App',
             ])
         ;
     }
@@ -105,7 +105,7 @@ The ``choice`` field type also supports multiple values that can be separated by
                 'choices' => [
                     'r' => 'red',
                     'g' => 'green',
-                    'b' => 'blue'
+                    'b' => 'blue',
                 ]
             ])
         ;

--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -287,7 +287,7 @@ The available options are:
     ;
 
 ``to_string_callback``
-  defaults to ``null``. Callable function that can be used to change the default toString behaviour of entity::
+  defaults to ``null``. Callable function that can be used to change the default toString behavior of entity::
 
     $formMapper
         ->add('category', ModelAutocompleteType::class, [
@@ -402,49 +402,49 @@ The available options are:
   which is mapped in the target admin to ``AUTOCOMPLETE`` role. Please make sure that all valid users
   have the ``AUTOCOMPLETE`` role::
 
-    // src/Admin/ArticleAdmin.php
+      // src/Admin/ArticleAdmin.php
 
-    use Sonata\AdminBundle\Form\FormMapper;
-    use Sonata\AdminBundle\Admin\AbstractAdmin;
-    use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
+      use Sonata\AdminBundle\Form\FormMapper;
+      use Sonata\AdminBundle\Admin\AbstractAdmin;
+      use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 
-    final class ArticleAdmin extends AbstractAdmin
-    {
-        protected function configureFormFields(FormMapper $formMapper)
-        {
-            // the dropdown autocomplete list will show only Category
-            // entities that contain specified text in "title" attribute
-            $formMapper
-                ->add('category', ModelAutocompleteType::class, [
-                    'property' => 'title',
-                    'target_admin_access_action' => 'autocomplete'
-                ])
-            ;
-        }
-    }
+      final class ArticleAdmin extends AbstractAdmin
+      {
+          protected function configureFormFields(FormMapper $formMapper)
+          {
+              // the dropdown autocomplete list will show only Category
+              // entities that contain specified text in "title" attribute
+              $formMapper
+                  ->add('category', ModelAutocompleteType::class, [
+                      'property' => 'title',
+                      'target_admin_access_action' => 'autocomplete',
+                  ])
+              ;
+          }
+      }
 
-.. code-block:: php
+  You have to modify the target entity in the following way::
 
-    // src/Admin/CategoryAdmin.php
+      // src/Admin/CategoryAdmin.php
 
-    use Sonata\AdminBundle\Datagrid\DatagridMapper;
-    use Sonata\AdminBundle\Admin\AbstractAdmin;
+      use Sonata\AdminBundle\Datagrid\DatagridMapper;
+      use Sonata\AdminBundle\Admin\AbstractAdmin;
 
-    final class CategoryAdmin extends AbstractAdmin
-    {
-        protected $accessMapping = [
-            'autocomplete' => 'AUTOCOMPLETE',
-        ];
+      final class CategoryAdmin extends AbstractAdmin
+      {
+          protected $accessMapping = [
+              'autocomplete' => 'AUTOCOMPLETE',
+          ];
 
-        protected function configureDatagridFilters(DatagridMapper $datagridMapper)
-        {
-            // this text filter will be used to retrieve autocomplete fields
-            // only the users with role AUTOCOMPLETE will be able to get the items
-            $datagridMapper
-                ->add('title')
-            ;
-        }
-    }
+          protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+          {
+              // this text filter will be used to retrieve autocomplete fields
+              // only the users with role AUTOCOMPLETE will be able to get the items
+              $datagridMapper
+                  ->add('title')
+              ;
+          }
+      }
 
 Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/reference/routing.rst
+++ b/docs/reference/routing.rst
@@ -17,13 +17,7 @@ Route names
 
 You can set a ``baseRouteName`` property inside your ``Admin`` class. This
 represents the route prefix, to which an underscore and the action name will
-be added to generate the actual route names.
-
-.. note::
-
-    This is the internal *name* given to a route (it has nothing to do with the route's visible *URL*).
-
-.. code-block:: php
+be added to generate the actual route names::
 
     // src/Admin/PostAdmin.php
 
@@ -37,6 +31,10 @@ be added to generate the actual route names.
 
         // ...
     }
+
+.. note::
+
+    This is the internal *name* given to a route (it has nothing to do with the route's visible *URL*).
 
 If no ``baseRouteName`` is defined then the Admin will generate one for you,
 based on the following format: 'admin_vendor_bundlename_entityname' so you will have

--- a/docs/reference/search.rst
+++ b/docs/reference/search.rst
@@ -59,7 +59,7 @@ Configure the default search result action
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In general the search result generates a link to the edit action of an item or is using the show action, if the edit
-route is disabled or you haven't the required permission. You can change this behaviour by overriding the
+route is disabled or you haven't the required permission. You can change this behavior by overriding the
 ``searchResultActions`` property. The defined action list will we checked successive until a route with the required
 permissions exists. If no route is found, the item will be displayed as a text::
 

--- a/docs/reference/templates.rst
+++ b/docs/reference/templates.rst
@@ -160,21 +160,6 @@ can specify the templates to use in the ``Admin`` service definition:
 
 .. configuration-block::
 
-    .. code-block:: xml
-
-       <!-- config/services.xml -->
-
-        <service id="app.admin.post" class="App\Admin\PostAdmin">
-            <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
-            <argument/>
-            <argument>App\Entity\Post</argument>
-            <argument/>
-            <call method="setTemplate">
-                <argument>edit</argument>
-                <argument>@App/PostAdmin/edit.html.twig</argument>
-            </call>
-        </service>
-
     .. code-block:: yaml
 
         # config/services.yaml
@@ -190,6 +175,21 @@ can specify the templates to use in the ``Admin`` service definition:
                     - [setTemplate, ['edit', '@App/PostAdmin/edit.html.twig']]
                 tags:
                     - { name: sonata.admin, manager_type: orm, group: 'Content', label: 'Post' }
+
+    .. code-block:: xml
+
+       <!-- config/services.xml -->
+
+        <service id="app.admin.post" class="App\Admin\PostAdmin">
+            <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
+            <argument/>
+            <argument>App\Entity\Post</argument>
+            <argument/>
+            <call method="setTemplate">
+                <argument>edit</argument>
+                <argument>@App/PostAdmin/edit.html.twig</argument>
+            </call>
+        </service>
 
 .. note::
 


### PR DESCRIPTION
- ensure order in `.. configuration block::`: `yaml`, `xml`, `php`
- long lines
- American English ([Symfony-Docs are using it too](https://github.com/symfony/symfony-docs/pull/11196))
```diff
- behaviour
+ behavior
```
- no explicit use of `.. code-block:: php`, use `::` instead

These were detected with my tool and will be checked continously, if we can use GithubActions 👍 