### PR TITLE
Fix "cannot be used as a trait" in twig 2.11

### DIFF
--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -1,5 +1,4 @@
 {% block form %}
-    {% import "@SonataAdmin/CRUD/base_edit_form_macro.html.twig" as form_helper %}
     {{ sonata_block_render_event('sonata.admin.edit.form.top', { 'admin': admin, 'object': object }) }}
 
     {# NEXT_MAJOR: remove default filter #}


### PR DESCRIPTION
## Fix "cannot be used as a trait" in twig 2.11 (v2)

"Template "@SonataAdmin/CRUD/base_edit_form.html.twig" cannot be used as a trait." error with Twig v2.11 has not been fixed by 3.49.0 release. This PR fixes that 🚀 

The solution proposed by @fabpot was to **move** this line to `sonata_tab_content` block.

Closes #5564

### Replaces

#5566 