### PR TITLE
Fix redirect to tab when there is no tab explicitly selected

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1270,7 +1270,7 @@ class CRUDController implements ContainerAwareInterface
                     $url = $this->admin->generateObjectUrl(
                         $route,
                         $object,
-                        $request->request->has('_tab') ? ['_tab' => $request->request->get('_tab')] : []
+                        $this->getSelectedTab($request)
                     );
 
                     break;
@@ -1532,6 +1532,11 @@ class CRUDController implements ContainerAwareInterface
         $domain = $domain ?: $this->admin->getTranslationDomain();
 
         return $this->get('translator')->trans($id, $parameters, $domain, $locale);
+    }
+
+    private function getSelectedTab(Request $request)
+    {
+        return array_filter(['_tab' => $request->request->get('_tab')]);
     }
 
     private function checkParentChildAssociation(Request $request, $object): void

--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -729,6 +729,12 @@ var Admin = {
             setTimeout(function() {
                 form.find('button').prop('disabled', true);
             }, 1);
+
+            var tabSelected = form.find('.nav-tabs li.active .changer-tab');
+
+            if (tabSelected.length > 0) {
+                form.find('input[name="_tab"]').val(tabSelected.attr('aria-controls'));
+            }
         });
     },
     /**
@@ -758,7 +764,6 @@ var Admin = {
             window.history.pushState({
                 path: newurl
             }, '', newurl);
-            jQuery(this).parent('.nav-tabs-custom').find('input[name="_tab"]').val(tab);
         });
     }
 };


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
There are [some issues](https://github.com/sonata-project/SonataAdminBundle/pull/5314#issuecomment-477323631) after https://github.com/sonata-project/SonataAdminBundle/pull/5314.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed redirecting to a blank tab after saving an object
- Fixed modifying form values changing tabs
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
