### PR TITLE
Fix namespace of SourceIteratorInterface

### DIFF
--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Model;
 
-use Exporter\Source\SourceIteratorInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Exception\ModelManagerException;
+use Sonata\Exporter\Source\SourceIteratorInterface;
 
 /**
  * A model manager is a bridge between the model classes and the admin


### PR DESCRIPTION
## Fix namespace of SourceIteratorInterface
Following from this issue https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/313, from the build of scrutinizer I was able to detect that namespace here is also wrong 

I am targeting this branch because this should not break anything.

## Changelog

```markdown
### Fixed
- Use proper namespace for Sonata\Exporter\Source\SourceIteratorInterface
```
