### PR TITLE
fix ChoiceFieldMaskType script, escape field value

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -546,7 +546,7 @@ file that was distributed with this source code.
             {% if value is empty %}
                 choice_field_mask_show(showMaskChoiceEl.val());
             {% else %}
-                choice_field_mask_show('{{ value }}');
+                choice_field_mask_show('{{ value|e('js') }}');
             {% endif %}
         });
 


### PR DESCRIPTION
## Subject

ChoiceFieldMaskType's JavaScript in its twig template doesn't escape the field value, which breaks the JS when said value contains backslashes. The bug happens only if the ChoiceFieldMaskType field has a value already.

I am targeting this branch, because this is a patch.

Closes #5637 

## Changelog

```markdown
### Fixed
- Fixed ChoiceFieldMaskType's twig template JavaScript using unescaped field value
```