### PR TITLE
Fix typo in Russian translation

### DIFF
--- a/src/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ru.xliff
@@ -156,7 +156,7 @@
             </trans-unit>
             <trans-unit id="flash_create_success">
                 <source>flash_create_success</source>
-                <target>Элемент создан успешно</target>
+                <target>Элемент успешно создан</target>
             </trans-unit>
             <trans-unit id="flash_create_error">
                 <source>flash_create_error</source>


### PR DESCRIPTION
## Subject

The wording of the sentence is incorrect from the point of view of the norms of the Russian language.

## Changelog

```markdown
### Fixed
- Fix typo in Russian translation
```
