### PR TITLE
Add moment locale fallback for de_DE

### DIFF
--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -42,6 +42,7 @@ class SonataAdminExtension extends AbstractExtension
 {
     // @todo: there are more locales which are not supported by moment and they need to be translated/normalized/canonicalized here
     public const MOMENT_UNSUPPORTED_LOCALES = [
+        'de' => ['de', 'de-at'],
         'es' => ['es', 'es-do'],
         'nl' => ['nl', 'nl-be'],
         'fr' => ['fr', 'fr-ca', 'fr-ch'],

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -2547,6 +2547,7 @@ EOT
             ['da', 'da'],
             ['de-at', 'de-at'],
             ['de', 'de'],
+            ['de', 'de-de'],
             ['dv', 'dv'],
             ['el', 'el'],
             [null, 'en'],


### PR DESCRIPTION
As suggested in the code (see @TODO) the correct fallback for `de_DE` is missing.

## Subject

After updating an old sonata based app, the moment locale could not be loaded correctly. 
It was looking for `de-de.js` which is not shipped by moment.js

I am targeting this branch, because it seems an patchable bug.

## Changelog
```markdown
### Added
- Add canonicalization fallback for missing moment.js de_DE locale
```

Edit: Wording on changelog message 
