### PR TITLE
Fix error when showing revision list with strict variables enabled

### DIFF
--- a/src/Resources/views/CRUD/display_datetime.html.twig
+++ b/src/Resources/views/CRUD/display_datetime.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}
-        {% set options = field_description.options %}
+        {% set options = field_description.options|default(null) %}
         <time datetime="{{ value|date('c', 'UTC') }}" title="{{ value|date('c', 'UTC') }}">
             {{ value|date(options.format|default(null), options.timezone|default(null)) }}
         </time>


### PR DESCRIPTION
## Subject

I am targeting this branch, because this fix respects BC.

The bug was introduced with this PR: https://github.com/sonata-project/SonataAdminBundle/pull/5560
Revision list doesn't have `field_description` in template context. Therefore trying to open revision list with twig config `strict_variables: true` fails.

## Changelog

```markdown
### Fixed
- Fixed error when rendering revision list with Twig's `strict_variables` enabled
```