### PR TITLE
Restrict mappers from configured role

### DIFF
--- a/docs/reference/architecture.rst
+++ b/docs/reference/architecture.rst
@@ -196,8 +196,20 @@ which stores instances of ``FieldDescriptionInterface``. Picking up on our previ
                     'class' => User::class
                 ])
 
+                // "privateNotes" field will be rendered only if the authenticated
+                // user is granted with the "ROLE_ADMIN_MODERATOR" role
+                ->add('privateNotes', null, [], [
+                    'role' => 'ROLE_ADMIN_MODERATOR'
+                ])
+
                 // if no type is specified, SonataAdminBundle tries to guess it
                 ->add('body')
+
+                // conditionally add "status" field if the subject already exists
+                // `ifFalse()` is also available to build this kind of condition
+                ->ifTrue($this->hasSubject())
+                    ->add('status')
+                ->ifEnd()
 
                 // ...
             ;
@@ -209,6 +221,9 @@ which stores instances of ``FieldDescriptionInterface``. Picking up on our previ
             $datagridMapper
                 ->add('title')
                 ->add('author')
+                ->add('privateNotes', null, [], null, null, [
+                    'role' => 'ROLE_ADMIN_MODERATOR'
+                ])
             ;
         }
 
@@ -219,6 +234,9 @@ which stores instances of ``FieldDescriptionInterface``. Picking up on our previ
                 ->addIdentifier('title')
                 ->add('slug')
                 ->add('author')
+                ->add('privateNotes', null, [
+                    'role' => 'ROLE_ADMIN_MODERATOR'
+                ])
             ;
         }
 
@@ -230,6 +248,9 @@ which stores instances of ``FieldDescriptionInterface``. Picking up on our previ
                 ->add('title')
                 ->add('slug')
                 ->add('author')
+                ->add('privateNotes', null, [
+                    'role' => 'ROLE_ADMIN_MODERATOR'
+                ])
             ;
         }
     }
@@ -237,14 +258,14 @@ which stores instances of ``FieldDescriptionInterface``. Picking up on our previ
 Internally, the provided ``Admin`` class will use these three functions to create three
 ``FieldDescriptionCollection`` instances:
 
-* ``$formFieldDescriptions``, containing three ``FieldDescriptionInterface`` instances
-  for title, author and body
-* ``$filterFieldDescriptions``, containing two ``FieldDescriptionInterface`` instances
-  for title and author
-* ``$listFieldDescriptions``, containing three ``FieldDescriptionInterface`` instances
-  for title, slug and author
-* ``$showFieldDescriptions``, containing four ``FieldDescriptionInterface`` instances
-  for id, title, slug and author
+* ``$formFieldDescriptions``, containing four (and conditionally five) ``FieldDescriptionInterface``
+  instances for title, author, body and privateNotes (and status, if the condition is met)
+* ``$filterFieldDescriptions``, containing three ``FieldDescriptionInterface`` instances
+  for title, author and privateNotes
+* ``$listFieldDescriptions``, containing four ``FieldDescriptionInterface`` instances
+  for title, slug, author and privateNotes
+* ``$showFieldDescriptions``, containing five ``FieldDescriptionInterface`` instances
+  for id, title, slug, author and privateNotes
 
 The actual ``FieldDescription`` implementation is provided by the storage abstraction
 bundle that you choose during the installation process, based on the

--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -89,8 +89,10 @@ class DatagridMapper extends BaseMapper
             );
         }
 
-        // add the field with the DatagridBuilder
-        $this->builder->addFilter($this->datagrid, $type, $fieldDescription, $this->admin);
+        if (!isset($fieldDescriptionOptions['role']) || $this->admin->isGranted($fieldDescriptionOptions['role'])) {
+            // add the field with the DatagridBuilder
+            $this->builder->addFilter($this->datagrid, $type, $fieldDescription, $this->admin);
+        }
 
         return $this;
     }

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -129,8 +129,10 @@ class ListMapper extends BaseMapper
             );
         }
 
-        // add the field with the FormBuilder
-        $this->builder->addField($this->list, $type, $fieldDescription, $this->admin);
+        if (!isset($fieldDescriptionOptions['role']) || $this->admin->isGranted($fieldDescriptionOptions['role'])) {
+            // add the field with the FormBuilder
+            $this->builder->addField($this->list, $type, $fieldDescription, $this->admin);
+        }
 
         return $this;
     }

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -113,10 +113,13 @@ class FormMapper extends BaseGroupedMapper
         $this->admin->addFormFieldDescription($fieldName, $fieldDescription);
 
         if ($name instanceof FormBuilderInterface) {
-            $this->formBuilder->add($name);
+            $type = null;
+            $options = [];
         } else {
+            $name = $fieldDescription->getName();
+
             // Note that the builder var is actually the formContractor:
-            $options = array_replace_recursive($this->builder->getDefaultOptions($type, $fieldDescription), $options);
+            $options = array_replace_recursive($this->builder->getDefaultOptions($type, $fieldDescription) ?? [], $options);
 
             // be compatible with mopa if not installed, avoid generating an exception for invalid option
             // force the default to false ...
@@ -125,7 +128,7 @@ class FormMapper extends BaseGroupedMapper
             }
 
             if (!isset($options['label'])) {
-                $options['label'] = $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'form', 'label');
+                $options['label'] = $this->admin->getLabelTranslatorStrategy()->getLabel($name, 'form', 'label');
             }
 
             $help = null;
@@ -134,11 +137,13 @@ class FormMapper extends BaseGroupedMapper
                 unset($options['help']);
             }
 
-            $this->formBuilder->add($fieldDescription->getName(), $type, $options);
-
             if (null !== $help) {
-                $this->admin->getFormFieldDescription($fieldDescription->getName())->setHelp($help);
+                $this->admin->getFormFieldDescription($name)->setHelp($help);
             }
+        }
+
+        if (!isset($fieldDescriptionOptions['role']) || $this->admin->isGranted($fieldDescriptionOptions['role'])) {
+            $this->formBuilder->add($name, $type, $options);
         }
 
         return $this;

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -78,8 +78,10 @@ class ShowMapper extends BaseGroupedMapper
 
         $fieldDescription->setOption('safe', $fieldDescription->getOption('safe', false));
 
-        // add the field with the FormBuilder
-        $this->builder->addField($this->list, $type, $fieldDescription, $this->admin);
+        if (!isset($fieldDescriptionOptions['role']) || $this->admin->isGranted($fieldDescriptionOptions['role'])) {
+            // add the field with the FormBuilder
+            $this->builder->addField($this->list, $type, $fieldDescription, $this->admin);
+        }
 
         return $this;
     }

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CleanAdmin;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -29,6 +30,8 @@ use Symfony\Component\Form\ResolvedFormTypeInterface;
 
 class FormMapperTest extends TestCase
 {
+    private const DEFAULT_GRANTED_ROLE = 'ROLE_ADMIN_BAZ';
+
     /**
      * @var FormContractorInterface
      */
@@ -49,7 +52,7 @@ class FormMapperTest extends TestCase
      */
     protected $formMapper;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->contractor = $this->createMock(FormContractorInterface::class);
 
@@ -59,6 +62,15 @@ class FormMapperTest extends TestCase
         $formBuilder = new FormBuilder('test', 'stdClass', $eventDispatcher, $formFactory);
 
         $this->admin = new CleanAdmin('code', 'class', 'controller');
+        $securityHandler = $this->createMock(SecurityHandlerInterface::class);
+        $securityHandler
+            ->expects($this->any())
+            ->method('isGranted')
+            ->willReturnCallback(static function (AdminInterface $admin, $attributes, $object = null): bool {
+                return self::DEFAULT_GRANTED_ROLE === $attributes;
+            });
+
+        $this->admin->setSecurityHandler($securityHandler);
 
         $this->modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
 
@@ -117,6 +129,7 @@ class FormMapperTest extends TestCase
     {
         $this->formMapper->with('foobar', [
             'translation_domain' => 'Foobar',
+            'role' => self::DEFAULT_GRANTED_ROLE,
         ]);
 
         $this->assertSame(['foobar' => [
@@ -128,6 +141,7 @@ class FormMapperTest extends TestCase
             'name' => 'foobar',
             'box_class' => 'box box-primary',
             'fields' => [],
+            'role' => self::DEFAULT_GRANTED_ROLE,
         ]], $this->admin->getFormGroups());
 
         $this->assertSame(['default' => [
@@ -452,6 +466,30 @@ class FormMapperTest extends TestCase
         ;
 
         $this->assertSame(['fo__o', 'ba____z'], $this->formMapper->keys());
+    }
+
+    public function testAddOptionRole(): void
+    {
+        $this->formMapper->add('bar', 'bar');
+
+        $this->assertTrue($this->formMapper->has('bar'));
+
+        $this->formMapper->add('quux', 'bar', [], ['role' => 'ROLE_QUX']);
+
+        $this->assertTrue($this->formMapper->has('bar'));
+        $this->assertFalse($this->formMapper->has('quux'));
+
+        $this->formMapper
+            ->with('qux')
+                ->add('foobar', 'bar', [], ['role' => self::DEFAULT_GRANTED_ROLE])
+                ->add('foo', 'bar', [], ['role' => 'ROLE_QUX'])
+                ->add('baz', 'bar')
+            ->end();
+
+        $this->assertArrayHasKey('qux', $this->admin->getFormGroups());
+        $this->assertTrue($this->formMapper->has('foobar'));
+        $this->assertFalse($this->formMapper->has('foo'));
+        $this->assertTrue($this->formMapper->has('baz'));
     }
 
     private function getFieldDescriptionMock(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Restrict mappers from configured role
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are fully BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5584.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added "role" option for methods `ListMapper::add()`, `DatagridMapper::add()`, `ShowMapper::add()` and `FormMapper::add()`; in order to restrict the content rendering based on the provided role.
```
    
## To do
    
- [x] Update remaining methods;
- [x] Add tests;
- [x] Update the documentation.
