### PR TITLE
Bump "twig/twig" to "^2.9" in order to replace usages of deprecated features

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "symfony/twig-bundle": "^2.8 || ^3.2 || ^4.0",
         "symfony/validator": "^2.8 || ^3.2 || ^4.0",
         "twig/extensions": "^1.5",
-        "twig/twig": "^1.34 || ^2.0"
+        "twig/twig": "^2.9"
     },
     "conflict": {
         "jms/di-extra-bundle": "<1.9",

--- a/src/Resources/views/Block/block_admin_list.html.twig
+++ b/src/Resources/views/Block/block_admin_list.html.twig
@@ -13,10 +13,7 @@ file that was distributed with this source code.
 
 {% block block %}
     {% for group in groups %}
-        {% set display = (group.roles is empty or is_granted(sonata_admin.adminPool.getOption('role_super_admin')) ) %}
-        {% for role in group.roles if not display %}
-            {% set display = is_granted(role)%}
-        {% endfor %}
+        {% set display = group.roles is empty or is_granted(sonata_admin.adminPool.getOption('role_super_admin')) or group.roles|filter(role => is_granted(role))|length > 0 %}
 
         {% if display %}
             <div class="box">

--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
@@ -34,7 +34,7 @@ file that was distributed with this source code.
                         >
                             <fieldset>
                                 <div class="sonata-ba-collapsed-fields">
-                                    {% for field_name in form_group.fields if nested_group_field.children[field_name] is defined %}
+                                    {% for field_name in form_group.fields|filter(field_name => nested_group_field.children[field_name] is defined) %}
                                         {% set nested_field = nested_group_field.children[field_name] %}
                                         <div class="sonata-ba-field-{{ id }}-{{ field_name }}">
                                             {% if associationAdmin.formfielddescriptions[field_name] is defined %}

--- a/src/Resources/views/CRUD/action_buttons.html.twig
+++ b/src/Resources/views/CRUD/action_buttons.html.twig
@@ -8,10 +8,10 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% spaceless %}
+{% apply spaceless %}
     {% for item in admin.getActionButtons(action, (object is defined) ? object : null ) %}
         {% if item.template is defined %}
             {% include item.template %}
         {% endif %}
     {% endfor %}
-{% endspaceless %}
+{% endapply %}

--- a/src/Resources/views/CRUD/base_acl_macro.html.twig
+++ b/src/Resources/views/CRUD/base_acl_macro.html.twig
@@ -29,7 +29,7 @@ file that was distributed with this source code.
                         {% endfor %}
                     </colgroup>
 
-                    {% for child in form.children if child.vars.name != '_token' %}
+                    {% for child in form.children|filter(child => child.vars.name != '_token') %}
                         {% if loop.index0 == 0 or loop.index0 % 10 == 0 %}
                             <tr>
                                 <th>{{ td_type|trans({}, 'SonataAdminBundle') }}</th>

--- a/src/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -1,7 +1,7 @@
 {% macro render_groups(admin, form, groups, has_tab) %}
     <div class="row">
 
-    {% for code in groups if admin.formgroups[code] is defined %}
+    {% for code in groups|filter(code => admin.formgroups[code] is defined) %}
         {% set form_group = admin.formgroups[code] %}
 
         <div class="{{ form_group.class|default('col-md-12') }}">
@@ -17,7 +17,7 @@
                             <p>{{ form_group.description|trans({}, form_group.translation_domain ?: admin.translationDomain) }}</p>
                         {% endif %}
 
-                        {% for field_name in form_group.fields if form[field_name] is defined %}
+                        {% for field_name in form_group.fields|filter(field_name => form[field_name] is defined) %}
                             {{ form_row(form[field_name])}}
                         {% else %}
                             <em>{{ 'message_form_group_empty'|trans({}, 'SonataAdminBundle') }}</em>

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -78,7 +78,7 @@ file that was distributed with this source code.
                                                 {% set sort_by              = current ? admin.datagrid.values._sort_order : field_description.options._sort_order %}
                                             {% endif %}
 
-                                            {% spaceless %}
+                                            {% apply spaceless %}
                                                 <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.options.header_class is defined %} {{ field_description.options.header_class }}{% endif %}"{% if field_description.options.header_style is defined %} style="{{ field_description.options.header_style }}"{% endif %}>
                                                     {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters|merge({_list_mode: admin.getListMode()})) }}">{% endif %}
                                                     {% if field_description.getOption('label_icon') %}
@@ -87,7 +87,7 @@ file that was distributed with this source code.
                                                     {{ field_description.label|trans({}, field_description.translationDomain) }}
                                                     {% if sortable %}</a>{% endif %}
                                                 </th>
-                                            {% endspaceless %}
+                                            {% endapply %}
                                         {% endif %}
                                     {% endfor %}
                                 </tr>
@@ -247,7 +247,7 @@ file that was distributed with this source code.
                 </a>
 
                 <ul class="dropdown-menu" role="menu">
-                    {% for filter in admin.datagrid.filters if (filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null) %}
+                    {% for filter in admin.datagrid.filters|filter(filter => filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null) %}
                         {% set filterActive = ((filter.isActive() or filter.options['show_filter']) and not admin.isDefaultFilter(filter.formName)) %}
                         <li>
                             <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -20,7 +20,7 @@ file that was distributed with this source code.
     %}
         <a class="sonata-link-identifier" href="{{ admin.generateObjectUrl(route, object, field_description.options.route.parameters) }}">
             {%- block field %}
-                {% spaceless %}
+                {% apply spaceless %}
                 {% if field_description.options.collapse is defined %}
                     {% set collapse = field_description.options.collapse %}
                     <div class="sonata-readmore"
@@ -30,7 +30,7 @@ file that was distributed with this source code.
                 {% else %}
                     {{ value }}
                 {% endif %}
-                {% endspaceless %}
+                {% endapply %}
             {% endblock -%}
         </a>
     {% else %}

--- a/src/Resources/views/CRUD/base_show_field.html.twig
+++ b/src/Resources/views/CRUD/base_show_field.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 <th{% if(is_diff|default(false)) %} class="diff"{% endif %}>{% block name %}{{ field_description.label|trans({}, field_description.translationDomain ?: admin.translationDomain) }}{% endblock %}</th>
 <td>
     {%- block field -%}
-        {% spaceless %}
+        {% apply spaceless %}
             {% set collapse = field_description.options.collapse|default(false) %}
             {% if collapse %}
                 <div class="sonata-readmore"
@@ -26,7 +26,7 @@ file that was distributed with this source code.
             {% else %}
                 {{ block('field_value') }}
             {% endif %}
-        {% endspaceless %}
+        {% endapply %}
     {%- endblock -%}
 </td>
 

--- a/src/Resources/views/CRUD/display_boolean.html.twig
+++ b/src/Resources/views/CRUD/display_boolean.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- spaceless %}
+{%- apply spaceless %}
     {% if value %}
         {% set text = 'label_type_yes'|trans({}, 'SonataAdminBundle') %}
     {% else %}
@@ -23,4 +23,4 @@ file that was distributed with this source code.
     {% endif %}
 
     <span class="label {{ class }}">{{ text }}</span>
-{% endspaceless -%}
+{% endapply -%}

--- a/src/Resources/views/CRUD/display_date.html.twig
+++ b/src/Resources/views/CRUD/display_date.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- spaceless %}
+{%- apply spaceless %}
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}
@@ -18,4 +18,4 @@ file that was distributed with this source code.
             {{ value|date(options.format|default('F j, Y'), options.timezone|default(null)) }}
         </time>
     {%- endif -%}
-{% endspaceless -%}
+{% endapply -%}

--- a/src/Resources/views/CRUD/display_datetime.html.twig
+++ b/src/Resources/views/CRUD/display_datetime.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- spaceless %}
+{%- apply spaceless %}
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}
@@ -18,4 +18,4 @@ file that was distributed with this source code.
             {{ value|date(options.format|default(null), options.timezone|default(null)) }}
         </time>
     {%- endif -%}
-{% endspaceless -%}
+{% endapply -%}

--- a/src/Resources/views/CRUD/display_time.html.twig
+++ b/src/Resources/views/CRUD/display_time.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- spaceless %}
+{%- apply spaceless %}
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}
@@ -17,4 +17,4 @@ file that was distributed with this source code.
             {{ value|date('H:i:s', field_description.options.timezone|default(null)) }}
         </time>
     {%- endif -%}
-{% endspaceless -%}
+{% endapply -%}

--- a/src/Resources/views/CRUD/list_boolean.html.twig
+++ b/src/Resources/views/CRUD/list_boolean.html.twig
@@ -16,10 +16,10 @@ file that was distributed with this source code.
 
 {% if isEditable and xEditableType %}
     {% block field_span_attributes %}
-        {% spaceless %}
+        {% apply spaceless %}
             {{ parent() }}
             data-source="[{value: 0, text: '{%- trans from 'SonataAdminBundle' %}label_type_no{% endtrans -%}'},{value: 1, text: '{%- trans from 'SonataAdminBundle' %}label_type_yes{% endtrans -%}'}]"
-        {% endspaceless %}
+        {% endapply %}
     {% endblock %}
 {% endif %}
 

--- a/src/Resources/views/CRUD/list_choice.html.twig
+++ b/src/Resources/views/CRUD/list_choice.html.twig
@@ -20,15 +20,15 @@ file that was distributed with this source code.
 
 {% if is_editable and x_editable_type %}
     {% block field_span_attributes %}
-        {% spaceless %}
+        {% apply spaceless %}
             {{ parent() }}
             data-source="{{ field_description|sonata_xeditable_choices|json_encode }}"
-        {% endspaceless %}
+        {% endapply %}
     {% endblock %}
 {% endif %}
 
 {% block field %}
-{% spaceless %}
+{% apply spaceless %}
     {% if field_description.options.choices is defined %}
         {% if field_description.options.multiple is defined and field_description.options.multiple==true and value is iterable %}
 
@@ -63,5 +63,5 @@ file that was distributed with this source code.
     {% endif %}
 
     {{ value }}
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_url.html.twig
+++ b/src/Resources/views/CRUD/list_url.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-{% spaceless %}
+{% apply spaceless %}
     {% if value is empty %}
         &nbsp;
     {% else %}
@@ -51,5 +51,5 @@ file that was distributed with this source code.
             {{- value -}}
         </a>
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_choice.html.twig
+++ b/src/Resources/views/CRUD/show_choice.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field%}
-{% spaceless %}
+{% apply spaceless %}
     {% if field_description.options.choices  is defined %}
         {% if field_description.options.multiple is defined and field_description.options.multiple==true and value is iterable %}
 
@@ -51,5 +51,5 @@ file that was distributed with this source code.
         {{ value }}
     {% endif %}
 
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_url.html.twig
+++ b/src/Resources/views/CRUD/show_url.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-{% spaceless %}
+{% apply spaceless %}
     {% if value is empty %}
         &nbsp;
     {% else %}
@@ -55,5 +55,5 @@ file that was distributed with this source code.
             {%- endif -%}
         </a>
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/CRUD/tree.html.twig
+++ b/src/Resources/views/CRUD/tree.html.twig
@@ -18,7 +18,7 @@ file that was distributed with this source code.
 {% import _self as tree %}
 {% macro navigate_child(collection, admin, root) %}
     <ul{% if root %} class="sonata-tree"{% endif %}>
-        {% for element in collection if not root %}
+        {% for element in collection|filter(element => not root) %}
             <li>
                 <div class="sonata-tree__item">
                     {% if element.parent %}<i class="fa fa-caret-right" aria-hidden="true"></i>{% endif %}

--- a/src/Resources/views/Core/add_block.html.twig
+++ b/src/Resources/views/Core/add_block.html.twig
@@ -2,15 +2,8 @@
     {% set items_per_column = sonata_admin.adminPool.getOption('dropdown_number_groups_per_colums') %}
     {% set groups = [] %}
 
-    {% for group in sonata_admin.adminPool.dashboardgroups %}
-        {% set display_group = false %}
-
-        {% for admin in group.items if display_group == false %}
-            {% if admin.hasRoute('create') and admin.hasAccess('create') %}
-                {% set display_group = true %}
-                {% set groups = [group]|merge(groups) %}
-            {% endif %}
-        {% endfor %}
+    {% for group in sonata_admin.adminPool.dashboardgroups|filter(group => group.items|filter(admin => admin.hasRoute('create') and admin.hasAccess('create'))|length > 0) %}
+        {% set groups = [group]|merge(groups) %}
     {% endfor %}
 
     {% set column_count = (groups|length / items_per_column)|round(0, 'ceil') %}
@@ -19,10 +12,7 @@
         {% if column_count > 1 %}style="width: {{ column_count*140 }}px;"{% endif %}
     >
         {% for group in groups|reverse %}
-            {% set display = (group.roles is empty or is_granted(sonata_admin.adminPool.getOption('role_admin')) ) %}
-            {% for role in group.roles if not display %}
-                {% set display = is_granted(role) %}
-            {% endfor %}
+            {% set display = group.roles is empty or is_granted(sonata_admin.adminPool.getOption('role_admin')) or group.roles|filter(role => is_granted(role))|length > 0 %}
 
             {% if loop.first %}
                 {% set render_first_element = true %}

--- a/src/Resources/views/Core/search.html.twig
+++ b/src/Resources/views/Core/search.html.twig
@@ -20,10 +20,7 @@ file that was distributed with this source code.
         {% set count = 0 %}
         <div class="row" data-masonry='{ "itemSelector": ".search-box-item" }'>
         {% for group in groups %}
-            {% set display = (group.roles is empty or is_granted(sonata_admin.adminPool.getOption('role_super_admin')) ) %}
-            {% for role in group.roles if not display %}
-                {% set display = is_granted(role) %}
-            {% endfor %}
+            {% set display = group.roles is empty or is_granted(sonata_admin.adminPool.getOption('role_super_admin')) or group.roles|filter(role => is_granted(role))|length > 0 %}
 
             {% if display %}
                 {% for admin in group.items %}

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -8,7 +8,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% spaceless %}
+{% apply spaceless %}
 
     <input type="text" id="{{ id }}_autocomplete_input" value=""
         {%- for attribute,value in attr %} {{attribute}}="{{value}}" {% endfor -%}
@@ -20,14 +20,14 @@ file that was distributed with this source code.
         {%- if read_only|default(false) %} readonly="readonly"{% endif -%}
         {%- if disabled %} disabled="disabled"{% endif %}
     >
-        {%- for idx, val  in value if idx~'' != '_labels' -%}
+        {%- for idx, val  in value|filter((val, idx) => idx~'' != '_labels') -%}
             <option value="{{ val }}" selected>{{ value['_labels'][idx] }}</option>
         {%- endfor -%}
     </select>
 
     <div id="{{ id }}_hidden_inputs_wrap">
         {% if multiple -%}
-            {%- for idx, val in value if idx~'' != '_labels' -%}
+            {%- for idx, val  in value|filter((val, idx) => idx~'' != '_labels') -%}
                 <input type="hidden" name="{{ full_name }}[]" {%- if disabled %} disabled="disabled"{% endif %} value="{{ val }}">
             {%- endfor -%}
         {% else -%}
@@ -37,11 +37,11 @@ file that was distributed with this source code.
 
     {% if sonata_admin.field_description and sonata_admin.field_description.hasAssociationAdmin %}
         <div id="field_actions_{{ id }}" class="field-actions">
-            {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') 
+            {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create')
                                      and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
             {% if display_btn_add %}
                 <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create',
-                             sonata_admin.field_description.getOption('link_parameters', {})) 
+                             sonata_admin.field_description.getOption('link_parameters', {}))
                           }}"
                     onclick="return start_field_dialog_form_add_{{ id }}(this);"
                     class="btn btn-success btn-sm sonata-ba-action"
@@ -252,7 +252,7 @@ file that was distributed with this source code.
 
             {%- if value is not empty -%}
                 data = {%- if multiple -%}[ {%- endif -%}
-                {%- for idx, val  in value if idx~'' != '_labels' -%}
+                {%- for idx, val  in value|filter((val, idx) => idx~'' != '_labels') -%}
                     {%- if not loop.first -%}, {% endif -%}
                     {id: '{{ val }}', label:'{{ value['_labels'][idx] }}'}
                 {%- endfor -%}
@@ -273,14 +273,14 @@ file that was distributed with this source code.
             });
 
             // Automatically select the created record after closing the popup window
-            {% if sonata_admin.field_description 
-                and sonata_admin.field_description.hasAssociationAdmin 
-                and btn_add 
+            {% if sonata_admin.field_description
+                and sonata_admin.field_description.hasAssociationAdmin
+                and btn_add
                 and sonata_admin.field_description.associationadmin.hasRoute('create')
                 and sonata_admin.field_description.associationadmin.hasAccess('create') %}
 
                 {% set create_url = sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) %}
-    
+
                 $(document).ajaxSuccess(function(event, xhr, settings) {
                   if(typeof xhr.responseJSON != 'undefined') {
                       if ('{{ create_url }}'.indexOf(settings.url) !== -1 && typeof xhr.responseJSON != 'string' && xhr.responseJSON.result == 'ok') {
@@ -290,19 +290,19 @@ file that was distributed with this source code.
                           xhr.responseJSON.objectId,
                           true, true
                           );
-    
+
                         {%- if multiple -%}
                           var data = autocompleteInput.select2('data');
                           data.push(item);
                         {%- else -%}
                           var data = item;
                         {%- endif -%}
-    
+
                         $('#{{ id }}_hidden_inputs_wrap').html('<input type="hidden" name="{{ full_name }}" value="'+xhr.responseJSON.objectId+'" />');
-    
+
                         // append to Select2
                         autocompleteInput.select2('data', data).append(data).trigger('change');
-    
+
                         // manually trigger the `select2:select` event
                         autocompleteInput.select2('data', data).trigger({
                             type: 'select2:select',
@@ -317,4 +317,4 @@ file that was distributed with this source code.
         });
         {% endautoescape %}
     </script>
-{% endspaceless %}
+{% endapply %}

--- a/src/Resources/views/Form/filter_admin_fields.html.twig
+++ b/src/Resources/views/Form/filter_admin_fields.html.twig
@@ -31,7 +31,7 @@ file that was distributed with this source code.
 {% endblock form_widget_simple %}
 
 {% block choice_widget_expanded %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% set label_attr = label_attr|merge({'class': (label_attr.class|default(''))}) %}
         {% set label_attr = label_attr|merge({'class': (label_attr.class ~ ' ' ~ (widget_type is defined and widget_type != '' ? (multiple ? 'checkbox' : 'radio') ~ '-' ~ widget_type : ''))}) %}
         {% if expanded %}
@@ -56,11 +56,11 @@ file that was distributed with this source code.
         {% if expanded %}
             </div>
         {% endif %}
-    {% endspaceless %}
+    {% endapply %}
 {% endblock choice_widget_expanded %}
 
 {% block checkbox_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% if label is not same as(false) and label is empty %}
             {% set label = name|humanize %}
         {% endif %}
@@ -85,7 +85,7 @@ file that was distributed with this source code.
                 {{ block('form_message') }}
             {% endif %}
         {% endif %}
-    {% endspaceless %}
+    {% endapply %}
 {% endblock checkbox_widget %}
 
 {% block sonata_type_model_autocomplete_widget %}

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -24,11 +24,11 @@ file that was distributed with this source code.
 {%- endblock form_errors %}
 
 {% block sonata_help %}
-{% spaceless %}
+{% apply spaceless %}
 {% if sonata_help is defined and sonata_help %}
     <span class="help-block sonata-ba-field-widget-help">{{ sonata_help|raw }}</span>
 {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endblock %}
 
 {% block form_widget -%}
@@ -82,14 +82,14 @@ file that was distributed with this source code.
 {%- endblock money_widget %}
 
 {% block percent_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% set type = type|default('text') %}
         <div class="input-group">
             {{ block('form_widget_simple') }}
             <span class="input-group-addon">%</span>
         </div>
         {{ block('sonata_help') }}
-    {% endspaceless %}
+    {% endapply %}
 {% endblock percent_widget %}
 
 {% block checkbox_widget -%}
@@ -116,7 +116,7 @@ file that was distributed with this source code.
 
 {# Labels #}
 {% block form_label %}
-{% spaceless %}
+{% apply spaceless %}
     {% if label is not same as(false) and sonata_admin.options['form_type'] == 'horizontal' %}
         {% set label_class = 'col-sm-3' %}
     {% endif %}
@@ -154,7 +154,7 @@ file that was distributed with this source code.
             {% endif %}
         </label>
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endblock form_label %}
 
 {% block checkbox_label -%}
@@ -196,7 +196,7 @@ file that was distributed with this source code.
 {% endblock checkbox_radio_label %}
 
 {% block choice_widget_expanded %}
-{% spaceless %}
+{% apply spaceless %}
     {% set attr = attr|merge({'class': attr.class|default('') ~ ' list-unstyled'}) %}
     <ul {{ block('widget_container_attributes') }}>
     {% for child in form %}
@@ -209,11 +209,11 @@ file that was distributed with this source code.
         </li>
     {% endfor %}
     </ul>
-{% endspaceless %}
+{% endapply %}
 {% endblock choice_widget_expanded %}
 
 {% block choice_widget_collapsed %}
-{% spaceless %}
+{% apply spaceless %}
     {% if required and placeholder is defined and placeholder is none %}
         {% set required = false %}
     {% elseif required and empty_value is defined and empty_value_in_choices is defined and empty_value is none and not empty_value_in_choices and not multiple %}
@@ -257,11 +257,11 @@ file that was distributed with this source code.
             {{ block('choice_widget_options') }}
         </select>
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endblock choice_widget_collapsed %}
 
 {% block date_widget %}
-{% spaceless %}
+{% apply spaceless %}
     {% if widget == 'single_text' %}
         {{ block('form_widget_simple') }}
     {% else %}
@@ -280,11 +280,11 @@ file that was distributed with this source code.
     {% if datepicker_use_button is not defined %}
         {{ block('sonata_help') }}
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endblock date_widget %}
 
 {% block time_widget %}
-{% spaceless %}
+{% apply spaceless %}
     {% if widget == 'single_text' %}
         {{ block('form_widget_simple') }}
     {% else %}
@@ -309,11 +309,11 @@ file that was distributed with this source code.
         </div>
     {% endif %}
     {{ block('sonata_help') }}
-{% endspaceless %}
+{% endapply %}
 {% endblock time_widget %}
 
 {% block datetime_widget %}
-{% spaceless %}
+{% apply spaceless %}
     {% if widget == 'single_text' %}
         {{ block('form_widget_simple') }}
     {% else %}
@@ -342,7 +342,7 @@ file that was distributed with this source code.
     {% if datepicker_use_button is not defined %}
         {{ block('sonata_help') }}
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endblock datetime_widget %}
 
 {% block form_row %}
@@ -410,7 +410,7 @@ file that was distributed with this source code.
 {%- endblock radio_row %}
 
 {% block sonata_type_native_collection_widget_row %}
-{% spaceless %}
+{% apply spaceless %}
     <div class="sonata-collection-row">
         {% if allow_delete %}
             <div class="row">
@@ -427,11 +427,11 @@ file that was distributed with this source code.
             </div>
         {% endif %}
     </div>
-{% endspaceless %}
+{% endapply %}
 {% endblock sonata_type_native_collection_widget_row %}
 
 {% block sonata_type_native_collection_widget %}
-{% spaceless %}
+{% apply spaceless %}
     {% if prototype is defined %}
         {% set child = prototype %}
         {% set allow_delete_backup = allow_delete %}
@@ -449,11 +449,11 @@ file that was distributed with this source code.
             <div><a href="#" class="btn btn-link sonata-collection-add"><i class="fa fa-plus-circle" aria-hidden="true"></i></a></div>
         {% endif %}
     </div>
-{% endspaceless %}
+{% endapply %}
 {% endblock sonata_type_native_collection_widget %}
 
 {% block sonata_type_immutable_array_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         <div {{ block('widget_container_attributes') }}>
             {{ block('sonata_help') }}
 
@@ -465,11 +465,11 @@ file that was distributed with this source code.
 
             {{ form_rest(form) }}
         </div>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock sonata_type_immutable_array_widget %}
 
 {% block sonata_type_immutable_array_widget_row %}
-    {% spaceless %}
+    {% apply spaceless %}
         <div class="form-group{% if child.vars.errors|length > 0%} has-error{%endif%}" id="sonata-ba-field-container-{{ id }}-{{ key }}">
 
             {{ form_label(child) }}
@@ -491,7 +491,7 @@ file that was distributed with this source code.
                 </div>
             {% endif %}
         </div>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}
 
 {% block sonata_type_model_autocomplete_widget %}

--- a/src/Resources/views/Form/silex_form_div_layout.html.twig
+++ b/src/Resources/views/Form/silex_form_div_layout.html.twig
@@ -7,7 +7,7 @@
 
 {#
 {% block choice_widget %}
-{% spaceless %}
+{% apply spaceless %}
     {% if expanded %}
         <ul {{ block('widget_container_attributes') }} class="inputs-list">
         {% for child in form %}
@@ -35,20 +35,20 @@
         {{ block('choice_widget_options') }}
     </select>
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endblock choice_widget %}
 
 {% block form_widget_simple %}
-{% spaceless %}
+{% apply spaceless %}
     {% set type = type|default('text') %}
     <input type="{{ type }}" {{ block('widget_attributes') }} value="{{ value }}">
-{% endspaceless %}
+{% endapply %}
 {% endblock form_widget_simple %}
 
 &#123;&#35; Labels &#35;&#125;
 
 {% block form_label %}
-{% spaceless %}
+{% apply spaceless %}
     {% if not compound %}
         {% set attr = attr|merge({'for': id}) %}
     {% endif %}
@@ -65,13 +65,13 @@
     {% else %}
         <label{% for attrname,attrvalue in attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>{{ label|trans({}, translation_domain) }}</label>
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endblock %}
 
 &#123;&#35; Rows &#35;&#125;
 
 {% block form_row %}
-{% spaceless %}
+{% apply spaceless %}
     <div class="form-group {{ (0 < form_errors(form)|length)? 'has-error':'' }} ">
         {{ form_label(form, label|default(null)) }}
         <div class="col-sm-10 col-md-5">
@@ -79,13 +79,13 @@
             {{ form_errors(form) }}
         </div>
     </div>
-{% endspaceless %}
+{% endapply %}
 {% endblock form_row %}
 
 &#123;&#35; Misc &#35;&#125;
 
 {% block form_errors %}
-{% spaceless %}
+{% apply spaceless %}
     {% if errors|length > 0 %}
         {% if not form.parent  or 'repeated' in form.vars['block_prefixes'] %}
             <div class="form-group has-error">
@@ -101,6 +101,6 @@
             </div>
         {% endif %}
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endblock form_errors %}
 #}

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -9,10 +9,7 @@
 {% block item %}
     {%- if item.displayed %}
         {#- check role of the group #}
-        {%- set display = (item.extra('roles') is empty or is_granted(sonata_admin.adminPool.getOption('role_super_admin')) ) %}
-        {%- for role in item.extra('roles') if not display %}
-            {%- set display = is_granted(role) %}
-        {%- endfor %}
+        {%- set display = item.extra('roles') is empty or is_granted(sonata_admin.adminPool.getOption('role_super_admin')) or item.extra('roles')|filter(role => is_granted(role))|length > 0 %}
     {%- endif %}
 
     {%- if item.displayed and display|default %}
@@ -24,7 +21,7 @@
 {% endblock %}
 
 {% block linkElement %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% set translation_domain = item.extra('label_catalogue', 'messages') %}
         {% if item.extra('on_top') is defined and not item.extra('on_top') %}
             {% set icon = item.extra('icon')|default(item.level > 1 ? '<i class="fa fa-angle-double-right" aria-hidden="true"></i>' : '') %}
@@ -33,11 +30,11 @@
         {% endif %}
         {% set is_link = true %}
         {{ parent() }}
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}
 
 {% block spanElement %}
-    {% spaceless %}
+    {% apply spaceless %}
         <a href="#">
             {% set translation_domain = item.extra('label_catalogue') %}
             {% set icon = item.extra('icon')|default('') %}
@@ -47,7 +44,7 @@
                 <span class="pull-right-container"><i class="fa pull-right fa-angle-left"></i></span>
             {%- endif -%}
         </a>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}
 
 {% block label %}{% if is_link is defined and is_link %}{{ icon|default|raw }}{% endif %}{% if options.allow_safe_labels and item.extra('safe_label', false) %}{{ item.label|raw }}{% else %}{{ item.label|trans({}, translation_domain|default('messages')) }}{% endif %}{% endblock %}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -130,7 +130,7 @@ file that was distributed with this source code.
                     </noscript>
                 {% endblock %}
                 {% block logo %}
-                    {% spaceless %}
+                    {% apply spaceless %}
                         <a class="logo" href="{{ path('sonata_admin_dashboard') }}">
                             {% if 'single_image' == sonata_admin.adminPool.getOption('title_mode') or 'both' == sonata_admin.adminPool.getOption('title_mode') %}
                                 <img src="{{ asset(sonata_admin.adminPool.titlelogo) }}" alt="{{ sonata_admin.adminPool.title }}">
@@ -139,7 +139,7 @@ file that was distributed with this source code.
                                 <span>{{ sonata_admin.adminPool.title }}</span>
                             {% endif %}
                         </a>
-                    {% endspaceless %}
+                    {% endapply %}
                 {% endblock %}
                 {% block sonata_nav %}
                     <nav class="navbar navbar-static-top" role="navigation">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Bump "twig/twig" to "^2.9" in order to replace usages of deprecated features.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the changes are considered BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5573

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Bumped "twig/twig" dependency to "^2.9";
- Changed usages of `{% spaceless %}` tag, which is deprecated as of Twig 1.38 with `{% apply spaceless %}` filter;
- Changed usages of `{% for .. if .. %}`, which is deprecated as of Twig 2.10 with `filter` filter'.
```

**To Do**:
- [x] Update usages of `{% for .. if .. %}`, which are deprecated since Twig `2.10`.
