### PR TITLE
Implements "format" option to show type "trans" as it is already in the list type "trans"

### DIFF
--- a/docs/reference/field_types.rst
+++ b/docs/reference/field_types.rst
@@ -15,7 +15,7 @@ date            display a formatted date. Accepts an optional ``format`` paramet
 datetime        display a formatted date and time. Accepts an optional ``format`` and ``timezone`` parameter
 text            display a text
 textarea        display a textarea
-trans           translate the value with a provided ``catalogue`` option
+trans           translate the value with a provided ``catalogue`` (translation domain) and ``format`` (sprintf format) option
 string          display a text
 number          display a number
 currency        display a number with a provided ``currency`` option

--- a/src/Resources/views/CRUD/list_trans.html.twig
+++ b/src/Resources/views/CRUD/list_trans.html.twig
@@ -12,8 +12,8 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field%}
-    {% set translationDomain = field_description.options.catalogue|default(admin.translationDomain) %}
-    {% set valueFormat = field_description.options.format|default('%s') %}
+    {% set translation_domain = field_description.options.catalogue|default(admin.translationDomain) %}
+    {% set value_format = field_description.options.format|default('%s') %}
 
-    {{valueFormat|format(value)|trans({}, translationDomain)}}
+    {{ value_format|format(value)|trans({}, translation_domain) }}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_trans.html.twig
+++ b/src/Resources/views/CRUD/show_trans.html.twig
@@ -11,12 +11,12 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field%}
-    {% set valueFormat = field_description.options.format|default('%s') %}
+    {% set value_format = field_description.options.format|default('%s') %}
 
     {% if field_description.options.catalogue is not defined %}
-        {% set value = valueFormat|format(value)|trans %}
+        {% set value = value_format|format(value)|trans %}
     {% else %}
-        {% set value = valueFormat|format(value)|trans({}, field_description.options.catalogue) %}
+        {% set value = value_format|format(value)|trans({}, field_description.options.catalogue|default(admin.translationDomain)) %}
     {% endif %}
 
     {% if field_description.options.safe %}

--- a/src/Resources/views/CRUD/show_trans.html.twig
+++ b/src/Resources/views/CRUD/show_trans.html.twig
@@ -11,10 +11,12 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field%}
+    {% set valueFormat = field_description.options.format|default('%s') %}
+
     {% if field_description.options.catalogue is not defined %}
-        {% set value = value|trans %}
+        {% set value = valueFormat|format(value)|trans %}
     {% else %}
-        {% set value = value|trans({}, field_description.options.catalogue) %}
+        {% set value = valueFormat|format(value)|trans({}, field_description.options.catalogue) %}
     {% endif %}
 
     {% if field_description.options.safe %}

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -1580,6 +1580,12 @@ EOT
                 'action_delete',
                 ['safe' => false, 'catalogue' => 'SonataAdminBundle'],
             ],
+            [
+                '<th>Data</th> <td> Delete </td>',
+                'trans',
+                'delete',
+                ['safe' => false, 'catalogue' => 'SonataAdminBundle', 'format' => 'action_%s'],
+            ],
             ['<th>Data</th> <td>Status1</td>', 'choice', 'Status1', ['safe' => false]],
             [
                 '<th>Data</th> <td>Alias1</td>',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Implements `format` option to show type `trans` as it is already in the list type `trans`

<!-- Describe your Pull Request content here -->
This PR implements the same behaviour for show_trans as it is available in list_trans (format option).
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is a NON BC feature.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `format` option to show type `trans`
```