### PR TITLE
Narrow API

### DIFF
--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -56,10 +56,8 @@ final class SetObjectFieldValueAction
 
     /**
      * @throws NotFoundHttpException
-     *
-     * @return Response
      */
-    public function __invoke(Request $request)
+    public function __invoke(Request $request): Response
     {
         $field = $request->get('field');
         $code = $request->get('code');

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -40,15 +40,16 @@ use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
+use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Form\Validator\Constraints\InlineConstraint;
 use Sonata\Form\Validator\ErrorElement;
-use Sonata\Exporter\Source\SourceIteratorInterface;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface as RoutingUrlGeneratorInterface;
@@ -390,9 +391,9 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     ];
 
     /**
-     * @var array
+     * @var FormView
      */
-    protected $formTheme = [];
+    protected $formTheme;
 
     /**
      * @var array
@@ -2148,12 +2149,12 @@ EOT;
         return $this->show;
     }
 
-    public function setFormTheme(array $formTheme): void
+    public function setFormTheme(FormView $formTheme): void
     {
         $this->formTheme = $formTheme;
     }
 
-    public function getFormTheme(): array
+    public function getFormTheme(): FormView
     {
         return $this->formTheme;
     }

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1316,9 +1316,9 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     /**
      * Returns the master admin.
      *
-     * @return AbstractAdmin the root admin class
+     * @return AdminInterface the root admin class
      */
-    public function getRoot(): self
+    public function getRoot(): AdminInterface
     {
         $parentFieldDescription = $this->getParentFieldDescription();
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -985,7 +985,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     public function getActiveSubClass(): string
     {
         if (!$this->hasActiveSubClass()) {
-            throw new \BadMethodCallException();
+            throw new \BadMethodCallException('Admin has no active subclass.');
         }
 
         return $this->getSubClass($this->getActiveSubclassCode());
@@ -1790,13 +1790,7 @@ EOT;
         $parameters = [];
 
         foreach ($this->getExtensions() as $extension) {
-            $params = $extension->getPersistentParameters($this);
-
-            if (!\is_array($params)) {
-                throw new \RuntimeException(sprintf('The %s::getPersistentParameters must return an array', \get_class($extension)));
-            }
-
-            $parameters = array_merge($parameters, $params);
+            $parameters = array_merge($parameters, $extension->getPersistentParameters($this));
         }
 
         return $parameters;

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -787,10 +787,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      * value (ie the parent object) or to filter the object.
      *
      * @throws \InvalidArgumentException
-     *
-     * @return string|null
      */
-    public function getParentAssociationMapping()
+    public function getParentAssociationMapping(): ?string
     {
         // NEXT_MAJOR: remove array check
         if (\is_array($this->parentAssociationMapping) && $this->getParent()) {
@@ -827,7 +825,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      *
      * @return string the baseRoutePattern used to generate the routing information
      */
-    public function getBaseRoutePattern()
+    public function getBaseRoutePattern(): string
     {
         if (null !== $this->cachedBaseRoutePattern) {
             return $this->cachedBaseRoutePattern;
@@ -877,7 +875,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      *
      * @return string the baseRouteName used to generate the routing information
      */
-    public function getBaseRouteName()
+    public function getBaseRouteName(): string
     {
         if (null !== $this->cachedBaseRouteName) {
             return $this->cachedBaseRouteName;
@@ -1133,8 +1131,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     /**
      * @deprecated since 3.34, will be dropped in 4.0. Use TemplateRegistry services instead
-     *
-     * @return array
      */
     public function getTemplates(): array
     {
@@ -1145,15 +1141,13 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      * @deprecated since 3.34, will be dropped in 4.0. Use TemplateRegistry services instead
      *
      * @param string $name
-     *
-     * @return string|null
      */
-    public function getTemplate($name)
+    public function getTemplate($name): ?string
     {
         return $this->getTemplateRegistry()->getTemplate($name);
     }
 
-    public function getNewInstance()
+    public function getNewInstance(): object
     {
         $object = $this->getModelManager()->getModelInstance($this->getClass());
         foreach ($this->getExtensions() as $extension) {
@@ -1293,10 +1287,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     /**
      * @param string $action
-     *
-     * @return ItemInterface
      */
-    public function getSideMenu($action, AdminInterface $childAdmin = null)
+    public function getSideMenu($action, AdminInterface $childAdmin = null): ItemInterface
     {
         if ($this->isChild()) {
             return $this->getParent()->getSideMenu($action, $this);
@@ -1312,7 +1304,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      *
      * @return string the root code
      */
-    public function getRootCode()
+    public function getRootCode(): string
     {
         return $this->getRoot()->getCode();
     }
@@ -1322,7 +1314,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      *
      * @return AbstractAdmin the root admin class
      */
-    public function getRoot()
+    public function getRoot(): self
     {
         $parentFieldDescription = $this->getParentFieldDescription();
 
@@ -1373,9 +1365,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         $this->persistFilters = $persist;
     }
 
-    /**
-     * @param FilterPersisterInterface|null $filterPersister
-     */
     public function setFilterPersister(FilterPersisterInterface $filterPersister = null): void
     {
         $this->filterPersister = $filterPersister;
@@ -1391,10 +1380,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         $this->maxPerPage = $maxPerPage;
     }
 
-    /**
-     * @return int
-     */
-    public function getMaxPerPage()
+    public function getMaxPerPage(): int
     {
         return $this->maxPerPage;
     }
@@ -1407,10 +1393,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         $this->maxPageLinks = $maxPageLinks;
     }
 
-    /**
-     * @return int
-     */
-    public function getMaxPageLinks()
+    public function getMaxPageLinks(): int
     {
         return $this->maxPageLinks;
     }
@@ -1516,7 +1499,7 @@ EOT;
         $this->subject = $subject;
     }
 
-    public function getSubject()
+    public function getSubject(): object
     {
         if (null === $this->subject && $this->request && !$this->hasParentFieldDescription()) {
             $id = $this->request->get($this->getIdParameter());
@@ -1550,10 +1533,8 @@ EOT;
      * Returns true if the admin has a FieldDescription with the given $name.
      *
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasFormFieldDescription($name)
+    public function hasFormFieldDescription($name): bool
     {
         return \array_key_exists($name, $this->formFieldDescriptions) ? true : false;
     }
@@ -1578,7 +1559,7 @@ EOT;
      *
      * @return array collection of form FieldDescription
      */
-    public function getShowFieldDescriptions()
+    public function getShowFieldDescriptions(): array
     {
         $this->buildShow();
 
@@ -1589,10 +1570,8 @@ EOT;
      * Returns the form FieldDescription with the given $name.
      *
      * @param string $name
-     *
-     * @return FieldDescriptionInterface
      */
-    public function getShowFieldDescription($name)
+    public function getShowFieldDescription($name): FieldDescriptionInterface
     {
         $this->buildShow();
 
@@ -1776,7 +1755,7 @@ EOT;
      *
      * @return bool if the admin has children
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return \count($this->children) > 0;
     }
@@ -1845,7 +1824,7 @@ EOT;
      *
      * @return AdminInterface|null the current child admin instance
      */
-    public function getCurrentChildAdmin()
+    public function getCurrentChildAdmin(): ?AdminInterface
     {
         foreach ($this->children as $children) {
             if ($children->getCurrentChild()) {
@@ -1880,7 +1859,7 @@ EOT;
      *
      * @deprecated since 3.9, to be removed with 4.0
      */
-    public function transChoice($id, $count, array $parameters = [], $domain = null, $locale = null)
+    public function transChoice($id, $count, array $parameters = [], $domain = null, $locale = null): string
     {
         @trigger_error(
             'The '.__METHOD__.' method is deprecated since version 3.9 and will be removed in 4.0.',
@@ -1972,10 +1951,7 @@ EOT;
         $this->formContractor = $formBuilder;
     }
 
-    /**
-     * @return FormContractorInterface
-     */
-    public function getFormContractor()
+    public function getFormContractor(): FormContractorInterface
     {
         return $this->formContractor;
     }
@@ -2005,10 +1981,7 @@ EOT;
         $this->showBuilder = $showBuilder;
     }
 
-    /**
-     * @return ShowBuilderInterface
-     */
-    public function getShowBuilder()
+    public function getShowBuilder(): ShowBuilderInterface
     {
         return $this->showBuilder;
     }
@@ -2018,10 +1991,7 @@ EOT;
         $this->configurationPool = $configurationPool;
     }
 
-    /**
-     * @return Pool
-     */
-    public function getConfigurationPool()
+    public function getConfigurationPool(): Pool
     {
         return $this->configurationPool;
     }
@@ -2031,10 +2001,7 @@ EOT;
         $this->routeGenerator = $routeGenerator;
     }
 
-    /**
-     * @return RouteGeneratorInterface
-     */
-    public function getRouteGenerator()
+    public function getRouteGenerator(): RouteGeneratorInterface
     {
         return $this->routeGenerator;
     }
@@ -2098,10 +2065,8 @@ EOT;
      * Return the list of permissions the user should have in order to display the admin.
      *
      * @param string $context
-     *
-     * @return array
      */
-    public function getPermissionsShow($context)
+    public function getPermissionsShow($context): array
     {
         switch ($context) {
             case self::CONTEXT_DASHBOARD:
@@ -2221,7 +2186,7 @@ EOT;
         $this->menuFactory = $menuFactory;
     }
 
-    public function getMenuFactory()
+    public function getMenuFactory(): MenuFactoryInterface
     {
         return $this->menuFactory;
     }
@@ -2274,10 +2239,8 @@ EOT;
 
     /**
      * Returns predefined per page options.
-     *
-     * @return array
      */
-    public function getPerPageOptions()
+    public function getPerPageOptions(): array
     {
         return $this->perPageOptions;
     }
@@ -2294,10 +2257,8 @@ EOT;
 
     /**
      * Get pager type.
-     *
-     * @return string
      */
-    public function getPagerType()
+    public function getPagerType(): string
     {
         return $this->pagerType;
     }
@@ -2306,10 +2267,8 @@ EOT;
      * Returns true if the per page value is allowed, false otherwise.
      *
      * @param int $perPage
-     *
-     * @return bool
      */
-    public function determinedPerPageValue($perPage)
+    public function determinedPerPageValue($perPage): bool
     {
         return \in_array($perPage, $this->perPageOptions, true);
     }
@@ -2399,7 +2358,7 @@ EOT;
         return true;
     }
 
-    final public function getActionButtons($action, $object = null)
+    final public function getActionButtons($action, $object = null): array
     {
         $buttonList = [];
 
@@ -2527,10 +2486,8 @@ EOT;
      * Checks if a filter type is set to a default value.
      *
      * @param string $name
-     *
-     * @return bool
      */
-    final public function isDefaultFilter($name)
+    final public function isDefaultFilter($name): bool
     {
         $filter = $this->getFilterParameters();
         $default = $this->getDefaultFilterValues();
@@ -2547,10 +2504,8 @@ EOT;
      *
      * @param string $action
      * @param object $object
-     *
-     * @return bool
      */
-    public function canAccessObject($action, $object)
+    public function canAccessObject($action, $object): bool
     {
         return $object && $this->id($object) && $this->hasAccess($action, $object);
     }
@@ -2567,10 +2522,8 @@ EOT;
      *
      * @param string $word
      * @param string $sep  the separator
-     *
-     * @return string
      */
-    final protected function urlize($word, $sep = '_')
+    final protected function urlize($word, $sep = '_'): string
     {
         return strtolower(preg_replace('/[^a-z0-9_]/i', $sep.'$1', $word));
     }
@@ -2582,10 +2535,8 @@ EOT;
 
     /**
      * Returns a list of default filters.
-     *
-     * @return array
      */
-    final protected function getDefaultFilterValues()
+    final protected function getDefaultFilterValues(): array
     {
         $defaultFilterValues = [];
 
@@ -2630,10 +2581,8 @@ EOT;
      * Allows you to customize batch actions.
      *
      * @param array $actions List of actions
-     *
-     * @return array
      */
-    protected function configureBatchActions($actions)
+    protected function configureBatchActions($actions): array
     {
         return $actions;
     }
@@ -2786,7 +2735,7 @@ EOT;
      *
      * @return string the subclass
      */
-    protected function getSubClass($name)
+    protected function getSubClass($name): string
     {
         if ($this->hasSubClass($name)) {
             return $this->subClasses[$name];
@@ -2842,10 +2791,8 @@ EOT;
 
     /**
      * Return list routes with permissions name.
-     *
-     * @return array
      */
-    protected function getAccess()
+    protected function getAccess(): array
     {
         $access = array_merge([
             'acl' => 'MASTER',

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -74,17 +74,17 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     {
     }
 
-    public function getPersistentParameters(AdminInterface $admin)
+    public function getPersistentParameters(AdminInterface $admin): array
     {
         return [];
     }
 
-    public function getAccessMapping(AdminInterface $admin)
+    public function getAccessMapping(AdminInterface $admin): array
     {
         return [];
     }
 
-    public function configureBatchActions(AdminInterface $admin, array $actions)
+    public function configureBatchActions(AdminInterface $admin, array $actions): array
     {
         return $actions;
     }
@@ -118,7 +118,7 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     {
     }
 
-    public function configureActionButtons(AdminInterface $admin, $list, $action, $object)
+    public function configureActionButtons(AdminInterface $admin, $list, $action, $object): array
     {
         return $list;
     }

--- a/src/Admin/AccessRegistryInterface.php
+++ b/src/Admin/AccessRegistryInterface.php
@@ -22,10 +22,8 @@ interface AccessRegistryInterface
 {
     /**
      * Return the controller access mapping.
-     *
-     * @return array
      */
-    public function getAccessMapping();
+    public function getAccessMapping(): array;
 
     /**
      * Hook to handle access authorization.

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -91,31 +91,22 @@ interface AdminExtensionInterface
 
     /**
      * Get a chance to add persistent parameters.
-     *
-     * @return array
      */
-    public function getPersistentParameters(AdminInterface $admin);
+    public function getPersistentParameters(AdminInterface $admin): array;
 
     /**
      * Return the controller access mapping.
-     *
-     * @return array
      */
-    public function getAccessMapping(AdminInterface $admin);
+    public function getAccessMapping(AdminInterface $admin): array;
 
     /**
      * Returns the list of batch actions.
-     *
-     * @param array $actions
-     *
-     * @return array
      */
-    public function configureBatchActions(AdminInterface $admin, array $actions);
+    public function configureBatchActions(AdminInterface $admin, array $actions): array;
 
     /**
      * Get a chance to modify export fields.
      *
-     * @param string[] $fields
      *
      * @return string[]
      */
@@ -158,10 +149,8 @@ interface AdminExtensionInterface
      * @param array  $list
      * @param string $action
      * @param object $object
-     *
-     * @return array
      */
-    public function configureActionButtons(AdminInterface $admin, $list, $action, $object);
+    public function configureActionButtons(AdminInterface $admin, $list, $action, $object): array;
 
     /*
      * NEXT_MAJOR: Uncomment in next major release

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -128,7 +128,7 @@ class AdminHelper
 
         $form = $formBuilder->getForm();
         $form->setData($subject);
-        $form->handleRequest($admin->getRequest());
+        $form->handleRequest($admin->hasRequest() ? $admin->getRequest() : null);
 
         //Child form not found (probably nested one)
         //if childFormBuilder was not found resulted in fatal error getName() method call on non object
@@ -146,7 +146,7 @@ class AdminHelper
             } elseif ($collection instanceof Collection) {
                 $entityClassName = $this->getEntityClassName($admin, explode('.', preg_replace('#\[\d*?\]#', '', $path)));
             } else {
-                throw new \Exception('unknown collection class');
+                throw new \TypeError(sprintf('Expected collection to be an instance of "%s", "%s" given.', Collection::class, \is_object($collection) ? \get_class($collection) : \gettype($collection)));
             }
 
             $collection->add(new $entityClassName());

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -56,6 +56,8 @@ class AdminHelper
                 return $formBuilder;
             }
         }
+
+        return null;
     }
 
     /**
@@ -68,6 +70,8 @@ class AdminHelper
                 return $formView;
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -48,10 +48,8 @@ class AdminHelper
      * @param string $elementId
      *
      * @throws \RuntimeException
-     *
-     * @return FormBuilderInterface|null
      */
-    public function getChildFormBuilder(FormBuilderInterface $formBuilder, $elementId)
+    public function getChildFormBuilder(FormBuilderInterface $formBuilder, $elementId): ?FormBuilderInterface
     {
         foreach (new FormBuilderIterator($formBuilder) as $name => $formBuilder) {
             if ($name === $elementId) {
@@ -62,10 +60,8 @@ class AdminHelper
 
     /**
      * @param string $elementId
-     *
-     * @return FormView|null
      */
-    public function getChildFormView(FormView $formView, $elementId)
+    public function getChildFormView(FormView $formView, $elementId): ?FormView
     {
         foreach (new \RecursiveIteratorIterator(new FormViewIterator($formView), \RecursiveIteratorIterator::SELF_FIRST) as $name => $formView) {
             if ($name === $elementId) {
@@ -80,10 +76,8 @@ class AdminHelper
      * @deprecated
      *
      * @param string $code
-     *
-     * @return AdminInterface
      */
-    public function getAdmin($code)
+    public function getAdmin($code): AdminInterface
     {
         return $this->pool->getInstance($code);
     }
@@ -100,10 +94,8 @@ class AdminHelper
      *
      * @throws \RuntimeException
      * @throws \Exception
-     *
-     * @return array
      */
-    public function appendFormFieldElement(AdminInterface $admin, $subject, $elementId)
+    public function appendFormFieldElement(AdminInterface $admin, $subject, $elementId): array
     {
         // child rows marked as toDelete
         $toDelete = [];
@@ -254,10 +246,8 @@ class AdminHelper
      * @param mixed  $entity
      *
      * @throws \Exception
-     *
-     * @return string
      */
-    public function getElementAccessPath($elementId, $entity)
+    public function getElementAccessPath($elementId, $entity): string
     {
         $propertyAccessor = $this->pool->getPropertyAccessor();
 
@@ -291,10 +281,8 @@ class AdminHelper
      * Recursively find the class name of the admin responsible for the element at the end of an association chain.
      *
      * @param array $elements
-     *
-     * @return string
      */
-    protected function getEntityClassName(AdminInterface $admin, $elements)
+    protected function getEntityClassName(AdminInterface $admin, $elements): string
     {
         $element = array_shift($elements);
         $associationAdmin = $admin->getFormFieldDescription($element)->getAssociationAdmin();

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -26,6 +26,7 @@ use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -222,9 +223,9 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     public function getShow(): array;
 
-    public function setFormTheme(array $formTheme);
+    public function setFormTheme(FormView $formTheme);
 
-    public function getFormTheme(): array;
+    public function getFormTheme(): FormView;
 
     public function setFilterTheme(array $filterTheme);
 

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -22,6 +22,7 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Object\MetadataInterface;
 use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
+use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -36,33 +37,21 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 {
     public function setMenuFactory(MenuFactoryInterface $menuFactory);
 
-    /**
-     * @return MenuFactoryInterface
-     */
-    public function getMenuFactory();
+    public function getMenuFactory(): MenuFactoryInterface;
 
     public function setFormContractor(FormContractorInterface $formContractor);
 
     public function setListBuilder(ListBuilderInterface $listBuilder);
 
-    /**
-     * @return ListBuilderInterface
-     */
-    public function getListBuilder();
+    public function getListBuilder(): ListBuilderInterface;
 
     public function setDatagridBuilder(DatagridBuilderInterface $datagridBuilder);
 
-    /**
-     * @return DatagridBuilderInterface
-     */
-    public function getDatagridBuilder();
+    public function getDatagridBuilder(): DatagridBuilderInterface;
 
     public function setTranslator(TranslatorInterface $translator);
 
-    /**
-     * @return TranslatorInterface
-     */
-    public function getTranslator();
+    public function getTranslator(): TranslatorInterface;
 
     public function setRequest(Request $request);
 
@@ -73,17 +62,12 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * - subclass name if subclass parameter is defined
      * - subject class name if subject is defined
      * - class name if not.
-     *
-     * @return string
      */
-    public function getClass();
+    public function getClass(): string;
 
     public function attachAdminClass(FieldDescriptionInterface $fieldDescription);
 
-    /**
-     * @return \Sonata\AdminBundle\Datagrid\DatagridInterface
-     */
-    public function getDatagrid();
+    public function getDatagrid(): \Sonata\AdminBundle\Datagrid\DatagridInterface;
 
     /**
      * Set base controller name.
@@ -94,15 +78,11 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * Get base controller name.
-     *
-     * @return string
      */
-    public function getBaseControllerName();
+    public function getBaseControllerName(): string;
 
     /**
      * Sets a list of templates.
-     *
-     * @param array $templates
      */
     public function setTemplates(array $templates);
 
@@ -116,62 +96,45 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * Get all templates.
-     *
-     * @return array
      */
-    public function getTemplates();
+    public function getTemplates(): array;
 
-    /**
-     * @return \Sonata\AdminBundle\Model\ModelManagerInterface
-     */
-    public function getModelManager();
+    public function getModelManager(): \Sonata\AdminBundle\Model\ModelManagerInterface;
 
     /**
      * @return string the manager type of the admin
      */
-    public function getManagerType();
+    public function getManagerType(): string;
 
     /**
      * @param string $context NEXT_MAJOR: remove this argument
-     *
-     * @return ProxyQueryInterface
      */
-    public function createQuery($context = 'list');
+    public function createQuery($context = 'list'): ProxyQueryInterface;
 
     /**
      * @return FormBuilderInterface the form builder
      */
-    public function getFormBuilder();
+    public function getFormBuilder(): FormBuilderInterface;
 
     /**
      * Returns a form depend on the given $object.
-     *
-     * @return FormInterface
      */
-    public function getForm();
+    public function getForm(): FormInterface;
 
     /**
      * @throws \RuntimeException if no request is set
-     *
-     * @return Request
      */
-    public function getRequest();
+    public function getRequest(): Request;
 
     /**
      * @return bool true if a request object is linked to this Admin, false
      *              otherwise
      */
-    public function hasRequest();
+    public function hasRequest(): bool;
 
-    /**
-     * @return string
-     */
-    public function getCode();
+    public function getCode(): string;
 
-    /**
-     * @return string
-     */
-    public function getBaseCodeRoute();
+    public function getBaseCodeRoute(): string;
 
     /**
      * Return the roles and permissions per role
@@ -181,7 +144,7 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      *
      * @return array 'role' => ['permission', 'permission']
      */
-    public function getSecurityInformation();
+    public function getSecurityInformation(): array;
 
     public function setParentFieldDescription(FieldDescriptionInterface $parentFieldDescription);
 
@@ -190,14 +153,12 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      *
      * @return FieldDescriptionInterface The parent field description
      */
-    public function getParentFieldDescription();
+    public function getParentFieldDescription(): FieldDescriptionInterface;
 
     /**
      * Returns true if the Admin is linked to a parent FieldDescription.
-     *
-     * @return bool
      */
-    public function hasParentFieldDescription();
+    public function hasParentFieldDescription(): bool;
 
     /**
      * translate a message id.
@@ -212,45 +173,36 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      *
      * @deprecated since 3.9, to be removed in 4.0
      */
-    public function trans($id, array $parameters = [], $domain = null, $locale = null);
+    public function trans($id, array $parameters = [], $domain = null, $locale = null): string;
 
     /**
      * Returns the parameter representing request id, ie: id or childId.
-     *
-     * @return string
      */
-    public function getIdParameter();
+    public function getIdParameter(): string;
 
     /**
      * Returns true if the route $name is available.
      *
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasRoute($name);
+    public function hasRoute($name): bool;
 
     public function setSecurityHandler(SecurityHandlerInterface $securityHandler);
 
-    /**
-     * @return SecurityHandlerInterface|null
-     */
-    public function getSecurityHandler();
+    public function getSecurityHandler(): ?SecurityHandlerInterface;
 
     /**
      * @param string      $name
      * @param object|null $object
-     *
-     * @return bool
      */
-    public function isGranted($name, $object = null);
+    public function isGranted($name, $object = null): bool;
 
     /**
      * @param mixed $entity
      *
      * @return string a string representation of the identifiers for this instance
      */
-    public function getNormalizedIdentifier($entity);
+    public function getNormalizedIdentifier($entity): string;
 
     /**
      * Shorthand method for templating.
@@ -266,29 +218,17 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function setValidator($validator);
 
-    /**
-     * @return ValidatorInterface
-     */
-    public function getValidator();
+    public function getValidator(): ValidatorInterface;
 
-    /**
-     * @return array
-     */
-    public function getShow();
+    public function getShow(): array;
 
     public function setFormTheme(array $formTheme);
 
-    /**
-     * @return array
-     */
-    public function getFormTheme();
+    public function getFormTheme(): array;
 
     public function setFilterTheme(array $filterTheme);
 
-    /**
-     * @return array
-     */
-    public function getFilterTheme();
+    public function getFilterTheme(): array;
 
     public function addExtension(AdminExtensionInterface $extension);
 
@@ -297,42 +237,32 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      *
      * @return AdminExtensionInterface[]
      */
-    public function getExtensions();
+    public function getExtensions(): array;
 
     public function setRouteBuilder(RouteBuilderInterface $routeBuilder);
 
-    /**
-     * @return RouteBuilderInterface
-     */
-    public function getRouteBuilder();
+    public function getRouteBuilder(): RouteBuilderInterface;
 
     /**
      * @param mixed $object
-     *
-     * @return string
      */
-    public function toString($object);
+    public function toString($object): string;
 
     public function setLabelTranslatorStrategy(LabelTranslatorStrategyInterface $labelTranslatorStrategy);
 
-    /**
-     * @return LabelTranslatorStrategyInterface
-     */
-    public function getLabelTranslatorStrategy();
+    public function getLabelTranslatorStrategy(): LabelTranslatorStrategyInterface;
 
     /**
      * Returning true will enable preview mode for
      * the target entity and show a preview button
      * when editing/creating an entity.
-     *
-     * @return bool
      */
-    public function supportsPreviewMode();
+    public function supportsPreviewMode(): bool;
 
     /**
      * @return mixed a new object instance
      */
-    public function getNewInstance();
+    public function getNewInstance(): object;
 
     /**
      * @param string $uniqId
@@ -341,17 +271,15 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * Returns the uniqid.
-     *
-     * @return string
      */
-    public function getUniqid();
+    public function getUniqid(): string;
 
     /**
      * Returns the classname label.
      *
      * @return string the classname label
      */
-    public function getClassnameLabel();
+    public function getClassnameLabel(): string;
 
     /**
      * @param mixed $id
@@ -368,76 +296,59 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     /**
      * @return mixed
      */
-    public function getSubject();
+    public function getSubject(): object;
 
     /**
      * Returns a list FieldDescription.
      *
      * @param string $name
-     *
-     * @return FieldDescriptionInterface
      */
-    public function getListFieldDescription($name);
+    public function getListFieldDescription($name): FieldDescriptionInterface;
 
     /**
      * Returns true if the list FieldDescription exists.
      *
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasListFieldDescription($name);
+    public function hasListFieldDescription($name): bool;
 
     /**
      * Returns the collection of list FieldDescriptions.
-     *
-     * @return array
      */
-    public function getListFieldDescriptions();
+    public function getListFieldDescriptions(): array;
 
     /**
      * Returns the array of allowed export formats.
-     *
-     * @return array
      */
-    public function getExportFormats();
+    public function getExportFormats(): array;
 
     /**
      * Retuns a list of exported fields.
-     *
-     * @return array
      */
-    public function getExportFields();
+    public function getExportFields(): array;
 
     /**
      * Returns SourceIterator.
-     *
-     * @return \Sonata\Exporter\Source\SourceIteratorInterface
      */
-    public function getDataSourceIterator();
+    public function getDataSourceIterator(): SourceIteratorInterface;
 
     /**
      * Call before the batch action, allow you to alter the query and the idx.
      *
      * @param string $actionName
-     * @param array  $idx
      * @param bool   $allElements
      */
     public function preBatchAction($actionName, ProxyQueryInterface $query, array &$idx, $allElements);
 
     /**
      * Return array of filter parameters.
-     *
-     * @return array
      */
-    public function getFilterParameters();
+    public function getFilterParameters(): array;
 
     /**
      * Return true if the Admin is related to a subject.
-     *
-     * @return bool
      */
-    public function hasSubject();
+    public function hasSubject(): bool;
 
     /**
      * NEXT_MAJOR: remove this method.
@@ -451,10 +362,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * @param string $context
-     *
-     * @return bool
      */
-    public function showIn($context);
+    public function showIn($context): bool;
 
     /**
      * Add object security, fe. make the current user owner of the object.
@@ -463,19 +372,14 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function createObjectSecurity($object);
 
-    /**
-     * @return AdminInterface|null
-     */
-    public function getParent();
+    public function getParent(): ?self;
 
     public function setParent(self $admin);
 
     /**
      * Returns true if the Admin class has an Parent Admin defined.
-     *
-     * @return bool
      */
-    public function isChild();
+    public function isChild(): bool;
 
     /**
      * Returns template.
@@ -483,10 +387,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @deprecated since 3.35. To be removed in 4.0. Use TemplateRegistry services instead
      *
      * @param string $name
-     *
-     * @return string|null
      */
-    public function getTemplate($name);
+    public function getTemplate($name): ?string;
 
     /**
      * Set the translation domain.
@@ -500,14 +402,12 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      *
      * @return string the translation domain
      */
-    public function getTranslationDomain();
+    public function getTranslationDomain(): string;
 
     /**
      * Return the form groups.
-     *
-     * @return array
      */
-    public function getFormGroups();
+    public function getFormGroups(): array;
 
     /**
      * Set the form groups.
@@ -531,10 +431,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * Returns the show groups.
-     *
-     * @return array
      */
-    public function getShowGroups();
+    public function getShowGroups(): array;
 
     /**
      * Set the show groups.
@@ -564,17 +462,13 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * Returns true if this admin uses ACL.
-     *
-     * @return bool
      */
-    public function isAclEnabled();
+    public function isAclEnabled(): bool;
 
     /**
      * Returns list of supported sub classes.
-     *
-     * @return array
      */
-    public function getSubClasses();
+    public function getSubClasses(): array;
 
     /**
      * Adds a new class to a list of supported sub classes.
@@ -592,52 +486,44 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * Returns true if the admin has the sub classes.
      *
      * @param string $name The name of the sub class
-     *
-     * @return bool
      */
-    public function hasSubClass($name);
+    public function hasSubClass($name): bool;
 
     /**
      * Returns true if a subclass is currently active.
-     *
-     * @return bool
      */
-    public function hasActiveSubClass();
+    public function hasActiveSubClass(): bool;
 
     /**
      * Returns the currently active sub class.
      *
      * @return string the active sub class
      */
-    public function getActiveSubClass();
+    public function getActiveSubClass(): string;
 
     /**
      * Returns the currently active sub class code.
      *
      * @return string the code for active sub class
      */
-    public function getActiveSubclassCode();
+    public function getActiveSubclassCode(): string;
 
     /**
      * Returns the list of batchs actions.
      *
      * @return array the list of batchs actions
      */
-    public function getBatchActions();
+    public function getBatchActions(): array;
 
     /**
      * Returns Admin`s label.
-     *
-     * @return string
      */
-    public function getLabel();
+    public function getLabel(): string;
 
     /**
      * Returns an array of persistent parameters.
-     *
-     * @return array
      */
-    public function getPersistentParameters();
+    public function getPersistentParameters(): array;
 
     /**
      * @param string $name
@@ -655,10 +541,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * Returns the current child status.
-     *
-     * @return bool
      */
-    public function getCurrentChild();
+    public function getCurrentChild(): bool;
 
     /**
      * Get translation label using the current TranslationStrategy.
@@ -666,20 +550,12 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @param string $label
      * @param string $context
      * @param string $type
-     *
-     * @return string
      */
-    public function getTranslationLabel($label, $context = '', $type = '');
+    public function getTranslationLabel($label, $context = '', $type = ''): string;
 
-    /**
-     * @return MetadataInterface
-     */
-    public function getObjectMetadata($object);
+    public function getObjectMetadata($object): MetadataInterface;
 
-    /**
-     * @return array
-     */
-    public function getListModes();
+    public function getListModes(): array;
 
     /**
      * @param string $mode
@@ -688,46 +564,36 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * return the list mode.
-     *
-     * @return string
      */
-    public function getListMode();
+    public function getListMode(): string;
 
     /*
      * Configure buttons for an action
      *
      * @param string $action
      * @param mixed  $object
-     *
-     * @return array
      */
-    public function getActionButtons($action, $object = null);
+    public function getActionButtons($action, $object = null): array;
 
     /**
      * Get the list of actions that can be accessed directly from the dashboard.
-     *
-     * @return array
      */
-    public function getDashboardActions();
+    public function getDashboardActions(): array;
 
     /**
      * Check the current request is given route or not.
      *
      * @param string $name
      * @param string $adminCode
-     *
-     * @return bool
      */
-    public function isCurrentRoute($name, $adminCode = null);
+    public function isCurrentRoute($name, $adminCode = null): bool;
 
     /**
      * Returns the result link for an object.
      *
      * @param mixed $object
-     *
-     * @return string|null
      */
-    public function getSearchResultLink($object);
+    public function getSearchResultLink($object): ?string;
 
     /**
      * Setting to true will enable mosaic button for the admin screen.
@@ -741,10 +607,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * Checks if a filter type is set to a default value.
      *
      * @param string $name
-     *
-     * @return bool
      */
-    public function isDefaultFilter($name);
+    public function isDefaultFilter($name): bool;
 }
 
 class_exists(\Sonata\Form\Validator\ErrorElement::class);

--- a/src/Admin/AdminTreeInterface.php
+++ b/src/Admin/AdminTreeInterface.php
@@ -20,24 +20,18 @@ interface AdminTreeInterface
 {
     /**
      * Returns the root ancestor or itself if not a child.
-     *
-     * @return AdminInterface
      */
-    public function getRootAncestor();
+    public function getRootAncestor(): AdminInterface;
 
     /**
      * Returns the depth of the admin.
      * e.g. 0 if not a child; 2 if child of a child; etc...
-     *
-     * @return int
      */
-    public function getChildDepth();
+    public function getChildDepth(): int;
 
     /**
      * Returns the current leaf child admin instance,
      * or null if there's no current child.
-     *
-     * @return AdminInterface|null
      */
-    public function getCurrentLeafChildAdmin();
+    public function getCurrentLeafChildAdmin(): ?AdminInterface;
 }

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -136,7 +136,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         $this->fieldName = $fieldName;
     }
 
-    public function getFieldName()
+    public function getFieldName(): string
     {
         return $this->fieldName;
     }
@@ -150,7 +150,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         }
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -197,7 +197,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         $this->options = $options;
     }
 
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }
@@ -207,7 +207,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         $this->template = $template;
     }
 
-    public function getTemplate()
+    public function getTemplate(): string
     {
         return $this->template;
     }
@@ -227,22 +227,22 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         $this->parent = $parent;
     }
 
-    public function getParent()
+    public function getParent(): AdminInterface
     {
         return $this->parent;
     }
 
-    public function getAssociationMapping()
+    public function getAssociationMapping(): array
     {
         return $this->associationMapping;
     }
 
-    public function getFieldMapping()
+    public function getFieldMapping(): array
     {
         return $this->fieldMapping;
     }
 
-    public function getParentAssociationMappings()
+    public function getParentAssociationMappings(): array
     {
         return $this->parentAssociationMappings;
     }
@@ -253,7 +253,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         $this->associationAdmin->setParentFieldDescription($this);
     }
 
-    public function getAssociationAdmin()
+    public function getAssociationAdmin(): ?AdminInterface
     {
         return $this->associationAdmin;
     }
@@ -321,7 +321,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         $this->admin = $admin;
     }
 
-    public function getAdmin()
+    public function getAdmin(): AdminInterface
     {
         return $this->admin;
     }
@@ -369,7 +369,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         return $this->help;
     }
 
-    public function getLabel()
+    public function getLabel(): string
     {
         return $this->getOption('label');
     }
@@ -379,17 +379,17 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         return false !== $this->getOption('sortable', false);
     }
 
-    public function getSortFieldMapping()
+    public function getSortFieldMapping(): array
     {
         return $this->getOption('sort_field_mapping');
     }
 
-    public function getSortParentAssociationMapping()
+    public function getSortParentAssociationMapping(): array
     {
         return $this->getOption('sort_parent_association_mappings');
     }
 
-    public function getTranslationDomain()
+    public function getTranslationDomain(): string
     {
         return $this->getOption('translation_domain') ?: $this->getAdmin()->getTranslationDomain();
     }

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -136,7 +136,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         $this->fieldName = $fieldName;
     }
 
-    public function getFieldName(): string
+    public function getFieldName(): ?string
     {
         return $this->fieldName;
     }
@@ -150,7 +150,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         }
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }

--- a/src/Admin/BreadcrumbsBuilder.php
+++ b/src/Admin/BreadcrumbsBuilder.php
@@ -70,9 +70,7 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
      *
      * Note: the method will be called by the top admin instance (parent => child)
      *
-     * @param AdminInterface     $admin
-     * @param string             $action
-     * @param ItemInterface|null $menu
+     * @param string $action
      */
     public function buildBreadcrumbs(
         AdminInterface $admin,

--- a/src/Admin/FieldDescriptionCollection.php
+++ b/src/Admin/FieldDescriptionCollection.php
@@ -28,20 +28,15 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
         $this->elements[$fieldDescription->getName()] = $fieldDescription;
     }
 
-    /**
-     * @return array
-     */
-    public function getElements()
+    public function getElements(): array
     {
         return $this->elements;
     }
 
     /**
      * @param string $name
-     *
-     * @return bool
      */
-    public function has($name)
+    public function has($name): bool
     {
         return \array_key_exists($name, $this->elements);
     }
@@ -50,10 +45,8 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
      * @param string $name
      *
      * @throws \InvalidArgumentException
-     *
-     * @return FieldDescriptionInterface
      */
-    public function get($name)
+    public function get($name): FieldDescriptionInterface
     {
         if ($this->has($name)) {
             return $this->elements[$name];

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -28,9 +28,9 @@ interface FieldDescriptionInterface
     /**
      * return the field name.
      *
-     * @return string the field name
+     * @return string|null the field name
      */
-    public function getFieldName(): string;
+    public function getFieldName(): ?string;
 
     /**
      * Set the name.
@@ -42,9 +42,9 @@ interface FieldDescriptionInterface
     /**
      * Return the name, the name can be used as a form label or table header.
      *
-     * @return string the name
+     * @return string|null the name
      */
-    public function getName(): string;
+    public function getName(): ?string;
 
     /**
      * Return the value represented by the provided name.

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -30,7 +30,7 @@ interface FieldDescriptionInterface
      *
      * @return string the field name
      */
-    public function getFieldName();
+    public function getFieldName(): string;
 
     /**
      * Set the name.
@@ -44,7 +44,7 @@ interface FieldDescriptionInterface
      *
      * @return string the name
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Return the value represented by the provided name.
@@ -78,7 +78,7 @@ interface FieldDescriptionInterface
      *
      * @return array options
      */
-    public function getOptions();
+    public function getOptions(): array;
 
     /**
      * return the template used to render the field.
@@ -92,7 +92,7 @@ interface FieldDescriptionInterface
      *
      * @return string the template name
      */
-    public function getTemplate();
+    public function getTemplate(): string;
 
     /**
      * return the field type, the type is a mandatory field as it used to select the correct template
@@ -116,10 +116,8 @@ interface FieldDescriptionInterface
 
     /**
      * return the parent Admin (only used in nested admin).
-     *
-     * @return AdminInterface
      */
-    public function getParent();
+    public function getParent(): AdminInterface;
 
     /**
      * Define the association mapping definition.
@@ -130,17 +128,13 @@ interface FieldDescriptionInterface
 
     /**
      * return the association mapping definition.
-     *
-     * @return array
      */
-    public function getAssociationMapping();
+    public function getAssociationMapping(): array;
 
     /**
      * return the related Target Entity.
-     *
-     * @return string|null
      */
-    public function getTargetEntity();
+    public function getTargetEntity(): ?string;
 
     /**
      * set the field mapping information.
@@ -154,7 +148,7 @@ interface FieldDescriptionInterface
      *
      * @return array the field mapping definition
      */
-    public function getFieldMapping();
+    public function getFieldMapping(): array;
 
     /**
      * set the parent association mappings information.
@@ -166,7 +160,7 @@ interface FieldDescriptionInterface
      *
      * @return array the parent association mapping definitions
      */
-    public function getParentAssociationMappings();
+    public function getParentAssociationMappings(): array;
 
     /**
      * set the association admin instance (only used if the field is linked to an Admin).
@@ -177,17 +171,13 @@ interface FieldDescriptionInterface
 
     /**
      * return the associated Admin instance (only used if the field is linked to an Admin).
-     *
-     * @return AdminInterface|null
      */
-    public function getAssociationAdmin();
+    public function getAssociationAdmin(): ?AdminInterface;
 
     /**
      * return true if the FieldDescription is linked to an identifier field.
-     *
-     * @return bool
      */
-    public function isIdentifier();
+    public function isIdentifier(): bool;
 
     /**
      * return the value linked to the description.
@@ -206,7 +196,7 @@ interface FieldDescriptionInterface
     /**
      * @return AdminInterface the admin class linked to this FieldDescription
      */
-    public function getAdmin();
+    public function getAdmin(): AdminInterface;
 
     /**
      * merge option values related to the provided option name.
@@ -239,38 +229,32 @@ interface FieldDescriptionInterface
 
     /**
      * return the label to use for the current field.
-     *
-     * @return string
      */
-    public function getLabel();
+    public function getLabel(): string;
 
     /**
      * Return the translation domain to use for the current field.
-     *
-     * @return string
      */
-    public function getTranslationDomain();
+    public function getTranslationDomain(): string;
 
     /**
      * Return true if field is sortable.
-     *
-     * @return bool
      */
-    public function isSortable();
+    public function isSortable(): bool;
 
     /**
      * return the field mapping definition used when sorting.
      *
      * @return array the field mapping definition
      */
-    public function getSortFieldMapping();
+    public function getSortFieldMapping(): array;
 
     /**
      * return the parent association mapping definitions used when sorting.
      *
      * @return array the parent association mapping definitions
      */
-    public function getSortParentAssociationMapping();
+    public function getSortParentAssociationMapping(): array;
 
     /**
      * @param object|null $object

--- a/src/Admin/FieldDescriptionRegistryInterface.php
+++ b/src/Admin/FieldDescriptionRegistryInterface.php
@@ -24,26 +24,22 @@ interface FieldDescriptionRegistryInterface
      * Return FormFieldDescription.
      *
      * @param string $name
-     *
-     * @return FieldDescriptionInterface
      */
-    public function getFormFieldDescription($name);
+    public function getFormFieldDescription($name): FieldDescriptionInterface;
 
     /**
      * Build and return the collection of form FieldDescription.
      *
      * @return FieldDescriptionInterface[] collection of form FieldDescription
      */
-    public function getFormFieldDescriptions();
+    public function getFormFieldDescriptions(): array;
 
     /**
      * Returns true if the admin has a FieldDescription with the given $name.
      *
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasShowFieldDescription($name);
+    public function hasShowFieldDescription($name): bool;
 
     /**
      * Adds a FieldDescription.
@@ -75,19 +71,15 @@ interface FieldDescriptionRegistryInterface
 
     /**
      * Returns a list depend on the given $object.
-     *
-     * @return FieldDescriptionCollection
      */
-    public function getList();
+    public function getList(): FieldDescriptionCollection;
 
     /**
      * Returns true if the filter FieldDescription exists.
      *
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasFilterFieldDescription($name);
+    public function hasFilterFieldDescription($name): bool;
 
     /**
      * Adds a filter FieldDescription.
@@ -108,14 +100,12 @@ interface FieldDescriptionRegistryInterface
      *
      * @return FieldDescriptionInterface[]
      */
-    public function getFilterFieldDescriptions();
+    public function getFilterFieldDescriptions(): array;
 
     /**
      * Returns a filter FieldDescription.
      *
      * @param string $name
-     *
-     * @return FieldDescriptionInterface|null
      */
-    public function getFilterFieldDescription($name);
+    public function getFilterFieldDescription($name): ?FieldDescriptionInterface;
 }

--- a/src/Admin/LifecycleHookProviderInterface.php
+++ b/src/Admin/LifecycleHookProviderInterface.php
@@ -25,19 +25,15 @@ interface LifecycleHookProviderInterface
      * This method should call preUpdate, do the update, and call postUpdate.
      *
      * @param object $object
-     *
-     * @return object
      */
-    public function update($object);
+    public function update($object): object;
 
     /**
      * This method should call prePersist, do the creation, and call postPersist.
      *
      * @param object $object
-     *
-     * @return object
      */
-    public function create($object);
+    public function create($object): object;
 
     /**
      * This method should call preRemove, do the removal, and call postRemove.

--- a/src/Admin/ParentAdminInterface.php
+++ b/src/Admin/ParentAdminInterface.php
@@ -34,21 +34,19 @@ interface ParentAdminInterface
      *
      * @return bool True if child exist, false otherwise
      */
-    public function hasChild($code);
+    public function hasChild($code): bool;
 
     /**
      * Returns an collection of admin children.
      *
      * @return array list of Admin children
      */
-    public function getChildren();
+    public function getChildren(): array;
 
     /**
      * Returns an admin child with the given $code.
      *
      * @param string $code
-     *
-     * @return AdminInterface|null
      */
-    public function getChild($code);
+    public function getChild($code): ?AdminInterface;
 }

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -100,10 +100,7 @@ class Pool
         $this->propertyAccessor = $propertyAccessor;
     }
 
-    /**
-     * @return array
-     */
-    public function getGroups()
+    public function getGroups(): array
     {
         $groups = $this->adminGroups;
 
@@ -120,18 +117,13 @@ class Pool
      * Returns whether an admin group exists or not.
      *
      * @param string $group
-     *
-     * @return bool
      */
-    public function hasGroup($group)
+    public function hasGroup($group): bool
     {
         return isset($this->adminGroups[$group]);
     }
 
-    /**
-     * @return array
-     */
-    public function getDashboardGroups()
+    public function getDashboardGroups(): array
     {
         $groups = $this->adminGroups;
 
@@ -170,7 +162,7 @@ class Pool
      *
      * @return AdminInterface[]
      */
-    public function getAdminsByGroup($group)
+    public function getAdminsByGroup($group): array
     {
         if (!isset($this->adminGroups[$group])) {
             throw new \InvalidArgumentException(sprintf('Group "%s" not found in admin pool.', $group));
@@ -193,10 +185,8 @@ class Pool
      * Return the admin related to the given $class.
      *
      * @param string $class
-     *
-     * @return \Sonata\AdminBundle\Admin\AdminInterface|null
      */
-    public function getAdminByClass($class)
+    public function getAdminByClass($class): ?\Sonata\AdminBundle\Admin\AdminInterface
     {
         if (!$this->hasAdminByClass($class)) {
             return null;
@@ -219,10 +209,8 @@ class Pool
 
     /**
      * @param string $class
-     *
-     * @return bool
      */
-    public function hasAdminByClass($class)
+    public function hasAdminByClass($class): bool
     {
         return isset($this->adminClasses[$class]);
     }
@@ -289,10 +277,8 @@ class Pool
      * @param string $id
      *
      * @throws \InvalidArgumentException
-     *
-     * @return AdminInterface
      */
-    public function getInstance($id)
+    public function getInstance($id): AdminInterface
     {
         if (!\in_array($id, $this->adminServiceIds, true)) {
             $msg = sprintf('Admin service "%s" not found in admin pool.', $id);
@@ -331,10 +317,7 @@ class Pool
         return $admin;
     }
 
-    /**
-     * @return ContainerInterface|null
-     */
-    public function getContainer()
+    public function getContainer(): ?ContainerInterface
     {
         return $this->container;
     }
@@ -344,10 +327,7 @@ class Pool
         $this->adminGroups = $adminGroups;
     }
 
-    /**
-     * @return array
-     */
-    public function getAdminGroups()
+    public function getAdminGroups(): array
     {
         return $this->adminGroups;
     }
@@ -357,10 +337,7 @@ class Pool
         $this->adminServiceIds = $adminServiceIds;
     }
 
-    /**
-     * @return array
-     */
-    public function getAdminServiceIds()
+    public function getAdminServiceIds(): array
     {
         return $this->adminServiceIds;
     }
@@ -370,10 +347,7 @@ class Pool
         $this->adminClasses = $adminClasses;
     }
 
-    /**
-     * @return array
-     */
-    public function getAdminClasses()
+    public function getAdminClasses(): array
     {
         return $this->adminClasses;
     }
@@ -396,10 +370,8 @@ class Pool
 
     /**
      * @deprecated since 3.34, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
-     *
-     * @return array
      */
-    public function getTemplates()
+    public function getTemplates(): array
     {
         return $this->templateRegistry->getTemplates();
     }
@@ -408,26 +380,18 @@ class Pool
      * @deprecated since 3.34, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
      *
      * @param string $name
-     *
-     * @return string|null
      */
-    public function getTemplate($name)
+    public function getTemplate($name): ?string
     {
         return $this->templateRegistry->getTemplate($name);
     }
 
-    /**
-     * @return string
-     */
-    public function getTitleLogo()
+    public function getTitleLogo(): string
     {
         return $this->titleLogo;
     }
 
-    /**
-     * @return string
-     */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }

--- a/src/Admin/UrlGeneratorInterface.php
+++ b/src/Admin/UrlGeneratorInterface.php
@@ -29,14 +29,12 @@ interface UrlGeneratorInterface
      *
      * @return RouteCollection the list of available urls
      */
-    public function getRoutes();
+    public function getRoutes(): RouteCollection;
 
     /**
      * Return the parameter name used to represent the id in the url.
-     *
-     * @return string
      */
-    public function getRouterIdParameter();
+    public function getRouterIdParameter(): string;
 
     public function setRouteGenerator(RouteGeneratorInterface $routeGenerator);
 
@@ -54,7 +52,7 @@ interface UrlGeneratorInterface
         $object,
         array $parameters = [],
         $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH
-    );
+    ): string;
 
     /**
      * Generates a url for the given parameters.
@@ -64,7 +62,7 @@ interface UrlGeneratorInterface
      *
      * @return string return a complete url
      */
-    public function generateUrl($name, array $parameters = [], $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH);
+    public function generateUrl($name, array $parameters = [], $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH): string;
 
     /**
      * Generates a url for the given parameters.
@@ -74,12 +72,12 @@ interface UrlGeneratorInterface
      *
      * @return array return url parts: 'route', 'routeParameters', 'routeAbsolute'
      */
-    public function generateMenuUrl($name, array $parameters = [], $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH);
+    public function generateMenuUrl($name, array $parameters = [], $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH): array;
 
     /**
      * @param mixed $entity
      *
      * @return string a string representation of the id that is safe to use in a url
      */
-    public function getUrlsafeIdentifier($entity);
+    public function getUrlsafeIdentifier($entity): string;
 }

--- a/src/Builder/DatagridBuilderInterface.php
+++ b/src/Builder/DatagridBuilderInterface.php
@@ -34,11 +34,5 @@ interface DatagridBuilderInterface extends BuilderInterface
         AdminInterface $admin
     );
 
-    /**
-     * @param AdminInterface $admin
-     * @param array          $values
-     *
-     * @return DatagridInterface
-     */
-    public function getBaseDatagrid(AdminInterface $admin, array $values = []);
+    public function getBaseDatagrid(AdminInterface $admin, array $values = []): DatagridInterface;
 }

--- a/src/Builder/FormContractorInterface.php
+++ b/src/Builder/FormContractorInterface.php
@@ -33,10 +33,8 @@ interface FormContractorInterface extends BuilderInterface
      * @abstract
      *
      * @param string $name
-     *
-     * @return FormBuilder
      */
-    public function getFormBuilder($name, array $options = []);
+    public function getFormBuilder($name, array $options = []): FormBuilder;
 
     /**
      * Should provide Symfony form options.
@@ -44,8 +42,6 @@ interface FormContractorInterface extends BuilderInterface
      * @abstract
      *
      * @param string $type
-     *
-     * @return array
      */
-    public function getDefaultOptions($type, FieldDescriptionInterface $fieldDescription);
+    public function getDefaultOptions($type, FieldDescriptionInterface $fieldDescription): array;
 }

--- a/src/Builder/ListBuilderInterface.php
+++ b/src/Builder/ListBuilderInterface.php
@@ -22,10 +22,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
  */
 interface ListBuilderInterface extends BuilderInterface
 {
-    /**
-     * @return FieldDescriptionCollection
-     */
-    public function getBaseList(array $options = []);
+    public function getBaseList(array $options = []): FieldDescriptionCollection;
 
     /**
      * Modify a field description to display it in the list view.

--- a/src/Command/GenerateAdminCommand.php
+++ b/src/Command/GenerateAdminCommand.php
@@ -83,10 +83,8 @@ class GenerateAdminCommand extends QuestionableCommand
      * @param string $managerType
      *
      * @throws \InvalidArgumentException
-     *
-     * @return string
      */
-    public function validateManagerType($managerType)
+    public function validateManagerType($managerType): string
     {
         $managerTypes = $this->getAvailableManagerTypes();
 

--- a/src/Command/GenerateObjectAclCommand.php
+++ b/src/Command/GenerateObjectAclCommand.php
@@ -143,10 +143,7 @@ class GenerateObjectAclCommand extends QuestionableCommand
         }
     }
 
-    /**
-     * @return string
-     */
-    protected function getUserEntityClass(InputInterface $input, OutputInterface $output)
+    protected function getUserEntityClass(InputInterface $input, OutputInterface $output): string
     {
         if ('' === $this->userEntityClass) {
             if ($input->getOption('user_entity')) {

--- a/src/Command/QuestionableCommand.php
+++ b/src/Command/QuestionableCommand.php
@@ -49,8 +49,6 @@ abstract class QuestionableCommand extends Command
      * @param string $questionText
      * @param string $default
      * @param string $separator
-     *
-     * @return string
      */
     final protected function askConfirmation(
         InputInterface $input,
@@ -58,7 +56,7 @@ abstract class QuestionableCommand extends Command
         $questionText,
         $default,
         $separator
-    ) {
+    ): string {
         $questionHelper = $this->getQuestionHelper();
 
         $question = new ConfirmationQuestion($questionHelper->getQuestion(
@@ -70,10 +68,7 @@ abstract class QuestionableCommand extends Command
         return $questionHelper->ask($input, $output, $question);
     }
 
-    /**
-     * @return QuestionHelper
-     */
-    final protected function getQuestionHelper()
+    final protected function getQuestionHelper(): QuestionHelper
     {
         $questionHelper = $this->getHelper('question');
 

--- a/src/Command/Validators.php
+++ b/src/Command/Validators.php
@@ -42,10 +42,8 @@ class Validators
      * @param string $shortcut
      *
      * @throws \InvalidArgumentException
-     *
-     * @return array
      */
-    public static function validateEntityName($shortcut)
+    public static function validateEntityName($shortcut): array
     {
         $entity = str_replace('/', '\\', $shortcut);
 
@@ -66,10 +64,8 @@ class Validators
      * @param string $class
      *
      * @throws \InvalidArgumentException
-     *
-     * @return string
      */
-    public static function validateClass($class)
+    public static function validateClass($class): string
     {
         $class = str_replace('/', '\\', $class);
 
@@ -86,10 +82,8 @@ class Validators
      * @param string $adminClassBasename
      *
      * @throws \InvalidArgumentException
-     *
-     * @return string
      */
-    public static function validateAdminClassBasename($adminClassBasename)
+    public static function validateAdminClassBasename($adminClassBasename): string
     {
         $adminClassBasename = str_replace('/', '\\', $adminClassBasename);
 
@@ -110,10 +104,8 @@ class Validators
      * @param string $controllerClassBasename
      *
      * @throws \InvalidArgumentException
-     *
-     * @return string
      */
-    public static function validateControllerClassBasename($controllerClassBasename)
+    public static function validateControllerClassBasename($controllerClassBasename): string
     {
         $controllerClassBasename = str_replace('/', '\\', $controllerClassBasename);
 
@@ -136,10 +128,8 @@ class Validators
      * @static
      *
      * @param string $servicesFile
-     *
-     * @return string
      */
-    public static function validateServicesFile($servicesFile)
+    public static function validateServicesFile($servicesFile): string
     {
         return trim($servicesFile, '/');
     }
@@ -150,10 +140,8 @@ class Validators
      * @param string $serviceId
      *
      * @throws \InvalidArgumentException
-     *
-     * @return string
      */
-    public static function validateServiceId($serviceId)
+    public static function validateServiceId($serviceId): string
     {
         if (preg_match('/[^A-Za-z\._0-9]/', $serviceId, $matches)) {
             throw new \InvalidArgumentException(sprintf(

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -108,7 +108,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @deprecated since version 3.27, to be removed in 4.0. Use Sonata\AdminBundle\Controller\CRUDController::renderWithExtraParams() instead.
      */
-    public function render($view, array $parameters = [], Response $response = null)
+    public function render($view, array $parameters = [], Response $response = null): Response
     {
         @trigger_error(
             'Method '.__CLASS__.'::render has been renamed to '.__CLASS__.'::renderWithExtraParams.',
@@ -125,7 +125,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response A Response instance
      */
-    public function renderWithExtraParams($view, array $parameters = [], Response $response = null)
+    public function renderWithExtraParams($view, array $parameters = [], Response $response = null): Response
     {
         if (!$this->isXmlHttpRequest()) {
             $parameters['breadcrumbs_builder'] = $this->get('sonata.admin.breadcrumbs_builder');
@@ -146,10 +146,8 @@ class CRUDController implements ContainerAwareInterface
      * List action.
      *
      * @throws AccessDeniedException If access is not granted
-     *
-     * @return Response
      */
-    public function listAction()
+    public function listAction(): Response
     {
         $request = $this->getRequest();
 
@@ -189,10 +187,8 @@ class CRUDController implements ContainerAwareInterface
      * Execute a batch delete.
      *
      * @throws AccessDeniedException If access is not granted
-     *
-     * @return RedirectResponse
      */
-    public function batchActionDelete(ProxyQueryInterface $query)
+    public function batchActionDelete(ProxyQueryInterface $query): RedirectResponse
     {
         $this->admin->checkAccess('batchDelete');
 
@@ -552,10 +548,8 @@ class CRUDController implements ContainerAwareInterface
      *
      * @throws AccessDeniedException If access is not granted
      * @throws \RuntimeException     If no editable field is defined
-     *
-     * @return Response
      */
-    public function createAction()
+    public function createAction(): Response
     {
         $request = $this->getRequest();
         // the key used to lookup the template
@@ -677,10 +671,8 @@ class CRUDController implements ContainerAwareInterface
      *
      * @throws NotFoundHttpException If the object does not exist
      * @throws AccessDeniedException If access is not granted
-     *
-     * @return Response
      */
-    public function showAction($id = null)
+    public function showAction($id = null): Response
     {
         $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
@@ -733,10 +725,8 @@ class CRUDController implements ContainerAwareInterface
      *
      * @throws AccessDeniedException If access is not granted
      * @throws NotFoundHttpException If the object does not exist or the audit reader is not available
-     *
-     * @return Response
      */
-    public function historyAction($id = null)
+    public function historyAction($id = null): Response
     {
         $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
@@ -784,10 +774,8 @@ class CRUDController implements ContainerAwareInterface
      *
      * @throws AccessDeniedException If access is not granted
      * @throws NotFoundHttpException If the object or revision does not exist or the audit reader is not available
-     *
-     * @return Response
      */
-    public function historyViewRevisionAction($id = null, $revision = null)
+    public function historyViewRevisionAction($id = null, $revision = null): Response
     {
         $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
@@ -849,10 +837,8 @@ class CRUDController implements ContainerAwareInterface
      *
      * @throws AccessDeniedException If access is not granted
      * @throws NotFoundHttpException If the object or revision does not exist or the audit reader is not available
-     *
-     * @return Response
      */
-    public function historyCompareRevisionsAction($id = null, $base_revision = null, $compare_revision = null)
+    public function historyCompareRevisionsAction($id = null, $base_revision = null, $compare_revision = null): Response
     {
         $request = $this->getRequest();
 
@@ -924,10 +910,8 @@ class CRUDController implements ContainerAwareInterface
      *
      * @throws AccessDeniedException If access is not granted
      * @throws \RuntimeException     If the export format is invalid
-     *
-     * @return Response
      */
-    public function exportAction(Request $request)
+    public function exportAction(Request $request): Response
     {
         $this->admin->checkAccess('export');
 
@@ -1058,10 +1042,7 @@ class CRUDController implements ContainerAwareInterface
         ], null);
     }
 
-    /**
-     * @return Request
-     */
-    public function getRequest()
+    public function getRequest(): Request
     {
         return $this->container->get('request_stack')->getCurrentRequest();
     }
@@ -1087,7 +1068,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response with json encoded data
      */
-    protected function renderJson($data, $status = 200, $headers = [])
+    protected function renderJson($data, $status = 200, $headers = []): Response
     {
         return new JsonResponse($data, $status, $headers);
     }
@@ -1097,7 +1078,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return bool True if the request is an XMLHttpRequest, false otherwise
      */
-    protected function isXmlHttpRequest()
+    protected function isXmlHttpRequest(): bool
     {
         $request = $this->getRequest();
 
@@ -1110,7 +1091,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return string HTTP method, either
      */
-    protected function getRestMethod()
+    protected function getRestMethod(): string
     {
         $request = $this->getRequest();
 
@@ -1174,10 +1155,8 @@ class CRUDController implements ContainerAwareInterface
     /**
      * Proxy for the logger service of the container.
      * If no such service is found, a NullLogger is returned.
-     *
-     * @return LoggerInterface
      */
-    protected function getLogger()
+    protected function getLogger(): LoggerInterface
     {
         if ($this->container->has('logger')) {
             $logger = $this->container->get('logger');
@@ -1194,7 +1173,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return string The template name
      */
-    protected function getBaseTemplate()
+    protected function getBaseTemplate(): string
     {
         if ($this->isXmlHttpRequest()) {
             // NEXT_MAJOR: Remove this line and use commented line below it instead
@@ -1227,10 +1206,8 @@ class CRUDController implements ContainerAwareInterface
      * Redirect the user depend on this choice.
      *
      * @param object $object
-     *
-     * @return RedirectResponse
      */
-    protected function redirectTo($object)
+    protected function redirectTo($object): RedirectResponse
     {
         $request = $this->getRequest();
 
@@ -1278,10 +1255,8 @@ class CRUDController implements ContainerAwareInterface
 
     /**
      * Redirects the user to the list view.
-     *
-     * @return RedirectResponse
      */
-    final protected function redirectToList()
+    final protected function redirectToList(): RedirectResponse
     {
         $parameters = [];
 
@@ -1294,10 +1269,8 @@ class CRUDController implements ContainerAwareInterface
 
     /**
      * Returns true if the preview is requested to be shown.
-     *
-     * @return bool
      */
-    protected function isPreviewRequested()
+    protected function isPreviewRequested(): bool
     {
         $request = $this->getRequest();
 
@@ -1306,10 +1279,8 @@ class CRUDController implements ContainerAwareInterface
 
     /**
      * Returns true if the preview has been approved.
-     *
-     * @return bool
      */
-    protected function isPreviewApproved()
+    protected function isPreviewApproved(): bool
     {
         $request = $this->getRequest();
 
@@ -1321,10 +1292,8 @@ class CRUDController implements ContainerAwareInterface
      *
      * That means either a preview is requested or the preview has already been shown
      * and it got approved/declined.
-     *
-     * @return bool
      */
-    protected function isInPreviewMode()
+    protected function isInPreviewMode(): bool
     {
         return $this->admin->supportsPreviewMode()
         && ($this->isPreviewRequested()
@@ -1334,10 +1303,8 @@ class CRUDController implements ContainerAwareInterface
 
     /**
      * Returns true if the preview has been declined.
-     *
-     * @return bool
      */
-    protected function isPreviewDeclined()
+    protected function isPreviewDeclined(): bool
     {
         $request = $this->getRequest();
 
@@ -1346,10 +1313,8 @@ class CRUDController implements ContainerAwareInterface
 
     /**
      * Gets ACL users.
-     *
-     * @return \Traversable
      */
-    protected function getAclUsers()
+    protected function getAclUsers(): \Traversable
     {
         $aclUsers = [];
 
@@ -1367,10 +1332,8 @@ class CRUDController implements ContainerAwareInterface
 
     /**
      * Gets ACL roles.
-     *
-     * @return \Traversable
      */
-    protected function getAclRoles()
+    protected function getAclRoles(): \Traversable
     {
         $aclRoles = [];
         $roleHierarchy = $this->container->getParameter('security.role_hierarchy.roles');
@@ -1427,10 +1390,8 @@ class CRUDController implements ContainerAwareInterface
      * Escape string for html output.
      *
      * @param string $s
-     *
-     * @return string
      */
-    protected function escapeHtml($s)
+    protected function escapeHtml($s): string
     {
         return htmlspecialchars((string) $s, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
@@ -1456,10 +1417,8 @@ class CRUDController implements ContainerAwareInterface
      * It's called from createAction.
      *
      * @param mixed $object
-     *
-     * @return Response|null
      */
-    protected function preCreate(Request $request, $object)
+    protected function preCreate(Request $request, $object): ?Response
     {
     }
 
@@ -1468,10 +1427,8 @@ class CRUDController implements ContainerAwareInterface
      * It's called from editAction.
      *
      * @param mixed $object
-     *
-     * @return Response|null
      */
-    protected function preEdit(Request $request, $object)
+    protected function preEdit(Request $request, $object): ?Response
     {
     }
 
@@ -1480,10 +1437,8 @@ class CRUDController implements ContainerAwareInterface
      * It's called from deleteAction.
      *
      * @param mixed $object
-     *
-     * @return Response|null
      */
-    protected function preDelete(Request $request, $object)
+    protected function preDelete(Request $request, $object): ?Response
     {
     }
 
@@ -1492,20 +1447,16 @@ class CRUDController implements ContainerAwareInterface
      * It's called from showAction.
      *
      * @param mixed $object
-     *
-     * @return Response|null
      */
-    protected function preShow(Request $request, $object)
+    protected function preShow(Request $request, $object): ?Response
     {
     }
 
     /**
      * This method can be overloaded in your custom CRUD controller.
      * It's called from listAction.
-     *
-     * @return Response|null
      */
-    protected function preList(Request $request)
+    protected function preList(Request $request): ?Response
     {
     }
 
@@ -1518,7 +1469,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return string translated string
      */
-    final protected function trans($id, array $parameters = [], $domain = null, $locale = null)
+    final protected function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
         $domain = $domain ?: $this->admin->getTranslationDomain();
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1420,6 +1420,7 @@ class CRUDController implements ContainerAwareInterface
      */
     protected function preCreate(Request $request, $object): ?Response
     {
+        return null;
     }
 
     /**
@@ -1430,6 +1431,7 @@ class CRUDController implements ContainerAwareInterface
      */
     protected function preEdit(Request $request, $object): ?Response
     {
+        return null;
     }
 
     /**
@@ -1440,6 +1442,7 @@ class CRUDController implements ContainerAwareInterface
      */
     protected function preDelete(Request $request, $object): ?Response
     {
+        return null;
     }
 
     /**
@@ -1450,6 +1453,7 @@ class CRUDController implements ContainerAwareInterface
      */
     protected function preShow(Request $request, $object): ?Response
     {
+        return null;
     }
 
     /**
@@ -1458,6 +1462,7 @@ class CRUDController implements ContainerAwareInterface
      */
     protected function preList(Request $request): ?Response
     {
+        return null;
     }
 
     /**

--- a/src/Controller/CoreController.php
+++ b/src/Controller/CoreController.php
@@ -36,10 +36,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class CoreController extends Controller
 {
-    /**
-     * @return Response
-     */
-    public function dashboardAction()
+    public function dashboardAction(): Response
     {
         $dashboardAction = $this->container->get(DashboardAction::class);
 
@@ -70,10 +67,8 @@ class CoreController extends Controller
      *
      * @deprecated since 3.0, to be removed in 4.0 and action methods will be adjusted.
      *             Use Symfony\Component\HttpFoundation\Request as an action argument
-     *
-     * @return Request
      */
-    public function getRequest()
+    public function getRequest(): Request
     {
         @trigger_error(
             'The '.__METHOD__.' method is deprecated since 3.0 and will be removed in 4.0.'.
@@ -84,10 +79,7 @@ class CoreController extends Controller
         return $this->getCurrentRequest();
     }
 
-    /**
-     * @return Pool
-     */
-    protected function getAdminPool()
+    protected function getAdminPool(): Pool
     {
         $pool = $this->container->get('sonata.admin.pool');
         \assert($pool instanceof Pool);
@@ -95,10 +87,7 @@ class CoreController extends Controller
         return $pool;
     }
 
-    /**
-     * @return SearchHandler
-     */
-    protected function getSearchHandler()
+    protected function getSearchHandler(): SearchHandler
     {
         $searchHandler = $this->get('sonata.admin.search.handler');
         \assert($searchHandler instanceof SearchHandler);
@@ -106,10 +95,7 @@ class CoreController extends Controller
         return $searchHandler;
     }
 
-    /**
-     * @return string
-     */
-    protected function getBaseTemplate()
+    protected function getBaseTemplate(): string
     {
         if ($this->getCurrentRequest()->isXmlHttpRequest()) {
             return $this->getTemplateRegistry()->getTemplate('ajax');

--- a/src/Controller/HelperController.php
+++ b/src/Controller/HelperController.php
@@ -84,10 +84,8 @@ class HelperController
 
     /**
      * @throws NotFoundHttpException
-     *
-     * @return Response
      */
-    public function appendFormFieldElementAction(Request $request)
+    public function appendFormFieldElementAction(Request $request): Response
     {
         $action = new AppendFormFieldElementAction($this->twig, $this->pool, $this->helper);
 
@@ -96,10 +94,8 @@ class HelperController
 
     /**
      * @throws NotFoundHttpException
-     *
-     * @return Response
      */
-    public function retrieveFormFieldElementAction(Request $request)
+    public function retrieveFormFieldElementAction(Request $request): Response
     {
         $action = new RetrieveFormFieldElementAction($this->twig, $this->pool, $this->helper);
 
@@ -108,20 +104,15 @@ class HelperController
 
     /**
      * @throws NotFoundHttpException|\RuntimeException
-     *
-     * @return Response
      */
-    public function getShortObjectDescriptionAction(Request $request)
+    public function getShortObjectDescriptionAction(Request $request): Response
     {
         $action = new GetShortObjectDescriptionAction($this->twig, $this->pool);
 
         return $action($request);
     }
 
-    /**
-     * @return Response
-     */
-    public function setObjectFieldValueAction(Request $request)
+    public function setObjectFieldValueAction(Request $request): Response
     {
         $action = new SetObjectFieldValueAction($this->twig, $this->pool, $this->validator);
 
@@ -133,10 +124,8 @@ class HelperController
      *
      * @throws \RuntimeException
      * @throws AccessDeniedException
-     *
-     * @return JsonResponse
      */
-    public function retrieveAutocompleteItemsAction(Request $request)
+    public function retrieveAutocompleteItemsAction(Request $request): JsonResponse
     {
         $action = new RetrieveAutocompleteItemsAction($this->pool);
 

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -72,7 +72,7 @@ class Datagrid implements DatagridInterface
     /**
      * @var array
      */
-    protected $results;
+    protected $results = [];
 
     public function __construct(
         ProxyQueryInterface $query,
@@ -97,7 +97,7 @@ class Datagrid implements DatagridInterface
     {
         $this->buildPager();
 
-        if (null === $this->results) {
+        if (!$this->results) {
             $this->results = $this->pager->getResults();
         }
 
@@ -200,7 +200,11 @@ class Datagrid implements DatagridInterface
 
     public function getFilter($name): FilterInterface
     {
-        return $this->hasFilter($name) ? $this->filters[$name] : null;
+        if (!$this->hasFilter($name)) {
+            throw new \InvalidArgumentException(sprintf('Filter "%s" doesn\'t exist.', $name));
+        }
+
+        return $this->filters[$name];
     }
 
     public function getFilters(): array

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -88,12 +88,12 @@ class Datagrid implements DatagridInterface
         $this->formBuilder = $formBuilder;
     }
 
-    public function getPager()
+    public function getPager(): PagerInterface
     {
         return $this->pager;
     }
 
-    public function getResults()
+    public function getResults(): array
     {
         $this->buildPager();
 
@@ -188,7 +188,7 @@ class Datagrid implements DatagridInterface
         $this->filters[$filter->getName()] = $filter;
     }
 
-    public function hasFilter($name)
+    public function hasFilter($name): bool
     {
         return isset($this->filters[$name]);
     }
@@ -198,12 +198,12 @@ class Datagrid implements DatagridInterface
         unset($this->filters[$name]);
     }
 
-    public function getFilter($name)
+    public function getFilter($name): FilterInterface
     {
         return $this->hasFilter($name) ? $this->filters[$name] : null;
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return $this->filters;
     }
@@ -213,7 +213,7 @@ class Datagrid implements DatagridInterface
         $this->filters = array_merge(array_flip($keys), $this->filters);
     }
 
-    public function getValues()
+    public function getValues(): array
     {
         return $this->values;
     }
@@ -226,7 +226,7 @@ class Datagrid implements DatagridInterface
         ];
     }
 
-    public function hasActiveFilters()
+    public function hasActiveFilters(): bool
     {
         foreach ($this->filters as $name => $filter) {
             if ($filter->isActive()) {
@@ -237,7 +237,7 @@ class Datagrid implements DatagridInterface
         return false;
     }
 
-    public function hasDisplayableFilters()
+    public function hasDisplayableFilters(): bool
     {
         foreach ($this->filters as $name => $filter) {
             $showFilter = $filter->getOption('show_filter', null);
@@ -249,17 +249,17 @@ class Datagrid implements DatagridInterface
         return false;
     }
 
-    public function getColumns()
+    public function getColumns(): FieldDescriptionCollection
     {
         return $this->columns;
     }
 
-    public function getQuery()
+    public function getQuery(): ProxyQueryInterface
     {
         return $this->query;
     }
 
-    public function getForm()
+    public function getForm(): FormInterface
     {
         $this->buildPager();
 

--- a/src/Datagrid/DatagridInterface.php
+++ b/src/Datagrid/DatagridInterface.php
@@ -22,47 +22,26 @@ use Symfony\Component\Form\FormInterface;
  */
 interface DatagridInterface
 {
-    /**
-     * @return PagerInterface
-     */
-    public function getPager();
+    public function getPager(): PagerInterface;
 
-    /**
-     * @return ProxyQueryInterface
-     */
-    public function getQuery();
+    public function getQuery(): ProxyQueryInterface;
 
-    /**
-     * @return array
-     */
-    public function getResults();
+    public function getResults(): array;
 
     public function buildPager();
 
-    /**
-     * @return FilterInterface
-     */
-    public function addFilter(FilterInterface $filter);
+    public function addFilter(FilterInterface $filter): FilterInterface;
 
-    /**
-     * @return array
-     */
-    public function getFilters();
+    public function getFilters(): array;
 
     /**
      * Reorder filters.
      */
     public function reorderFilters(array $keys);
 
-    /**
-     * @return array
-     */
-    public function getValues();
+    public function getValues(): array;
 
-    /**
-     * @return FieldDescriptionCollection
-     */
-    public function getColumns();
+    public function getColumns(): FieldDescriptionCollection;
 
     /**
      * @param string      $name
@@ -71,37 +50,24 @@ interface DatagridInterface
      */
     public function setValue($name, $operator, $value);
 
-    /**
-     * @return FormInterface
-     */
-    public function getForm();
+    public function getForm(): FormInterface;
 
     /**
      * @param string $name
-     *
-     * @return FilterInterface
      */
-    public function getFilter($name);
+    public function getFilter($name): FilterInterface;
 
     /**
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasFilter($name);
+    public function hasFilter($name): bool;
 
     /**
      * @param string $name
      */
     public function removeFilter($name);
 
-    /**
-     * @return bool
-     */
-    public function hasActiveFilters();
+    public function hasActiveFilters(): bool;
 
-    /**
-     * @return bool
-     */
-    public function hasDisplayableFilters();
+    public function hasDisplayableFilters(): bool;
 }

--- a/src/Datagrid/DatagridInterface.php
+++ b/src/Datagrid/DatagridInterface.php
@@ -30,7 +30,7 @@ interface DatagridInterface
 
     public function buildPager();
 
-    public function addFilter(FilterInterface $filter): FilterInterface;
+    public function addFilter(FilterInterface $filter): void;
 
     public function getFilters(): array;
 

--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -46,8 +46,6 @@ class DatagridMapper extends BaseMapper
      * @param array  $fieldOptions
      *
      * @throws \RuntimeException
-     *
-     * @return DatagridMapper
      */
     public function add(
         $name,
@@ -56,7 +54,7 @@ class DatagridMapper extends BaseMapper
         $fieldType = null,
         $fieldOptions = null,
         array $fieldDescriptionOptions = []
-    ) {
+    ): self {
         if (\is_array($fieldOptions)) {
             $filterOptions['field_options'] = $fieldOptions;
         }

--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -100,7 +100,7 @@ class DatagridMapper extends BaseMapper
         return $this->datagrid->getFilter($name);
     }
 
-    public function has($key)
+    public function has($key): bool
     {
         return $this->datagrid->hasFilter($key);
     }

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -131,7 +131,7 @@ class ListMapper extends BaseMapper
         return $this->list->get($name);
     }
 
-    public function has($key)
+    public function has($key): bool
     {
         return $this->list->has($key);
     }

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -98,20 +98,16 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
 
     /**
      * Returns the current pager's max link.
-     *
-     * @return int
      */
-    public function getCurrentMaxLink()
+    public function getCurrentMaxLink(): int
     {
         return $this->currentMaxLink;
     }
 
     /**
      * Returns the current pager's max record limit.
-     *
-     * @return int
      */
-    public function getMaxRecordLimit()
+    public function getMaxRecordLimit(): int
     {
         return $this->maxRecordLimit;
     }
@@ -130,10 +126,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      * Returns an array of page numbers to use in pagination links.
      *
      * @param int $nbLinks The maximum number of page numbers to return
-     *
-     * @return array
      */
-    public function getLinks($nbLinks = null)
+    public function getLinks($nbLinks = null): array
     {
         if (null === $nbLinks) {
             $nbLinks = $this->getMaxPageLinks();
@@ -156,20 +150,16 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
 
     /**
      * Returns true if the current query requires pagination.
-     *
-     * @return bool
      */
-    public function haveToPaginate()
+    public function haveToPaginate(): bool
     {
         return $this->getMaxPerPage() && $this->getNbResults() > $this->getMaxPerPage();
     }
 
     /**
      * Returns the current cursor.
-     *
-     * @return int
      */
-    public function getCursor()
+    public function getCursor(): int
     {
         return $this->cursor;
     }
@@ -246,10 +236,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
 
     /**
      * Returns the first index on the current page.
-     *
-     * @return int
      */
-    public function getFirstIndex()
+    public function getFirstIndex(): int
     {
         if (0 === $this->page) {
             return 1;
@@ -276,10 +264,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
 
     /**
      * Returns the last index on the current page.
-     *
-     * @return int
      */
-    public function getLastIndex()
+    public function getLastIndex(): int
     {
         if (0 === $this->page) {
             return $this->nbResults;
@@ -307,50 +293,32 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         return $this->getLastIndex();
     }
 
-    /**
-     * @return int
-     */
-    public function getNbResults()
+    public function getNbResults(): int
     {
         return $this->nbResults;
     }
 
-    /**
-     * @return int
-     */
-    public function getFirstPage()
+    public function getFirstPage(): int
     {
         return 1;
     }
 
-    /**
-     * @return int
-     */
-    public function getLastPage()
+    public function getLastPage(): int
     {
         return $this->lastPage;
     }
 
-    /**
-     * @return int
-     */
-    public function getPage()
+    public function getPage(): int
     {
         return $this->page;
     }
 
-    /**
-     * @return int
-     */
-    public function getNextPage()
+    public function getNextPage(): int
     {
         return min($this->getPage() + 1, $this->getLastPage());
     }
 
-    /**
-     * @return int
-     */
-    public function getPreviousPage()
+    public function getPreviousPage(): int
     {
         return max($this->getPage() - 1, $this->getFirstPage());
     }
@@ -402,30 +370,24 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
 
     /**
      * Returns true if on the first page.
-     *
-     * @return bool
      */
-    public function isFirstPage()
+    public function isFirstPage(): bool
     {
         return 1 === $this->page;
     }
 
     /**
      * Returns true if on the last page.
-     *
-     * @return bool
      */
-    public function isLastPage()
+    public function isLastPage(): bool
     {
         return $this->page === $this->lastPage;
     }
 
     /**
      * Returns the current pager's parameter holder.
-     *
-     * @return array
      */
-    public function getParameters()
+    public function getParameters(): array
     {
         return $this->parameters;
     }
@@ -447,10 +409,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      * Checks whether a parameter has been set.
      *
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasParameter($name)
+    public function hasParameter($name): bool
     {
         return isset($this->parameters[$name]);
     }
@@ -537,18 +497,12 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         }
     }
 
-    /**
-     * @return array
-     */
-    public function getCountColumn()
+    public function getCountColumn(): array
     {
         return $this->countColumn;
     }
 
-    /**
-     * @return array
-     */
-    public function setCountColumn(array $countColumn)
+    public function setCountColumn(array $countColumn): array
     {
         return $this->countColumn = $countColumn;
     }
@@ -558,10 +512,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         $this->query = $query;
     }
 
-    /**
-     * @return ProxyQueryInterface
-     */
-    public function getQuery()
+    public function getQuery(): ProxyQueryInterface
     {
         return $this->query;
     }
@@ -588,10 +539,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
 
     /**
      * Returns true if the properties used for iteration have been initialized.
-     *
-     * @return bool
      */
-    protected function isIteratorInitialized()
+    protected function isIteratorInitialized(): bool
     {
         return null !== $this->results;
     }
@@ -618,10 +567,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      * Retrieve the object for a certain offset.
      *
      * @param int $offset
-     *
-     * @return object
      */
-    protected function retrieveObject($offset)
+    protected function retrieveObject($offset): object
     {
         $queryForRetrieve = clone $this->getQuery();
         $queryForRetrieve

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -333,7 +333,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         }
     }
 
-    public function getMaxPerPage()
+    public function getMaxPerPage(): int
     {
         return $this->maxPerPage;
     }
@@ -358,7 +358,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         }
     }
 
-    public function getMaxPageLinks()
+    public function getMaxPageLinks(): int
     {
         return $this->maxPageLinks;
     }

--- a/src/Datagrid/PagerInterface.php
+++ b/src/Datagrid/PagerInterface.php
@@ -25,10 +25,8 @@ interface PagerInterface
 
     /**
      * Returns the maximum number of results per page.
-     *
-     * @return int
      */
-    public function getMaxPerPage();
+    public function getMaxPerPage(): int;
 
     /**
      * Sets the maximum number of results per page.
@@ -53,10 +51,8 @@ interface PagerInterface
 
     /**
      * Returns an array of results on the given page.
-     *
-     * @return array
      */
-    public function getResults();
+    public function getResults(): array;
 
     /**
      * Sets the maximum number of page numbers.
@@ -67,8 +63,6 @@ interface PagerInterface
 
     /**
      * Returns the maximum number of page numbers.
-     *
-     * @return int
      */
-    public function getMaxPageLinks();
+    public function getMaxPageLinks(): int;
 }

--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -38,10 +38,8 @@ interface ProxyQueryInterface
     /**
      * @param array $parentAssociationMappings
      * @param array $fieldMapping
-     *
-     * @return ProxyQueryInterface
      */
-    public function setSortBy($parentAssociationMappings, $fieldMapping);
+    public function setSortBy($parentAssociationMappings, $fieldMapping): self;
 
     /**
      * @return mixed
@@ -50,10 +48,8 @@ interface ProxyQueryInterface
 
     /**
      * @param mixed $sortOrder
-     *
-     * @return ProxyQueryInterface
      */
-    public function setSortOrder($sortOrder);
+    public function setSortOrder($sortOrder): self;
 
     /**
      * @return mixed
@@ -67,10 +63,8 @@ interface ProxyQueryInterface
 
     /**
      * @param int|null $firstResult
-     *
-     * @return ProxyQueryInterface
      */
-    public function setFirstResult($firstResult);
+    public function setFirstResult($firstResult): self;
 
     /**
      * @return mixed
@@ -79,10 +73,8 @@ interface ProxyQueryInterface
 
     /**
      * @param int|null $maxResults
-     *
-     * @return ProxyQueryInterface
      */
-    public function setMaxResults($maxResults);
+    public function setMaxResults($maxResults): self;
 
     /**
      * @return mixed
@@ -95,8 +87,6 @@ interface ProxyQueryInterface
     public function getUniqueParameterId();
 
     /**
-     * @param array $associationMappings
-     *
      * @return mixed
      */
     public function entityJoin(array $associationMappings);

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -134,10 +134,7 @@ class SimplePager extends Pager
         $this->threshold = (int) $threshold;
     }
 
-    /**
-     * @return int
-     */
-    public function getThreshold()
+    public function getThreshold(): int
     {
         return $this->threshold;
     }

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -56,7 +56,7 @@ class SimplePager extends Pager
         $this->setThreshold($threshold);
     }
 
-    public function getNbResults()
+    public function getNbResults(): int
     {
         $n = ($this->getLastPage() - 1) * $this->getMaxPerPage();
         if ($this->getLastPage() === $this->getPage()) {
@@ -66,7 +66,7 @@ class SimplePager extends Pager
         return $n;
     }
 
-    public function getResults($hydrationMode = null)
+    public function getResults($hydrationMode = null): array
     {
         if ($this->results) {
             return $this->results;
@@ -88,7 +88,7 @@ class SimplePager extends Pager
         return $this->results;
     }
 
-    public function haveToPaginate()
+    public function haveToPaginate(): bool
     {
         return $this->haveToPaginate || $this->getPage() > 1;
     }

--- a/src/DependencyInjection/AbstractSonataAdminExtension.php
+++ b/src/DependencyInjection/AbstractSonataAdminExtension.php
@@ -21,14 +21,11 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 abstract class AbstractSonataAdminExtension extends Extension
 {
-    /**
-     * @return array
-     */
     protected function fixTemplatesConfiguration(
         array $configs,
         ContainerBuilder $container,
         array $defaultSonataDoctrineConfig = []
-    ) {
+    ): array {
         $defaultConfig = [
             'templates' => [
                 'types' => [

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -250,10 +250,8 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
      * Apply the default values required by the AdminInterface to the Admin service definition.
      *
      * @param string $serviceId
-     *
-     * @return Definition
      */
-    public function applyDefaults(ContainerBuilder $container, $serviceId, array $attributes = [])
+    public function applyDefaults(ContainerBuilder $container, $serviceId, array $attributes = []): Definition
     {
         $definition = $container->getDefinition($serviceId);
         $settings = $container->getParameter('sonata.admin.configuration.admin_services');

--- a/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -88,10 +88,8 @@ final class ExtensionCompilerPass implements CompilerPassInterface
 
     /**
      * @param string $id
-     *
-     * @return array
      */
-    private function getExtensionsForAdmin($id, Definition $admin, ContainerBuilder $container, array $extensionMap)
+    private function getExtensionsForAdmin($id, Definition $admin, ContainerBuilder $container, array $extensionMap): array
     {
         $extensions = [];
         $classReflection = $subjectReflection = null;
@@ -149,10 +147,8 @@ final class ExtensionCompilerPass implements CompilerPassInterface
 
     /**
      * Resolves the class argument of the admin to an actual class (in case of %parameter%).
-     *
-     * @return string
      */
-    private function getManagedClass(Definition $admin, ContainerBuilder $container)
+    private function getManagedClass(Definition $admin, ContainerBuilder $container): string
     {
         return $container->getParameterBag()->resolveValue($admin->getArgument(1));
     }
@@ -169,7 +165,7 @@ final class ExtensionCompilerPass implements CompilerPassInterface
      *     'uses'       => ['<trait>'     => ['<extension_id>' => ['priority' => <int>]]],
      * ]
      */
-    private function flattenExtensionConfiguration(array $config)
+    private function flattenExtensionConfiguration(array $config): array
     {
         $extensionMap = [
             'excludes' => [],
@@ -196,10 +192,7 @@ final class ExtensionCompilerPass implements CompilerPassInterface
         return $extensionMap;
     }
 
-    /**
-     * @return bool
-     */
-    private function hasTrait(\ReflectionClass $class, $traitName)
+    private function hasTrait(\ReflectionClass $class, $traitName): bool
     {
         if (\in_array($traitName, $class->getTraitNames(), true)) {
             return true;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,10 +26,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 final class Configuration implements ConfigurationInterface
 {
-    /**
-     * @return TreeBuilder
-     */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sonata_admin');
 

--- a/src/Event/ConfigureEvent.php
+++ b/src/Event/ConfigureEvent.php
@@ -70,18 +70,12 @@ class ConfigureEvent extends Event
         return $this->type;
     }
 
-    /**
-     * @return AdminInterface
-     */
-    public function getAdmin()
+    public function getAdmin(): AdminInterface
     {
         return $this->admin;
     }
 
-    /**
-     * @return BaseMapper
-     */
-    public function getMapper()
+    public function getMapper(): BaseMapper
     {
         return $this->mapper;
     }

--- a/src/Event/ConfigureMenuEvent.php
+++ b/src/Event/ConfigureMenuEvent.php
@@ -42,18 +42,12 @@ class ConfigureMenuEvent extends Event
         $this->menu = $menu;
     }
 
-    /**
-     * @return FactoryInterface
-     */
-    public function getFactory()
+    public function getFactory(): FactoryInterface
     {
         return $this->factory;
     }
 
-    /**
-     * @return ItemInterface
-     */
-    public function getMenu()
+    public function getMenu(): ItemInterface
     {
         return $this->menu;
     }

--- a/src/Event/ConfigureQueryEvent.php
+++ b/src/Event/ConfigureQueryEvent.php
@@ -54,26 +54,17 @@ class ConfigureQueryEvent extends Event
         $this->context = $context;
     }
 
-    /**
-     * @return AdminInterface
-     */
-    public function getAdmin()
+    public function getAdmin(): AdminInterface
     {
         return $this->admin;
     }
 
-    /**
-     * @return string
-     */
-    public function getContext()
+    public function getContext(): string
     {
         return $this->context;
     }
 
-    /**
-     * @return ProxyQueryInterface
-     */
-    public function getProxyQuery()
+    public function getProxyQuery(): ProxyQueryInterface
     {
         return $this->proxyQuery;
     }

--- a/src/Event/PersistenceEvent.php
+++ b/src/Event/PersistenceEvent.php
@@ -63,18 +63,12 @@ class PersistenceEvent extends Event
         $this->type = $type;
     }
 
-    /**
-     * @return AdminInterface
-     */
-    public function getAdmin()
+    public function getAdmin(): AdminInterface
     {
         return $this->admin;
     }
 
-    /**
-     * @return object
-     */
-    public function getObject()
+    public function getObject(): object
     {
         return $this->object;
     }

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -46,12 +46,12 @@ abstract class Filter implements FilterInterface
         $this->setOptions($options);
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function getFormName()
+    public function getFormName(): string
     {
         /*
            Symfony default form class sadly can't handle
@@ -77,12 +77,12 @@ abstract class Filter implements FilterInterface
         $this->options[$name] = $value;
     }
 
-    public function getFieldType()
+    public function getFieldType(): string
     {
         return $this->getOption('field_type', TextType::class);
     }
 
-    public function getFieldOptions()
+    public function getFieldOptions(): array
     {
         return $this->getOption('field_options', ['required' => false]);
     }
@@ -111,7 +111,7 @@ abstract class Filter implements FilterInterface
         $this->setOption('label', $label);
     }
 
-    public function getFieldName()
+    public function getFieldName(): string
     {
         $fieldName = $this->getOption('field_name');
 
@@ -122,12 +122,12 @@ abstract class Filter implements FilterInterface
         return $fieldName;
     }
 
-    public function getParentAssociationMappings()
+    public function getParentAssociationMappings(): array
     {
         return $this->getOption('parent_association_mappings', []);
     }
 
-    public function getFieldMapping()
+    public function getFieldMapping(): array
     {
         $fieldMapping = $this->getOption('field_mapping');
 
@@ -138,7 +138,7 @@ abstract class Filter implements FilterInterface
         return $fieldMapping;
     }
 
-    public function getAssociationMapping()
+    public function getAssociationMapping(): array
     {
         $associationMapping = $this->getOption('association_mapping');
 
@@ -189,7 +189,7 @@ abstract class Filter implements FilterInterface
         return $this->value;
     }
 
-    public function isActive()
+    public function isActive(): bool
     {
         $values = $this->getValue();
 
@@ -203,12 +203,12 @@ abstract class Filter implements FilterInterface
         $this->condition = $condition;
     }
 
-    public function getCondition()
+    public function getCondition(): string
     {
         return $this->condition;
     }
 
-    public function getTranslationDomain()
+    public function getTranslationDomain(): string
     {
         return $this->getOption('translation_domain');
     }

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -163,10 +163,8 @@ abstract class Filter implements FilterInterface
 
     /**
      * Get options.
-     *
-     * @return array
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -41,17 +41,13 @@ interface FilterInterface
 
     /**
      * Returns the filter name.
-     *
-     * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Returns the filter form name.
-     *
-     * @return string
      */
-    public function getFormName();
+    public function getFormName(): string;
 
     /**
      * Returns the label name.
@@ -65,10 +61,7 @@ interface FilterInterface
      */
     public function setLabel($label);
 
-    /**
-     * @return array
-     */
-    public function getDefaultOptions();
+    public function getDefaultOptions(): array;
 
     /**
      * @param string     $name
@@ -89,30 +82,24 @@ interface FilterInterface
      */
     public function initialize($name, array $options = []);
 
-    /**
-     * @return string
-     */
-    public function getFieldName();
+    public function getFieldName(): string;
 
     /**
      * @return array of mappings
      */
-    public function getParentAssociationMappings();
+    public function getParentAssociationMappings(): array;
 
     /**
      * @return array field mapping
      */
-    public function getFieldMapping();
+    public function getFieldMapping(): array;
 
     /**
      * @return array association mapping
      */
-    public function getAssociationMapping();
+    public function getAssociationMapping(): array;
 
-    /**
-     * @return array
-     */
-    public function getFieldOptions();
+    public function getFieldOptions(): array;
 
     /**
      * Get field option.
@@ -132,24 +119,17 @@ interface FilterInterface
      */
     public function setFieldOption($name, $value);
 
-    /**
-     * @return string
-     */
-    public function getFieldType();
+    public function getFieldType(): string;
 
     /**
      * Returns the main widget used to render the filter.
-     *
-     * @return array
      */
-    public function getRenderSettings();
+    public function getRenderSettings(): array;
 
     /**
      * Returns true if filter is active.
-     *
-     * @return bool
      */
-    public function isActive();
+    public function isActive(): bool;
 
     /**
      * Set the condition to use with the left side of the query : OR or AND.
@@ -158,13 +138,7 @@ interface FilterInterface
      */
     public function setCondition($condition);
 
-    /**
-     * @return string
-     */
-    public function getCondition();
+    public function getCondition(): string;
 
-    /**
-     * @return string
-     */
-    public function getTranslationDomain();
+    public function getTranslationDomain(): string;
 }

--- a/src/Filter/Persister/FilterPersisterInterface.php
+++ b/src/Filter/Persister/FilterPersisterInterface.php
@@ -28,7 +28,7 @@ interface FilterPersisterInterface
      *
      * @return array The persisted filters
      */
-    public function get($adminCode);
+    public function get($adminCode): array;
 
     /**
      * Set persisted filters for given admin.

--- a/src/Filter/Persister/SessionFilterPersister.php
+++ b/src/Filter/Persister/SessionFilterPersister.php
@@ -36,7 +36,7 @@ final class SessionFilterPersister implements FilterPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function get($adminCode)
+    public function get($adminCode): array
     {
         return $this->session->get($this->buildStorageKey($adminCode), []);
     }

--- a/src/Filter/Persister/SessionFilterPersister.php
+++ b/src/Filter/Persister/SessionFilterPersister.php
@@ -28,9 +28,6 @@ final class SessionFilterPersister implements FilterPersisterInterface
      */
     private $session;
 
-    /**
-     * @param SessionInterface $session
-     */
     public function __construct(SessionInterface $session)
     {
         $this->session = $session;

--- a/src/Form/ChoiceList/ModelChoiceList.php
+++ b/src/Form/ChoiceList/ModelChoiceList.php
@@ -129,10 +129,7 @@ class ModelChoiceList extends SimpleChoiceList
         parent::__construct($this->load($choices));
     }
 
-    /**
-     * @return array
-     */
-    public function getIdentifier()
+    public function getIdentifier(): array
     {
         return $this->identifier;
     }
@@ -146,7 +143,7 @@ class ModelChoiceList extends SimpleChoiceList
      *
      * @return array An array of entities
      */
-    public function getEntities()
+    public function getEntities(): array
     {
         return $this->entities;
     }
@@ -167,7 +164,7 @@ class ModelChoiceList extends SimpleChoiceList
      *
      * @return object The matching entity
      */
-    public function getEntity($key)
+    public function getEntity($key): object
     {
         if (\count($this->identifier) > 1) {
             // $key is a collection index
@@ -192,10 +189,8 @@ class ModelChoiceList extends SimpleChoiceList
      *
      * @throws InvalidArgumentException If the entity does not exist in Doctrine's
      *                                  identity map
-     *
-     * @return array
      */
-    public function getIdentifierValues($entity)
+    public function getIdentifierValues($entity): array
     {
         try {
             return $this->modelManager->getIdentifierValues($entity);
@@ -204,18 +199,12 @@ class ModelChoiceList extends SimpleChoiceList
         }
     }
 
-    /**
-     * @return ModelManagerInterface
-     */
-    public function getModelManager()
+    public function getModelManager(): ModelManagerInterface
     {
         return $this->modelManager;
     }
 
-    /**
-     * @return string
-     */
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }
@@ -239,7 +228,7 @@ class ModelChoiceList extends SimpleChoiceList
      *
      * @return array An array of choices
      */
-    protected function load($choices)
+    protected function load($choices): array
     {
         if (\is_array($choices) && \count($choices) > 0) {
             $entities = $choices;

--- a/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -211,10 +211,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
         return $value;
     }
 
-    /**
-     * @return string
-     */
-    protected function getClass(FormBuilderInterface $formBuilder)
+    protected function getClass(FormBuilderInterface $formBuilder): string
     {
         foreach ($this->getTypes($formBuilder) as $type) {
             // NEXT_MAJOR: Remove the else part when dropping support for SF 2.8
@@ -232,10 +229,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
         return '';
     }
 
-    /**
-     * @return array
-     */
-    protected function getTypes(FormBuilderInterface $formBuilder)
+    protected function getTypes(FormBuilderInterface $formBuilder): array
     {
         $types = [];
 

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -219,10 +219,7 @@ class FormMapper extends BaseGroupedMapper
         return $this;
     }
 
-    /**
-     * @return FormBuilderInterface
-     */
-    public function getFormBuilder()
+    public function getFormBuilder(): FormBuilderInterface
     {
         return $this->formBuilder;
     }
@@ -230,18 +227,13 @@ class FormMapper extends BaseGroupedMapper
     /**
      * @param string $name
      * @param mixed  $type
-     *
-     * @return FormBuilderInterface
      */
-    public function create($name, $type = null, array $options = [])
+    public function create($name, $type = null, array $options = []): FormBuilderInterface
     {
         return $this->formBuilder->create($name, $type, $options);
     }
 
-    /**
-     * @return FormMapper
-     */
-    public function setHelps(array $helps = [])
+    public function setHelps(array $helps = []): self
     {
         foreach ($helps as $name => $help) {
             $this->addHelp($name, $help);
@@ -250,10 +242,7 @@ class FormMapper extends BaseGroupedMapper
         return $this;
     }
 
-    /**
-     * @return FormMapper
-     */
-    public function addHelp($name, $help)
+    public function addHelp($name, $help): self
     {
         if ($this->admin->hasFormFieldDescription($name)) {
             $this->admin->getFormFieldDescription($name)->setHelp($help);
@@ -269,10 +258,8 @@ class FormMapper extends BaseGroupedMapper
      * So use this trick to avoid any issue.
      *
      * @param string $fieldName
-     *
-     * @return string
      */
-    protected function sanitizeFieldName($fieldName)
+    protected function sanitizeFieldName($fieldName): string
     {
         return str_replace(['__', '.'], ['____', '__'], $fieldName);
     }

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -156,7 +156,7 @@ class FormMapper extends BaseGroupedMapper
         return $this->formBuilder->get($name);
     }
 
-    public function has($key)
+    public function has($key): bool
     {
         $key = $this->sanitizeFieldName($key);
 
@@ -264,7 +264,7 @@ class FormMapper extends BaseGroupedMapper
         return str_replace(['__', '.'], ['____', '__'], $fieldName);
     }
 
-    protected function getGroups()
+    protected function getGroups(): array
     {
         return $this->admin->getFormGroups();
     }
@@ -274,7 +274,7 @@ class FormMapper extends BaseGroupedMapper
         $this->admin->setFormGroups($groups);
     }
 
-    protected function getTabs()
+    protected function getTabs(): array
     {
         return $this->admin->getFormTabs();
     }
@@ -284,7 +284,7 @@ class FormMapper extends BaseGroupedMapper
         $this->admin->setFormTabs($tabs);
     }
 
-    protected function getName()
+    protected function getName(): string
     {
         return 'form';
     }

--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -135,10 +135,8 @@ class AdminType extends AbstractType
 
     /**
      * @throws \RuntimeException
-     *
-     * @return FieldDescriptionInterface
      */
-    protected function getFieldDescription(array $options)
+    protected function getFieldDescription(array $options): FieldDescriptionInterface
     {
         if (!isset($options['sonata_field_description'])) {
             throw new \RuntimeException('Please provide a valid `sonata_field_description` option');
@@ -147,10 +145,7 @@ class AdminType extends AbstractType
         return $options['sonata_field_description'];
     }
 
-    /**
-     * @return AdminInterface
-     */
-    protected function getAdmin(array $options)
+    protected function getAdmin(array $options): AdminInterface
     {
         return $this->getFieldDescription($options)->getAssociationAdmin();
     }

--- a/src/Generator/AdminGenerator.php
+++ b/src/Generator/AdminGenerator.php
@@ -74,18 +74,12 @@ class AdminGenerator extends Generator
         ]);
     }
 
-    /**
-     * @return string|null
-     */
-    public function getClass()
+    public function getClass(): ?string
     {
         return $this->class;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getFile()
+    public function getFile(): ?string
     {
         return $this->file;
     }

--- a/src/Generator/ControllerGenerator.php
+++ b/src/Generator/ControllerGenerator.php
@@ -69,18 +69,12 @@ class ControllerGenerator extends Generator
         ]);
     }
 
-    /**
-     * @return string|null
-     */
-    public function getClass()
+    public function getClass(): ?string
     {
         return $this->class;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getFile()
+    public function getFile(): ?string
     {
         return $this->file;
     }

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -238,23 +238,15 @@ abstract class BaseGroupedMapper extends BaseMapper
 
     /**
      * Returns a boolean indicating if there is an open tab at the moment.
-     *
-     * @return bool
      */
-    public function hasOpenTab()
+    public function hasOpenTab(): bool
     {
         return null !== $this->currentTab;
     }
 
-    /**
-     * @return array
-     */
-    abstract protected function getGroups();
+    abstract protected function getGroups(): array;
 
-    /**
-     * @return array
-     */
-    abstract protected function getTabs();
+    abstract protected function getTabs(): array;
 
     abstract protected function setGroups(array $groups);
 
@@ -262,10 +254,8 @@ abstract class BaseGroupedMapper extends BaseMapper
 
     /**
      * NEXT_MAJOR: make this method abstract.
-     *
-     * @return string
      */
-    protected function getName()
+    protected function getName(): string
     {
         @trigger_error(__METHOD__.' should be implemented and will be abstract in 4.0.', E_USER_DEPRECATED);
 
@@ -295,10 +285,8 @@ abstract class BaseGroupedMapper extends BaseMapper
      *
      * Note that this can have the side effect to change the 'group' value
      * returned by the getGroup function
-     *
-     * @return string
      */
-    protected function getCurrentGroupName()
+    protected function getCurrentGroupName(): string
     {
         if (!$this->currentGroup) {
             $this->with($this->admin->getLabel(), ['auto_created' => true]);

--- a/src/Mapper/BaseMapper.php
+++ b/src/Mapper/BaseMapper.php
@@ -39,10 +39,7 @@ abstract class BaseMapper
         $this->admin = $admin;
     }
 
-    /**
-     * @return AdminInterface
-     */
-    public function getAdmin()
+    public function getAdmin(): AdminInterface
     {
         return $this->admin;
     }
@@ -56,10 +53,8 @@ abstract class BaseMapper
 
     /**
      * @param string $key
-     *
-     * @return bool
      */
-    abstract public function has($key);
+    abstract public function has($key): bool;
 
     /**
      * @param string $key

--- a/src/Menu/Matcher/Voter/ChildrenVoter.php
+++ b/src/Menu/Matcher/Voter/ChildrenVoter.php
@@ -38,8 +38,6 @@ class ChildrenVoter implements VoterInterface
 
     /**
      * ChildrenVoter constructor.
-     *
-     * @param MatcherInterface $matcher
      */
     public function __construct(MatcherInterface $matcher)
     {

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -62,10 +62,8 @@ class MenuBuilder
 
     /**
      * Builds sidebar menu.
-     *
-     * @return ItemInterface
      */
-    public function createSidebarMenu()
+    public function createSidebarMenu(): ItemInterface
     {
         $menu = $this->factory->createItem('root');
 

--- a/src/Menu/Provider/GroupMenuProvider.php
+++ b/src/Menu/Provider/GroupMenuProvider.php
@@ -76,10 +76,8 @@ class GroupMenuProvider implements MenuProviderInterface
      * @param string $name
      *
      * @throws \InvalidArgumentException if the menu does not exists
-     *
-     * @return \Knp\Menu\ItemInterface
      */
-    public function get($name, array $options = [])
+    public function get($name, array $options = []): \Knp\Menu\ItemInterface
     {
         $group = $options['group'];
 
@@ -115,10 +113,8 @@ class GroupMenuProvider implements MenuProviderInterface
      * Checks whether a menu exists in this provider.
      *
      * @param string $name
-     *
-     * @return bool
      */
-    public function has($name, array $options = [])
+    public function has($name, array $options = []): bool
     {
         return 'sonata_group_menu' === $name;
     }

--- a/src/Model/AuditManager.php
+++ b/src/Model/AuditManager.php
@@ -45,7 +45,7 @@ class AuditManager implements AuditManagerInterface
         $this->readers[$serviceId] = $classes;
     }
 
-    public function hasReader($class)
+    public function hasReader($class): bool
     {
         foreach ($this->readers as $classes) {
             if (\in_array($class, $classes, true)) {
@@ -56,7 +56,7 @@ class AuditManager implements AuditManagerInterface
         return false;
     }
 
-    public function getReader($class)
+    public function getReader($class): AuditReaderInterface
     {
         foreach ($this->readers as $readerId => $classes) {
             if (\in_array($class, $classes, true)) {

--- a/src/Model/AuditManagerInterface.php
+++ b/src/Model/AuditManagerInterface.php
@@ -29,10 +29,8 @@ interface AuditManagerInterface
      * Returns true if $class has AuditReaderInterface.
      *
      * @param string $class
-     *
-     * @return bool
      */
-    public function hasReader($class);
+    public function hasReader($class): bool;
 
     /**
      * Get AuditReaderInterface service for $class.
@@ -40,8 +38,6 @@ interface AuditManagerInterface
      * @param string $class
      *
      * @throws \RuntimeException
-     *
-     * @return AuditReaderInterface
      */
-    public function getReader($class);
+    public function getReader($class): AuditReaderInterface;
 }

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -28,10 +28,8 @@ interface ModelManagerInterface
     /**
      * @param string $class
      * @param string $name
-     *
-     * @return FieldDescriptionInterface
      */
-    public function getNewFieldDescriptionInstance($class, $name, array $options = []);
+    public function getNewFieldDescriptionInstance($class, $name, array $options = []): FieldDescriptionInterface;
 
     /**
      * @param mixed $object
@@ -59,14 +57,14 @@ interface ModelManagerInterface
      *
      * @return array all objects matching the criteria
      */
-    public function findBy($class, array $criteria = []);
+    public function findBy($class, array $criteria = []): array;
 
     /**
      * @param string $class
      *
      * @return object an object matching the criteria or null if none match
      */
-    public function findOneBy($class, array $criteria = []);
+    public function findOneBy($class, array $criteria = []): object;
 
     /**
      * @param string $class
@@ -74,7 +72,7 @@ interface ModelManagerInterface
      *
      * @return object|null the object with id or null if not found
      */
-    public function find($class, $id);
+    public function find($class, $id): ?object;
 
     /**
      * @param string $class
@@ -92,19 +90,15 @@ interface ModelManagerInterface
     /**
      * @param string $class
      * @param string $alias
-     *
-     * @return ProxyQueryInterface
      */
-    public function createQuery($class, $alias = 'o');
+    public function createQuery($class, $alias = 'o'): ProxyQueryInterface;
 
     /**
      * Get the identifier for the model type of this class.
      *
      * @param string $class fully qualified class name
-     *
-     * @return string
      */
-    public function getModelIdentifier($class);
+    public function getModelIdentifier($class): string;
 
     /**
      * Get the identifiers of this model class.
@@ -117,17 +111,15 @@ interface ModelManagerInterface
      *
      * @return array list of all identifiers of this model
      */
-    public function getIdentifierValues($model);
+    public function getIdentifierValues($model): array;
 
     /**
      * Get a list of the field names models of the specified class use to store
      * the identifier.
      *
      * @param string $class fully qualified class name
-     *
-     * @return array
      */
-    public function getIdentifierFieldNames($class);
+    public function getIdentifierFieldNames($class): array;
 
     /**
      * Get the identifiers for this model class as a string.
@@ -137,7 +129,7 @@ interface ModelManagerInterface
      * @return string a string representation of the identifiers for this
      *                instance
      */
-    public function getNormalizedIdentifier($model);
+    public function getNormalizedIdentifier($model): string;
 
     /**
      * Get the identifiers as a string that is safe to use in a url.
@@ -149,7 +141,7 @@ interface ModelManagerInterface
      *
      * @return string string representation of the id that is safe to use in a url
      */
-    public function getUrlsafeIdentifier($model);
+    public function getUrlsafeIdentifier($model): string;
 
     /**
      * Create a new instance of the model of the specified class.
@@ -190,10 +182,8 @@ interface ModelManagerInterface
      *
      * @param mixed $collection
      * @param mixed $element
-     *
-     * @return bool
      */
-    public function collectionHasElement(&$collection, &$element);
+    public function collectionHasElement(&$collection, &$element): bool;
 
     /**
      * Clear the collection.
@@ -206,17 +196,13 @@ interface ModelManagerInterface
 
     /**
      * Returns the parameters used in the columns header.
-     *
-     * @return array
      */
-    public function getSortParameters(FieldDescriptionInterface $fieldDescription, DatagridInterface $datagrid);
+    public function getSortParameters(FieldDescriptionInterface $fieldDescription, DatagridInterface $datagrid): array;
 
     /**
      * @param string $class
-     *
-     * @return array
      */
-    public function getDefaultSortValues($class);
+    public function getDefaultSortValues($class): array;
 
     /**
      * @param string $class
@@ -237,22 +223,18 @@ interface ModelManagerInterface
     /**
      * @param int|null $firstResult
      * @param int|null $maxResult
-     *
-     * @return SourceIteratorInterface
      */
     public function getDataSourceIterator(
         DatagridInterface $datagrid,
         array $fields,
         $firstResult = null,
         $maxResult = null
-    );
+    ): SourceIteratorInterface;
 
     /**
      * @param string $class
-     *
-     * @return array
      */
-    public function getExportFields($class);
+    public function getExportFields($class): array;
 
     /**
      * @param int $page
@@ -263,7 +245,6 @@ interface ModelManagerInterface
 
     /**
      * @param string $class
-     * @param array  $idx
      */
     public function addIdentifiersToQuery($class, ProxyQueryInterface $query, array $idx);
 }

--- a/src/Resources/skeleton/Admin.tpl.php
+++ b/src/Resources/skeleton/Admin.tpl.php
@@ -1,8 +1,8 @@
-<?= "<?php\n" ?>
+<?= "<?php\n"; ?>
 
 declare(strict_types=1);
 
-namespace <?= $namespace ?>;
+namespace <?= $namespace; ?>;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
@@ -10,19 +10,19 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 
-final class <?= $class_name ?> extends AbstractAdmin
+final class <?= $class_name; ?> extends AbstractAdmin
 {
 
     protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
     {
         $datagridMapper
-<?= $fields ?>;
+<?= $fields; ?>;
     }
 
     protected function configureListFields(ListMapper $listMapper): void
     {
         $listMapper
-<?= $fields ?>->add('_action', null, [
+<?= $fields; ?>->add('_action', null, [
                 'actions' => [
                     'show' => [],
                     'edit' => [],
@@ -34,12 +34,12 @@ final class <?= $class_name ?> extends AbstractAdmin
     protected function configureFormFields(FormMapper $formMapper): void
     {
         $formMapper
-<?= $fields ?>;
+<?= $fields; ?>;
     }
 
     protected function configureShowFields(ShowMapper $showMapper): void
     {
         $showMapper
-<?= $fields ?>;
+<?= $fields; ?>;
     }
 }

--- a/src/Resources/skeleton/Admin.tpl.php
+++ b/src/Resources/skeleton/Admin.tpl.php
@@ -1,8 +1,8 @@
-<?= "<?php\n"; ?>
+<?= "<?php\n" ?>
 
 declare(strict_types=1);
 
-namespace <?= $namespace; ?>;
+namespace <?= $namespace ?>;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
@@ -10,19 +10,19 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 
-final class <?= $class_name; ?> extends AbstractAdmin
+final class <?= $class_name ?> extends AbstractAdmin
 {
 
     protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
     {
         $datagridMapper
-<?= $fields; ?>;
+<?= $fields ?>;
     }
 
     protected function configureListFields(ListMapper $listMapper): void
     {
         $listMapper
-<?= $fields; ?>->add('_action', null, [
+<?= $fields ?>->add('_action', null, [
                 'actions' => [
                     'show' => [],
                     'edit' => [],
@@ -34,12 +34,12 @@ final class <?= $class_name; ?> extends AbstractAdmin
     protected function configureFormFields(FormMapper $formMapper): void
     {
         $formMapper
-<?= $fields; ?>;
+<?= $fields ?>;
     }
 
     protected function configureShowFields(ShowMapper $showMapper): void
     {
         $showMapper
-<?= $fields; ?>;
+<?= $fields ?>;
     }
 }

--- a/src/Resources/skeleton/AdminController.tpl.php
+++ b/src/Resources/skeleton/AdminController.tpl.php
@@ -1,12 +1,12 @@
-<?= "<?php\n" ?>
+<?= "<?php\n"; ?>
 
 declare(strict_types=1);
 
-namespace <?= $namespace ?>;
+namespace <?= $namespace; ?>;
 
 use Sonata\AdminBundle\Controller\CRUDController;
 
-final class <?= $class_name ?> extends CRUDController
+final class <?= $class_name; ?> extends CRUDController
 {
 
 }

--- a/src/Resources/skeleton/AdminController.tpl.php
+++ b/src/Resources/skeleton/AdminController.tpl.php
@@ -1,12 +1,12 @@
-<?= "<?php\n"; ?>
+<?= "<?php\n" ?>
 
 declare(strict_types=1);
 
-namespace <?= $namespace; ?>;
+namespace <?= $namespace ?>;
 
 use Sonata\AdminBundle\Controller\CRUDController;
 
-final class <?= $class_name; ?> extends CRUDController
+final class <?= $class_name ?> extends CRUDController
 {
 
 }

--- a/src/Route/DefaultRouteGenerator.php
+++ b/src/Route/DefaultRouteGenerator.php
@@ -48,7 +48,7 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
         $this->cache = $cache;
     }
 
-    public function generate($name, array $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
+    public function generate($name, array $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
         return $this->router->generate($name, $parameters, $absolute);
     }
@@ -58,7 +58,7 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
         $name,
         array $parameters = [],
         $absolute = UrlGeneratorInterface::ABSOLUTE_PATH
-    ) {
+    ): string {
         $arrayRoute = $this->generateMenuUrl($admin, $name, $parameters, $absolute);
 
         return $this->router->generate($arrayRoute['route'], $arrayRoute['routeParameters'], $arrayRoute['routeAbsolute']);
@@ -69,7 +69,7 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
         $name,
         array $parameters = [],
         $absolute = UrlGeneratorInterface::ABSOLUTE_PATH
-    ) {
+    ): array {
         // if the admin is a child we automatically append the parent's id
         if ($admin->isChild() && $admin->hasRequest()) {
             // twig template does not accept variable hash key ... so cannot use admin.idparameter ...
@@ -118,7 +118,7 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
         ];
     }
 
-    public function hasAdminRoute(AdminInterface $admin, $name)
+    public function hasAdminRoute(AdminInterface $admin, $name): bool
     {
         return \array_key_exists($this->getCode($admin, $name), $this->caches);
     }

--- a/src/Route/RouteCollection.php
+++ b/src/Route/RouteCollection.php
@@ -66,8 +66,6 @@ class RouteCollection
      * @param string $pattern   Pattern (will be automatically combined with @see $this->baseRoutePattern and $name
      * @param string $host
      * @param string $condition
-     *
-     * @return RouteCollection
      */
     public function add(
         $name,
@@ -79,7 +77,7 @@ class RouteCollection
         array $schemes = [],
         array $methods = [],
         $condition = ''
-    ) {
+    ): self {
         $pattern = $this->baseRoutePattern.'/'.($pattern ?: $name);
         $code = $this->getCode($name);
         $routeName = $this->baseRouteName.'_'.$name;
@@ -109,10 +107,8 @@ class RouteCollection
 
     /**
      * @param string $name
-     *
-     * @return string
      */
-    public function getCode($name)
+    public function getCode($name): string
     {
         if (false !== strrpos($name, '.')) {
             return $name;
@@ -121,10 +117,7 @@ class RouteCollection
         return $this->baseCodeRoute.'.'.$name;
     }
 
-    /**
-     * @return RouteCollection
-     */
-    public function addCollection(self $collection)
+    public function addCollection(self $collection): self
     {
         foreach ($collection->getElements() as $code => $route) {
             $this->elements[$code] = $route;
@@ -136,7 +129,7 @@ class RouteCollection
     /**
      * @return Route[]
      */
-    public function getElements()
+    public function getElements(): array
     {
         foreach ($this->elements as $name => $element) {
             $this->elements[$name] = $this->resolve($element);
@@ -147,10 +140,8 @@ class RouteCollection
 
     /**
      * @param string $name
-     *
-     * @return bool
      */
-    public function has($name)
+    public function has($name): bool
     {
         return \array_key_exists($this->getCode($name), $this->elements);
     }
@@ -159,10 +150,8 @@ class RouteCollection
      * @param string $name
      *
      * @throws \InvalidArgumentException
-     *
-     * @return Route
      */
-    public function get($name)
+    public function get($name): Route
     {
         if ($this->has($name)) {
             $code = $this->getCode($name);
@@ -177,10 +166,8 @@ class RouteCollection
 
     /**
      * @param string $name
-     *
-     * @return RouteCollection
      */
-    public function remove($name)
+    public function remove($name): self
     {
         unset($this->elements[$this->getCode($name)]);
 
@@ -191,10 +178,8 @@ class RouteCollection
      * Remove all routes except routes in $routeList.
      *
      * @param string[]|string $routeList
-     *
-     * @return RouteCollection
      */
-    public function clearExcept($routeList)
+    public function clearExcept($routeList): self
     {
         if (!\is_array($routeList)) {
             $routeList = [$routeList];
@@ -217,10 +202,8 @@ class RouteCollection
 
     /**
      * Remove all routes.
-     *
-     * @return RouteCollection
      */
-    public function clear()
+    public function clear(): self
     {
         $this->elements = [];
 
@@ -234,7 +217,7 @@ class RouteCollection
      *
      * @return string Actionified word
      */
-    public function actionify($action)
+    public function actionify($action): string
     {
         if (false !== ($pos = strrpos($action, '.'))) {
             $action = substr($action, $pos + 1);
@@ -249,34 +232,22 @@ class RouteCollection
         return lcfirst(str_replace(' ', '', ucwords(strtr($action, '_-', '  '))));
     }
 
-    /**
-     * @return string
-     */
-    public function getBaseCodeRoute()
+    public function getBaseCodeRoute(): string
     {
         return $this->baseCodeRoute;
     }
 
-    /**
-     * @return string
-     */
-    public function getBaseControllerName()
+    public function getBaseControllerName(): string
     {
         return $this->baseControllerName;
     }
 
-    /**
-     * @return string
-     */
-    public function getBaseRouteName()
+    public function getBaseRouteName(): string
     {
         return $this->baseRouteName;
     }
 
-    /**
-     * @return string
-     */
-    public function getBaseRoutePattern()
+    public function getBaseRoutePattern(): string
     {
         return $this->baseRoutePattern;
     }

--- a/src/Route/RouteGeneratorInterface.php
+++ b/src/Route/RouteGeneratorInterface.php
@@ -23,31 +23,23 @@ interface RouteGeneratorInterface
     /**
      * @param string $name
      * @param bool   $absolute
-     *
-     * @return string
      */
-    public function generateUrl(AdminInterface $admin, $name, array $parameters = [], $absolute = false);
+    public function generateUrl(AdminInterface $admin, $name, array $parameters = [], $absolute = false): string;
 
     /**
      * @param string $name
      * @param bool   $absolute
-     *
-     * @return array
      */
-    public function generateMenuUrl(AdminInterface $admin, $name, array $parameters = [], $absolute = false);
+    public function generateMenuUrl(AdminInterface $admin, $name, array $parameters = [], $absolute = false): array;
 
     /**
      * @param string $name
      * @param bool   $absolute
-     *
-     * @return string
      */
-    public function generate($name, array $parameters = [], $absolute = false);
+    public function generate($name, array $parameters = [], $absolute = false): string;
 
     /**
      * @param string $name
-     *
-     * @return bool
      */
-    public function hasAdminRoute(AdminInterface $admin, $name);
+    public function hasAdminRoute(AdminInterface $admin, $name): bool;
 }

--- a/src/Security/Handler/AclSecurityHandler.php
+++ b/src/Security/Handler/AclSecurityHandler.php
@@ -99,7 +99,7 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
         $this->adminPermissions = $permissions;
     }
 
-    public function getAdminPermissions()
+    public function getAdminPermissions(): array
     {
         return $this->adminPermissions;
     }
@@ -109,12 +109,12 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
         $this->objectPermissions = $permissions;
     }
 
-    public function getObjectPermissions()
+    public function getObjectPermissions(): array
     {
         return $this->objectPermissions;
     }
 
-    public function isGranted(AdminInterface $admin, $attributes, $object = null)
+    public function isGranted(AdminInterface $admin, $attributes, $object = null): bool
     {
         if (!\is_array($attributes)) {
             $attributes = [$attributes];
@@ -127,7 +127,7 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
         }
     }
 
-    public function getBaseRole(AdminInterface $admin)
+    public function getBaseRole(AdminInterface $admin): string
     {
         return 'ROLE_'.str_replace('.', '_', strtoupper($admin->getCode())).'_%s';
     }
@@ -168,18 +168,18 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
         $this->deleteAcl($objectIdentity);
     }
 
-    public function getObjectAcl(ObjectIdentityInterface $objectIdentity)
+    public function getObjectAcl(ObjectIdentityInterface $objectIdentity): ?AclInterface
     {
         try {
             $acl = $this->aclProvider->findAcl($objectIdentity);
         } catch (AclNotFoundException $e) {
-            return;
+            return null;
         }
 
         return $acl;
     }
 
-    public function findObjectAcls(\Traversable $oids, array $sids = [])
+    public function findObjectAcls(\Traversable $oids, array $sids = []): \SplObjectStorage
     {
         try {
             $acls = $this->aclProvider->findAcls(iterator_to_array($oids), $sids);
@@ -230,7 +230,7 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
         }
     }
 
-    public function createAcl(ObjectIdentityInterface $objectIdentity)
+    public function createAcl(ObjectIdentityInterface $objectIdentity): AclInterface
     {
         return $this->aclProvider->createAcl($objectIdentity);
     }

--- a/src/Security/Handler/AclSecurityHandlerInterface.php
+++ b/src/Security/Handler/AclSecurityHandlerInterface.php
@@ -33,10 +33,8 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
      * Return the permissions not related to an object instance and also to be available when objects do not exist.
      *
      * @abstract
-     *
-     * @return array
      */
-    public function getAdminPermissions();
+    public function getAdminPermissions(): array;
 
     /**
      * Set the permissions related to an object instance.
@@ -49,10 +47,8 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
      * Return the permissions related to an object instance.
      *
      * @abstract
-     *
-     * @return array
      */
-    public function getObjectPermissions();
+    public function getObjectPermissions(): array;
 
     /**
      * Get the ACL for the passed object identity.
@@ -61,7 +57,7 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
      *
      * @return AclInterface|null or NULL if not found
      */
-    public function getObjectAcl(ObjectIdentityInterface $objectIdentity);
+    public function getObjectAcl(ObjectIdentityInterface $objectIdentity): ?AclInterface;
 
     /**
      * Find the ACLs for the passed object identities.
@@ -75,7 +71,7 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
      *
      * @return \SplObjectStorage mapping the passed object identities to ACLs
      */
-    public function findObjectAcls(\Traversable $oids, array $sids = []);
+    public function findObjectAcls(\Traversable $oids, array $sids = []): \SplObjectStorage;
 
     /**
      * Add an object owner ACE to the object ACL.
@@ -93,10 +89,8 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
      * Create an object ACL.
      *
      * @abstract
-     *
-     * @return AclInterface
      */
-    public function createAcl(ObjectIdentityInterface $objectIdentity);
+    public function createAcl(ObjectIdentityInterface $objectIdentity): AclInterface;
 
     /**
      * Update the ACL.

--- a/src/Security/Handler/NoopSecurityHandler.php
+++ b/src/Security/Handler/NoopSecurityHandler.php
@@ -20,12 +20,12 @@ use Sonata\AdminBundle\Admin\AdminInterface;
  */
 class NoopSecurityHandler implements SecurityHandlerInterface
 {
-    public function isGranted(AdminInterface $admin, $attributes, $object = null)
+    public function isGranted(AdminInterface $admin, $attributes, $object = null): bool
     {
         return true;
     }
 
-    public function getBaseRole(AdminInterface $admin)
+    public function getBaseRole(AdminInterface $admin): string
     {
         return '';
     }

--- a/src/Security/Handler/RoleSecurityHandler.php
+++ b/src/Security/Handler/RoleSecurityHandler.php
@@ -46,7 +46,7 @@ class RoleSecurityHandler implements SecurityHandlerInterface
         $this->superAdminRoles = $superAdminRoles;
     }
 
-    public function isGranted(AdminInterface $admin, $attributes, $object = null)
+    public function isGranted(AdminInterface $admin, $attributes, $object = null): bool
     {
         if (!\is_array($attributes)) {
             $attributes = [$attributes];
@@ -67,7 +67,7 @@ class RoleSecurityHandler implements SecurityHandlerInterface
         }
     }
 
-    public function getBaseRole(AdminInterface $admin)
+    public function getBaseRole(AdminInterface $admin): string
     {
         return 'ROLE_'.str_replace('.', '_', strtoupper($admin->getCode())).'_%s';
     }

--- a/src/Security/Handler/SecurityHandlerInterface.php
+++ b/src/Security/Handler/SecurityHandlerInterface.php
@@ -23,17 +23,13 @@ interface SecurityHandlerInterface
     /**
      * @param string|array $attributes
      * @param mixed|null   $object
-     *
-     * @return bool
      */
-    public function isGranted(AdminInterface $admin, $attributes, $object = null);
+    public function isGranted(AdminInterface $admin, $attributes, $object = null): bool;
 
     /**
      * Get a sprintf template to get the role.
-     *
-     * @return string
      */
-    public function getBaseRole(AdminInterface $admin);
+    public function getBaseRole(AdminInterface $admin): string;
 
     public function buildSecurityInformation(AdminInterface $admin);
 

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -91,7 +91,7 @@ class ShowMapper extends BaseGroupedMapper
         return $this->list->get($name);
     }
 
-    public function has($key)
+    public function has($key): bool
     {
         return $this->list->has($key);
     }
@@ -158,7 +158,7 @@ class ShowMapper extends BaseGroupedMapper
         return $this;
     }
 
-    protected function getGroups()
+    protected function getGroups(): array
     {
         return $this->admin->getShowGroups();
     }
@@ -168,7 +168,7 @@ class ShowMapper extends BaseGroupedMapper
         $this->admin->setShowGroups($groups);
     }
 
-    protected function getTabs()
+    protected function getTabs(): array
     {
         return $this->admin->getShowTabs();
     }
@@ -178,7 +178,7 @@ class ShowMapper extends BaseGroupedMapper
         $this->admin->setShowTabs($tabs);
     }
 
-    protected function getName()
+    protected function getName(): string
     {
         return 'show';
     }

--- a/src/Templating/TemplateRegistry.php
+++ b/src/Templating/TemplateRegistry.php
@@ -50,13 +50,13 @@ final class TemplateRegistry implements MutableTemplateRegistryInterface
     /**
      * @param string $name
      */
-    public function getTemplate($name): ?string
+    public function getTemplate($name): string
     {
         if (isset($this->templates[$name])) {
             return $this->templates[$name];
         }
 
-        return null;
+        throw new \InvalidArgumentException();
     }
 
     public function setTemplate($name, $template): void

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -21,12 +21,10 @@ interface TemplateRegistryInterface
     /**
      * @return array 'name' => 'file_path.html.twig'
      */
-    public function getTemplates();
+    public function getTemplates(): array;
 
     /**
      * @param string $name
-     *
-     * @return string
      */
-    public function getTemplate($name);
+    public function getTemplate($name): string;
 }

--- a/src/Translator/BCLabelTranslatorStrategy.php
+++ b/src/Translator/BCLabelTranslatorStrategy.php
@@ -18,7 +18,7 @@ namespace Sonata\AdminBundle\Translator;
  */
 class BCLabelTranslatorStrategy implements LabelTranslatorStrategyInterface
 {
-    public function getLabel($label, $context = '', $type = '')
+    public function getLabel($label, $context = '', $type = ''): string
     {
         if ('breadcrumb' === $context) {
             return sprintf('%s.%s_%s', $context, $type, strtolower($label));

--- a/src/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/src/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -91,10 +91,8 @@ final class AdminExtractor implements ExtractorInterface, TranslatorInterface, S
      * Extract messages to MessageCatalogue.
      *
      * @throws \Exception|\RuntimeException
-     *
-     * @return MessageCatalogue
      */
-    public function extract()
+    public function extract(): MessageCatalogue
     {
         if ($this->catalogue) {
             throw new \RuntimeException('Invalid state');

--- a/src/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/src/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -211,7 +211,7 @@ final class AdminExtractor implements ExtractorInterface, TranslatorInterface, S
         return $this->translator->getLocale();
     }
 
-    public function isGranted(AdminInterface $admin, $attributes, $object = null)
+    public function isGranted(AdminInterface $admin, $attributes, $object = null): bool
     {
         return true;
     }
@@ -228,11 +228,11 @@ final class AdminExtractor implements ExtractorInterface, TranslatorInterface, S
     {
     }
 
-    public function getBaseRole(AdminInterface $admin): void
+    public function getBaseRole(AdminInterface $admin): string
     {
     }
 
-    public function getLabel($label, $context = '', $type = '')
+    public function getLabel($label, $context = '', $type = ''): string
     {
         $label = $this->labelStrategy->getLabel($label, $context, $type);
 

--- a/src/Translator/FormLabelTranslatorStrategy.php
+++ b/src/Translator/FormLabelTranslatorStrategy.php
@@ -18,7 +18,7 @@ namespace Sonata\AdminBundle\Translator;
  */
 class FormLabelTranslatorStrategy implements LabelTranslatorStrategyInterface
 {
-    public function getLabel($label, $context = '', $type = '')
+    public function getLabel($label, $context = '', $type = ''): string
     {
         return ucfirst(strtolower($label));
     }

--- a/src/Translator/LabelTranslatorStrategyInterface.php
+++ b/src/Translator/LabelTranslatorStrategyInterface.php
@@ -22,8 +22,6 @@ interface LabelTranslatorStrategyInterface
      * @param string $label
      * @param string $context
      * @param string $type
-     *
-     * @return string
      */
-    public function getLabel($label, $context = '', $type = '');
+    public function getLabel($label, $context = '', $type = ''): string;
 }

--- a/src/Translator/NativeLabelTranslatorStrategy.php
+++ b/src/Translator/NativeLabelTranslatorStrategy.php
@@ -18,7 +18,7 @@ namespace Sonata\AdminBundle\Translator;
  */
 class NativeLabelTranslatorStrategy implements LabelTranslatorStrategyInterface
 {
-    public function getLabel($label, $context = '', $type = '')
+    public function getLabel($label, $context = '', $type = ''): string
     {
         $label = str_replace(['_', '.'], ' ', $label);
         $label = strtolower(preg_replace('~(?<=\\w)([A-Z])~', '_$1', $label));

--- a/src/Translator/NoopLabelTranslatorStrategy.php
+++ b/src/Translator/NoopLabelTranslatorStrategy.php
@@ -18,7 +18,7 @@ namespace Sonata\AdminBundle\Translator;
  */
 class NoopLabelTranslatorStrategy implements LabelTranslatorStrategyInterface
 {
-    public function getLabel($label, $context = '', $type = '')
+    public function getLabel($label, $context = '', $type = ''): string
     {
         return $label;
     }

--- a/src/Translator/UnderscoreLabelTranslatorStrategy.php
+++ b/src/Translator/UnderscoreLabelTranslatorStrategy.php
@@ -18,7 +18,7 @@ namespace Sonata\AdminBundle\Translator;
  */
 class UnderscoreLabelTranslatorStrategy implements LabelTranslatorStrategyInterface
 {
-    public function getLabel($label, $context = '', $type = '')
+    public function getLabel($label, $context = '', $type = ''): string
     {
         $label = str_replace('.', '_', $label);
 

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -162,15 +162,13 @@ final class SonataAdminExtension extends AbstractExtension
      *
      * @param mixed $object
      * @param array $params
-     *
-     * @return string
      */
     public function renderListElement(
         Environment $environment,
         $object,
         FieldDescriptionInterface $fieldDescription,
         $params = []
-    ) {
+    ): string {
         $template = $this->getTemplate(
             $fieldDescription,
             // NEXT_MAJOR: Remove this line and use commented line below instead
@@ -191,14 +189,12 @@ final class SonataAdminExtension extends AbstractExtension
      * render a view element.
      *
      * @param mixed $object
-     *
-     * @return string
      */
     public function renderViewElement(
         Environment $environment,
         FieldDescriptionInterface $fieldDescription,
         $object
-    ) {
+    ): string {
         $template = $this->getTemplate(
             $fieldDescription,
             '@SonataAdmin/CRUD/base_show_field.html.twig',
@@ -224,15 +220,13 @@ final class SonataAdminExtension extends AbstractExtension
      *
      * @param mixed $baseObject
      * @param mixed $compareObject
-     *
-     * @return string
      */
     public function renderViewElementCompare(
         Environment $environment,
         FieldDescriptionInterface $fieldDescription,
         $baseObject,
         $compareObject
-    ) {
+    ): string {
         $template = $this->getTemplate(
             $fieldDescription,
             '@SonataAdmin/CRUD/base_show_field.html.twig',
@@ -331,7 +325,7 @@ final class SonataAdminExtension extends AbstractExtension
      *
      * @return string string representation of the id that is safe to use in a url
      */
-    public function getUrlsafeIdentifier($model, AdminInterface $admin = null)
+    public function getUrlsafeIdentifier($model, AdminInterface $admin = null): string
     {
         if (null === $admin) {
             $admin = $this->pool->getAdminByClass(ClassUtils::getClass($model));
@@ -362,10 +356,8 @@ final class SonataAdminExtension extends AbstractExtension
      *     ['Status1' => 'Alias1', 'Status2' => 'Alias2']
      * The method will return:
      *     [['value' => 'Status1', 'text' => 'Alias1'], ['value' => 'Status2', 'text' => 'Alias2']].
-     *
-     * @return array
      */
-    public function getXEditableChoices(FieldDescriptionInterface $fieldDescription)
+    public function getXEditableChoices(FieldDescriptionInterface $fieldDescription): array
     {
         $choices = $fieldDescription->getOption('choices', []);
         $catalogue = $fieldDescription->getOption('catalogue');
@@ -434,10 +426,8 @@ final class SonataAdminExtension extends AbstractExtension
     /**
      * Returns a canonicalized locale for "select2" NPM library,
      * or `null` if the locale's language is "en", which doesn't require localization.
-     *
-     * @return string|null
      */
-    public function getCanonicalizedLocaleForSelect2(array $context)
+    public function getCanonicalizedLocaleForSelect2(array $context): ?string
     {
         $locale = str_replace('_', '-', $context['app']->getRequest()->getLocale());
 
@@ -469,10 +459,8 @@ final class SonataAdminExtension extends AbstractExtension
      * @param string|array $role
      * @param object|null  $object
      * @param string|null  $field
-     *
-     * @return bool
      */
-    public function isGrantedAffirmative($role, $object = null, $field = null)
+    public function isGrantedAffirmative($role, $object = null, $field = null): bool
     {
         if (null === $this->securityChecker) {
             return false;
@@ -535,14 +523,12 @@ final class SonataAdminExtension extends AbstractExtension
      * Get template.
      *
      * @param string $defaultTemplate
-     *
-     * @return TemplateWrapper
      */
     private function getTemplate(
         FieldDescriptionInterface $fieldDescription,
         $defaultTemplate,
         Environment $environment
-    ) {
+    ): TemplateWrapper {
         $templateName = $fieldDescription->getTemplate() ?: $defaultTemplate;
 
         try {

--- a/src/Twig/Extension/TemplateRegistryExtension.php
+++ b/src/Twig/Extension/TemplateRegistryExtension.php
@@ -56,10 +56,8 @@ final class TemplateRegistryExtension extends AbstractExtension
      *
      * @throws ServiceNotFoundException
      * @throws ServiceCircularReferenceException
-     *
-     * @return string|null
      */
-    public function getAdminTemplate($name, $adminCode)
+    public function getAdminTemplate($name, $adminCode): ?string
     {
         // NEXT_MAJOR: Remove this line and use commented line below it instead
         return $this->getAdmin($adminCode)->getTemplate($name);
@@ -70,20 +68,16 @@ final class TemplateRegistryExtension extends AbstractExtension
      * @deprecated Sinds 3.34, to be removed in 4.0. Use getGlobalTemplate instead.
      *
      * @param string $name
-     *
-     * @return string|null
      */
-    public function getPoolTemplate($name)
+    public function getPoolTemplate($name): ?string
     {
         return $this->getGlobalTemplate($name);
     }
 
     /**
      * @param string $name
-     *
-     * @return string|null
      */
-    public function getGlobalTemplate($name)
+    public function getGlobalTemplate($name): ?string
     {
         return $this->globalTemplateRegistry->getTemplate($name);
     }

--- a/src/Twig/GlobalVariables.php
+++ b/src/Twig/GlobalVariables.php
@@ -67,10 +67,7 @@ class GlobalVariables
         );
     }
 
-    /**
-     * @return Pool
-     */
-    public function getAdminPool()
+    public function getAdminPool(): Pool
     {
         return $this->adminPool;
     }
@@ -80,10 +77,8 @@ class GlobalVariables
      * @param string $action
      * @param array  $parameters
      * @param int    $absolute
-     *
-     * @return string
      */
-    public function url($code, $action, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
+    public function url($code, $action, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
         list($action, $code) = $this->getCodeAction($code, $action);
 
@@ -96,10 +91,8 @@ class GlobalVariables
      * @param mixed  $object
      * @param array  $parameters
      * @param int    $absolute
-     *
-     * @return string
      */
-    public function objectUrl($code, $action, $object, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
+    public function objectUrl($code, $action, $object, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
         list($action, $code) = $this->getCodeAction($code, $action);
 

--- a/src/Util/AdminAclManipulatorInterface.php
+++ b/src/Util/AdminAclManipulatorInterface.php
@@ -38,5 +38,5 @@ interface AdminAclManipulatorInterface
         AclInterface $acl,
         AclSecurityHandlerInterface $securityHandler,
         array $roleInformation = []
-    );
+    ): bool;
 }

--- a/src/Util/AdminObjectAclData.php
+++ b/src/Util/AdminObjectAclData.php
@@ -97,10 +97,8 @@ class AdminObjectAclData
 
     /**
      * Gets admin.
-     *
-     * @return AdminInterface
      */
-    public function getAdmin()
+    public function getAdmin(): AdminInterface
     {
         return $this->admin;
     }
@@ -117,30 +115,24 @@ class AdminObjectAclData
 
     /**
      * Gets ACL users.
-     *
-     * @return \Traversable
      */
-    public function getAclUsers()
+    public function getAclUsers(): \Traversable
     {
         return $this->aclUsers;
     }
 
     /**
      * Gets ACL roles.
-     *
-     * @return \Traversable
      */
-    public function getAclRoles()
+    public function getAclRoles(): \Traversable
     {
         return $this->aclRoles;
     }
 
     /**
      * Sets ACL.
-     *
-     * @return AdminObjectAclData
      */
-    public function setAcl(Acl $acl)
+    public function setAcl(Acl $acl): self
     {
         $this->acl = $acl;
 
@@ -149,20 +141,16 @@ class AdminObjectAclData
 
     /**
      * Gets ACL.
-     *
-     * @return Acl
      */
-    public function getAcl()
+    public function getAcl(): Acl
     {
         return $this->acl;
     }
 
     /**
      * Gets masks.
-     *
-     * @return array
      */
-    public function getMasks()
+    public function getMasks(): array
     {
         return $this->masks;
     }
@@ -172,11 +160,10 @@ class AdminObjectAclData
      *
      * NEXT_MAJOR: remove this method.
      *
-     * @return AdminObjectAclData
      *
      * @deprecated Deprecated since version 3.0. Use setAclUsersForm() instead
      */
-    public function setForm(Form $form)
+    public function setForm(Form $form): self
     {
         @trigger_error(
             'setForm() is deprecated since version 3.0 and will be removed in 4.0. '
@@ -192,11 +179,10 @@ class AdminObjectAclData
      *
      * NEXT_MAJOR: remove this method.
      *
-     * @return Form
      *
      * @deprecated Deprecated since version 3.0. Use getAclUsersForm() instead
      */
-    public function getForm()
+    public function getForm(): Form
     {
         @trigger_error(
             'getForm() is deprecated since version 3.0 and will be removed in 4.0. '
@@ -209,10 +195,8 @@ class AdminObjectAclData
 
     /**
      * Sets ACL users form.
-     *
-     * @return AdminObjectAclData
      */
-    public function setAclUsersForm(Form $form)
+    public function setAclUsersForm(Form $form): self
     {
         $this->aclUsersForm = $form;
 
@@ -221,20 +205,16 @@ class AdminObjectAclData
 
     /**
      * Gets ACL users form.
-     *
-     * @return Form
      */
-    public function getAclUsersForm()
+    public function getAclUsersForm(): Form
     {
         return $this->aclUsersForm;
     }
 
     /**
      * Sets ACL roles form.
-     *
-     * @return AdminObjectAclData
      */
-    public function setAclRolesForm(Form $form)
+    public function setAclRolesForm(Form $form): self
     {
         $this->aclRolesForm = $form;
 
@@ -243,30 +223,24 @@ class AdminObjectAclData
 
     /**
      * Gets ACL roles form.
-     *
-     * @return Form
      */
-    public function getAclRolesForm()
+    public function getAclRolesForm(): Form
     {
         return $this->aclRolesForm;
     }
 
     /**
      * Gets permissions.
-     *
-     * @return array
      */
-    public function getPermissions()
+    public function getPermissions(): array
     {
         return $this->admin->getSecurityHandler()->getObjectPermissions();
     }
 
     /**
      * Get permissions that the current user can set.
-     *
-     * @return array
      */
-    public function getUserPermissions()
+    public function getUserPermissions(): array
     {
         $permissions = $this->getPermissions();
 
@@ -289,10 +263,8 @@ class AdminObjectAclData
 
     /**
      * Tests if the current user has the OWNER right.
-     *
-     * @return bool
      */
-    public function isOwner()
+    public function isOwner(): bool
     {
         // Only a owner can set MASTER and OWNER ACL
         return $this->admin->isGranted('OWNER', $this->object);
@@ -300,18 +272,13 @@ class AdminObjectAclData
 
     /**
      * Gets security handler.
-     *
-     * @return SecurityHandlerInterface
      */
-    public function getSecurityHandler()
+    public function getSecurityHandler(): SecurityHandlerInterface
     {
         return $this->admin->getSecurityHandler();
     }
 
-    /**
-     * @return array
-     */
-    public function getSecurityInformation()
+    public function getSecurityInformation(): array
     {
         return $this->admin->getSecurityHandler()->buildSecurityInformation($this->admin);
     }

--- a/src/Util/AdminObjectAclManipulator.php
+++ b/src/Util/AdminObjectAclManipulator.php
@@ -55,10 +55,8 @@ class AdminObjectAclManipulator
 
     /**
      * Gets mask builder class name.
-     *
-     * @return string
      */
-    public function getMaskBuilderClass()
+    public function getMaskBuilderClass(): string
     {
         return $this->maskBuilderClass;
     }
@@ -68,11 +66,10 @@ class AdminObjectAclManipulator
      *
      * NEXT_MAJOR: remove this method.
      *
-     * @return Form
      *
      * @deprecated Deprecated since version 3.0. Use createAclUsersForm() instead
      */
-    public function createForm(AdminObjectAclData $data)
+    public function createForm(AdminObjectAclData $data): Form
     {
         @trigger_error(
             'createForm() is deprecated since version 3.0 and will be removed in 4.0. '
@@ -85,10 +82,8 @@ class AdminObjectAclManipulator
 
     /**
      * Gets the ACL users form.
-     *
-     * @return Form
      */
-    public function createAclUsersForm(AdminObjectAclData $data)
+    public function createAclUsersForm(AdminObjectAclData $data): Form
     {
         $aclValues = $data->getAclUsers();
         $formBuilder = $this->formFactory->createNamedBuilder(self::ACL_USERS_FORM_NAME, FormType::class);
@@ -100,10 +95,8 @@ class AdminObjectAclManipulator
 
     /**
      * Gets the ACL roles form.
-     *
-     * @return Form
      */
-    public function createAclRolesForm(AdminObjectAclData $data)
+    public function createAclRolesForm(AdminObjectAclData $data): Form
     {
         $aclValues = $data->getAclRoles();
         $formBuilder = $this->formFactory->createNamedBuilder(self::ACL_ROLES_FORM_NAME, FormType::class);
@@ -222,10 +215,8 @@ class AdminObjectAclManipulator
 
     /**
      * Builds the form.
-     *
-     * @return Form
      */
-    protected function buildForm(AdminObjectAclData $data, FormBuilderInterface $formBuilder, \Traversable $aclValues)
+    protected function buildForm(AdminObjectAclData $data, FormBuilderInterface $formBuilder, \Traversable $aclValues): Form
     {
         // Retrieve object identity
         $objectIdentity = ObjectIdentity::fromDomainObject($data->getObject());

--- a/src/Util/FormBuilderIterator.php
+++ b/src/Util/FormBuilderIterator.php
@@ -95,10 +95,8 @@ class FormBuilderIterator extends \RecursiveArrayIterator
 
     /**
      * @static
-     *
-     * @return array
      */
-    private static function getKeys(FormBuilderInterface $formBuilder)
+    private static function getKeys(FormBuilderInterface $formBuilder): array
     {
         return array_keys($formBuilder->all());
     }

--- a/src/Util/ObjectAclManipulator.php
+++ b/src/Util/ObjectAclManipulator.php
@@ -35,7 +35,7 @@ abstract class ObjectAclManipulator implements ObjectAclManipulatorInterface
         AdminInterface $admin,
         \Traversable $oids,
         UserSecurityIdentity $securityIdentity = null
-    ) {
+    ): array {
         $countAdded = 0;
         $countUpdated = 0;
         $securityHandler = $admin->getSecurityHandler();

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -91,7 +91,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $this->admin->getNewInstance()->willReturn($object);
         $this->admin->setSubject($object)->shouldBeCalled();
         $this->admin->hasAccess('create')->willReturn(true);
-        $this->admin->getFormFieldDescriptions()->willReturn(null);
+        $this->admin->getFormFieldDescriptions()->willReturn([]);
         $this->admin->getFormFieldDescription('barField')->willReturn($fieldDescription->reveal());
 
         $fieldDescription->getTargetEntity()->willReturn(Foo::class);
@@ -119,7 +119,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $this->admin->setSubject($object)->shouldBeCalled();
         $this->admin->hasAccess('create')->willReturn(true);
         $this->admin->getFormFieldDescription('barField')->willReturn($fieldDescription->reveal());
-        $this->admin->getFormFieldDescriptions()->willReturn(null);
+        $this->admin->getFormFieldDescriptions()->willReturn([]);
         $targetAdmin->checkAccess('list')->shouldBeCalled();
         $fieldDescription->getTargetEntity()->willReturn(Foo::class);
         $fieldDescription->getName()->willReturn('barField');

--- a/tests/Admin/AdminHelperTest.php
+++ b/tests/Admin/AdminHelperTest.php
@@ -265,6 +265,7 @@ class AdminHelperTest extends TestCase
     public function testAppendFormFieldElementNested(): void
     {
         $admin = $this->createMock(AdminInterface::class);
+
         $object = $this->getMockBuilder('stdClass')
             ->setMethods(['getSubObject'])
             ->getMock();
@@ -298,7 +299,8 @@ class AdminHelperTest extends TestCase
         $admin->expects($this->once())->method('getFormBuilder')->willReturn($formBuilder);
         $admin->expects($this->once())->method('getSubject')->willReturn($object);
 
-        $this->expectException(\Exception::class, 'unknown collection class');
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage(sprintf('Expected collection to be an instance of "%s", "string" given.', Collection::class));
 
         $this->helper->appendFormFieldElement($admin, $simpleObject, 'uniquePartOfId_sub_object_0_and_more_0_final_data');
     }

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1497,14 +1497,14 @@ class AdminTest extends TestCase
 
     public function testGetPersistentParametersWithInvalidExtension(): void
     {
-        $this->expectException(\RuntimeException::class);
-
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
 
         $extension = $this->createMock(AdminExtensionInterface::class);
         $extension->expects($this->once())->method('getPersistentParameters')->willReturn(null);
 
         $admin->addExtension($extension);
+
+        $this->expectException(\TypeError::class);
 
         $admin->getPersistentParameters();
     }

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1810,10 +1810,7 @@ class AdminTest extends TestCase
         $modelAdmin->getSideMenu('foo');
     }
 
-    /**
-     * @return array
-     */
-    public function provideGetSubject()
+    public function provideGetSubject(): array
     {
         return [
             [23],

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -174,12 +174,12 @@ class BaseFieldDescriptionTest extends TestCase
 
     public function testGetValueNoValueException(): void
     {
-        $this->expectException(\Sonata\AdminBundle\Exception\NoValueException::class);
-
         $description = new FieldDescription();
         $mock = $this->getMockBuilder('stdClass')
             ->setMethods(['getFoo'])
             ->getMock();
+
+        $this->expectException(NoValueException::class);
 
         $description->getFieldValue($mock, 'fake');
     }

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -114,7 +114,6 @@ class DatagridTest extends TestCase
     public function testFilter(): void
     {
         $this->assertFalse($this->datagrid->hasFilter('foo'));
-        $this->assertNull($this->datagrid->getFilter('foo'));
 
         $filter = $this->createMock(FilterInterface::class);
         $filter->expects($this->once())
@@ -130,6 +129,10 @@ class DatagridTest extends TestCase
         $this->datagrid->removeFilter('foo');
 
         $this->assertFalse($this->datagrid->hasFilter('foo'));
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->datagrid->getFilter('foo');
     }
 
     public function testGetFilters(): void
@@ -309,20 +312,22 @@ class DatagridTest extends TestCase
 
     public function testGetResults(): void
     {
-        $this->assertNull($this->datagrid->getResults());
+        $this->assertEmpty($this->datagrid->getResults());
 
         $this->pager->expects($this->once())
             ->method('getResults')
             ->willReturn(['foo', 'bar']);
+
+        $this->query->expects($this->never())
+            ->method('execute');
 
         $this->assertSame(['foo', 'bar'], $this->datagrid->getResults());
     }
 
     public function testEmptyResults(): void
     {
-        $this->pager->expects($this->once())
-            ->method('getResults')
-            ->willReturn([]);
+        $this->pager->expects($this->exactly(2))
+            ->method('getResults');
 
         $this->assertSame([], $this->datagrid->getResults());
         $this->assertSame([], $this->datagrid->getResults());

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -566,10 +566,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $this->assertSame('extra_argument_2', $definition->getArgument(3));
     }
 
-    /**
-     * @return array
-     */
-    protected function getConfig()
+    protected function getConfig(): array
     {
         $config = [
             'dashboard' => [

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -315,10 +315,7 @@ class ExtensionCompilerPassTest extends TestCase
         $container->compile();
     }
 
-    /**
-     * @return array
-     */
-    protected function getConfig()
+    protected function getConfig(): array
     {
         $config = [
             'extensions' => [

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -249,7 +249,7 @@ class ConfigurationTest extends TestCase
      *
      * @return array A normalized array
      */
-    protected function process($configs)
+    protected function process($configs): array
     {
         $processor = new Processor();
 

--- a/tests/Event/AdminEventExtensionTest.php
+++ b/tests/Event/AdminEventExtensionTest.php
@@ -27,10 +27,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class AdminEventExtensionTest extends TestCase
 {
-    /**
-     * @return AdminEventExtension
-     */
-    public function getExtension($args)
+    public function getExtension($args): AdminEventExtension
     {
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $stub = $eventDispatcher->expects($this->once())->method('dispatch');
@@ -49,10 +46,8 @@ class AdminEventExtensionTest extends TestCase
 
     /**
      * @param $type
-     *
-     * @return callable
      */
-    public function getConfigureEventClosure($type)
+    public function getConfigureEventClosure($type): callable
     {
         return static function ($event) use ($type) {
             if (!$event instanceof ConfigureEvent) {
@@ -69,10 +64,8 @@ class AdminEventExtensionTest extends TestCase
 
     /**
      * @param $type
-     *
-     * @return callable
      */
-    public function getConfigurePersistenceClosure($type)
+    public function getConfigurePersistenceClosure($type): callable
     {
         return static function ($event) use ($type) {
             if (!$event instanceof PersistenceEvent) {

--- a/tests/Fixtures/Admin/AbstractDummyGroupedMapper.php
+++ b/tests/Fixtures/Admin/AbstractDummyGroupedMapper.php
@@ -17,7 +17,7 @@ use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
 
 abstract class AbstractDummyGroupedMapper extends BaseGroupedMapper
 {
-    protected function getName()
+    protected function getName(): string
     {
         return 'dummy';
     }

--- a/tests/Fixtures/Admin/FieldDescription.php
+++ b/tests/Fixtures/Admin/FieldDescription.php
@@ -22,7 +22,7 @@ class FieldDescription extends BaseFieldDescription
         // TODO: Implement setAssociationMapping() method.
     }
 
-    public function getTargetEntity(): void
+    public function getTargetEntity(): ?string
     {
         // TODO: Implement getTargetEntity() method.
     }
@@ -32,7 +32,7 @@ class FieldDescription extends BaseFieldDescription
         // TODO: Implement setFieldMapping() method.
     }
 
-    public function isIdentifier(): void
+    public function isIdentifier(): bool
     {
         // TODO: Implement isIdentifier() method.
     }

--- a/tests/Fixtures/Admin/ModelAdmin.php
+++ b/tests/Fixtures/Admin/ModelAdmin.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Sonata Project package.
- *
- * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Sonata\AdminBundle\Tests\Fixtures\Admin;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;

--- a/tests/Fixtures/Admin/ModelAdmin.php
+++ b/tests/Fixtures/Admin/ModelAdmin.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sonata\AdminBundle\Tests\Fixtures\Admin;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;

--- a/tests/Fixtures/Admin/PostAdmin.php
+++ b/tests/Fixtures/Admin/PostAdmin.php
@@ -43,7 +43,7 @@ class PostAdmin extends AbstractAdmin
      *
      * @return array
      */
-    protected function configureBatchActions($actions)
+    protected function configureBatchActions($actions): array
     {
         $actions['foo'] = [
             'label' => 'action_foo',

--- a/tests/Fixtures/Admin/TagAdmin.php
+++ b/tests/Fixtures/Admin/TagAdmin.php
@@ -17,7 +17,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 
 class TagAdmin extends AbstractAdmin
 {
-    public function getParentAssociationMapping()
+    public function getParentAssociationMapping(): ?string
     {
         if ($this->getParent() instanceof PostAdmin) {
             return 'posts';

--- a/tests/Fixtures/Controller/BatchAdminController.php
+++ b/tests/Fixtures/Controller/BatchAdminController.php
@@ -27,11 +27,11 @@ class BatchAdminController extends CRUDController
      */
     public function batchActionFooIsRelevant(array $idx, $allElements)
     {
-        if (isset($idx[0]) && 123 == $idx[0] && isset($idx[1]) && 456 == $idx[1]) {
+        if (isset($idx[0]) && 123 === $idx[0] && isset($idx[1]) && 456 === $idx[1]) {
             return true;
         }
 
-        if (isset($idx[0]) && 999 == $idx[0]) {
+        if (isset($idx[0]) && 999 === $idx[0]) {
             return 'flash_foo_error';
         }
 

--- a/tests/Fixtures/Controller/ModelAdminController.php
+++ b/tests/Fixtures/Controller/ModelAdminController.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Sonata Project package.
- *
- * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Sonata\AdminBundle\Tests\Fixtures\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController;

--- a/tests/Fixtures/Controller/ModelAdminController.php
+++ b/tests/Fixtures/Controller/ModelAdminController.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sonata\AdminBundle\Tests\Fixtures\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController;

--- a/tests/Fixtures/Controller/PreCRUDController.php
+++ b/tests/Fixtures/Controller/PreCRUDController.php
@@ -24,27 +24,27 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class PreCRUDController extends CRUDController
 {
-    protected function preCreate(Request $request, $object)
+    protected function preCreate(Request $request, $object): ?Response
     {
         return new Response(sprintf('preCreate called: %s', $object->foo));
     }
 
-    protected function preEdit(Request $request, $object)
+    protected function preEdit(Request $request, $object): ?Response
     {
         return new Response(sprintf('preEdit called: %s', $object->foo));
     }
 
-    protected function preDelete(Request $request, $object)
+    protected function preDelete(Request $request, $object): ?Response
     {
         return new Response(sprintf('preDelete called: %s', $object->foo));
     }
 
-    protected function preShow(Request $request, $object)
+    protected function preShow(Request $request, $object): ?Response
     {
         return new Response(sprintf('preShow called: %s', $object->foo));
     }
 
-    protected function preList(Request $request)
+    protected function preList(Request $request): ?Response
     {
         return new Response(sprintf('preList called'));
     }

--- a/tests/Fixtures/Filter/FooFilter.php
+++ b/tests/Fixtures/Filter/FooFilter.php
@@ -26,14 +26,14 @@ class FooFilter extends Filter
     {
     }
 
-    public function getDefaultOptions()
+    public function getDefaultOptions(): array
     {
         return [
             'foo' => 'bar',
         ];
     }
 
-    public function getRenderSettings(): void
+    public function getRenderSettings(): array
     {
     }
 }

--- a/tests/Menu/Integration/BaseMenuTest.php
+++ b/tests/Menu/Integration/BaseMenuTest.php
@@ -65,10 +65,8 @@ abstract class BaseMenuTest extends TestCase
      * Helper method to strip newline and space characters from html string to make comparing easier.
      *
      * @param string $html
-     *
-     * @return string
      */
-    protected function cleanHtmlWhitespace($html)
+    protected function cleanHtmlWhitespace($html): string
     {
         $html = preg_replace_callback('/>([^<]+)</', static function ($value) {
             return '>'.trim($value[1]).'<';

--- a/tests/Menu/Matcher/Voter/AbstractVoterTest.php
+++ b/tests/Menu/Matcher/Voter/AbstractVoterTest.php
@@ -19,10 +19,7 @@ use PHPUnit\Framework\TestCase;
 
 abstract class AbstractVoterTest extends TestCase
 {
-    /**
-     * @return array
-     */
-    abstract public function provideData();
+    abstract public function provideData(): array;
 
     /**
      * @param mixed     $itemData
@@ -43,15 +40,11 @@ abstract class AbstractVoterTest extends TestCase
     /**
      * @param mixed $dataVoter
      * @param mixed $route
-     *
-     * @return VoterInterface
      */
-    abstract protected function createVoter($dataVoter, $route);
+    abstract protected function createVoter($dataVoter, $route): VoterInterface;
 
     /**
      * @param mixed $data
-     *
-     * @return ItemInterface
      */
-    abstract protected function createItem($data);
+    abstract protected function createItem($data): ItemInterface;
 }

--- a/tests/Menu/Matcher/Voter/ActiveVoterTest.php
+++ b/tests/Menu/Matcher/Voter/ActiveVoterTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Menu\Matcher\Voter;
 
 use Knp\Menu\ItemInterface;
+use Knp\Menu\Matcher\Voter\VoterInterface;
 use Sonata\AdminBundle\Menu\Matcher\Voter\ActiveVoter;
 
 class ActiveVoterTest extends AbstractVoterTest
@@ -21,7 +22,7 @@ class ActiveVoterTest extends AbstractVoterTest
     /**
      * {@inheritdoc}
      */
-    public function createVoter($dataVoter, $route)
+    public function createVoter($dataVoter, $route): VoterInterface
     {
         return new ActiveVoter();
     }
@@ -29,7 +30,7 @@ class ActiveVoterTest extends AbstractVoterTest
     /**
      * {@inheritdoc}
      */
-    public function provideData()
+    public function provideData(): array
     {
         return [
             'active' => [true, null, true, true],

--- a/tests/Menu/Matcher/Voter/ActiveVoterTest.php
+++ b/tests/Menu/Matcher/Voter/ActiveVoterTest.php
@@ -40,10 +40,8 @@ class ActiveVoterTest extends AbstractVoterTest
 
     /**
      * @param mixed $data
-     *
-     * @return ItemInterface
      */
-    protected function createItem($data)
+    protected function createItem($data): ItemInterface
     {
         $item = $this->getMockForAbstractClass(ItemInterface::class);
         $item->expects($this->any())

--- a/tests/Menu/Matcher/Voter/AdminVoterTest.php
+++ b/tests/Menu/Matcher/Voter/AdminVoterTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Menu\Matcher\Voter;
 
 use Knp\Menu\ItemInterface;
+use Knp\Menu\Matcher\Voter\VoterInterface;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,7 +25,7 @@ class AdminVoterTest extends AbstractVoterTest
     /**
      * {@inheritdoc}
      */
-    public function provideData()
+    public function provideData(): array
     {
         return [
             'no data' => [null, null, null, null],
@@ -59,7 +60,7 @@ class AdminVoterTest extends AbstractVoterTest
     /**
      * {@inheritdoc}
      */
-    protected function createVoter($dataVoter, $route)
+    protected function createVoter($dataVoter, $route): VoterInterface
     {
         $request = new Request();
         $request->request->set('_sonata_admin', $dataVoter);
@@ -76,7 +77,7 @@ class AdminVoterTest extends AbstractVoterTest
     /**
      * {@inheritdoc}
      */
-    protected function createItem($data)
+    protected function createItem($data): ItemInterface
     {
         $item = $this->getMockForAbstractClass(ItemInterface::class);
         $item->expects($this->any())

--- a/tests/Menu/Matcher/Voter/ChildrenVoterTest.php
+++ b/tests/Menu/Matcher/Voter/ChildrenVoterTest.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Tests\Menu\Matcher\Voter;
 
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Matcher;
+use Knp\Menu\Matcher\Voter\VoterInterface;
 use Sonata\AdminBundle\Menu\Matcher\Voter\ChildrenVoter;
 
 /**
@@ -26,7 +27,7 @@ class ChildrenVoterTest extends AbstractVoterTest
     /**
      * {@inheritdoc}
      */
-    public function provideData()
+    public function provideData(): array
     {
         return [
             'with no current' => [[false, false], null, new Matcher(), null],
@@ -38,7 +39,7 @@ class ChildrenVoterTest extends AbstractVoterTest
     /**
      * {@inheritdoc}
      */
-    protected function createVoter($dataVoter, $route)
+    protected function createVoter($dataVoter, $route): VoterInterface
     {
         return new ChildrenVoter($route);
     }
@@ -46,7 +47,7 @@ class ChildrenVoterTest extends AbstractVoterTest
     /**
      * {@inheritdoc}
      */
-    protected function createItem($data)
+    protected function createItem($data): ItemInterface
     {
         $childItems = [];
         foreach ($data as $childData) {

--- a/tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/tests/Menu/Provider/GroupMenuProviderTest.php
@@ -67,7 +67,6 @@ class GroupMenuProviderTest extends TestCase
     /**
      * NEXT_MAJOR: Remove this test.
      *
-     * @param array $adminGroups
      *
      * @group legacy
      * @dataProvider getAdminGroups
@@ -110,8 +109,6 @@ class GroupMenuProviderTest extends TestCase
     }
 
     /**
-     * @param array $adminGroups
-     *
      * @dataProvider getAdminGroups
      */
     public function testGetMenuProviderWithCheckerGrantedGroupRoles(array $adminGroups): void
@@ -151,10 +148,8 @@ class GroupMenuProviderTest extends TestCase
 
     /**
      * @param array $args
-     *
-     * @return bool
      */
-    public function unanimousGrantCheckerMock($args)
+    public function unanimousGrantCheckerMock($args): bool
     {
         if ($args === ['foo', 'bar']) {
             return false;
@@ -169,10 +164,8 @@ class GroupMenuProviderTest extends TestCase
 
     /**
      * @param array $args
-     *
-     * @return bool
      */
-    public function unanimousGrantCheckerNoBazMock($args)
+    public function unanimousGrantCheckerNoBazMock($args): bool
     {
         if ($args === ['foo', 'bar'] || $args === ['baz']) {
             return false;
@@ -186,8 +179,6 @@ class GroupMenuProviderTest extends TestCase
     }
 
     /**
-     * @param array $adminGroups
-     *
      * @dataProvider getAdminGroupsMultipleRoles
      */
     public function testGetMenuProviderWithCheckerGrantedMultipleGroupRoles(
@@ -213,8 +204,6 @@ class GroupMenuProviderTest extends TestCase
     }
 
     /**
-     * @param array $adminGroups
-     *
      * @dataProvider getAdminGroupsMultipleRoles
      */
     public function testGetMenuProviderWithCheckerGrantedGroupAndItemRoles(
@@ -241,8 +230,6 @@ class GroupMenuProviderTest extends TestCase
     }
 
     /**
-     * @param array $adminGroups
-     *
      * @dataProvider getAdminGroupsMultipleRolesOnTop
      */
     public function testGetMenuProviderWithCheckerGrantedMultipleGroupRolesOnTop(
@@ -265,8 +252,6 @@ class GroupMenuProviderTest extends TestCase
     }
 
     /**
-     * @param array $adminGroups
-     *
      * @dataProvider getAdminGroups
      */
     public function testGetMenuProviderWithAdmin(array $adminGroups): void
@@ -309,8 +294,6 @@ class GroupMenuProviderTest extends TestCase
     }
 
     /**
-     * @param array $adminGroups
-     *
      * @dataProvider getAdminGroups
      */
     public function testGetKnpMenuWithListRoute(array $adminGroups): void
@@ -339,8 +322,6 @@ class GroupMenuProviderTest extends TestCase
     }
 
     /**
-     * @param array $adminGroups
-     *
      * @dataProvider getAdminGroups
      */
     public function testGetKnpMenuWithGrantedList(array $adminGroups): void
@@ -369,8 +350,6 @@ class GroupMenuProviderTest extends TestCase
     }
 
     /**
-     * @param array $adminGroupsOnTopOption
-     *
      * @dataProvider getAdminGroupsWithOnTopOption
      */
     public function testGetMenuProviderOnTopOptions(array $adminGroupsOnTopOption): void
@@ -393,8 +372,6 @@ class GroupMenuProviderTest extends TestCase
     }
 
     /**
-     * @param array $adminGroups
-     *
      * @dataProvider getAdminGroups
      */
     public function testGetMenuProviderKeepOpenOption(array $adminGroups): void
@@ -423,10 +400,7 @@ class GroupMenuProviderTest extends TestCase
         $this->assertTrue($menu->getExtra('keep_open'));
     }
 
-    /**
-     * @return array
-     */
-    public function getAdminGroups()
+    public function getAdminGroups(): array
     {
         return [
             [
@@ -456,10 +430,7 @@ class GroupMenuProviderTest extends TestCase
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function getAdminGroupsMultipleRoles()
+    public function getAdminGroupsMultipleRoles(): array
     {
         return [
             [
@@ -552,10 +523,7 @@ class GroupMenuProviderTest extends TestCase
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function getAdminGroupsMultipleRolesOnTop()
+    public function getAdminGroupsMultipleRolesOnTop(): array
     {
         return [
             [
@@ -616,10 +584,7 @@ class GroupMenuProviderTest extends TestCase
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function getAdminGroupsWithOnTopOption()
+    public function getAdminGroupsWithOnTopOption(): array
     {
         return [
             [

--- a/tests/Resources/XliffTest.php
+++ b/tests/Resources/XliffTest.php
@@ -20,7 +20,7 @@ class XliffTest extends XliffValidatorTestCase
     /**
      * @return array List all path to validate xliff
      */
-    public function getXliffPaths()
+    public function getXliffPaths(): array
     {
         return [[__DIR__.'/../../src/Resources/translations']];
     }

--- a/tests/Search/SearchHandlerTest.php
+++ b/tests/Search/SearchHandlerTest.php
@@ -27,10 +27,8 @@ class SearchHandlerTest extends TestCase
 {
     /**
      * @param AdminInterface $admin
-     *
-     * @return Pool
      */
-    public function getPool(AdminInterface $admin = null)
+    public function getPool(AdminInterface $admin = null): Pool
     {
         $container = $this->getMockForAbstractClass(ContainerInterface::class);
         $container->expects($this->any())->method('get')->willReturnCallback(static function ($id) use ($admin) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Narrow API by using explicit type declarations.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes could break BC, although these cases aren't valid.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added explicit return declarations in methods were they are missing and the return type was declared with docblocks.
```

## To do
    
- [ ] Check missing occurrences;
- [ ] Try to remove before the methods that should not be present on 4.0 (maybe another PR for that will be the better choice);
- [ ] Check if is possible to perform similar update for method arguments;
- [ ] Validate if getters can throw exceptions (like [`FormInterface::get()`](https://github.com/symfony/symfony/blob/288bc24d0362fe87c4eb5c67f89d08f9b93e5807/src/Symfony/Component/Form/Form.php#L932-L939)) instead of returning `null` for nonexistent values (by instance, `DatagridInterface::getFilter($name)`).