### PR TITLE
Ensure boolean values for "identifier" option passed to `ListMapper::add()`

### DIFF
--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -92,6 +92,17 @@ class ListMapper extends BaseMapper
             $fieldDescriptionOptions['virtual_field'] = true;
         }
 
+        if (\array_key_exists('identifier', $fieldDescriptionOptions) && !\is_bool($fieldDescriptionOptions['identifier'])) {
+            @trigger_error(
+                'Passing a non boolean value for the "identifier" option is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.',
+                E_USER_DEPRECATED
+            );
+
+            $fieldDescriptionOptions['identifier'] = (bool) $fieldDescriptionOptions['identifier'];
+            // NEXT_MAJOR: Remove the previous 6 lines and use commented line below it instead
+            // throw new \InvalidArgumentException(sprintf('Value for "identifier" option must be boolean, %s given.', gettype($fieldDescriptionOptions['identifier'])));
+        }
+
         if ($name instanceof FieldDescriptionInterface) {
             $fieldDescription = $name;
             $fieldDescription->mergeOptions($fieldDescriptionOptions);

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
     {% set route = field_description.options.route.name|default(null) %}
 
     {% if
-        field_description.options.identifier is defined
+        field_description.options.identifier|default(false)
         and route
         and admin.hasRoute(route)
         and admin.hasAccess(route, route in ['show', 'edit'] ? object : null)

--- a/src/Resources/views/CRUD/base_list_flat_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_flat_field.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 <span class="sonata-ba-list-field sonata-ba-list-field-{{ field_description.type }}" objectId="{{ admin.id(object) }}">
     {% if
-            field_description.options.identifier is defined
+        field_description.options.identifier|default(false)
         and field_description.options.route is defined
         and admin.hasAccess(field_description.options.route.name, object)
         and admin.hasRoute(field_description.options.route.name)

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -108,6 +108,71 @@ class ListMapperTest extends TestCase
 
         $this->listMapper->addIdentifier($fieldDescription);
         $this->assertTrue($this->listMapper->has('fooName'));
+
+        $fieldDescription = $this->listMapper->get('fooName');
+        $this->assertTrue($fieldDescription->getOption('identifier'));
+    }
+
+    public function testAddOptionIdentifier(): void
+    {
+        $this->assertFalse($this->listMapper->has('fooName'));
+        $this->assertFalse($this->listMapper->has('barName'));
+        $this->assertFalse($this->listMapper->has('bazName'));
+
+        $this->listMapper->add('barName');
+        $this->assertNull($this->listMapper->get('barName')->getOption('identifier'));
+        $this->listMapper->add('fooName', null, ['identifier' => true]);
+        $this->assertTrue($this->listMapper->has('fooName'));
+        $this->assertTrue($this->listMapper->get('fooName')->getOption('identifier'));
+        $this->listMapper->add('bazName', null, ['identifier' => false]);
+        $this->assertTrue($this->listMapper->has('bazName'));
+        $this->assertFalse($this->listMapper->get('bazName')->getOption('identifier'));
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation Passing a non boolean value for the "identifier" option is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.
+     *
+     * @dataProvider getWrongIdentifierOptions
+     */
+    public function testAddOptionIdentifierWithDeprecatedValue(bool $expected, $value): void
+    {
+        $this->assertFalse($this->listMapper->has('fooName'));
+        $this->listMapper->add('fooName', null, ['identifier' => $value]);
+        $this->assertTrue($this->listMapper->has('fooName'));
+        $this->assertSame($expected, $this->listMapper->get('fooName')->getOption('identifier'));
+    }
+
+    /**
+     * @dataProvider getWrongIdentifierOptions
+     */
+    public function testAddOptionIdentifierWithWrongValue(bool $expected, $value): void
+    {
+        // NEXT_MAJOR: Remove the following `markTestSkipped()` call and the `testAddOptionIdentifierWithDeprecatedValue()` test
+        $this->markTestSkipped('This test must be run in 4.0');
+
+        $this->assertFalse($this->listMapper->has('fooName'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('{^Value for "identifier" option must be boolean, [^]+ given.$}');
+
+        $this->listMapper->add('fooName', null, ['identifier' => $value]);
+    }
+
+    public function getWrongIdentifierOptions(): iterable
+    {
+        return [
+            [true, 1],
+            [true, 'string'],
+            [true, new \stdClass()],
+            [true, [null]],
+            [false, 0],
+            [false, null],
+            [false, ''],
+            [false, '0'],
+            [false, []],
+        ];
     }
 
     public function testAdd(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Ensure boolean values for "identifier" option passed to `ListMapper::add()`
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4554.

## Changelog

<!--
MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->

```markdown
### Changed
- Values to passed with the "identifier" option for `ListMapper::add()` are cast to boolean before using them to infer if the field must be used as identifier or not.

### Deprecated
- Passing non boolean values to "identifier" option for `ListMapper::add()`.
```
    
## To do
    
- [x] Update the tests;
