### PR TITLE
Don't truncate subjects to 15 characters at navbar

### DIFF
--- a/src/Resources/views/CRUD/base_edit.html.twig
+++ b/src/Resources/views/CRUD/base_edit.html.twig
@@ -11,17 +11,19 @@ file that was distributed with this source code.
 
 {% extends base_template %}
 
+{# NEXT_MAJOR: remove default filter #}
+{% if objectId|default(admin.id(object)) is not null %}
+    {% set title = 'title_edit'|trans({'%name%': admin.toString(object) }, 'SonataAdminBundle') %}
+{% else %}
+    {% set title = 'title_create'|trans({}, 'SonataAdminBundle') %}
+{% endif %}
+
 {% block title %}
-    {# NEXT_MAJOR: remove default filter #}
-    {% if objectId|default(admin.id(object)) is not null %}
-        {{ "title_edit"|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
-    {% else %}
-        {{ "title_create"|trans({}, 'SonataAdminBundle') }}
-    {% endif %}
+    {{ title|truncate(15) }}
 {% endblock %}
 
 {% block navbar_title %}
-    {{ block('title') }}
+    {{ title }}
 {% endblock %}
 
 {%- block actions -%}

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -22,19 +22,14 @@ file that was distributed with this source code.
     }, 'twig') }}
 {%- endblock -%}
 
-{% block title %}
-    {#
-        The list template can be used in nested mode,
-        so we define the title corresponding to the parent's admin.
-    #}
+{% set title = admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject) }, 'SonataAdminBundle') : '' %}
 
-    {% if admin.isChild and admin.parent.subject %}
-        {{ "title_edit"|trans({'%name%': admin.parent.toString(admin.parent.subject)|truncate(15) }, 'SonataAdminBundle') }}
-    {% endif %}
+{% block title %}
+    {{ title|truncate(15) }}
 {% endblock %}
 
 {% block navbar_title %}
-    {{ block('title') }}
+    {{ title }}
 {% endblock %}
 
 {% block list_table %}

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -11,12 +11,14 @@ file that was distributed with this source code.
 
 {% extends base_template %}
 
+{% set title = 'title_show'|trans({'%name%': admin.toString(object) }, 'SonataAdminBundle') %}
+
 {% block title %}
-    {{ "title_show"|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
+    {{ title|truncate(15) }}
 {% endblock %}
 
 {% block navbar_title %}
-    {{ block('title') }}
+    {{ title }}
 {% endblock %}
 
 {%- block actions -%}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Don't truncate subjects to 15 characters at navbar.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Subject is now fully displayed at navbar. Before, it was using the same title as the `<title>` tag, which is truncated to 15 characters.
```
**BEFORE**:
![image](https://user-images.githubusercontent.com/1231441/59723125-ed908100-91fb-11e9-87e0-359414f77ee1.png)


**AFTER**:
![image](https://user-images.githubusercontent.com/1231441/59723092-d9e51a80-91fb-11e9-8682-c136efa185b8.png)


