### PR TITLE
Allow to use pluralized translations with block stats widgets

### DIFF
--- a/docs/reference/dashboard.rst
+++ b/docs/reference/dashboard.rst
@@ -319,10 +319,33 @@ counter is related to the filters from one admin
                         settings:
                             code:  sonata.page.admin.page    # admin code - service id
                             icon:  fa-magic                  # font awesome icon
-                            text:  Edited Pages
+                            text:  app.page.stats            # static text or translation message
                             color: bg-yellow                 # colors: bg-green, bg-red and bg-aqua
                             filters:                         # filter values
                                 edited: { value: 1 }
+
+The block configuration for ``settings.text`` accepts static text or a translation message,
+which could also have a pluralized translation target:
+
+.. code-block:: xml
+
+    <!-- messages.en.xlf -->
+
+    <trans-unit id="app.page.stats">
+        <source>app.page.stats</source>
+        <target>{0} results|{1} result|]1,Inf] results</target>
+    </trans-unit>
+
+**If you're using ``symfony/translation`` >= 4.2, you can also opt in for the ICU Message Format**
+
+.. code-block:: xml
+
+    <!-- messages+intl-icu.en.xlf -->
+
+    <trans-unit id="app.page.stats">
+        <source>app.page.stats</source>
+        <target>{count, plural, =0 {results} one {result} other {results}}</target>
+    </trans-unit>
 
 Dashboard Layout
 ~~~~~~~~~~~~~~~~

--- a/src/Resources/views/Block/block_stats.html.twig
+++ b/src/Resources/views/Block/block_stats.html.twig
@@ -20,7 +20,9 @@ file that was distributed with this source code.
             <h3>{{ pager.count() }}</h3>
             <p>
                 {% if translation_domain %}
-                    {{ settings.text|trans({}, translation_domain) }}
+                    {{ settings.text|transchoice({'%count%': pager.count()}, translation_domain) }}
+                    {# NEXT_MAJOR: bump "symfony/translation" to ^4.2 and replace the previous line with the following #}
+                    {# {{ settings.text|trans({'%count%': pager.count()}, translation_domain) }} #}
                 {% else %}
                     {{ settings.text }}
                 {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Allow to use pluralized translations with block stats widgets.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Allow to use pluralized translations with text provided through `sonata_admin.dashboard.blocks.{offset}.settings.text`.
```
## To do
   
- [x] ~~Add tests~~ (I don't think it could be possible without testing [responsibilities which aren't part of this bundle](https://github.com/symfony/twig-bridge/blob/a265f8ddc0d9a2787f7683270a859c83893e4a94/Tests/Extension/TranslationExtensionTest.php#L35-L48));
- [x] Update the documentation.

### Example:
```xml
<!-- translations/messages.xlf -->

<trans-unit id="admin.block.stats.results">
    <source>admin.block.stats.results</source>
    <target>{0} Results|{1} Result|]1,Inf[ Results</target>
</trans-unit>
```

![image](https://user-images.githubusercontent.com/1231441/65294184-4261d180-db34-11e9-8dc6-e2309a7066a9.png)
