### PR TITLE
[#5564] Fix "cannot be used as a trait" in twig 2.11

### DIFF
--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -28,6 +28,7 @@
             {% endblock %}
 
             {% block sonata_tab_content %}
+                {% import "@SonataAdmin/CRUD/base_edit_form_macro.html.twig" as form_helper %}
                 {% set has_tab = ((admin.formtabs|length == 1 and admin.formtabs|keys[0] != 'default') or admin.formtabs|length > 1 ) %}
 
                 <div class="col-md-12">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## "cannot be used as a trait" with Twig 2.11

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because Twig 2.11 causes: "Template "@SonataAdmin/CRUD/base_edit_form.html.twig" cannot be used as a trait." error 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5564

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Import the macros in the sonata_tab_content

```