### PR TITLE
Make truncable all breadcrumb fragments

### DIFF
--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -162,6 +162,8 @@ file that was distributed with this source code.
                                                             {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
                                                         {%- endif -%}
 
+                                                        {% set label = label|truncate(100) %}
+
                                                         {% if not loop.last %}
                                                             <li>
                                                                 {% if menu.uri is not empty %}
@@ -177,7 +179,7 @@ file that was distributed with this source code.
                                                                 {% endif %}
                                                             </li>
                                                         {% else %}
-                                                            <li class="active"><span>{{ label|truncate(100) }}</span></li>
+                                                            <li class="active"><span>{{ label }}</span></li>
                                                         {% endif %}
                                                     {% endfor %}
                                                 {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Make truncable all breadcrumb fragments.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Broken layout on very large breadcrumb fragments.
```
**BEFORE:**
![image](https://user-images.githubusercontent.com/1231441/65295008-658d8080-db36-11e9-9169-9c0d8566513c.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/1231441/65295162-d92f8d80-db36-11e9-9603-c09d53163140.png)
