### PR TITLE
Fix tab name in base_edit_form

### DIFF
--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -47,7 +47,7 @@
                             </ul>
                             <div class="tab-content">
                                 {% for code, form_tab in admin.formtabs %}
-                                    {% set _tab_name = tab_prefix ~ loop.index %}
+                                    {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                                     <div
                                         class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (tab_query_index == loop.index) %} in active{% endif %}"
                                         id="{{ _tab_name }}"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

With #5260 The Tabs in the Edit Form doesn't work anymore because the controls and the ids are not equal any more

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the Error was added into the 3.x branch with 3.48.2 release

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed Tabs in Edit Form
```

