### PR TITLE
Documentation fixes, correct FQDN and FQDN escaping

### DIFF
--- a/docs/reference/security.rst
+++ b/docs/reference/security.rst
@@ -132,15 +132,15 @@ service), Sonata will check if the user has the ``ROLE_APP_ADMIN_FOO_EDIT`` or `
 
 .. note::
 
-    Declaring the same admin as `App\Admin\FooAdmin` results in
-    ``ROLE_APPBUNDLE\ADMIN\FOOADMIN_EDIT`` and ``ROLE_APPBUNDLE\ADMIN\FOOADMIN_ALL``!
+    Declaring the same admin as ``App\Admin\FooAdmin`` results in
+    ``ROLE_APP\ADMIN\FOOADMIN_EDIT`` and ``ROLE_APP\ADMIN\FOOADMIN_ALL``!
 
 The role name will be based on the name of your admin service.
 
 ========================   ======================================================
 app.admin.foo              ROLE_APP_ADMIN_FOO_{PERMISSION}
 my.blog.admin.foo_bar      ROLE_MY_BLOG_ADMIN_FOO_BAR_{PERMISSION}
-App\Admin\FooAdmin         ROLE_APPBUNDLE\ADMIN\FOOADMIN_{PERMISSION}
+App\\Admin\\FooAdmin       ROLE_APP\\ADMIN\\FOOADMIN_{PERMISSION}
 ========================   ======================================================
 
 .. note::


### PR DESCRIPTION
## Documentation fixes, correct FQDN and FQDN escaping

Browsing through the documentation I got confused by the implementation of `sonata.admin.security.handler.role` because in the examples the FQDN are not escaped, and thus displaying ``AppAdminFooAdmin``  instead of ``App\Admin\FooAdmin``. Also I think the word `AppBundle` has been renamed to `App` in some but not all instances (causing the example to not work).

I am targetting this branch, because this documentation fix should not have any BC-breaks. 

No issues have been created for these documentation fixes.