### PR TITLE
Resolve some "NEXT_MAJOR" comments from 3.x

### DIFF
--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -250,12 +250,12 @@ class Pool
 
         foreach ($codes as $code) {
             if (!\in_array($code, $this->adminServiceIds, true)) {
-                @trigger_error(sprintf(
-                    'Passing an invalid admin code as argument 1 for %s() is deprecated since 3.50 and will throw an exception in 4.0.',
-                    __METHOD__
-                ), E_USER_DEPRECATED);
-
-                // NEXT_MAJOR : throw `\InvalidArgumentException` instead
+                throw new \InvalidArgumentException(sprintf(
+                    'Argument 1 passed to %s() must contain a valid admin reference, "%s" found at "%s".',
+                    __METHOD__,
+                    $code,
+                    $adminCode
+                ));
             }
 
             if (!$admin->hasChild($code)) {

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -78,14 +78,7 @@ class ListMapper extends BaseMapper
         }
 
         if (\array_key_exists('identifier', $fieldDescriptionOptions) && !\is_bool($fieldDescriptionOptions['identifier'])) {
-            @trigger_error(
-                'Passing a non boolean value for the "identifier" option is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.',
-                E_USER_DEPRECATED
-            );
-
-            $fieldDescriptionOptions['identifier'] = (bool) $fieldDescriptionOptions['identifier'];
-            // NEXT_MAJOR: Remove the previous 6 lines and use commented line below it instead
-            // throw new \InvalidArgumentException(sprintf('Value for "identifier" option must be boolean, %s given.', gettype($fieldDescriptionOptions['identifier'])));
+            throw new \InvalidArgumentException(sprintf('Value for "identifier" option must be boolean, %s given.', \gettype($fieldDescriptionOptions['identifier'])));
         }
 
         if ($name instanceof FieldDescriptionInterface) {

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -138,32 +138,14 @@ class ListMapperTest extends TestCase
     }
 
     /**
-     * @group legacy
-     *
-     * @expectedDeprecation Passing a non boolean value for the "identifier" option is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.
-     *
-     * @dataProvider getWrongIdentifierOptions
-     */
-    public function testAddOptionIdentifierWithDeprecatedValue(bool $expected, $value): void
-    {
-        $this->assertFalse($this->listMapper->has('fooName'));
-        $this->listMapper->add('fooName', null, ['identifier' => $value]);
-        $this->assertTrue($this->listMapper->has('fooName'));
-        $this->assertSame($expected, $this->listMapper->get('fooName')->getOption('identifier'));
-    }
-
-    /**
      * @dataProvider getWrongIdentifierOptions
      */
     public function testAddOptionIdentifierWithWrongValue(bool $expected, $value): void
     {
-        // NEXT_MAJOR: Remove the following `markTestSkipped()` call and the `testAddOptionIdentifierWithDeprecatedValue()` test
-        $this->markTestSkipped('This test must be run in 4.0');
-
         $this->assertFalse($this->listMapper->has('fooName'));
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('{^Value for "identifier" option must be boolean, [^]+ given.$}');
+        $this->expectExceptionMessageRegExp('{^Value for "identifier" option must be boolean, [^ ]+ given\.$}');
 
         $this->listMapper->add('fooName', null, ['identifier' => $value]);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Resolve some "NEXT_MAJOR" comments from 3.x
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes break BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to #5601.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Possibility to pass a non boolean value to "identifier" option for `ListMapper::add()`;
- Possibility to pass an invalid admin service as part of argument 1 for `Pool::getAdminByAdminCode()`.
```
