### PR TITLE
Allow validate CSRF token from query string

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1419,7 +1419,7 @@ class CRUDController implements ContainerAwareInterface
     protected function validateCsrfToken($intention)
     {
         $request = $this->getRequest();
-        $token = $request->request->get('_sonata_csrf_token');
+        $token = $request->get('_sonata_csrf_token');
 
         if ($this->container->has('security.csrf.token_manager')) {
             $valid = $this->container->get('security.csrf.token_manager')->isTokenValid(new CsrfToken($intention, $token));


### PR DESCRIPTION
## Subject

Allow `CRUDController::validateCsrfToken` to also validate CSRF from other sources, like the query string.

I am targeting this branch, so others can benefit from this function inside their custom actions. For instance one can generate a link to a custom action, with a csrf token to protect it.

## Changelog

```markdown
### Changed

- `CRUDController::validateCsrfToken` to validate tokens not only from a POST request, but GET as well
```