### PR TITLE
Update `dispatch()` calls in order to respect signatures from "symfony/event-dispatcher:^4.3"

### DIFF
--- a/src/Event/AdminEventExtension.php
+++ b/src/Event/AdminEventExtension.php
@@ -21,7 +21,6 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -32,160 +31,94 @@ class AdminEventExtension extends AbstractAdminExtension
 
     public function __construct(EventDispatcherInterface $eventDispatcher)
     {
-        $this->eventDispatcher = $eventDispatcher;
+        $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
     }
 
     public function configureFormFields(FormMapper $form)
     {
-        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $event = new ConfigureEvent($form->getAdmin(), $form, ConfigureEvent::TYPE_FORM);
-            $eventName = 'sonata.admin.event.configure.form';
-        } else {
-            // BC for Symfony < 4.3 where `dispatch()` has a different signature
-            // NEXT_MAJOR: Remove this condition
-            $event = 'sonata.admin.event.configure.form';
-            $eventName = new ConfigureEvent($form->getAdmin(), $form, ConfigureEvent::TYPE_FORM);
-        }
-        $this->eventDispatcher->dispatch($event, $eventName);
+        $this->eventDispatcher->dispatch(
+            'sonata.admin.event.configure.form',
+            new ConfigureEvent($form->getAdmin(), $form, ConfigureEvent::TYPE_FORM)
+        );
     }
 
     public function configureListFields(ListMapper $list)
     {
-        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $event = new ConfigureEvent($list->getAdmin(), $list, ConfigureEvent::TYPE_LIST);
-            $eventName = 'sonata.admin.event.configure.list';
-        } else {
-            // BC for Symfony < 4.3 where `dispatch()` has a different signature
-            // NEXT_MAJOR: Remove this condition
-            $event = 'sonata.admin.event.configure.list';
-            $eventName = new ConfigureEvent($list->getAdmin(), $list, ConfigureEvent::TYPE_LIST);
-        }
-        $this->eventDispatcher->dispatch($event, $eventName);
+        $this->eventDispatcher->dispatch(
+            'sonata.admin.event.configure.list',
+            new ConfigureEvent($list->getAdmin(), $list, ConfigureEvent::TYPE_LIST)
+        );
     }
 
     public function configureDatagridFilters(DatagridMapper $filter)
     {
-        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $event = new ConfigureEvent($filter->getAdmin(), $filter, ConfigureEvent::TYPE_DATAGRID);
-            $eventName = 'sonata.admin.event.configure.datagrid';
-        } else {
-            // BC for Symfony < 4.3 where `dispatch()` has a different signature
-            // NEXT_MAJOR: Remove this condition
-            $event = 'sonata.admin.event.configure.datagrid';
-            $eventName = new ConfigureEvent($filter->getAdmin(), $filter, ConfigureEvent::TYPE_DATAGRID);
-        }
-        $this->eventDispatcher->dispatch($event, $eventName);
+        $this->eventDispatcher->dispatch(
+            'sonata.admin.event.configure.datagrid',
+            new ConfigureEvent($filter->getAdmin(), $filter, ConfigureEvent::TYPE_DATAGRID)
+        );
     }
 
     public function configureShowFields(ShowMapper $show)
     {
-        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $event = new ConfigureEvent($show->getAdmin(), $show, ConfigureEvent::TYPE_SHOW);
-            $eventName = 'sonata.admin.event.configure.show';
-        } else {
-            // BC for Symfony < 4.3 where `dispatch()` has a different signature
-            // NEXT_MAJOR: Remove this condition
-            $event = 'sonata.admin.event.configure.show';
-            $eventName = new ConfigureEvent($show->getAdmin(), $show, ConfigureEvent::TYPE_SHOW);
-        }
-        $this->eventDispatcher->dispatch($event, $eventName);
+        $this->eventDispatcher->dispatch(
+            'sonata.admin.event.configure.show',
+            new ConfigureEvent($show->getAdmin(), $show, ConfigureEvent::TYPE_SHOW)
+        );
     }
 
     public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list')
     {
-        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $event = new ConfigureQueryEvent($admin, $query, $context);
-            $eventName = 'sonata.admin.event.configure.query';
-        } else {
-            // BC for Symfony < 4.3 where `dispatch()` has a different signature
-            // NEXT_MAJOR: Remove this condition
-            $event = 'sonata.admin.event.configure.query';
-            $eventName = new ConfigureQueryEvent($admin, $query, $context);
-        }
-        $this->eventDispatcher->dispatch($event, $eventName);
+        $this->eventDispatcher->dispatch(
+            'sonata.admin.event.configure.query',
+            new ConfigureQueryEvent($admin, $query, $context)
+        );
     }
 
     public function preUpdate(AdminInterface $admin, $object)
     {
-        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $event = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_UPDATE);
-            $eventName = 'sonata.admin.event.persistence.pre_update';
-        } else {
-            // BC for Symfony < 4.3 where `dispatch()` has a different signature
-            // NEXT_MAJOR: Remove this condition
-            $event = 'sonata.admin.event.persistence.pre_update';
-            $eventName = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_UPDATE);
-        }
-        $this->eventDispatcher->dispatch($event, $eventName);
+        $this->eventDispatcher->dispatch(
+            'sonata.admin.event.persistence.pre_update',
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_UPDATE)
+        );
     }
 
     public function postUpdate(AdminInterface $admin, $object)
     {
-        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $event = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_UPDATE);
-            $eventName = 'sonata.admin.event.persistence.post_update';
-        } else {
-            // BC for Symfony < 4.3 where `dispatch()` has a different signature
-            // NEXT_MAJOR: Remove this condition
-            $event = 'sonata.admin.event.persistence.post_update';
-            $eventName = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_UPDATE);
-        }
-        $this->eventDispatcher->dispatch($event, $eventName);
+        $this->eventDispatcher->dispatch(
+            'sonata.admin.event.persistence.post_update',
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_UPDATE)
+        );
     }
 
     public function prePersist(AdminInterface $admin, $object)
     {
-        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $event = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_PERSIST);
-            $eventName = 'sonata.admin.event.persistence.pre_persist';
-        } else {
-            // BC for Symfony < 4.3 where `dispatch()` has a different signature
-            // NEXT_MAJOR: Remove this condition
-            $event = 'sonata.admin.event.persistence.pre_persist';
-            $eventName = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_PERSIST);
-        }
-        $this->eventDispatcher->dispatch($event, $eventName);
+        $this->eventDispatcher->dispatch(
+            'sonata.admin.event.persistence.pre_persist',
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_PERSIST)
+        );
     }
 
     public function postPersist(AdminInterface $admin, $object)
     {
-        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $event = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_PERSIST);
-            $eventName = 'sonata.admin.event.persistence.post_persist';
-        } else {
-            // BC for Symfony < 4.3 where `dispatch()` has a different signature
-            // NEXT_MAJOR: Remove this condition
-            $event = 'sonata.admin.event.persistence.post_persist';
-            $eventName = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_PERSIST);
-        }
-        $this->eventDispatcher->dispatch($event, $eventName);
+        $this->eventDispatcher->dispatch(
+            'sonata.admin.event.persistence.post_persist',
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_PERSIST)
+        );
     }
 
     public function preRemove(AdminInterface $admin, $object)
     {
-        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $event = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_REMOVE);
-            $eventName = 'sonata.admin.event.persistence.pre_remove';
-        } else {
-            // BC for Symfony < 4.3 where `dispatch()` has a different signature
-            // NEXT_MAJOR: Remove this condition
-            $event = 'sonata.admin.event.persistence.pre_remove';
-            $eventName = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_REMOVE);
-        }
-        $this->eventDispatcher->dispatch($event, $eventName);
+        $this->eventDispatcher->dispatch(
+            'sonata.admin.event.persistence.pre_remove',
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_REMOVE)
+        );
     }
 
     public function postRemove(AdminInterface $admin, $object)
     {
-        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $event = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_REMOVE);
-            $eventName = 'sonata.admin.event.persistence.post_remove';
-        } else {
-            // BC for Symfony < 4.3 where `dispatch()` has a different signature
-            // NEXT_MAJOR: Remove this condition
-            $event = 'sonata.admin.event.persistence.post_remove';
-            $eventName = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_REMOVE);
-        }
-        $this->eventDispatcher->dispatch($event, $eventName);
+        $this->eventDispatcher->dispatch(
+            'sonata.admin.event.persistence.post_remove',
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_REMOVE)
+        );
     }
 }

--- a/src/Event/AdminEventExtension.php
+++ b/src/Event/AdminEventExtension.php
@@ -21,6 +21,7 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -36,89 +37,155 @@ class AdminEventExtension extends AbstractAdminExtension
 
     public function configureFormFields(FormMapper $form)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.form',
-            new ConfigureEvent($form->getAdmin(), $form, ConfigureEvent::TYPE_FORM)
-        );
+        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $event = new ConfigureEvent($form->getAdmin(), $form, ConfigureEvent::TYPE_FORM);
+            $eventName = 'sonata.admin.event.configure.form';
+        } else {
+            // BC for Symfony < 4.3 where `dispatch()` has a different signature
+            // NEXT_MAJOR: Remove this condition
+            $event = 'sonata.admin.event.configure.form';
+            $eventName = new ConfigureEvent($form->getAdmin(), $form, ConfigureEvent::TYPE_FORM);
+        }
+        $this->eventDispatcher->dispatch($event, $eventName);
     }
 
     public function configureListFields(ListMapper $list)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.list',
-            new ConfigureEvent($list->getAdmin(), $list, ConfigureEvent::TYPE_LIST)
-        );
+        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $event = new ConfigureEvent($list->getAdmin(), $list, ConfigureEvent::TYPE_LIST);
+            $eventName = 'sonata.admin.event.configure.list';
+        } else {
+            // BC for Symfony < 4.3 where `dispatch()` has a different signature
+            // NEXT_MAJOR: Remove this condition
+            $event = 'sonata.admin.event.configure.list';
+            $eventName = new ConfigureEvent($list->getAdmin(), $list, ConfigureEvent::TYPE_LIST);
+        }
+        $this->eventDispatcher->dispatch($event, $eventName);
     }
 
     public function configureDatagridFilters(DatagridMapper $filter)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.datagrid',
-            new ConfigureEvent($filter->getAdmin(), $filter, ConfigureEvent::TYPE_DATAGRID)
-        );
+        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $event = new ConfigureEvent($filter->getAdmin(), $filter, ConfigureEvent::TYPE_DATAGRID);
+            $eventName = 'sonata.admin.event.configure.datagrid';
+        } else {
+            // BC for Symfony < 4.3 where `dispatch()` has a different signature
+            // NEXT_MAJOR: Remove this condition
+            $event = 'sonata.admin.event.configure.datagrid';
+            $eventName = new ConfigureEvent($filter->getAdmin(), $filter, ConfigureEvent::TYPE_DATAGRID);
+        }
+        $this->eventDispatcher->dispatch($event, $eventName);
     }
 
     public function configureShowFields(ShowMapper $show)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.show',
-            new ConfigureEvent($show->getAdmin(), $show, ConfigureEvent::TYPE_SHOW)
-        );
+        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $event = new ConfigureEvent($show->getAdmin(), $show, ConfigureEvent::TYPE_SHOW);
+            $eventName = 'sonata.admin.event.configure.show';
+        } else {
+            // BC for Symfony < 4.3 where `dispatch()` has a different signature
+            // NEXT_MAJOR: Remove this condition
+            $event = 'sonata.admin.event.configure.show';
+            $eventName = new ConfigureEvent($show->getAdmin(), $show, ConfigureEvent::TYPE_SHOW);
+        }
+        $this->eventDispatcher->dispatch($event, $eventName);
     }
 
     public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list')
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.query',
-            new ConfigureQueryEvent($admin, $query, $context)
-        );
+        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $event = new ConfigureQueryEvent($admin, $query, $context);
+            $eventName = 'sonata.admin.event.configure.query';
+        } else {
+            // BC for Symfony < 4.3 where `dispatch()` has a different signature
+            // NEXT_MAJOR: Remove this condition
+            $event = 'sonata.admin.event.configure.query';
+            $eventName = new ConfigureQueryEvent($admin, $query, $context);
+        }
+        $this->eventDispatcher->dispatch($event, $eventName);
     }
 
     public function preUpdate(AdminInterface $admin, $object)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.pre_update',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_UPDATE)
-        );
+        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $event = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_UPDATE);
+            $eventName = 'sonata.admin.event.persistence.pre_update';
+        } else {
+            // BC for Symfony < 4.3 where `dispatch()` has a different signature
+            // NEXT_MAJOR: Remove this condition
+            $event = 'sonata.admin.event.persistence.pre_update';
+            $eventName = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_UPDATE);
+        }
+        $this->eventDispatcher->dispatch($event, $eventName);
     }
 
     public function postUpdate(AdminInterface $admin, $object)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.post_update',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_UPDATE)
-        );
+        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $event = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_UPDATE);
+            $eventName = 'sonata.admin.event.persistence.post_update';
+        } else {
+            // BC for Symfony < 4.3 where `dispatch()` has a different signature
+            // NEXT_MAJOR: Remove this condition
+            $event = 'sonata.admin.event.persistence.post_update';
+            $eventName = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_UPDATE);
+        }
+        $this->eventDispatcher->dispatch($event, $eventName);
     }
 
     public function prePersist(AdminInterface $admin, $object)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.pre_persist',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_PERSIST)
-        );
+        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $event = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_PERSIST);
+            $eventName = 'sonata.admin.event.persistence.pre_persist';
+        } else {
+            // BC for Symfony < 4.3 where `dispatch()` has a different signature
+            // NEXT_MAJOR: Remove this condition
+            $event = 'sonata.admin.event.persistence.pre_persist';
+            $eventName = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_PERSIST);
+        }
+        $this->eventDispatcher->dispatch($event, $eventName);
     }
 
     public function postPersist(AdminInterface $admin, $object)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.post_persist',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_PERSIST)
-        );
+        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $event = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_PERSIST);
+            $eventName = 'sonata.admin.event.persistence.post_persist';
+        } else {
+            // BC for Symfony < 4.3 where `dispatch()` has a different signature
+            // NEXT_MAJOR: Remove this condition
+            $event = 'sonata.admin.event.persistence.post_persist';
+            $eventName = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_PERSIST);
+        }
+        $this->eventDispatcher->dispatch($event, $eventName);
     }
 
     public function preRemove(AdminInterface $admin, $object)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.pre_remove',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_REMOVE)
-        );
+        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $event = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_REMOVE);
+            $eventName = 'sonata.admin.event.persistence.pre_remove';
+        } else {
+            // BC for Symfony < 4.3 where `dispatch()` has a different signature
+            // NEXT_MAJOR: Remove this condition
+            $event = 'sonata.admin.event.persistence.pre_remove';
+            $eventName = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_REMOVE);
+        }
+        $this->eventDispatcher->dispatch($event, $eventName);
     }
 
     public function postRemove(AdminInterface $admin, $object)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.post_remove',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_REMOVE)
-        );
+        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $event = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_REMOVE);
+            $eventName = 'sonata.admin.event.persistence.post_remove';
+        } else {
+            // BC for Symfony < 4.3 where `dispatch()` has a different signature
+            // NEXT_MAJOR: Remove this condition
+            $event = 'sonata.admin.event.persistence.post_remove';
+            $eventName = new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_REMOVE);
+        }
+        $this->eventDispatcher->dispatch($event, $eventName);
     }
 }

--- a/src/Event/LegacyEventDispatcherProxy.php
+++ b/src/Event/LegacyEventDispatcherProxy.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Event;
+
+use Psr\EventDispatcher\StoppableEventInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\Event as ContractsEvent;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
+
+/**
+ * An helper class to provide BC/FC with the legacy signature of EventDispatcherInterface::dispatch().
+ *
+ * BC for Symfony < 4.3 where `dispatch()` has a different signature
+ * NEXT_MAJOR: Remove this class
+ *
+ * @author Javier Spagnoletti <jspagnoletti@nubity.com>
+ */
+final class LegacyEventDispatcherProxy implements EventDispatcherInterface
+{
+    private $dispatcher;
+
+    /**
+     * Proxies all method calls to the original event dispatcher.
+     */
+    public function __call($method, $arguments)
+    {
+        return $this->dispatcher->{$method}(...$arguments);
+    }
+
+    public static function decorate(?ContractsEventDispatcherInterface $dispatcher): ?ContractsEventDispatcherInterface
+    {
+        if (null === $dispatcher) {
+            return null;
+        }
+        $r = new \ReflectionMethod($dispatcher, 'dispatch');
+        $param2 = $r->getParameters()[1] ?? null;
+
+        if (!$param2 || !$param2->hasType() || $param2->getType()->isBuiltin()) {
+            return $dispatcher;
+        }
+
+        @trigger_error(sprintf('The signature of the "%s::dispatch()" method should be updated to "dispatch($event, string $eventName = null)", not doing so is deprecated since Symfony 4.3.', $r->class), E_USER_DEPRECATED);
+
+        $self = new self();
+        $self->dispatcher = $dispatcher;
+
+        return $self;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param string|null $eventName
+     */
+    public function dispatch($event/*, string $eventName = null*/)
+    {
+        $eventName = 1 < \func_num_args() ? func_get_arg(1) : null;
+
+        if (\is_object($event)) {
+            $eventName = $eventName ?? \get_class($event);
+        } else {
+            @trigger_error(sprintf('Calling the "%s::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead.', ContractsEventDispatcherInterface::class), E_USER_DEPRECATED);
+            $swap = $event;
+            $event = $eventName ?? new Event();
+            $eventName = $swap;
+
+            if (!$event instanceof Event) {
+                throw new \TypeError(sprintf('Argument 1 passed to "%s::dispatch()" must be an instance of %s, %s given.', ContractsEventDispatcherInterface::class, Event::class, \is_object($event) ? \get_class($event) : \gettype($event)));
+            }
+        }
+
+        $listeners = $this->getListeners($eventName);
+        $stoppable = $event instanceof Event || $event instanceof ContractsEvent || $event instanceof StoppableEventInterface;
+
+        foreach ($listeners as $listener) {
+            if ($stoppable && $event->isPropagationStopped()) {
+                break;
+            }
+            $listener($event, $eventName, $this);
+        }
+
+        return $event;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addListener($eventName, $listener, $priority = 0)
+    {
+        return $this->dispatcher->addListener($eventName, $listener, $priority);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addSubscriber(EventSubscriberInterface $subscriber)
+    {
+        return $this->dispatcher->addSubscriber($subscriber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeListener($eventName, $listener)
+    {
+        return $this->dispatcher->removeListener($eventName, $listener);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeSubscriber(EventSubscriberInterface $subscriber)
+    {
+        return $this->dispatcher->removeSubscriber($subscriber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListeners($eventName = null)
+    {
+        return $this->dispatcher->getListeners($eventName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListenerPriority($eventName, $listener)
+    {
+        return $this->dispatcher->getListenerPriority($eventName, $listener);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasListeners($eventName = null)
+    {
+        return $this->dispatcher->hasListeners($eventName);
+    }
+}

--- a/tests/Event/AdminEventExtensionTest.php
+++ b/tests/Event/AdminEventExtensionTest.php
@@ -20,25 +20,15 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Event\AdminEventExtension;
 use Sonata\AdminBundle\Event\ConfigureEvent;
+use Sonata\AdminBundle\Event\ConfigureQueryEvent;
 use Sonata\AdminBundle\Event\PersistenceEvent;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
 class AdminEventExtensionTest extends TestCase
 {
-    /**
-     * @return AdminEventExtension
-     */
-    public function getExtension($args)
-    {
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $stub = $eventDispatcher->expects($this->once())->method('dispatch');
-        \call_user_func_array([$stub, 'with'], $args);
-
-        return new AdminEventExtension($eventDispatcher);
-    }
-
     public function getMapper($class)
     {
         $mapper = $this->getMockBuilder($class)->disableOriginalConstructor()->getMock();
@@ -139,6 +129,7 @@ class AdminEventExtensionTest extends TestCase
     {
         $this->getExtension([
             $this->equalTo('sonata.admin.event.configure.query'),
+            $this->callback($this->getConfigureQueryEventClosure()),
         ])->configureQuery($this->createMock(AdminInterface::class), $this->createMock(ProxyQueryInterface::class));
     }
 
@@ -180,5 +171,26 @@ class AdminEventExtensionTest extends TestCase
             $this->equalTo('sonata.admin.event.persistence.post_remove'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_REMOVE)),
         ])->postRemove($this->createMock(AdminInterface::class), new \stdClass());
+    }
+
+    private function getExtension($args): AdminEventExtension
+    {
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        if ($eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            // BC for Symfony < 4.3 where `dispatch()` has a different signature
+            // NEXT_MAJOR: Remove this condition and update the calls to this method
+            $args = array_reverse($args);
+        }
+        $stub = $eventDispatcher->expects($this->once())->method('dispatch');
+        \call_user_func_array([$stub, 'with'], $args);
+
+        return new AdminEventExtension($eventDispatcher);
+    }
+
+    private function getConfigureQueryEventClosure(): callable
+    {
+        return static function ($event) {
+            return $event instanceof ConfigureQueryEvent;
+        };
     }
 }

--- a/tests/Menu/MenuBuilderTest.php
+++ b/tests/Menu/MenuBuilderTest.php
@@ -22,6 +22,7 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Event\ConfigureMenuEvent;
 use Sonata\AdminBundle\Menu\MenuBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
 class MenuBuilderTest extends TestCase
 {
@@ -132,13 +133,25 @@ class MenuBuilderTest extends TestCase
 
         $this->preparePool($adminGroups);
 
-        $this->eventDispatcher
-            ->expects($this->once())
-            ->method('dispatch')
-            ->with(
-                $this->equalTo('sonata.admin.event.configure.menu.sidebar'),
-                $this->isInstanceOf(ConfigureMenuEvent::class)
-            );
+        if ($this->eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            // BC for Symfony < 4.3 where `dispatch()` has a different signature
+            // NEXT_MAJOR: Remove this condition
+            $this->eventDispatcher
+                ->expects($this->once())
+                ->method('dispatch')
+                ->with(
+                    $this->isInstanceOf(ConfigureMenuEvent::class),
+                    $this->equalTo('sonata.admin.event.configure.menu.sidebar')
+                );
+        } else {
+            $this->eventDispatcher
+                ->expects($this->once())
+                ->method('dispatch')
+                ->with(
+                    $this->equalTo('sonata.admin.event.configure.menu.sidebar'),
+                    $this->isInstanceOf(ConfigureMenuEvent::class)
+                );
+        }
 
         $this->builder->createSidebarMenu();
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Update `dispatch()` calls in order to respect signatures from "symfony/event-dispatcher:^4.3" ([ref](https://github.com/symfony/symfony/blob/v4.3.0/UPGRADE-4.3.md#eventdispatcher)).
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

There is no changelog since these changes are not perceived by the end user.

This PR should be merged after #5571.

**TODO**:
- [x] Update tests.
- [ ] Cover the usage of the deprecated signature