### PR TITLE
Deprecate some invalid arguments at `Pool::getAdminByAdminCode()`

### DIFF
--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -239,6 +239,16 @@ class Pool
      */
     public function getAdminByAdminCode($adminCode)
     {
+        if (!\is_string($adminCode)) {
+            @trigger_error(sprintf(
+                'Passing a non string value as argument 1 for %s() is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+
+            return false;
+
+            // NEXT_MAJOR : remove this condition check and declare "string" as type without default value for argument 1
+        }
         $codes = explode('|', $adminCode);
         $code = trim(array_shift($codes));
 
@@ -251,7 +261,7 @@ class Pool
         foreach ($codes as $code) {
             if (!\in_array($code, $this->adminServiceIds, true)) {
                 @trigger_error(sprintf(
-                    'Passing an invalid admin code as argument 1 for %s() is deprecated since 3.50 and will throw an exception in 4.0.',
+                    'Passing an invalid admin code as argument 1 for %s() is deprecated since sonata-project/admin-bundle 3.50 and will throw an exception in 4.0.',
                     __METHOD__
                 ), E_USER_DEPRECATED);
 
@@ -259,6 +269,19 @@ class Pool
             }
 
             if (!$admin->hasChild($code)) {
+                @trigger_error(sprintf(
+                    'Passing an invalid admin hierarchy inside argument 1 for %s() is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.',
+                    __METHOD__
+                ), E_USER_DEPRECATED);
+
+                // NEXT_MAJOR : remove the previous `trigger_error()` call, uncomment the following excception and declare AdminInterface as return type
+                // throw new InvalidArgumentException(sprintf(
+                //    'Argument 1 passed to %s() must contain a valid admin hierarchy, "%s" is not a valid child for "%s"',
+                //    __METHOD__,
+                //    $code,
+                //    $admin->getCode()
+                // ));
+
                 return false;
             }
 

--- a/src/Block/AdminSearchBlockService.php
+++ b/src/Block/AdminSearchBlockService.php
@@ -92,12 +92,15 @@ class AdminSearchBlockService extends AbstractBlockService
 
     public function configureSettings(OptionsResolver $resolver)
     {
-        $resolver->setDefaults([
-            'admin_code' => false,
-            'query' => '',
-            'page' => 0,
-            'per_page' => 10,
-            'icon' => '<i class="fa fa-list"></i>',
-        ]);
+        $resolver
+            ->setDefaults([
+                'admin_code' => '',
+                'query' => '',
+                'page' => 0,
+                'per_page' => 10,
+                'icon' => '<i class="fa fa-list"></i>',
+            ])
+            ->setRequired('admin_code')
+            ->setAllowedTypes('admin_code', ['string']);
     }
 }

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -228,9 +228,9 @@ class PoolTest extends TestCase
     /**
      * @group legacy
      *
-     * @expectedDeprecation Passing an invalid admin code as argument 1 for Sonata\AdminBundle\Admin\Pool::getAdminByAdminCode() is deprecated since 3.50 and will throw an exception in 4.0.
+     * @expectedDeprecation Passing an invalid admin code as argument 1 for Sonata\AdminBundle\Admin\Pool::getAdminByAdminCode() is deprecated since sonata-project/admin-bundle 3.50 and will throw an exception in 4.0.
      */
-    public function testGetAdminByAdminCodeForChildInvalidClass(): void
+    public function testGetAdminByAdminCodeWithInvalidCode(): void
     {
         $adminMock = $this->getMockBuilder(AdminInterface::class)
             ->disableOriginalConstructor()
@@ -248,6 +248,56 @@ class PoolTest extends TestCase
         $this->pool->setAdminServiceIds(['sonata.news.admin.post']);
 
         $this->assertFalse($this->pool->getAdminByAdminCode('sonata.news.admin.post|sonata.news.admin.invalid'));
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation Passing a non string value as argument 1 for Sonata\AdminBundle\Admin\Pool::getAdminByAdminCode() is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.
+     */
+    public function testGetAdminByAdminCodeWithNonStringCode(): void
+    {
+        $this->pool = new Pool($this->createMock(ContainerInterface::class), 'Sonata', '/path/to/logo.png');
+
+        $this->assertFalse($this->pool->getAdminByAdminCode(false));
+        $this->assertFalse($this->pool->getAdminByAdminCode(true));
+        $this->assertFalse($this->pool->getAdminByAdminCode(null));
+        $this->assertFalse($this->pool->getAdminByAdminCode(['']));
+        $this->assertFalse($this->pool->getAdminByAdminCode(['some_value']));
+        $this->assertFalse($this->pool->getAdminByAdminCode(1));
+        $this->assertFalse($this->pool->getAdminByAdminCode(new \stdClass()));
+        // NEXT_MAJOR: remove the previous assertions, the "@group" and "@expectedDeprecation" annotations, and uncomment the following line
+        // $this->expectException(\TypeError::class);
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation Passing an invalid admin hierarchy inside argument 1 for Sonata\AdminBundle\Admin\Pool::getAdminByAdminCode() is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.
+     */
+    public function testGetAdminByAdminCodeWithCodeNotChild(): void
+    {
+        $adminMock = $this->getMockBuilder(AdminInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $adminMock->expects($this->any())
+            ->method('hasChild')
+            ->willReturn(false);
+        $adminMock->expects($this->any())
+            ->method('getCode')
+            ->willReturn('sonata.news.admin.post');
+        $containerMock = $this->createMock(ContainerInterface::class);
+        $containerMock->expects($this->any())
+            ->method('get')
+            ->willReturn($adminMock);
+        $this->pool = new Pool($containerMock, 'Sonata', '/path/to/logo.png');
+        $this->pool->setAdminServiceIds(['sonata.news.admin.post', 'sonata.news.admin.valid']);
+        $this->assertFalse($this->pool->getAdminByAdminCode('sonata.news.admin.post|sonata.news.admin.valid'));
+        // NEXT_MAJOR: remove the "@group" and "@expectedDeprecation" annotations, the previous assertion and uncomment the following lines
+        // $this->expectException(\InvalidArgumentException::class);
+        // $this->expectExceptionMessage('Argument 1 passed to Sonata\AdminBundle\Admin\Pool::getAdminByAdminCode() must contain a valid admin hierarchy, "sonata.news.admin.valid" is not a valid child for "sonata.news.admin.post"');
+        //
+        // $this->pool->getAdminByAdminCode('sonata.news.admin.post|sonata.news.admin.valid');
     }
 
     /**
@@ -290,7 +340,7 @@ class PoolTest extends TestCase
      *
      * @group legacy
      *
-     * @expectedDeprecation Passing an invalid admin code as argument 1 for Sonata\AdminBundle\Admin\Pool::getAdminByAdminCode() is deprecated since 3.50 and will throw an exception in 4.0.
+     * @expectedDeprecation Passing an invalid admin code as argument 1 for Sonata\AdminBundle\Admin\Pool::getAdminByAdminCode() is deprecated since sonata-project/admin-bundle 3.50 and will throw an exception in 4.0.
      */
     public function testGetAdminByAdminCodeWithInvalidChildCode(string $adminId): void
     {

--- a/tests/Block/AdminSearchBlockServiceTest.php
+++ b/tests/Block/AdminSearchBlockServiceTest.php
@@ -49,7 +49,7 @@ class AdminSearchBlockServiceTest extends AbstractBlockServiceTestCase
         $blockContext = $this->getBlockContext($blockService);
 
         $this->assertSettings([
-            'admin_code' => false,
+            'admin_code' => '',
             'query' => '',
             'page' => 0,
             'per_page' => 10,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Deprecate some invalid arguments at `Pool::getAdminByAdminCode()`
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are fully BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5538.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- The default value for "admin_code" setting  at `AdminSearchBlockService`.

### Deprecated
- Passing a non string value as argument 1 to `Pool::getAdminByAdminCode()`;
- Passing a non valid admin hierarchy as argument 1 to `Pool::getAdminByAdminCode()`.
```
