### PR TITLE
Add "block.admin_preview" block

### DIFF
--- a/docs/reference/dashboard.rst
+++ b/docs/reference/dashboard.rst
@@ -324,6 +324,33 @@ counter is related to the filters from one admin
                             filters:                         # filter values
                                 edited: { value: 1 }
 
+Preview Block
+~~~~~~~~~~~~~
+
+A preview block can be used to display a brief of an admin list.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/sonata_admin.yaml
+
+        sonata_admin:
+            dashboard:
+                blocks:
+                    -
+                        position: top                        # zone in the dashboard
+                        type:     sonata.admin.block.admin_preview # block id
+                        settings:
+                            code:  sonata.page.admin.page    # admin code - service id
+                            icon:  fa-magic                  # font awesome icon
+                            limit: 10
+                            text:  Latest Edited Pages
+                            filters:                         # filter values
+                                edited: { value: 1 }
+                                _sort_by: updatedAt
+                                _sort_order: DESC
+
 Dashboard Layout
 ~~~~~~~~~~~~~~~~
 

--- a/src/Block/AdminPreviewBlockService.php
+++ b/src/Block/AdminPreviewBlockService.php
@@ -18,10 +18,10 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -109,7 +109,7 @@ final class AdminPreviewBlockService extends AbstractBlockService
     }
 
     /**
-     * Maps the block filters to standard admin filters
+     * Maps the block filters to standard admin filters.
      */
     private function handleFilters(AdminInterface $admin, BlockContextInterface $blockContext): void
     {

--- a/src/Block/AdminPreviewBlockService.php
+++ b/src/Block/AdminPreviewBlockService.php
@@ -25,23 +25,23 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Javier Spagnoletti <phansys@gmail.com>
  */
-class AdminPreviewBlockService extends AbstractBlockService
+final class AdminPreviewBlockService extends AbstractBlockService
 {
     /**
      * @var Pool
      */
-    protected $pool;
+    private $pool;
 
-    /**
-     * @param string $name
-     */
-    public function __construct($name, EngineInterface $templating, Pool $pool)
+    public function __construct(string $name, EngineInterface $templating, Pool $pool)
     {
         parent::__construct($name, $templating);
 
         $this->pool = $pool;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function execute(BlockContextInterface $blockContext, Response $response = null)
     {
         $admin = $this->pool->getAdminByAdminCode($blockContext->getSetting('code'));

--- a/src/Block/AdminPreviewBlockService.php
+++ b/src/Block/AdminPreviewBlockService.php
@@ -81,6 +81,7 @@ final class AdminPreviewBlockService extends AbstractBlockService
         $resolver->setDefaults([
             'text' => 'Preview',
             'filters' => [],
+            'icon' => false,
             'limit' => 10,
             'code' => false,
             'template' => '@SonataAdmin/Block/block_admin_preview.html.twig',

--- a/src/Block/AdminPreviewBlockService.php
+++ b/src/Block/AdminPreviewBlockService.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Block;
+
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class AdminPreviewBlockService extends AbstractBlockService
+{
+    /**
+     * @var Pool
+     */
+    protected $pool;
+
+    /**
+     * @param string $name
+     */
+    public function __construct($name, EngineInterface $templating, Pool $pool)
+    {
+        parent::__construct($name, $templating);
+
+        $this->pool = $pool;
+    }
+
+    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    {
+        $admin = $this->pool->getAdminByAdminCode($blockContext->getSetting('code'));
+
+        $filters = $blockContext->getSetting('filters');
+
+        if ($sortBy = $filters['_sort_by'] ?? null) {
+            $sortFilters = ['_sort_by' => $sortBy];
+            if ($sortOrder = $filters['_sort_order'] ?? null) {
+                $sortFilters['_sort_order'] = $sortOrder;
+                unset($filters['_sort_order']);
+            }
+            // setting a request to the admin is a workaround since the admin only can handle the "_sort_by" parameter from the query string
+            $request = new Request(['filter' => $sortFilters]);
+            $request->setSession(new Session());
+            $admin->setRequest($request);
+            unset($filters['_sort_by'], $request);
+        }
+
+        if (!isset($filters['_per_page'])) {
+            $filters['_per_page'] = ['value' => $blockContext->getSetting('limit')];
+        }
+
+        $datagrid = $admin->getDatagrid();
+
+        foreach ($filters as $name => $data) {
+            $datagrid->setValue($name, $data['type'] ?? null, $data['value']);
+        }
+
+        $datagrid->buildPager();
+
+        foreach ($blockContext->getSetting('remove_list_fields') as $listField) {
+            $admin->getList()->remove($listField);
+        }
+
+        return $this->renderPrivateResponse($blockContext->getTemplate(), [
+            'block' => $blockContext->getBlock(),
+            'settings' => $blockContext->getSettings(),
+            'admin_pool' => $this->pool,
+            'admin' => $admin,
+            'pager' => $datagrid->getPager(),
+            'datagrid' => $datagrid,
+        ], $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'Admin preview';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureSettings(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'text' => 'Preview',
+            'filters' => [],
+            'limit' => 10,
+            'code' => false,
+            'template' => '@SonataAdmin/Block/block_admin_preview.html.twig',
+            'remove_list_fields' => ['_action'],
+        ]);
+    }
+}

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -21,5 +21,12 @@
             <argument type="service" id="sonata.templating"/>
             <argument type="service" id="sonata.admin.pool"/>
         </service>
+        <service id="sonata.admin.block.admin_preview" class="Sonata\AdminBundle\Block\AdminPreviewBlockService" public="true">
+            <tag name="sonata.block"/>
+            <argument>sonata.admin.block.admin_preview</argument>
+            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="sonata.admin.global_template_registry"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/translations/SonataAdminBundle.ar.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ar.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>stats_view_more</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>title_select_subclass</target>

--- a/src/Resources/translations/SonataAdminBundle.bg.xliff
+++ b/src/Resources/translations/SonataAdminBundle.bg.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>Показване на още</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Показване на още</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Избор на тип обект</target>

--- a/src/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ca.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>Veure més</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Veure més</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Escull el tipus d'element</target>

--- a/src/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/src/Resources/translations/SonataAdminBundle.cs.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>Zobrazit více</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Zobrazit více</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>title_select_subclass</target>

--- a/src/Resources/translations/SonataAdminBundle.de.xliff
+++ b/src/Resources/translations/SonataAdminBundle.de.xliff
@@ -462,6 +462,10 @@
                 <source>stats_view_more</source>
                 <target>mehr</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>mehr</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Typ auswählen</target>

--- a/src/Resources/translations/SonataAdminBundle.en.xliff
+++ b/src/Resources/translations/SonataAdminBundle.en.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>View more</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>View more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Select object type</target>

--- a/src/Resources/translations/SonataAdminBundle.es.xliff
+++ b/src/Resources/translations/SonataAdminBundle.es.xliff
@@ -462,6 +462,10 @@
                 <source>stats_view_more</source>
                 <target>Ver más</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Ver más</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Selecciona el tipo de elemento</target>

--- a/src/Resources/translations/SonataAdminBundle.eu.xliff
+++ b/src/Resources/translations/SonataAdminBundle.eu.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>stats_view_more</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>title_select_subclass</target>

--- a/src/Resources/translations/SonataAdminBundle.fa.xliff
+++ b/src/Resources/translations/SonataAdminBundle.fa.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>مشاهده بیشتر</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>مشاهده بیشتر</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>انتخاب نوع شی</target>

--- a/src/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.fr.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Voir plus</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Voir plus</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Sélectionnez le type d'objet</target>

--- a/src/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.hr.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>stats_view_more</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>title_select_subclass</target>

--- a/src/Resources/translations/SonataAdminBundle.hu.xliff
+++ b/src/Resources/translations/SonataAdminBundle.hu.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>Több megjelenítése</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Több megjelenítése</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Objektum típus kiválasztása</target>

--- a/src/Resources/translations/SonataAdminBundle.it.xliff
+++ b/src/Resources/translations/SonataAdminBundle.it.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Mostra dettagli</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Mostra dettagli</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Seleziona il tipo</target>

--- a/src/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ja.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>詳細を表示</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>詳細を表示</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>オブジェクトの種類を選択</target>

--- a/src/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/src/Resources/translations/SonataAdminBundle.lb.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Méi</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Méi</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Typ auswielen</target>

--- a/src/Resources/translations/SonataAdminBundle.lt.xliff
+++ b/src/Resources/translations/SonataAdminBundle.lt.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>stats_view_more</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>title_select_subclass</target>

--- a/src/Resources/translations/SonataAdminBundle.lv.xliff
+++ b/src/Resources/translations/SonataAdminBundle.lv.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>Skatīt vēl</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Skatīt vēl</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Izvēlieties objekta veidu</target>

--- a/src/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.nl.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Bekijk meer</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Bekijk meer</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Selecteer object type</target>

--- a/src/Resources/translations/SonataAdminBundle.no.xliff
+++ b/src/Resources/translations/SonataAdminBundle.no.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>stats_view_more</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Velg objekttype</target>

--- a/src/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.pl.xliff
@@ -462,6 +462,10 @@
                 <source>stats_view_more</source>
                 <target>Zobacz więcej</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Zobacz więcej</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>title_select_subclass</target>

--- a/src/Resources/translations/SonataAdminBundle.pt.xliff
+++ b/src/Resources/translations/SonataAdminBundle.pt.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>stats_view_more</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>title_select_subclass</target>

--- a/src/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/src/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>Ver mais</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Ver mais</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Selecione o tipo do objeto</target>

--- a/src/Resources/translations/SonataAdminBundle.ro.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ro.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>stats_view_more</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>title_select_subclass</target>

--- a/src/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ru.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Показать еще</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Показать еще</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Выберите тип объекта</target>

--- a/src/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/src/Resources/translations/SonataAdminBundle.sk.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>Zobraziť viac</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Zobraziť viac</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>title_select_subclass</target>

--- a/src/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.sl.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>Poglej več</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Poglej več</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Izberi tip objekta</target>

--- a/src/Resources/translations/SonataAdminBundle.sv_SE.xliff
+++ b/src/Resources/translations/SonataAdminBundle.sv_SE.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>stats_view_more</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>title_select_subclass</target>

--- a/src/Resources/translations/SonataAdminBundle.tr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.tr.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>Devamını göster</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Devamını göster</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Nesne türünü seç</target>

--- a/src/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/src/Resources/translations/SonataAdminBundle.uk.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>Показати ще</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Показати ще</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Оберіть тип об'єкта</target>

--- a/src/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/src/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -458,6 +458,10 @@
                 <source>stats_view_more</source>
                 <target>stats_view_more</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>title_select_subclass</target>

--- a/src/Resources/translations/SonataAdminBundle.zh_HK.xliff
+++ b/src/Resources/translations/SonataAdminBundle.zh_HK.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>顯示更多</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>顯示更多</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>選擇物件類別</target>

--- a/src/Resources/views/Block/block_admin_preview.html.twig
+++ b/src/Resources/views/Block/block_admin_preview.html.twig
@@ -1,0 +1,85 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends sonata_block.templates.block_base %}
+
+{% set translation_domain = settings.translation_domain ?? admin.translationDomain %}
+
+{% block block %}
+    {% set inlineAnchor = settings.text|replace({'.':'_'}) %}
+    <div class="box box-primary" id="{{ inlineAnchor }}">
+        <div class="box-header with-border">
+            {% set icon = settings.icon|default('') %}
+            {% if icon %}
+                <i class="fa {{ icon|raw }}"></i>
+            {% endif %}
+            <h3 class="box-title">
+                <a href="#{{ inlineAnchor }}">{{ settings.text|trans({}, translation_domain) }}</a>
+            </h3>
+        </div>
+        <div class="box-body {% if admin.datagrid.results|length > 0 %}table-responsive no-padding{% endif %}">
+            {{ sonata_block_render_event('sonata.admin.list.table.top', { 'admin': admin }) }}
+
+            {% block list_header %}{% endblock %}
+
+            {% if admin.datagrid.results|length > 0 %}
+                <table class="table table-bordered table-striped table-hover sonata-ba-list">
+                    {% block table_header %}
+                        <thead>
+                            <tr class="sonata-ba-list-field-header">
+                                {% for field_description in admin.list.elements %}
+                                    {% if field_description.getOption('code') == '_select' %}
+                                        <th class="sonata-ba-list-field-header sonata-ba-list-field-header-select"></th>
+                                    {% else %}
+                                        {% filter spaceless %}
+                                            <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if field_description.options.header_class is defined %} {{ field_description.options.header_class }}{% endif %}"{% if field_description.options.header_style is defined %} style="{{ field_description.options.header_style }}"{% endif %}>
+                                                {% if field_description.getOption('label_icon') %}
+                                                    <i class="sonata-ba-list-field-header-label-icon {{ field_description.getOption('label_icon') }}" aria-hidden="true"></i>
+                                                {% endif %}
+                                                {{ field_description.label|trans({}, field_description.translationDomain) }}
+                                            </th>
+                                        {% endfilter %}
+                                    {% endif %}
+                                {% endfor %}
+                            </tr>
+                        </thead>
+                    {% endblock %}
+
+                    {% block table_body %}
+                        <tbody>
+                            {% include get_admin_template('outer_list_rows_' ~ admin.getListMode(), admin.code) %}
+                        </tbody>
+                    {% endblock %}
+
+                    {% block table_footer %}
+                    {% endblock %}
+                </table>
+                <div class="box-footer">
+                    {% if admin.hasAccess('list') %}
+                        <a href="{{ admin.generateUrl('list', {filter: settings.filters}) }}" class="btn btn-primary btn-block">
+                            <i class="fa fa-list" aria-hidden="true"></i> {{ 'preview_view_more'|trans({}, 'SonataAdminBundle') }}
+                        </a>
+                    {% endif %}
+                </div>
+            {% else %}
+                {% block no_result_content %}
+                    <div class="info-box">
+                        <div class="info-box">
+                            <span class="info-box-text">{{ 'no_result'|trans({}, 'SonataAdminBundle') }}</span>
+                        </div><!-- /.info-box-content -->
+                    </div>
+                {% endblock %}
+            {% endif %}
+
+            {{ sonata_block_render_event('sonata.admin.list.table.bottom', { 'admin': admin }) }}
+        </div>
+    </div>
+{% endblock %}

--- a/tests/Block/AdminPreviewBlockServiceTest.php
+++ b/tests/Block/AdminPreviewBlockServiceTest.php
@@ -13,9 +13,14 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Block;
 
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Block\AdminPreviewBlockService;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\BlockBundle\Test\FakeTemplating;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @author Javier Spagnoletti <phansys@gmail.com>
@@ -47,5 +52,26 @@ class AdminPreviewBlockServiceTest extends AbstractBlockServiceTestCase
             'template' => '@SonataAdmin/Block/block_admin_preview.html.twig',
             'remove_list_fields' => ['_action'],
         ], $blockContext);
+    }
+
+    public function testBlockExecution(): void
+    {
+        $admin = $this->createMock(AbstractAdmin::class);
+        $templating = $this->createMock(FakeTemplating::class);
+        $datagrid = $this->createMock(Datagrid::class);
+
+        $blockService = new AdminPreviewBlockService('bar', $templating, $this->pool);
+        $blockContext = $this->getBlockContext($blockService)->setSetting('code', 'admin.bar');
+
+        $this->pool->expects(self::once())->method('getAdminByAdminCode')->willReturn($admin);
+        $admin->expects(self::once())->method('checkAccess')->with('list')->willReturn(true);
+        $admin->expects(self::exactly(2))->method('getDatagrid')->willReturn($datagrid);
+        $admin->expects(self::once())->method('getList')->willReturn(new FieldDescriptionCollection());
+        $templating->expects(self::once())->method('renderResponse')->willReturn(new Response());
+
+        $response = $blockService->execute($blockContext);
+
+        static::assertSame('', $response->getContent());
+        static::assertSame(200, $response->getStatusCode());
     }
 }

--- a/tests/Block/AdminPreviewBlockServiceTest.php
+++ b/tests/Block/AdminPreviewBlockServiceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Block;
+
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Block\AdminPreviewBlockService;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class AdminPreviewBlockServiceTest extends AbstractBlockServiceTestCase
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+    }
+
+    public function testDefaultSettings(): void
+    {
+        $blockService = new AdminPreviewBlockService('bar', $this->templating, $this->pool);
+        $blockContext = $this->getBlockContext($blockService);
+
+        $this->assertSettings([
+            'text' => 'Preview',
+            'filters' => [],
+            'limit' => 10,
+            'code' => false,
+            'template' => '@SonataAdmin/Block/block_admin_preview.html.twig',
+            'remove_list_fields' => ['_action'],
+        ], $blockContext);
+    }
+}

--- a/tests/Block/AdminPreviewBlockServiceTest.php
+++ b/tests/Block/AdminPreviewBlockServiceTest.php
@@ -47,6 +47,7 @@ class AdminPreviewBlockServiceTest extends AbstractBlockServiceTestCase
         $this->assertSettings([
             'text' => 'Preview',
             'filters' => [],
+            'icon' => false,
             'limit' => 10,
             'code' => false,
             'template' => '@SonataAdmin/Block/block_admin_preview.html.twig',

--- a/tests/Block/AdminPreviewBlockServiceTest.php
+++ b/tests/Block/AdminPreviewBlockServiceTest.php
@@ -15,9 +15,9 @@ namespace Sonata\AdminBundle\Tests\Block;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
-use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Block\AdminPreviewBlockService;
+use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\BlockBundle\Test\FakeTemplating;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Block/AdminPreviewBlockServiceTest.php
+++ b/tests/Block/AdminPreviewBlockServiceTest.php
@@ -31,7 +31,7 @@ class AdminPreviewBlockServiceTest extends AbstractBlockServiceTestCase
     {
         parent::setUp();
 
-        $this->pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $this->pool = $this->createMock(Pool::class);
     }
 
     public function testDefaultSettings(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Add "block.admin_preview" block in order to show a preview for admin lists in dashboard

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this feature respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added "block.admin_preview" block in order to show a preview for admin lists in dashboard
```
## To do
    
- [x] Add missing translations;
- [ ] Use "_sort_by" and "_sort_order" filters in a proper way;
- [x] Add tests;
- [x] Add documentation.
