### PR TITLE
Truncate navbar title at 100 characters

### DIFF
--- a/src/Resources/views/CRUD/base_edit.html.twig
+++ b/src/Resources/views/CRUD/base_edit.html.twig
@@ -11,19 +11,22 @@ file that was distributed with this source code.
 
 {% extends base_template %}
 
-{# NEXT_MAJOR: remove default filter #}
-{% if objectId|default(admin.id(object)) is not null %}
-    {% set title = 'title_edit'|trans({'%name%': admin.toString(object) }, 'SonataAdminBundle') %}
-{% else %}
-    {% set title = 'title_create'|trans({}, 'SonataAdminBundle') %}
-{% endif %}
-
 {% block title %}
-    {{ title|truncate(15) }}
+    {# NEXT_MAJOR: remove default filter #}
+    {% if objectId|default(admin.id(object)) is not null %}
+        {{ 'title_edit'|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
+    {% else %}
+        {{ 'title_create'|trans({}, 'SonataAdminBundle')|truncate(15) }}
+    {% endif %}
 {% endblock %}
 
 {% block navbar_title %}
-    {{ title }}
+    {# NEXT_MAJOR: remove default filter #}
+    {% if objectId|default(admin.id(object)) is not null %}
+        {{ 'title_edit'|trans({'%name%': admin.toString(object)|truncate(100) }, 'SonataAdminBundle') }}
+    {% else %}
+        {{ 'title_create'|trans({}, 'SonataAdminBundle')|truncate(100) }}
+    {% endif %}
 {% endblock %}
 
 {%- block actions -%}

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -22,14 +22,12 @@ file that was distributed with this source code.
     }, 'twig') }}
 {%- endblock -%}
 
-{% set title = admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject) }, 'SonataAdminBundle') : '' %}
-
 {% block title %}
-    {{ title|truncate(15) }}
+    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject|truncate(15)) }, 'SonataAdminBundle') : '' }}
 {% endblock %}
 
 {% block navbar_title %}
-    {{ title }}
+    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject|truncate(100)) }, 'SonataAdminBundle') : '' }}
 {% endblock %}
 
 {% block list_table %}

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -11,14 +11,12 @@ file that was distributed with this source code.
 
 {% extends base_template %}
 
-{% set title = 'title_show'|trans({'%name%': admin.toString(object) }, 'SonataAdminBundle') %}
-
 {% block title %}
-    {{ title|truncate(15) }}
+    {{ 'title_show'|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
 {% endblock %}
 
 {% block navbar_title %}
-    {{ title }}
+    {{ 'title_show'|trans({'%name%': admin.toString(object)|truncate(100) }, 'SonataAdminBundle') }}
 {% endblock %}
 
 {%- block actions -%}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -143,7 +143,7 @@ file that was distributed with this source code.
                 {% endblock %}
                 {% block sonata_nav %}
                     <nav class="navbar navbar-static-top" role="navigation">
-                        <a href="#" class="sidebar-toggle" data-toggle="offcanvas" 
+                        <a href="#" class="sidebar-toggle" data-toggle="offcanvas"
                            role="button" title="{{ 'toggle_navigation'|trans({}, 'SonataAdminBundle') }}">
                             <span class="sr-only">{{ 'toggle_navigation'|trans({}, 'SonataAdminBundle') }}</span>
                         </a>
@@ -177,7 +177,7 @@ file that was distributed with this source code.
                                                                 {% endif %}
                                                             </li>
                                                         {% else %}
-                                                            <li class="active"><span>{{ label }}</span></li>
+                                                            <li class="active"><span>{{ label|truncate(100) }}</span></li>
                                                         {% endif %}
                                                     {% endfor %}
                                                 {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Truncate navbar titles at 100 characters (follow up of #5593).
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are fully BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Truncate long titles at 100 characters at breadcrumb and navbar.
```

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->

**BEFORE**:

![image](https://user-images.githubusercontent.com/1231441/59792916-a95cb980-92ab-11e9-9c37-7ea8a2e438f6.png)


**AFTER**:

![image](https://user-images.githubusercontent.com/1231441/59792699-2b98ae00-92ab-11e9-9bcc-315a7b54f953.png)


## To do
    
- [x] Truncate long titles at breadcrumb.