### PR TITLE
[Pool] Adding Pool::hasAdminByAdminCode()

### DIFF
--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -241,7 +241,7 @@ class Pool
     {
         if (!\is_string($adminCode)) {
             @trigger_error(sprintf(
-                'Passing a non string value as argument 1 for %s() is deprecated since sonata-project/admin-bundle 3.51 and will result in a PHP TypeError in 4.0.',
+                'Passing a non string value as argument 1 for %s() is deprecated since sonata-project/admin-bundle 3.51 and will cause a \TypeError in 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
 
@@ -271,7 +271,7 @@ class Pool
 
             if (!$admin->hasChild($code)) {
                 @trigger_error(sprintf(
-                    'Calling "%s()" with an invalid admin hierarchy is deprecated since sonata-project/admin-bundle 3.51 and will throw an exception in 4.0.',
+                    'Passing an invalid admin hierarchy inside argument 1 for %s() is deprecated since sonata-project/admin-bundle 3.51 and will throw an exception in 4.0.',
                     __METHOD__
                 ), E_USER_DEPRECATED);
 
@@ -293,47 +293,17 @@ class Pool
     }
 
     /**
-     * See if an admin with a certain admin code exists.
-     *
-     * @param string $adminCode
-     *
-     * @return bool
+     * Checks if an admin with a certain admin code exists.
      */
-    public function hasAdminByAdminCode($adminCode)
+    final public function hasAdminByAdminCode(string $adminCode): bool
     {
-        if (!\is_string($adminCode)) {
-            @trigger_error(sprintf(
-                'Passing a non string value as argument 1 for %s() is deprecated since sonata-project/admin-bundle 3.x and will result in a PHP TypeError in 4.0.',
-                __METHOD__
-            ), E_USER_DEPRECATED);
-
-            return false;
-
-            // NEXT_MAJOR : remove this condition check and declare "string" as type without default value for argument 1
-        }
-
-        $codes = explode('|', $adminCode);
-        $code = trim(array_shift($codes));
-
-        if ('' === $code) {
-            return false;
-        }
-
         try {
-            $admin = $this->getInstance($code);
+            if (!$this->getAdminByAdminCode($adminCode) instanceof AdminInterface) {
+                // NEXT_MAJOR : remove `if (...instanceof...) { return false; }` as getAdminByAdminCode() will then always throw an \InvalidArgumentException when somethings wrong
+                return false;
+            }
         } catch (\InvalidArgumentException $e) {
             return false;
-        }
-
-        foreach ($codes as $code) {
-            if (!\in_array($code, $this->adminServiceIds, true)) {
-                return false;
-            }
-            if (!$admin->hasChild($code)) {
-                return false;
-            }
-
-            $admin = $admin->getChild($code);
         }
 
         return true;

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -235,13 +235,13 @@ class Pool
      *
      * @throws \InvalidArgumentException if the root admin code is an empty string
      *
-     * @return \Sonata\AdminBundle\Admin\AdminInterface|false
+     * @return AdminInterface|false
      */
     public function getAdminByAdminCode($adminCode)
     {
         if (!\is_string($adminCode)) {
             @trigger_error(sprintf(
-                'Passing a non string value as argument 1 for %s() is deprecated since sonata-project/admin-bundle 3.51 and will throw an exception in 4.0.',
+                'Passing a non string value as argument 1 for %s() is deprecated since sonata-project/admin-bundle 3.51 and will result in a PHP TypeError in 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
 
@@ -249,6 +249,7 @@ class Pool
 
             // NEXT_MAJOR : remove this condition check and declare "string" as type without default value for argument 1
         }
+
         $codes = explode('|', $adminCode);
         $code = trim(array_shift($codes));
 
@@ -270,12 +271,12 @@ class Pool
 
             if (!$admin->hasChild($code)) {
                 @trigger_error(sprintf(
-                    'Passing an invalid admin hierarchy inside argument 1 for %s() is deprecated since sonata-project/admin-bundle 3.51 and will throw an exception in 4.0.',
+                    'Calling "%s()" with an invalid admin hierarchy is deprecated since sonata-project/admin-bundle 3.51 and will throw an exception in 4.0.',
                     __METHOD__
                 ), E_USER_DEPRECATED);
 
-                // NEXT_MAJOR : remove the previous `trigger_error()` call, uncomment the following excception and declare AdminInterface as return type
-                // throw new InvalidArgumentException(sprintf(
+                // NEXT_MAJOR : remove the previous `trigger_error()` call, uncomment the following exception and declare AdminInterface as return type
+                // throw new \InvalidArgumentException(sprintf(
                 //    'Argument 1 passed to %s() must contain a valid admin hierarchy, "%s" is not a valid child for "%s"',
                 //    __METHOD__,
                 //    $code,
@@ -289,6 +290,53 @@ class Pool
         }
 
         return $admin;
+    }
+
+    /**
+     * See if an admin with a certain admin code exists.
+     *
+     * @param string $adminCode
+     *
+     * @return bool
+     */
+    public function hasAdminByAdminCode($adminCode)
+    {
+        if (!\is_string($adminCode)) {
+            @trigger_error(sprintf(
+                'Passing a non string value as argument 1 for %s() is deprecated since sonata-project/admin-bundle 3.x and will result in a PHP TypeError in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+
+            return false;
+
+            // NEXT_MAJOR : remove this condition check and declare "string" as type without default value for argument 1
+        }
+
+        $codes = explode('|', $adminCode);
+        $code = trim(array_shift($codes));
+
+        if ('' === $code) {
+            return false;
+        }
+
+        try {
+            $admin = $this->getInstance($code);
+        } catch (\InvalidArgumentException $e) {
+            return false;
+        }
+
+        foreach ($codes as $code) {
+            if (!\in_array($code, $this->adminServiceIds, true)) {
+                return false;
+            }
+            if (!$admin->hasChild($code)) {
+                return false;
+            }
+
+            $admin = $admin->getChild($code);
+        }
+
+        return true;
     }
 
     /**

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -204,9 +204,7 @@ class PoolTest extends TestCase
 
     public function testGetAdminByAdminCodeForChildClass(): void
     {
-        $adminMock = $this->getMockBuilder(AdminInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $adminMock = $this->createMock(AdminInterface::class);
         $adminMock->expects($this->any())
             ->method('hasChild')
             ->willReturn(true);
@@ -233,9 +231,7 @@ class PoolTest extends TestCase
      */
     public function testGetAdminByAdminCodeWithInvalidCode(): void
     {
-        $adminMock = $this->getMockBuilder(AdminInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $adminMock = $this->createMock(AdminInterface::class);
         $adminMock->expects($this->any())
             ->method('hasChild')
             ->willReturn(false);
@@ -258,7 +254,7 @@ class PoolTest extends TestCase
      *
      * @group legacy
      *
-     * @expectedDeprecation Passing a non string value as argument 1 for Sonata\AdminBundle\Admin\Pool::getAdminByAdminCode() is deprecated since sonata-project/admin-bundle 3.51 and will result in a PHP TypeError in 4.0.
+     * @expectedDeprecation Passing a non string value as argument 1 for Sonata\AdminBundle\Admin\Pool::getAdminByAdminCode() is deprecated since sonata-project/admin-bundle 3.51 and will cause a \TypeError in 4.0.
      */
     public function testGetAdminByAdminCodeWithNonStringCode($adminId): void
     {
@@ -281,13 +277,11 @@ class PoolTest extends TestCase
     /**
      * @group legacy
      *
-     * @expectedDeprecation Calling "Sonata\AdminBundle\Admin\Pool::getAdminByAdminCode()" with an invalid admin hierarchy is deprecated since sonata-project/admin-bundle 3.51 and will throw an exception in 4.0.
+     * @expectedDeprecation Passing an invalid admin hierarchy inside argument 1 for %s() is deprecated since sonata-project/admin-bundle 3.51 and will throw an exception in 4.0.
      */
     public function testGetAdminByAdminCodeWithCodeNotChild(): void
     {
-        $adminMock = $this->getMockBuilder(AdminInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $adminMock = $this->createMock(AdminInterface::class);
         $adminMock->expects($this->any())
             ->method('hasChild')
             ->willReturn(false);
@@ -393,17 +387,17 @@ class PoolTest extends TestCase
      */
     public function testHasAdminByAdminCode(string $adminId): void
     {
-        $adminMock = $this->getMockBuilder(AdminInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $adminMock = $this->createMock(AdminInterface::class);
+
         if (false !== strpos($adminId, '|')) {
+            $childAdminMock = $this->createMock(AdminInterface::class);
             $adminMock->expects($this->any())
                 ->method('hasChild')
                 ->willReturn(true);
             $adminMock->expects($this->once())
                 ->method('getChild')
                 ->with($this->equalTo('sonata.news.admin.comment'))
-                ->willReturn('commentAdminClass');
+                ->willReturn($childAdminMock);
         } else {
             $adminMock->expects($this->never())
                 ->method('hasChild');
@@ -432,16 +426,11 @@ class PoolTest extends TestCase
 
     /**
      * @dataProvider getNonStringAdminServiceNames
-     *
-     * @group legacy
-     *
-     * @expectedDeprecation Passing a non string value as argument 1 for Sonata\AdminBundle\Admin\Pool::hasAdminByAdminCode() is deprecated since sonata-project/admin-bundle 3.x and will result in a PHP TypeError in 4.0.
      */
     public function testHasAdminByAdminCodeWithNonStringCode($adminId): void
     {
-        // NEXT_MAJOR: remove the assertion around hasAdminByAdminCode(), remove the "@group" and "@expectedDeprecation" annotations, and uncomment the following line
-        // $this->expectException(\TypeError::class);
-        $this->assertFalse($this->pool->hasAdminByAdminCode($adminId));
+        $this->expectException(\TypeError::class);
+        $this->pool->hasAdminByAdminCode($adminId);
     }
 
     /**
@@ -449,9 +438,7 @@ class PoolTest extends TestCase
      */
     public function testHasAdminByAdminCodeWithInvalidCodes(string $adminId): void
     {
-        $adminMock = $this->getMockBuilder(AdminInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $adminMock = $this->createMock(AdminInterface::class);
         $adminMock->expects($this->any())
             ->method('hasChild')
             ->willReturn(false);
@@ -482,27 +469,21 @@ class PoolTest extends TestCase
         $containerMock->expects($this->never())
             ->method('get');
 
-        /** @var MockObject|Pool $poolMock */
-        $poolMock = $this->getMockBuilder(Pool::class)
-            ->setConstructorArgs([$containerMock, 'Sonata', '/path/to/logo.png'])
-            ->disableOriginalClone()
-            ->setMethodsExcept(['hasAdminByAdminCode'])
-            ->getMock();
-        $poolMock->expects($this->once())
-            ->method('getInstance')
-            ->will($this->throwException(new \InvalidArgumentException()));
+        $this->pool = new Pool($containerMock, 'Sonata', '/path/to/logo.png');
 
-        $this->assertFalse($poolMock->hasAdminByAdminCode('sonata.news.admin.nonexistent_code'));
+        $this->assertFalse($this->pool->hasAdminByAdminCode('sonata.news.admin.nonexistent_code'));
     }
 
     /**
      * @dataProvider getInvalidChildAdminServiceNamesToCheck
+     *
+     * @group legacy
+     *
+     * @expectedDeprecation Passing an invalid admin %s argument 1 for Sonata\AdminBundle\Admin\Pool::getAdminByAdminCode() is deprecated since sonata-project/admin-bundle 3.%s and will throw an exception in 4.0.
      */
     public function testHasAdminByAdminCodeWithInvalidChildCodes(string $adminId): void
     {
-        $adminMock = $this->getMockBuilder(AdminInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $adminMock = $this->createMock(AdminInterface::class);
         $adminMock->expects($this->any())
             ->method('hasChild')
             ->willReturn(false);


### PR DESCRIPTION
## Subject

Adding `Pool::hasAdminByAdminCode()` as discussed in #5538 (but already closed), accompanied with tests, to check if an admin with a certain code exists (e.g. before calling `Pool::getAdminByAdminCode()` which will be throwing exceptions in 4.0)

I did minor improvements to the code in `Pool::getAdminByAdminCode()` and more improvements to its tests, recently introduced in #5543 and #5603

I am targeting the 3.x branch, because the changes are fully backwards compatible

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added the method `\Sonata\AdminBundle\Admin\Pool::hasAdminByAdminCode()` in order to check if an admin with a certain code exists
```

## To do
- [x] Discuss if passing a non-string argument to `Pool::hasAdminByAdminCode()` should cause a TypeError already in 3.x or keep it consistent with `Pool::hasAdminByAdminCode()` and allow this but trigger a deprecation error (the latter has my preference and I did it that way now)
