### PR TITLE
[#5547] [WIP] Add `ConfigureFilterParametersEvent`

### DIFF
--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -17,6 +17,7 @@ use Knp\Menu\ItemInterface as MenuItemInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Filter\FilterBag;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Show\ShowMapper;
@@ -127,6 +128,10 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
      * Returns a list of default filters.
      */
     public function configureDefaultFilterValues(AdminInterface $admin, array &$filterValues)
+    {
+    }
+
+    public function configureFilterParameters(AdminInterface $admin, FilterBag $filterBag): void
     {
     }
 }

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -179,7 +179,7 @@ interface AdminExtensionInterface
     /*
      * NEXT_MAJOR: Uncomment in next major release
      */
-    // public function configureFilterParameters(AdminInterface $admin, FilterBag $filterBag);
+    // public function configureFilterParameters(AdminInterface $admin, FilterBag $filterBag): void;
 }
 
 class_exists(\Sonata\Form\Validator\ErrorElement::class);

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -17,6 +17,7 @@ use Knp\Menu\ItemInterface as MenuItemInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Filter\FilterBag;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Show\ShowMapper;
@@ -174,6 +175,11 @@ interface AdminExtensionInterface
      * @param array          $filterValues
      */
     // public function configureDefaultFilterValues(AdminInterface $admin, array &$filterValues);
+
+    /*
+     * NEXT_MAJOR: Uncomment in next major release
+     */
+    // public function configureFilterParameters(AdminInterface $admin, FilterBag $filterBag);
 }
 
 class_exists(\Sonata\Form\Validator\ErrorElement::class);

--- a/src/Event/AdminEventExtension.php
+++ b/src/Event/AdminEventExtension.php
@@ -123,7 +123,7 @@ class AdminEventExtension extends AbstractAdminExtension
         );
     }
 
-    public function configureFilterParameters(AdminInterface $admin, FilterBag $filterBag)
+    public function configureFilterParameters(AdminInterface $admin, FilterBag $filterBag): void
     {
         $this->eventDispatcher->dispatch(
             ConfigureFilterParametersEvent::EVENT_FILTER_PARAMETERS,

--- a/src/Event/AdminEventExtension.php
+++ b/src/Event/AdminEventExtension.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Filter\FilterBag;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -119,6 +120,14 @@ class AdminEventExtension extends AbstractAdminExtension
         $this->eventDispatcher->dispatch(
             'sonata.admin.event.persistence.post_remove',
             new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_REMOVE)
+        );
+    }
+
+    public function configureFilterParameters(AdminInterface $admin, FilterBag $filterBag)
+    {
+        $this->eventDispatcher->dispatch(
+            ConfigureFilterParametersEvent::EVENT_FILTER_PARAMETERS,
+            new ConfigureFilterParametersEvent($admin, $filterBag)
         );
     }
 }

--- a/src/Event/ConfigureFilterParametersEvent.php
+++ b/src/Event/ConfigureFilterParametersEvent.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Filter\FilterBag;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * This event is dispatched by hook "configureFilterParameters".
+ *
+ * You can listen this event by subscribing to "sonata.admin.event.configure.filter_parameters" event
+ *
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class ConfigureFilterParametersEvent extends Event
+{
+    public const EVENT_FILTER_PARAMETERS = 'sonata.admin.event.configure.filter_parameters';
+
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var FilterBag
+     */
+    private $filterBag;
+
+    public function __construct(AdminInterface $admin, FilterBag $filterBag)
+    {
+        $this->admin = $admin;
+        $this->filterBag = $filterBag;
+    }
+
+    public function getAdmin(): AdminInterface
+    {
+        return $this->admin;
+    }
+
+    public function getFilterBag(): FilterBag
+    {
+        return $this->filterBag;
+    }
+}

--- a/src/Filter/FilterBag.php
+++ b/src/Filter/FilterBag.php
@@ -56,7 +56,7 @@ final class FilterBag implements \IteratorAggregate, \Countable
      *
      * @param array $filters An array of filters
      */
-    public function replace(array $filters = [])
+    public function replace(array $filters = []): void
     {
         $this->filters = $filters;
     }
@@ -66,7 +66,7 @@ final class FilterBag implements \IteratorAggregate, \Countable
      *
      * @param array $filters An array of filters
      */
-    public function add(array $filters = [])
+    public function add(array $filters = []): void
     {
         $this->filters = array_replace($this->filters, $filters);
     }
@@ -90,7 +90,7 @@ final class FilterBag implements \IteratorAggregate, \Countable
      * @param string $key   The key
      * @param mixed  $value The value
      */
-    public function set(string $key, $value)
+    public function set(string $key, $value): void
     {
         $this->filters[$key] = $value;
     }
@@ -112,7 +112,7 @@ final class FilterBag implements \IteratorAggregate, \Countable
      *
      * @param string $key The key
      */
-    public function remove(string $key)
+    public function remove(string $key): void
     {
         unset($this->filters[$key]);
     }

--- a/src/Filter/FilterBag.php
+++ b/src/Filter/FilterBag.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Filter;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+final class FilterBag implements \IteratorAggregate, \Countable
+{
+    /**
+     * Filter storage.
+     */
+    private $filters = [];
+
+    /**
+     * @param array $filters An array of filters
+     */
+    public function __construct(array $filters = [])
+    {
+        $this->filters = $filters;
+    }
+
+    /**
+     * Returns the filters.
+     *
+     * @return array An array of filters
+     */
+    public function all(): array
+    {
+        return $this->filters;
+    }
+
+    /**
+     * Returns the filter keys.
+     *
+     * @return array An array of filter keys
+     */
+    public function keys(): array
+    {
+        return array_keys($this->filters);
+    }
+
+    /**
+     * Replaces the current filters by a new set.
+     *
+     * @param array $filters An array of filters
+     */
+    public function replace(array $filters = [])
+    {
+        $this->filters = $filters;
+    }
+
+    /**
+     * Adds filters.
+     *
+     * @param array $filters An array of filters
+     */
+    public function add(array $filters = [])
+    {
+        $this->filters = array_replace($this->filters, $filters);
+    }
+
+    /**
+     * Returns a filter by name.
+     *
+     * @param string $key     The key
+     * @param mixed  $default The default value if the filter key does not exist
+     *
+     * @return mixed
+     */
+    public function get(string $key, $default = null)
+    {
+        return \array_key_exists($key, $this->filters) ? $this->filters[$key] : $default;
+    }
+
+    /**
+     * Sets a filter by name.
+     *
+     * @param string $key   The key
+     * @param mixed  $value The value
+     */
+    public function set(string $key, $value)
+    {
+        $this->filters[$key] = $value;
+    }
+
+    /**
+     * Returns true if the filter is defined.
+     *
+     * @param string $key The key
+     *
+     * @return bool true if the filter exists, false otherwise
+     */
+    public function has(string $key): bool
+    {
+        return \array_key_exists($key, $this->filters);
+    }
+
+    /**
+     * Removes a filter.
+     *
+     * @param string $key The key
+     */
+    public function remove(string $key)
+    {
+        unset($this->filters[$key]);
+    }
+
+    /**
+     * Returns the alphabetic characters of the filter value.
+     *
+     * @param string $key     The filter key
+     * @param string $default The default value if the filter key does not exist
+     *
+     * @return string The filtered value
+     */
+    public function getAlpha(string $key, string $default = ''): string
+    {
+        return preg_replace('/[^[:alpha:]]/', '', $this->get($key, $default));
+    }
+
+    /**
+     * Returns the alphabetic characters and digits of the filter value.
+     *
+     * @param string $key     The filter key
+     * @param string $default The default value if the filter key does not exist
+     *
+     * @return string The filtered value
+     */
+    public function getAlnum(string $key, string $default = ''): string
+    {
+        return preg_replace('/[^[:alnum:]]/', '', $this->get($key, $default));
+    }
+
+    /**
+     * Returns the digits of the filter value.
+     *
+     * @param string $key     The filter key
+     * @param string $default The default value if the filter key does not exist
+     *
+     * @return string The filtered value
+     */
+    public function getDigits(string $key, string $default = ''): string
+    {
+        // we need to remove - and + because they're allowed in the filter
+        return str_replace(['-', '+'], '', $this->filter($key, $default, FILTER_SANITIZE_NUMBER_INT));
+    }
+
+    /**
+     * Returns the filter value converted to integer.
+     *
+     * @param string $key     The filter key
+     * @param int    $default The default value if the filter key does not exist
+     *
+     * @return int The filtered value
+     */
+    public function getInt(string $key, int $default = 0): int
+    {
+        return (int) $this->get($key, $default);
+    }
+
+    /**
+     * Returns the filter value converted to boolean.
+     *
+     * @param string $key     The filter key
+     * @param bool   $default The default value if the filter key does not exist
+     *
+     * @return bool The filtered value
+     */
+    public function getBoolean(string $key, bool $default = false): bool
+    {
+        return $this->filter($key, $default, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Filter key.
+     *
+     * @param string $key     Key
+     * @param mixed  $default Default = null
+     * @param int    $filter  FILTER_* constant
+     * @param mixed  $options Filter options
+     *
+     * @see http://php.net/manual/en/function.filter-var.php
+     *
+     * @return mixed
+     */
+    public function filter(string $key, $default = null, int $filter = FILTER_DEFAULT, $options = [])
+    {
+        $value = $this->get($key, $default);
+
+        // Always turn $options into an array - this allows filter_var option shortcuts.
+        if (!\is_array($options) && $options) {
+            $options = ['flags' => $options];
+        }
+
+        // Add a convenience check for arrays.
+        if (\is_array($value) && !isset($options['flags'])) {
+            $options['flags'] = FILTER_REQUIRE_ARRAY;
+        }
+
+        return filter_var($value, $filter, $options);
+    }
+
+    /**
+     * Returns an iterator for filters.
+     *
+     * @return \ArrayIterator An \ArrayIterator instance
+     */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->filters);
+    }
+
+    /**
+     * Returns the number of filters.
+     *
+     * @return int The number of filters
+     */
+    public function count(): int
+    {
+        return \count($this->filters);
+    }
+}

--- a/tests/Event/AdminEventExtensionTest.php
+++ b/tests/Event/AdminEventExtensionTest.php
@@ -20,7 +20,9 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Event\AdminEventExtension;
 use Sonata\AdminBundle\Event\ConfigureEvent;
+use Sonata\AdminBundle\Event\ConfigureFilterParametersEvent;
 use Sonata\AdminBundle\Event\PersistenceEvent;
+use Sonata\AdminBundle\Filter\FilterBag;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -180,5 +182,12 @@ class AdminEventExtensionTest extends TestCase
             $this->equalTo('sonata.admin.event.persistence.post_remove'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_REMOVE)),
         ])->postRemove($this->createMock(AdminInterface::class), new \stdClass());
+    }
+
+    public function testConfigureFilterParameters(): void
+    {
+        $this->getExtension([
+            $this->equalTo(ConfigureFilterParametersEvent::EVENT_FILTER_PARAMETERS),
+        ])->configureFilterParameters($this->createMock(AdminInterface::class), new FilterBag());
     }
 }

--- a/tests/Event/ConfigureFilterParametersEventTest.php
+++ b/tests/Event/ConfigureFilterParametersEventTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Event;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Event\ConfigureFilterParametersEvent;
+use Sonata\AdminBundle\Filter\FilterBag;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class ConfigureFilterParametersEventTest extends TestCase
+{
+    /**
+     * @var ConfigureFilterParametersEvent
+     */
+    private $event;
+
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var FilterBag
+     */
+    private $filterBag;
+
+    protected function setUp(): void
+    {
+        $this->admin = $this->getMockBuilder(AbstractAdmin::class)
+                    ->disableOriginalConstructor()
+                    ->disableOriginalClone()
+                    ->disableArgumentCloning()
+                    ->disallowMockingUnknownTypes()
+                    ->setMethodsExcept(['getFilterParameters', 'getExtensions'])
+                    ->getMockForAbstractClass();
+
+        $this->filterBag = new FilterBag();
+
+        $this->event = new ConfigureFilterParametersEvent($this->admin, $this->filterBag);
+    }
+
+    public function testGetAdmin(): void
+    {
+        $result = $this->event->getAdmin();
+
+        $this->assertInstanceOf(AdminInterface::class, $result);
+        $this->assertSame($this->admin, $result);
+    }
+
+    public function testGetFilterBag(): void
+    {
+        $result = $this->event->getFilterBag();
+
+        $this->assertInstanceOf(FilterBag::class, $result);
+        $this->assertSame($this->filterBag, $result);
+    }
+
+    public function testAdminGetFilterParameters(): void
+    {
+        $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
+        $modelManager->method('getDefaultSortValues')
+             ->willReturn(['some_filter' => 'another_value']);
+
+        $this->admin->method('getModelManager')
+             ->willReturn($modelManager);
+
+        $result = $this->event->getFilterBag();
+
+        \Closure::bind(function (FilterBag $filterBag): void {
+            $this->filterBag = $filterBag;
+        }, $this->admin, AbstractAdmin::class)($result);
+
+        $this->assertArrayHasKey('some_filter', $this->admin->getFilterParameters());
+        $this->assertSame('another_value', $this->admin->getFilterParameters()['some_filter']);
+
+        $result->set('some_filter', 'some_value');
+
+        $this->assertArrayHasKey('some_filter', $this->admin->getFilterParameters());
+        $this->assertSame('some_value', $this->admin->getFilterParameters()['some_filter']);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Add `ConfigureFilterParametersEvent` in order to allow manipulate admin filters

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5547

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Dispatch "sonata.admin.event.configure.filter_parameters" event after populating admin's filter bag in order to allow set extra custom filters
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Validate the approach
-->
