### PR TITLE
Fix and update doc about template in order to not use the Twig namespaced syntax

### DIFF
--- a/docs/reference/templates.rst
+++ b/docs/reference/templates.rst
@@ -172,7 +172,7 @@ can specify the templates to use in the ``Admin`` service definition:
                     - App\Entity\Post
                     - ~
                 calls:
-                    - [setTemplate, ['edit', '@App/PostAdmin/edit.html.twig']]
+                    - [setTemplate, ['edit', 'PostAdmin/edit.html.twig']]
                 tags:
                     - { name: sonata.admin, manager_type: orm, group: 'Content', label: 'Post' }
 
@@ -187,7 +187,7 @@ can specify the templates to use in the ``Admin`` service definition:
             <argument/>
             <call method="setTemplate">
                 <argument>edit</argument>
-                <argument>@App/PostAdmin/edit.html.twig</argument>
+                <argument>PostAdmin/edit.html.twig</argument>
             </call>
         </service>
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because it's just a documentation fix.

Closes #5577