### PR TITLE
Fix arguments passed to `transchoice()` Twig filter at `block_stats.html.twig`

### DIFF
--- a/src/Resources/views/Block/block_stats.html.twig
+++ b/src/Resources/views/Block/block_stats.html.twig
@@ -20,7 +20,7 @@ file that was distributed with this source code.
             <h3>{{ pager.count() }}</h3>
             <p>
                 {% if translation_domain %}
-                    {{ settings.text|transchoice({'%count%': pager.count()}, translation_domain) }}
+                    {{ settings.text|transchoice(pager.count(), {}, translation_domain) }}
                     {# NEXT_MAJOR: bump "symfony/translation" to ^4.2 and replace the previous line with the following #}
                     {# {{ settings.text|trans({'%count%': pager.count()}, translation_domain) }} #}
                 {% else %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Fix arguments passed to `transchoice()` Twig filter at `block_stats.html.twig`:
```
Argument 3 passed to Symfony\Bridge\Twig\Extension\TranslationExtension::transchoice() must be of the type array, string given
```
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Issue introduced at #5690.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Arguments passed to `transchoice()` Twig filter at `block_stats.html.twig`
```

/cc @sonata-project/release-managers: the issue makes the admin dashboard unusable if the block stats are used with v3.54.0. My apologies.