### PR TITLE
Add missing dev requirement against "phpspec/prophecy"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
         "jms/di-extra-bundle": "^1.9",
         "jms/translation-bundle": "^1.4",
         "matthiasnoback/symfony-dependency-injection-test": "^3.1",
+        "phpspec/prophecy": "^1.8",
         "sensio/generator-bundle": "^3.1",
         "sonata-project/intl-bundle": "^2.4",
         "symfony/class-loader": "^2.8 || ^3.2",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Add missing dev requirement against "phpspec/prophecy".
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Development dependency against "phpspec/prophecy".
```
