### PR TITLE
Adding some space betwen column header label and column header sorting icon

### DIFF
--- a/src/Resources/public/css/layout.css
+++ b/src/Resources/public/css/layout.css
@@ -156,7 +156,7 @@ th.sonata-ba-list-field-header-order-desc.sonata-ba-list-field-order-active a:ho
     display: block;
     position: absolute;
     top: 50%;
-    right: -12px;
+    right: -18px;
     margin-top: -12px;
 }
 
@@ -170,7 +170,7 @@ th.sonata-ba-list-field-header-order-asc.sonata-ba-list-field-order-active a:hov
     display: block;
     position: absolute;
     top: 50%;
-    right: -12px;
+    right: -18px;
     margin-top: -12px;
 }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Adding some space between column header label and column header sorting icon to improve readability.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- The visual aspect at column headers with sorting icons, in order to add some extra spacing between the column's title and its sorting icon.
```
**Before**: 
![before](https://user-images.githubusercontent.com/3944894/57011379-af1a1500-6c01-11e9-8849-3441a603aeaf.png)

**After**:
 ![sonata-admin](https://user-images.githubusercontent.com/3944894/57008980-1d57db00-6bf4-11e9-9071-0651515fa3fd.png)
