### PR TITLE
Leverage `display_datetime.html.twig` from `history_revision_timestamp.html.twig`

### DIFF
--- a/src/Resources/views/CRUD/history_revision_timestamp.html.twig
+++ b/src/Resources/views/CRUD/history_revision_timestamp.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{{ revision.timestamp|date }}
+{%- include '@SonataAdmin/CRUD/display_datetime.html.twig' with { value: revision.timestamp } -%}


### PR DESCRIPTION
## Subject

Use `<time>` html tag when displaying the audit revision timestamp. This allows to print the UTC dates using the "datetime" and "title" attributes. This change is a follow up of #5530.

I am targeting this branch, because these changes respect BC.

## Changelog

```markdown

### Changed
- Changed the rendering for the audit revision timestamp in order to use `<time>` tags, which print the dates in UTC using `datetime` and `title` attributes, allowing to view the UTC date with the default browser tooltip.
```

Example of UTC date 2017-04-06T00:11:38+00:00 printed with `America/Argentina/Buenos_Aires` (UTC -3) timezone:
```
<time datetime="2017-04-06T00:11:38+00:00" title="2017-04-06T00:11:38+00:00">
    05/04/2017 21:11:38
</time>
```
![datetime](https://user-images.githubusercontent.com/1231441/54076868-15805800-428f-11e9-9852-7087db8bc556.png)
