### PR TITLE
Fix links to un-editable results

### DIFF
--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -103,8 +103,8 @@ final class SearchAction extends Controller
             foreach ($pager->getResults() as $result) {
                 $results[] = [
                     'label' => $admin->toString($result),
-                    'link'  => $admin->getSearchResultLink($result),
-                    'id'    => $admin->id($result),
+                    'link' => $admin->getSearchResultLink($result),
+                    'id' => $admin->id($result),
                 ];
             }
             $page = (int) $pager->getPage();

--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -103,8 +103,8 @@ final class SearchAction extends Controller
             foreach ($pager->getResults() as $result) {
                 $results[] = [
                     'label' => $admin->toString($result),
-                    'link' => $admin->generateObjectUrl('edit', $result),
-                    'id' => $admin->id($result),
+                    'link'  => $admin->getSearchResultLink($result),
+                    'id'    => $admin->id($result),
                 ];
             }
             $page = (int) $pager->getPage();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Use `getSearchResultLink` instead of `generateObjectUrl('edit')` to prevent generating invalid URLs (when editing isn't available).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is the most up to date and still features this bug.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
Changed the way the search action generates links to the results. It used to consider every item editable, but would throw an error if it wasn't the case. It now uses the `getSearchResultLink` that choses the best way to link to a search result; eg. `edit` if available, or `show`.
```
