### PR TITLE
[docs] Fix line numbers describing CategoryAdmin class

### DIFF
--- a/docs/getting_started/creating_an_admin.rst
+++ b/docs/getting_started/creating_an_admin.rst
@@ -134,12 +134,12 @@ easiest way to do this is by extending ``Sonata\AdminBundle\Admin\AbstractAdmin`
 
 So, what does this code do?
 
-* **Line 11-14**: These lines configure which fields are displayed on the edit
+* **configureFormFields()**: This method configures which fields are displayed on the edit
   and create actions. The ``FormMapper`` behaves similar to the ``FormBuilder``
   of the Symfony Form component;
-* **Line 16-19**: This method configures the filters, used to filter and sort
+* **configureDatagridFilters()**: This method configures the filters, used to filter and sort
   the list of models;
-* **Line 21-24**: Here you specify which fields are shown when all models are
+* **configureListFields()**: Here you specify which fields are shown when all models are
   listed (the ``addIdentifier()`` method means that this field will link to the
   show/edit page of this particular model).
 


### PR DESCRIPTION
Method names will better reflect the reference of code instead of relying on line numbers which may shift if the code blocks change around.

Seen here: https://symfony.com/doc/3.x/bundles/SonataAdminBundle/getting_started/creating_an_admin.html

Replaces #5625