### PR TITLE
fix php7.3 warning: checking that count() isn't called on a NULL

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2947,7 +2947,7 @@ EOT;
 
         $mapper = new ListMapper($this->getListBuilder(), $this->list, $this);
 
-        if (\count($this->getBatchActions()) > 0 && $this->hasRequest() && !$this->getRequest()->isXmlHttpRequest()) {
+        if (!empty($this->getBatchActions()) && \count($this->getBatchActions()) > 0 && $this->hasRequest() && !$this->getRequest()->isXmlHttpRequest()) {
             $fieldDescription = $this->getModelManager()->getNewFieldDescriptionInstance(
                 $this->getClass(),
                 'batch',


### PR DESCRIPTION
## PHP 7.3 throws a warning when count() is called on a non-countable object.

Fixes #5469 

Here $this->getBatchActions() can be NULL and the Warning can be thrown.
I added non-breaking !empty() check avoid the warning.

I am targeting 3.x because the modified condition wasn't going to enter the the tested value is NULL. Making the same with PHP 7.2 and PHP 7.3.

## Changelog

### Fixed
- PHP 7.3 warning on count()
```
