### PR TITLE
Fix wrong mocked return value for `Admin::getChild()` at `PoolTest`

### DIFF
--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -208,10 +208,13 @@ class PoolTest extends TestCase
         $adminMock->expects($this->any())
             ->method('hasChild')
             ->willReturn(true);
+
+        $childAdmin = $this->createMock(AdminInterface::class);
+
         $adminMock->expects($this->once())
             ->method('getChild')
             ->with($this->equalTo('sonata.news.admin.comment'))
-            ->willReturn('commentAdminClass');
+            ->willReturn($childAdmin);
 
         $containerMock = $this->createMock(ContainerInterface::class);
         $containerMock->expects($this->any())
@@ -221,7 +224,7 @@ class PoolTest extends TestCase
         $this->pool = new Pool($containerMock, 'Sonata', '/path/to/logo.png');
         $this->pool->setAdminServiceIds(['sonata.news.admin.post', 'sonata.news.admin.comment']);
 
-        $this->assertSame('commentAdminClass', $this->pool->getAdminByAdminCode('sonata.news.admin.post|sonata.news.admin.comment'));
+        $this->assertSame($childAdmin, $this->pool->getAdminByAdminCode('sonata.news.admin.post|sonata.news.admin.comment'));
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Fix wrong mocked return value for `Admin::getChild()` at `PoolTest`.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change doesn't affect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->