### PR TITLE
[Doc] Use "auto" as password encoder instead of "bcrypt"

### DIFF
--- a/docs/cookbook/recipe_sonata_admin_without_user_bundle.rst
+++ b/docs/cookbook/recipe_sonata_admin_without_user_bundle.rst
@@ -327,7 +327,7 @@ Setup firewall in `security.yaml`
                 - ROLE_SONATA_PAGE_ADMIN_PAGE_EDIT
 
         encoders:
-            App\Entity\User: bcrypt
+            App\Entity\User: auto # use bcrypt if you are using "symfony/security-bundle" < 4.3
 
         providers:
             users:


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Use "auto" as password encoder instead of "bcrypt".
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

Using "bcrypt" as algorithm is deprecated since "symfony/security-bundle:4.3". See https://github.com/symfony/symfony/blob/v4.3.0/UPGRADE-4.3.md#securitybundle. 