### PR TITLE
Allow to sort menu groups by their position value

### DIFF
--- a/docs/cookbook/recipe_knp_menu.rst
+++ b/docs/cookbook/recipe_knp_menu.rst
@@ -296,6 +296,39 @@ Your can't use this option for two or more items at the same time:
 
 In this case you have an exception: "You can't use ``on_top`` option with multiple same name groups".
 
+Order menu groups
+-----------------
+
+By default, menu groups are displayed in their declaration order. You can modify this order by adding a ``position``
+option in your sonata_admin dashboard group configuration:
+
+.. code-block:: yaml
+
+    # config/packages/sonata_admin.yaml
+
+    sonata_admin:
+        dashboard:
+            groups:
+                sonata.admin.group.content:
+                    position:        2
+                    label:           sonata_media
+                    label_catalogue: SonataMediaBundle
+                    icon:            '<i class="fa fa-image"></i>'
+                    items:
+                        - sonata.media.admin.media
+                        - sonata.media.admin.gallery
+                news:
+                    position:       1
+                    label:           ~
+                    label_catalogue: ~
+                    items:
+                        - sonata.news.admin.post
+                        - route:        blog_home
+                          label:        Blog
+
+In this case, ``news`` will be displayed before ``sonata.admin.group.content``. Each group has a ``position`` default
+value of 255.
+
 .. _KnpMenu: https://github.com/KnpLabs/KnpMenu
 .. _Knp documentation: http://symfony.com/doc/current/bundles/KnpMenuBundle/index.html#create-your-first-menu
 .. _Using events to allow a menu to be extended: http://symfony.com/doc/master/bundles/KnpMenuBundle/events.html

--- a/docs/cookbook/recipe_knp_menu.rst
+++ b/docs/cookbook/recipe_knp_menu.rst
@@ -300,7 +300,7 @@ Order menu groups
 -----------------
 
 By default, menu groups are displayed in their declaration order. You can modify this order by adding a ``position``
-option in your sonata_admin dashboard group configuration:
+option in your `sonata_admin` dashboard group configuration:
 
 .. code-block:: yaml
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -101,6 +101,7 @@ Full Configuration Options
                     id:
                         label: ~
                         label_catalogue: ~
+                        position: 1
                         icon: '<i class="fa fa-folder"></i>'
                         provider: ~
                         items:

--- a/docs/reference/dashboard.rst
+++ b/docs/reference/dashboard.rst
@@ -156,6 +156,7 @@ declarations.
                     app.admin.group.content:
                         label: app.admin.group.content
                         label_catalogue: App
+                        position: 1
                         items:
                             - app.admin.post
 

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -131,10 +131,6 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $dashboardGroupsSettings = $container->getParameter('sonata.admin.configuration.dashboard_groups');
         if (!empty($dashboardGroupsSettings)) {
             uasort($dashboardGroupsSettings, static function ($a, $b) {
-                if ($a['position'] === $b['position']) {
-                    return 0;
-                }
-
                 return $a['position'] <=> $b['position'];
             });
 

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -130,8 +130,8 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         $dashboardGroupsSettings = $container->getParameter('sonata.admin.configuration.dashboard_groups');
         if (!empty($dashboardGroupsSettings)) {
-            uasort($dashboardGroupsSettings, function ($a, $b) {
-                if ($a['position'] == $b['position']) {
+            uasort($dashboardGroupsSettings, static function ($a, $b) {
+                if ($a['position'] === $b['position']) {
                     return 0;
                 }
 

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -130,6 +130,14 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         $dashboardGroupsSettings = $container->getParameter('sonata.admin.configuration.dashboard_groups');
         if (!empty($dashboardGroupsSettings)) {
+            uasort($dashboardGroupsSettings, function ($a, $b) {
+                if ($a['position'] == $b['position']) {
+                    return 0;
+                }
+
+                return ($a['position'] < $b['position']) ? -1 : 1;
+            });
+
             $groups = $dashboardGroupsSettings;
 
             foreach ($dashboardGroupsSettings as $groupName => $group) {

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -135,7 +135,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     return 0;
                 }
 
-                return ($a['position'] < $b['position']) ? -1 : 1;
+                return $a['position'] <=> $b['position'];
             });
 
             $groups = $dashboardGroupsSettings;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -203,6 +203,7 @@ CASESENSITIVE;
                                 ->children()
                                     ->scalarNode('label')->end()
                                     ->scalarNode('label_catalogue')->end()
+                                    ->scalarNode('position')->defaultValue(255)->end()
                                     ->scalarNode('icon')->defaultValue('<i class="fa fa-folder"></i>')->end()
                                     ->scalarNode('on_top')->defaultFalse()->info('Show menu item in side dashboard menu without treeview')->end()
                                     ->scalarNode('keep_open')->defaultFalse()->info('Keep menu group always open')->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -203,7 +203,7 @@ CASESENSITIVE;
                                 ->children()
                                     ->scalarNode('label')->end()
                                     ->scalarNode('label_catalogue')->end()
-                                    ->scalarNode('position')->defaultValue(255)->end()
+                                    ->integerNode('position')->defaultValue(255)->end()
                                     ->scalarNode('icon')->defaultValue('<i class="fa fa-folder"></i>')->end()
                                     ->scalarNode('on_top')->defaultFalse()->info('Show menu item in side dashboard menu without treeview')->end()
                                     ->scalarNode('keep_open')->defaultFalse()->info('Keep menu group always open')->end()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This pull request allows to sort menu groups from `sonata_admin.dashboard.groups` by a position value added in the configuration.
It's useful when you write bundle recipes, you can add the dedicated menu declaration in a configuration file an chose his position into the menu.

I am targeting this branch, because it's Backward Compatible with other versions. Each menu groups has a default value.

## Changelog

```markdown
### Added
- Added a new `position` option into `sonata_admin.dashboard.groups` to order menu groups.

### Changed
- Changed `AddDependencyCallsCompilerPass::process()` to reorder the groups by position.
```