### PR TITLE
#5633 fix using Commands for symfony 2.8.x versions

### DIFF
--- a/src/Command/CreateClassCacheCommand.php
+++ b/src/Command/CreateClassCacheCommand.php
@@ -57,7 +57,10 @@ class CreateClassCacheCommand extends Command
 
     public function configure()
     {
-        $this->setDescription('Generate the classes.php files');
+        $this->setDescription('Generate the classes.php files')
+            ->setName(static::$defaultName)// BC for symfony/console < 3.4.0
+            // NEXT_MAJOR: drop this line after drop support symfony/console < 3.4.0
+        ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)

--- a/src/Command/ExplainAdminCommand.php
+++ b/src/Command/ExplainAdminCommand.php
@@ -50,7 +50,10 @@ class ExplainAdminCommand extends Command
 
     public function configure()
     {
-        $this->setDescription('Explain an admin service');
+        $this->setDescription('Explain an admin service')
+            ->setName(static::$defaultName)// BC for symfony/console < 3.4.0
+            // NEXT_MAJOR: drop this line after drop support symfony/console < 3.4.0
+        ;
 
         $this->addArgument('admin', InputArgument::REQUIRED, 'The admin service id');
     }

--- a/src/Command/GenerateAdminCommand.php
+++ b/src/Command/GenerateAdminCommand.php
@@ -64,6 +64,8 @@ class GenerateAdminCommand extends QuestionableCommand
     {
         $this
             ->setDescription('Generates an admin class based on the given model class')
+            ->setName(static::$defaultName)// BC for symfony/console < 3.4.0
+            // NEXT_MAJOR: drop this line after drop support symfony/console < 3.4.0
             ->addArgument('model', InputArgument::REQUIRED, 'The fully qualified model class')
             ->addOption('bundle', 'b', InputOption::VALUE_OPTIONAL, 'The bundle name')
             ->addOption('admin', 'a', InputOption::VALUE_OPTIONAL, 'The admin class basename')

--- a/src/Command/GenerateObjectAclCommand.php
+++ b/src/Command/GenerateObjectAclCommand.php
@@ -68,6 +68,8 @@ class GenerateObjectAclCommand extends QuestionableCommand
     {
         $this
             ->setDescription('Install ACL for the objects of the Admin Classes.')
+            ->setName(static::$defaultName)// BC for symfony/console < 3.4.0
+            // NEXT_MAJOR: drop this line after drop support symfony/console < 3.4.0
             ->addOption('object_owner', null, InputOption::VALUE_OPTIONAL, 'If set, the task will set the object owner for each admin.')
             ->addOption('user_entity', null, InputOption::VALUE_OPTIONAL, 'Shortcut notation like <comment>AcmeDemoBundle:User</comment>. If not set, it will be asked the first time an object owner is set.')
             ->addOption('step', null, InputOption::VALUE_NONE, 'If set, the task will ask for each admin if the ACLs need to be generated and what object owner to set, if any.')

--- a/src/Command/ListAdminCommand.php
+++ b/src/Command/ListAdminCommand.php
@@ -42,7 +42,10 @@ class ListAdminCommand extends Command
 
     public function configure()
     {
-        $this->setDescription('List all admin services available');
+        $this->setDescription('List all admin services available')
+            ->setName(static::$defaultName)// BC for symfony/console < 3.4.0
+            // NEXT_MAJOR: drop this line after drop support symfony/console < 3.4.0
+        ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)

--- a/src/Command/SetupAclCommand.php
+++ b/src/Command/SetupAclCommand.php
@@ -50,7 +50,10 @@ class SetupAclCommand extends Command
 
     public function configure()
     {
-        $this->setDescription('Install ACL for Admin Classes');
+        $this->setDescription('Install ACL for Admin Classes')
+            ->setName(static::$defaultName)// BC for symfony/console < 3.4.0
+            // NEXT_MAJOR: drop this line after drop support symfony/console < 3.4.0
+        ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

fix #5633. Add setName for all Commands in the bundle.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5633

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Call setName method in configure part of Command, for backward compatibility wiht sf 2.8.x 
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
