### PR TITLE
Implement interfaces from SonataBlockBundle

### DIFF
--- a/src/Block/AbstractAdminBlockService.php
+++ b/src/Block/AbstractAdminBlockService.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Block;
+
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
+use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\Form\Validator\ErrorElement;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+abstract class AbstractAdminBlockService extends AbstractBlockService implements EditableBlockService
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureEditForm(FormMapper $formMapper, BlockInterface $block): void
+    {
+        $this->configureCreateForm($formMapper, $block);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param string|null $code This param must be removed
+     */
+    public function getMetadata($code = null): MetadataInterface
+    {
+        return new Metadata($this->getName(), $this->getName(), false, 'SonataAdminBundle', ['class' => 'fa fa-file']);
+    }
+}

--- a/src/Block/AdminListBlockService.php
+++ b/src/Block/AdminListBlockService.php
@@ -17,7 +17,6 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -25,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AdminListBlockService extends AbstractBlockService
+class AdminListBlockService extends AbstractAdminBlockService
 {
     /**
      * @var Pool

--- a/src/Block/AdminSearchBlockService.php
+++ b/src/Block/AdminSearchBlockService.php
@@ -17,7 +17,6 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Search\SearchHandler;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,7 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AdminSearchBlockService extends AbstractBlockService
+class AdminSearchBlockService extends AbstractAdminBlockService
 {
     /**
      * @var Pool

--- a/src/Block/AdminStatsBlockService.php
+++ b/src/Block/AdminStatsBlockService.php
@@ -15,7 +15,6 @@ namespace Sonata\AdminBundle\Block;
 
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -23,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AdminStatsBlockService extends AbstractBlockService
+class AdminStatsBlockService extends AbstractAdminBlockService
 {
     /**
      * @var Pool


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Implement interfaces from SonataBlockBundle.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Triggered by #5622.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added implementation of `Sonata\BlockBundle\Block\Service\EditableBlockService` at `Sonata\AdminBundle\Block\AdminListBlockService`, `Sonata\AdminBundle\Block\AdminSearchBlockService` and `Sonata\AdminBundle\Block\AdminStatsBlockService`.
```

## To do:
- [ ] Check how to add implementation of `Sonata\BlockBundle\Form\Mapper\FormMapper` at `Sonata\AdminBundle\Form\FormMapper`, since the implementation of `add()` method has an extra argument.