### PR TITLE
Update AbstractAdmin.php

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -790,6 +790,11 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
                 $filters
             );
 
+            //$parameters['_per_page'] is string, but it has to be an integer
+            if (isset($parameters['_per_page'])) {
+                $parameters['_per_page'] = (int) $parameters['_per_page'];
+            }            
+            
             if (!$this->determinedPerPageValue($parameters['_per_page'])) {
                 $parameters['_per_page'] = $this->maxPerPage;
             }


### PR DESCRIPTION
Sonata Admin Bundle Version 3.51.0
Sumfony 3.4

Not working for me still, updated to the most stable version.

I found the issue, it is around determinedPerPageValue and it checks the value against list of available pagination options and also checks against the data type. so I think we need to add the following setting on vendor/sonata-project/admin-bundle/src/Admin/AbstractAdmin.php on line 786 before if (!$this->determinedPerPageValue($parameters['_per_page'])) { and it will work.

if (isset($parameters['_per_page'])) {
    $parameters['_per_page'] = (int) $parameters['_per_page'];
}

Reason being the $parameters['_per_page'] is string while determinedPerPageValue expecting it to be integer. Or, otherwise on determinedPerPageValue function code sniff we should remove the data type check setting and only check the values.