### PR TITLE
Fix when a service have a numeric id

### DIFF
--- a/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
@@ -30,6 +30,10 @@ final class ModelManagerCompilerPass implements CompilerPassInterface
         $availableManagers = [];
 
         foreach ($container->getServiceIds() as $id) {
+            // NEXT_MAJOR: Remove when dropping Symfony <3.4 support.
+            // @see https://github.com/sonata-project/SonataAdminBundle/pull/5638
+            $id = (string) $id;
+
             if (0 !== strpos($id, 'sonata.admin.manager.') || !is_subclass_of($container->getDefinition($id)->getClass(), ModelManagerInterface::class)) {
                 continue;
             }

--- a/src/DependencyInjection/Compiler/ObjectAclManipulatorCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ObjectAclManipulatorCompilerPass.php
@@ -30,6 +30,10 @@ final class ObjectAclManipulatorCompilerPass implements CompilerPassInterface
         $availableManagers = [];
 
         foreach ($container->getServiceIds() as $id) {
+            // NEXT_MAJOR: Remove when dropping Symfony <3.4 support.
+            // @see https://github.com/sonata-project/SonataAdminBundle/pull/5638
+            $id = (string) $id;
+
             if (0 !== strpos($id, 'sonata.admin.manipulator.acl.object.') || !is_subclass_of($container->getDefinition($id)->getClass(), ObjectAclManipulatorInterface::class)) {
                 continue;
             }


### PR DESCRIPTION
## Subject

sometimes Symfony generates services with numeric ids (eg: `Symfony\Component\DependencyInjection\ServiceLocator`) and when iterating over the services ids, their service id is an int not a string. that triggers an error because strpos accpet only a string for its first argument when strict_types=1

I am targeting this branch, because this is a backward compatible fix

There's no corresponding issue

## Changelog

```markdown
### Fixed
- Fixed `ModelManagerCompilerPass` & `ObjectAclManipulatorCompilerPass` to avoid crashing when there's services with numerical ids
```