### PR TITLE
Use @method annotation to propagate new methods

### DIFF
--- a/src/Admin/AccessRegistryInterface.php
+++ b/src/Admin/AccessRegistryInterface.php
@@ -17,6 +17,8 @@ namespace Sonata\AdminBundle\Admin;
  * Tells if the current user has access to a given action.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @method hasAccess(string $action, ?object $object = null): bool
  */
 interface AccessRegistryInterface
 {

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -24,6 +24,12 @@ use Sonata\Form\Validator\ErrorElement;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @method getAccessMapping(AdminInterface $admin): array
+ * @method configureBatchActions(AdminInterface $admin, array $actions): array
+ * @method configureExportFields(AdminInterface $admin, array $fields): array
+ * @method configureActionButtons(AdminInterface $admin, array $list, string $action, object $object): array
+ * @method configureDefaultFilterValues(AdminInterface $admin, array &$filterValues): void
  */
 interface AdminExtensionInterface
 {

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -32,6 +32,13 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @method configureActionButtons(string $action, ?object $object = null): array
+ * @method getSearchResultLink(object $object): ?strin
+ * @method showMosaicButton(bool $isShown): void
+ * @method isDefaultFilter(string $name): bool
+ *
+ * Configure buttons for an action
  */
 interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface
 {

--- a/src/Admin/LifecycleHookProviderInterface.php
+++ b/src/Admin/LifecycleHookProviderInterface.php
@@ -18,6 +18,8 @@ namespace Sonata\AdminBundle\Admin;
  * during the lifecycle of the object.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @method preValidate($object): void
  */
 interface LifecycleHookProviderInterface
 {

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -15,6 +15,8 @@ namespace Sonata\AdminBundle\Templating;
 
 /**
  * @author Timo Bakx <timobakx@gmail.com>
+ *
+ * @method hasTemplate(string $name): bool
  */
 interface TemplateRegistryInterface
 {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is a nice hack to propagate new method on our interfaces without breaking the API. If the user wants to use the new method, he should implement it and can benefit from a nice IDE autocompletion and code analysis.

I'm not sure if it's a good idea or not.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Use `@method` annotation to propagate new methods
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
