### PR TITLE
Fixed checks for array and traversable values

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -3029,7 +3029,7 @@ EOT;
 
             $value = $propertyAccessor->getValue($object, $propertyPath);
 
-            if (\is_array($value) || ($value instanceof \Traversable && $value instanceof \ArrayAccess)) {
+            if (\is_array($value) || $value instanceof \ArrayAccess) {
                 $value[] = $parent;
                 $propertyAccessor->setValue($object, $propertyPath, $value);
             } else {

--- a/src/Form/Type/ChoiceFieldMaskType.php
+++ b/src/Form/Type/ChoiceFieldMaskType.php
@@ -32,7 +32,7 @@ class ChoiceFieldMaskType extends AbstractType
         $sanitizedMap = [];
         $allFieldNames = [];
         foreach ($options['map'] as $value => $fieldNames) {
-            if (\is_array($fieldNames) || $fieldNames instanceof \Traversable) {
+            if (is_iterable($fieldNames)) {
                 foreach ($fieldNames as $fieldName) {
                     $sanitizedFieldName = str_replace(['__', '.'], ['____', '__'], $fieldName);
                     $sanitizedMap[$value][] = $sanitizedFieldName;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Simplified checks for array and traversable values
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Using array accessor in traversable objects which aren't implementing `\ArrayAccess` at `AbstractAdmin::buildForm()`.
```