### PR TITLE
Add scalar value for _per_page to Datagrid in AdminStatsBlockService

### DIFF
--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -132,7 +133,15 @@ class Datagrid implements DatagridInterface
 
         $this->formBuilder->add('_sort_order', $hiddenType);
         $this->formBuilder->add('_page', $hiddenType);
-        $this->formBuilder->add('_per_page', $hiddenType);
+
+        if (isset($this->values['_per_page']) && \is_array($this->values['_per_page'])) {
+            $this->formBuilder->add('_per_page', CollectionType::class, [
+                'entry_type' => $hiddenType,
+                'allow_add' => true,
+            ]);
+        } else {
+            $this->formBuilder->add('_per_page', $hiddenType);
+        }
 
         $this->form = $this->formBuilder->getForm();
         $this->form->submit($this->values);

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -516,6 +516,8 @@ class DatagridTest extends TestCase
             ['3', '50'],
             [3, '50'],
             ['3', 50],
+            [3, ['type' => null, 'value' => 50]],
+            [3, ['type' => null, 'value' => '50']],
         ];
     }
 


### PR DESCRIPTION
## Subject
Fix form validation in admin homepage.

Before the _per_page was an array with type and value but the type was HiddenType...

To fix this error : In AdminStatsBlockService, we inject _per_page via a new `Datagrid` function : setSimpleValue. So _per_page is now a scalar...

This change should fix https://github.com/sonata-project/SonataAdminBundle/issues/5457