### PR TITLE
CRUDController::validateCsrfToken missing token

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1419,7 +1419,7 @@ class CRUDController implements ContainerAwareInterface
     protected function validateCsrfToken($intention)
     {
         $request = $this->getRequest();
-        $token = $request->request->get('_sonata_csrf_token', false);
+        $token = $request->request->get('_sonata_csrf_token');
 
         if ($this->container->has('security.csrf.token_manager')) {
             $valid = $this->container->get('security.csrf.token_manager')->isTokenValid(new CsrfToken($intention, $token));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

The CsrfToken constructor requires the token to be `?string`. 

If the token is missing in the request we end up with

 `Argument 2 passed to Symfony\Component\Security\Csrf\CsrfToken::__construct() must be of the type string or null, bool given, called in /var/www/html/vendor/sonata-project/admin-bundle/src/Controller/CRUDController.php on line 1425`

The default value for the missing token should be `null`, not boolean `false`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targeting this branch, because I think it's a bug.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed

- `CRUDController::validateCsrfToken` to accept missing request token.

```
