### PR TITLE
Add alias in core.xml service definition

### DIFF
--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -18,22 +18,34 @@
             <argument type="service" id="service_container"/>
             <tag name="routing.loader"/>
         </service>
+        <service id="Sonata\AdminBundle\Route\AdminPoolLoader" alias="sonata.admin.route_loader"/>
         <service id="sonata.admin.helper" class="Sonata\AdminBundle\Admin\AdminHelper" public="true">
             <argument type="service" id="sonata.admin.pool"/>
         </service>
+        <service id="Sonata\AdminBundle\Admin\AdminHelper" alias="sonata.admin.helper"/>
         <service id="sonata.admin.builder.filter.factory" class="Sonata\AdminBundle\Filter\FilterFactory" public="true">
             <argument type="service" id="service_container"/>
             <argument/>
         </service>
+        <service id="Sonata\AdminBundle\Filter\FilterFactory" alias="sonata.admin.builder.filter.factory"/>
+        <service id="Sonata\AdminBundle\Filter\FilterFactoryInterface" alias="sonata.admin.builder.filter.factory"/>
         <service id="sonata.admin.breadcrumbs_builder" class="Sonata\AdminBundle\Admin\BreadcrumbsBuilder" public="true">
             <argument>%sonata.admin.configuration.breadcrumbs%</argument>
         </service>
+        <service id="Sonata\AdminBundle\Admin\BreadcrumbsBuilder" alias="sonata.admin.breadcrumbs_builder"/>
+        <service id="Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface" alias="sonata.admin.breadcrumbs_builder"/>
         <!-- Services used to format the label, default is sonata.admin.label.strategy.noop -->
         <service id="sonata.admin.label.strategy.bc" class="Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy" public="true"/>
+        <service id="Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy" alias="sonata.admin.label.strategy.bc"/>
         <service id="sonata.admin.label.strategy.native" class="Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy" public="true"/>
+        <service id="Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy" alias="sonata.admin.label.strategy.native"/>
+        <service id="Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface" alias="sonata.admin.label.strategy.native"/>
         <service id="sonata.admin.label.strategy.noop" class="Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy" public="true"/>
+        <service id="Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy" alias="sonata.admin.label.strategy.noop"/>
         <service id="sonata.admin.label.strategy.underscore" class="Sonata\AdminBundle\Translator\UnderscoreLabelTranslatorStrategy" public="true"/>
+        <service id="Sonata\AdminBundle\Translator\UnderscoreLabelTranslatorStrategy" alias="sonata.admin.label.strategy.underscore"/>
         <service id="sonata.admin.label.strategy.form_component" class="Sonata\AdminBundle\Translator\FormLabelTranslatorStrategy" public="true"/>
+        <service id="Sonata\AdminBundle\Translator\FormLabelTranslatorStrategy" alias="sonata.admin.label.strategy.form_component"/>
         <!-- Translation extractor -->
         <service id="sonata.admin.translator.extractor.jms_translator_bundle" class="Sonata\AdminBundle\Translator\Extractor\JMSTranslatorBundle\AdminExtractor" public="true">
             <tag name="jms_translation.extractor" alias="sonata_admin"/>
@@ -55,6 +67,8 @@
         <service id="sonata.admin.audit.manager" class="Sonata\AdminBundle\Model\AuditManager" public="true">
             <argument type="service" id="service_container"/>
         </service>
+        <service id="Sonata\AdminBundle\Model\AuditManager" alias="sonata.admin.audit.manager"/>
+        <service id="Sonata\AdminBundle\Model\AuditManagerInterface" alias="sonata.admin.audit.manager"/>
         <!-- NEXT_MAJOR : remove this service -->
         <service id="sonata.admin.exporter" class="Sonata\AdminBundle\Export\Exporter" public="true">
             <deprecated>The service "%service_id%" is deprecated in favor of the "sonata.exporter.exporter" service since version 3.14 and will be removed in 4.0.</deprecated>
@@ -63,11 +77,13 @@
             <argument type="service" id="sonata.admin.pool"/>
             <argument>%sonata.admin.configuration.global_search.case_sensitive%</argument>
         </service>
+        <service id="Sonata\AdminBundle\Search\SearchHandler" alias="sonata.admin.search.handler"/>
         <!-- event -->
         <service id="sonata.admin.event.extension" class="Sonata\AdminBundle\Event\AdminEventExtension" public="true">
             <argument type="service" id="event_dispatcher"/>
             <tag name="sonata.admin.extension" global="true"/>
         </service>
+        <service id="Sonata\AdminBundle\Event\AdminEventExtension" alias="sonata.admin.event.extension"/>
         <!-- lock -->
         <service id="sonata.admin.lock.extension" class="Sonata\AdminBundle\Admin\Extension\LockExtension" public="true">
             <tag name="sonata.admin.extension" global="true"/>
@@ -77,13 +93,18 @@
             <argument type="service" id="sonata.admin.pool"/>
             <argument>%sonata.admin.configuration.mosaic_background%</argument>
         </service>
+        <service id="Sonata\AdminBundle\Twig\GlobalVariables" alias="sonata.admin.twig.global"/>
         <!-- filter persister -->
         <service id="sonata.admin.filter_persister.session" class="Sonata\AdminBundle\Filter\Persister\SessionFilterPersister">
             <argument type="service" id="session"/>
         </service>
+        <service id="Sonata\AdminBundle\Filter\Persister\SessionFilterPersister" alias="sonata.admin.filter_persister.session"/>
+        <service id="Sonata\AdminBundle\Filter\Persister\FilterPersisterInterface" alias="sonata.admin.filter_persister.session"/>
         <!-- templating -->
         <service id="sonata.admin.global_template_registry" class="Sonata\AdminBundle\Templating\TemplateRegistry" public="true">
             <argument>%sonata.admin.configuration.templates%</argument>
         </service>
+        <service id="Sonata\AdminBundle\Templating\TemplateRegistry" alias="sonata.admin.global_template_registry"/>
+        <service id="Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface" alias="sonata.admin.global_template_registry"/>
     </services>
 </container>

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -14,8 +14,30 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\AdminBundle\Admin\AdminHelper;
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilder;
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
+use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Bridge\Exporter\AdminExporter;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
+use Sonata\AdminBundle\Event\AdminEventExtension;
+use Sonata\AdminBundle\Filter\FilterFactory;
+use Sonata\AdminBundle\Filter\FilterFactoryInterface;
+use Sonata\AdminBundle\Filter\Persister\FilterPersisterInterface;
+use Sonata\AdminBundle\Filter\Persister\SessionFilterPersister;
+use Sonata\AdminBundle\Model\AuditManager;
+use Sonata\AdminBundle\Model\AuditManagerInterface;
+use Sonata\AdminBundle\Route\AdminPoolLoader;
+use Sonata\AdminBundle\Search\SearchHandler;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
+use Sonata\AdminBundle\Templating\TemplateRegistry;
+use Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy;
+use Sonata\AdminBundle\Translator\FormLabelTranslatorStrategy;
+use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
+use Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy;
+use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
+use Sonata\AdminBundle\Translator\UnderscoreLabelTranslatorStrategy;
+use Sonata\AdminBundle\Twig\GlobalVariables;
 
 class SonataAdminExtensionTest extends AbstractExtensionTestCase
 {
@@ -40,6 +62,47 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $this->defaultJavascripts = $this->container
             ->getDefinition('sonata.admin.pool')->getArgument(3)['javascripts']
         ;
+    }
+
+    public function testHasCoreServicesAlias(): void
+    {
+        $this->assertContainerBuilderHasService(Pool::class);
+        $this->assertContainerBuilderHasService(AdminPoolLoader::class);
+        $this->assertContainerBuilderHasService(AdminHelper::class);
+        $this->assertContainerBuilderHasService(FilterFactory::class);
+        $this->assertContainerBuilderHasService(
+            FilterFactoryInterface::class,
+            FilterFactory::class
+        );
+        $this->assertContainerBuilderHasService(BreadcrumbsBuilder::class);
+        $this->assertContainerBuilderHasService(
+            BreadcrumbsBuilderInterface::class,
+            BreadcrumbsBuilder::class
+        );
+        $this->assertContainerBuilderHasService(BCLabelTranslatorStrategy::class);
+        $this->assertContainerBuilderHasService(NativeLabelTranslatorStrategy::class);
+        $this->assertContainerBuilderHasService(
+            LabelTranslatorStrategyInterface::class,
+            NativeLabelTranslatorStrategy::class
+        );
+        $this->assertContainerBuilderHasService(NoopLabelTranslatorStrategy::class);
+        $this->assertContainerBuilderHasService(UnderscoreLabelTranslatorStrategy::class);
+        $this->assertContainerBuilderHasService(FormLabelTranslatorStrategy::class);
+        $this->assertContainerBuilderHasService(AuditManager::class);
+        $this->assertContainerBuilderHasService(AuditManagerInterface::class, AuditManager::class);
+        $this->assertContainerBuilderHasService(SearchHandler::class);
+        $this->assertContainerBuilderHasService(AdminEventExtension::class);
+        $this->assertContainerBuilderHasService(GlobalVariables::class);
+        $this->assertContainerBuilderHasService(SessionFilterPersister::class);
+        $this->assertContainerBuilderHasService(
+            FilterPersisterInterface::class,
+            SessionFilterPersister::class
+        );
+        $this->assertContainerBuilderHasService(TemplateRegistry::class);
+        $this->assertContainerBuilderHasService(
+            MutableTemplateRegistryInterface::class,
+            TemplateRegistry::class
+        );
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because there is no BC, I add alias for autowire compatibility.

Following PR #5039

## Changelog

```markdown
### Fixed
 - Fixed deprecation notice when core services are injected in service through autowiring
```