### PR TITLE
Replace calls to `call_user_func()` and `call_user_func_array()`

### DIFF
--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -107,7 +107,7 @@ final class RetrieveAutocompleteItemsAction
                 throw new \RuntimeException('Callback does not contain callable function.');
             }
 
-            \call_user_func($callback, $targetAdmin, $property, $searchText);
+            $callback($targetAdmin, $property, $searchText);
         } else {
             if (\is_array($property)) {
                 // multiple properties
@@ -154,7 +154,7 @@ final class RetrieveAutocompleteItemsAction
                     throw new \RuntimeException('Option "to_string_callback" does not contain callable function.');
                 }
 
-                $label = \call_user_func($toStringCallback, $entity, $property);
+                $label = $toStringCallback($entity, $property);
             } else {
                 $resultMetadata = $targetAdmin->getObjectMetadata($entity);
                 $label = $resultMetadata->getTitle();

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -297,14 +297,14 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
             if (method_exists($object, $getter) && \is_callable([$object, $getter])) {
                 $this->cacheFieldGetter($object, $fieldName, 'getter', $getter);
 
-                return \call_user_func_array([$object, $getter], $parameters);
+                return $object->{$getter}(...$parameters);
             }
         }
 
         if (method_exists($object, '__call')) {
             $this->cacheFieldGetter($object, $fieldName, 'call');
 
-            return \call_user_func_array([$object, '__call'], [$fieldName, $parameters]);
+            return $object->{$fieldName}(...$parameters);
         }
 
         if (isset($object->{$fieldName})) {
@@ -459,15 +459,9 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     {
         $getterKey = $this->getFieldGetterKey($object, $fieldName);
         if ('getter' === self::$fieldGetters[$getterKey]['method']) {
-            return \call_user_func_array(
-                [$object, self::$fieldGetters[$getterKey]['getter']],
-                $parameters
-            );
+            return $object->{self::$fieldGetters[$getterKey]['getter']}(...$parameters);
         } elseif ('call' === self::$fieldGetters[$getterKey]['method']) {
-            return \call_user_func_array(
-                [$object, '__call'],
-                [$fieldName, $parameters]
-            );
+            return $object->{$fieldName}(...$parameters);
         }
 
         return $object->{$fieldName};

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -79,7 +79,7 @@ class CRUDController implements ContainerAwareInterface
     public function __call($method, $arguments)
     {
         if (\in_array($method, ['get', 'has'], true)) {
-            return \call_user_func_array([$this->container, $method], $arguments);
+            return $this->container->{$method}(...$arguments);
         }
 
         if (method_exists($this, 'proxyToControllerClass')) {
@@ -478,7 +478,7 @@ class CRUDController implements ContainerAwareInterface
         $isRelevantAction = sprintf('batchAction%sIsRelevant', $camelizedAction);
 
         if (method_exists($this, $isRelevantAction)) {
-            $nonRelevantMessage = \call_user_func([$this, $isRelevantAction], $idx, $allElements, $request);
+            $nonRelevantMessage = $this->{$isRelevantAction}($idx, $allElements, $request);
         } else {
             $nonRelevantMessage = 0 !== \count($idx) || $allElements; // at least one item is selected
         }
@@ -553,7 +553,7 @@ class CRUDController implements ContainerAwareInterface
             return $this->redirectToList();
         }
 
-        return \call_user_func([$this, $finalAction], $query, $request);
+        return $this->{$finalAction}($query, $request);
     }
 
     /**

--- a/src/Controller/PolyfillControllerTrait.php
+++ b/src/Controller/PolyfillControllerTrait.php
@@ -61,7 +61,7 @@ class PolyfillProxyContainer extends Controller
 
     public function proxyCall($method, $arguments)
     {
-        return \call_user_func_array([$this, $method], $arguments);
+        return $this->{$method}(...$arguments);
     }
 }
 

--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -141,7 +141,7 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
                     throw new \RuntimeException('Callback in "to_string_callback" option doesn`t contain callable function.');
                 }
 
-                $label = \call_user_func($this->toStringCallback, $entity, $this->property);
+                $label = ($this->toStringCallback)($entity, $this->property);
             } else {
                 try {
                     $label = (string) $entity;

--- a/src/Route/RouteCollection.php
+++ b/src/Route/RouteCollection.php
@@ -285,10 +285,6 @@ class RouteCollection
 
     private function resolve($element): Route
     {
-        if (\is_callable($element)) {
-            return \call_user_func($element);
-        }
-
-        return $element;
+        return \is_callable($element) ? $element() : $element;
     }
 }

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -369,7 +369,7 @@ class SonataAdminExtension extends AbstractExtension
                 ));
             }
 
-            return \call_user_func([$element, $method]);
+            return $element->{$method}();
         }
 
         if (\is_callable($propertyPath)) {

--- a/tests/Event/AdminEventExtensionTest.php
+++ b/tests/Event/AdminEventExtensionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Event;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminExtensionInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -27,14 +28,11 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class AdminEventExtensionTest extends TestCase
 {
-    /**
-     * @return AdminEventExtension
-     */
-    public function getExtension($args)
+    public function getExtension(array $args): AdminExtensionInterface
     {
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $stub = $eventDispatcher->expects($this->once())->method('dispatch');
-        \call_user_func_array([$stub, 'with'], $args);
+        $stub->with(...$args);
 
         return new AdminEventExtension($eventDispatcher);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Replace calls to `call_user_func()` and `call_user_func_array()`.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->