### PR TITLE
added error-response when running request with XHR

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1607,7 +1607,7 @@ class CRUDController implements ContainerAwareInterface
 
         return $this->renderJson([
             'result' => 'error',
-            'errors' => $errors
+            'errors' => $errors,
         ], 400, []);
     }
 }

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1592,7 +1592,7 @@ class CRUDController implements ContainerAwareInterface
 
     private function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): ?JsonResponse
     {
-        if ($request->headers->get('Accept') !== 'application/json') {
+        if ('application/json' !== $request->headers->get('Accept')) {
             @trigger_error('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json`', E_USER_DEPRECATED);
             return null;
         }
@@ -1609,20 +1609,17 @@ class CRUDController implements ContainerAwareInterface
     }
 
     /**
-     * @param Request $request
-     * @param object  $object
-     *
-     * @return JsonResponse
+     * @param object $object
      */
     private function handleXmlHttpRequestSuccessResponse(Request $request, $object): JsonResponse
     {
-        if ($request->headers->get('Accept') !== 'application/json') {
+        if ('application/json' !== $request->headers->get('Accept')) {
             @trigger_error('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json`', E_USER_DEPRECATED);
         }
 
         return $this->renderJson([
-            'result'     => 'ok',
-            'objectId'   => $this->admin->getNormalizedIdentifier($object),
+            'result' => 'ok',
+            'objectId' => $this->admin->getNormalizedIdentifier($object),
             'objectName' => $this->escapeHtml($this->admin->toString($object)),
         ], 200);
     }

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -388,16 +388,26 @@ class CRUDController implements ContainerAwareInterface
 
             // show an error message if the form failed validation
             if (!$isFormValid) {
-                if (!$this->isXmlHttpRequest()) {
-                    $this->addFlash(
-                        'sonata_flash_error',
-                        $this->trans(
-                            'flash_edit_error',
-                            ['%name%' => $this->escapeHtml($this->admin->toString($existingObject))],
-                            'SonataAdminBundle'
-                        )
-                    );
+                if ($this->isXmlHttpRequest()) {
+                    $errors = [];
+                    foreach ($form->getErrors(true) as $error) {
+                        $errors[] = $error->getMessage();
+                    }
+
+                    return $this->renderJson([
+                        'result' => 'error',
+                        'errors' => $errors
+                    ], 400, []);
                 }
+
+                $this->addFlash(
+                    'sonata_flash_error',
+                    $this->trans(
+                        'flash_edit_error',
+                        ['%name%' => $this->escapeHtml($this->admin->toString($existingObject))],
+                        'SonataAdminBundle'
+                    )
+                );
             } elseif ($this->isPreviewRequested()) {
                 // enable the preview template if the form was valid and preview was requested
                 $templateKey = 'preview';
@@ -646,16 +656,26 @@ class CRUDController implements ContainerAwareInterface
 
             // show an error message if the form failed validation
             if (!$isFormValid) {
-                if (!$this->isXmlHttpRequest()) {
-                    $this->addFlash(
-                        'sonata_flash_error',
-                        $this->trans(
-                            'flash_create_error',
-                            ['%name%' => $this->escapeHtml($this->admin->toString($newObject))],
-                            'SonataAdminBundle'
-                        )
-                    );
+                if ($this->isXmlHttpRequest()) {
+                    $errors = [];
+                    foreach ($form->getErrors(true) as $error) {
+                        $errors[] = $error->getMessage();
+                    }
+
+                    return $this->renderJson([
+                        'result' => 'error',
+                        'errors' => $errors
+                    ], 400, []);
                 }
+
+                $this->addFlash(
+                    'sonata_flash_error',
+                    $this->trans(
+                        'flash_create_error',
+                        ['%name%' => $this->escapeHtml($this->admin->toString($newObject))],
+                        'SonataAdminBundle'
+                    )
+                );
             } elseif ($this->isPreviewRequested()) {
                 // pick the preview template if the form was valid and preview was requested
                 $templateKey = 'preview';

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -385,8 +385,8 @@ class CRUDController implements ContainerAwareInterface
 
             // show an error message if the form failed validation
             if (!$isFormValid) {
-                if ($this->isXmlHttpRequest()) {
-                    return $this->handleXmlHttpRequestErrorResponse($request, $form);
+                if ($this->isXmlHttpRequest() && null !== ($response = $this->handleXmlHttpRequestErrorResponse($request, $form))) {
+                    return $response;
                 }
 
                 $this->addFlash(
@@ -641,8 +641,8 @@ class CRUDController implements ContainerAwareInterface
 
             // show an error message if the form failed validation
             if (!$isFormValid) {
-                if ($this->isXmlHttpRequest()) {
-                    return $this->handleXmlHttpRequestErrorResponse($request, $form);
+                if ($this->isXmlHttpRequest() && null !== ($response = $this->handleXmlHttpRequestErrorResponse($request, $form))) {
+                    return $response;
                 }
 
                 $this->addFlash(
@@ -1590,8 +1590,13 @@ class CRUDController implements ContainerAwareInterface
         $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
     }
 
-    private function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): JsonResponse
+    private function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): ?JsonResponse
     {
+        if ($request->headers->get('Accept') !== 'application/json') {
+            @trigger_error('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json`', E_USER_DEPRECATED);
+            return null;
+        }
+
         $errors = [];
         foreach ($form->getErrors(true) as $error) {
             $errors[] = $error->getMessage();
@@ -1611,6 +1616,10 @@ class CRUDController implements ContainerAwareInterface
      */
     private function handleXmlHttpRequestSuccessResponse(Request $request, $object): JsonResponse
     {
+        if ($request->headers->get('Accept') !== 'application/json') {
+            @trigger_error('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json`', E_USER_DEPRECATED);
+        }
+
         return $this->renderJson([
             'result'     => 'ok',
             'objectId'   => $this->admin->getNormalizedIdentifier($object),

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1099,9 +1099,9 @@ class CRUDController implements ContainerAwareInterface
      * @param int   $status
      * @param array $headers
      *
-     * @return Response with json encoded data
+     * @return JsonResponse with json encoded data
      */
-    protected function renderJson($data, $status = 200, $headers = [])
+    protected function renderJson($data, $status = 200, $headers = []): JsonResponse
     {
         return new JsonResponse($data, $status, $headers);
     }
@@ -1598,7 +1598,7 @@ class CRUDController implements ContainerAwareInterface
         $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
     }
 
-    private function handleXmlHttpRequestErrorResponse(FormInterface $form): Response
+    private function handleXmlHttpRequestErrorResponse(FormInterface $form): JsonResponse
     {
         $errors = [];
         foreach ($form->getErrors(true) as $error) {

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -356,7 +356,7 @@ class CRUDController implements ContainerAwareInterface
                     $existingObject = $this->admin->update($submittedObject);
 
                     if ($this->isXmlHttpRequest()) {
-                        return $this->handleXmlHttpRequestSuccessResponse($existingObject);
+                        return $this->handleXmlHttpRequestSuccessResponse($request, $existingObject);
                     }
 
                     $this->addFlash(
@@ -386,7 +386,7 @@ class CRUDController implements ContainerAwareInterface
             // show an error message if the form failed validation
             if (!$isFormValid) {
                 if ($this->isXmlHttpRequest()) {
-                    return $this->handleXmlHttpRequestErrorResponse($form);
+                    return $this->handleXmlHttpRequestErrorResponse($request, $form);
                 }
 
                 $this->addFlash(
@@ -618,7 +618,7 @@ class CRUDController implements ContainerAwareInterface
                     $newObject = $this->admin->create($submittedObject);
 
                     if ($this->isXmlHttpRequest()) {
-                        return $this->handleXmlHttpRequestSuccessResponse($newObject);
+                        return $this->handleXmlHttpRequestSuccessResponse($request, $newObject);
                     }
 
                     $this->addFlash(
@@ -642,7 +642,7 @@ class CRUDController implements ContainerAwareInterface
             // show an error message if the form failed validation
             if (!$isFormValid) {
                 if ($this->isXmlHttpRequest()) {
-                    return $this->handleXmlHttpRequestErrorResponse($form);
+                    return $this->handleXmlHttpRequestErrorResponse($request, $form);
                 }
 
                 $this->addFlash(
@@ -1590,7 +1590,7 @@ class CRUDController implements ContainerAwareInterface
         $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
     }
 
-    private function handleXmlHttpRequestErrorResponse(FormInterface $form): JsonResponse
+    private function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): JsonResponse
     {
         $errors = [];
         foreach ($form->getErrors(true) as $error) {
@@ -1604,11 +1604,12 @@ class CRUDController implements ContainerAwareInterface
     }
 
     /**
-     * @param object $object
+     * @param Request $request
+     * @param object  $object
      *
      * @return JsonResponse
      */
-    private function handleXmlHttpRequestSuccessResponse($object): JsonResponse
+    private function handleXmlHttpRequestSuccessResponse(Request $request, $object): JsonResponse
     {
         return $this->renderJson([
             'result'     => 'ok',

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1101,7 +1101,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return JsonResponse with json encoded data
      */
-    protected function renderJson($data, $status = 200, $headers = []): Response
+    protected function renderJson($data, $status = 200, $headers = [])
     {
         return new JsonResponse($data, $status, $headers);
     }

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1101,7 +1101,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return JsonResponse with json encoded data
      */
-    protected function renderJson($data, $status = 200, $headers = []): JsonResponse
+    protected function renderJson($data, $status = 200, $headers = []): Response
     {
         return new JsonResponse($data, $status, $headers);
     }

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -356,11 +356,7 @@ class CRUDController implements ContainerAwareInterface
                     $existingObject = $this->admin->update($submittedObject);
 
                     if ($this->isXmlHttpRequest()) {
-                        return $this->renderJson([
-                            'result' => 'ok',
-                            'objectId' => $objectId,
-                            'objectName' => $this->escapeHtml($this->admin->toString($existingObject)),
-                        ], 200, []);
+                        return $this->handleXmlHttpRequestSuccessResponse($existingObject);
                     }
 
                     $this->addFlash(
@@ -622,11 +618,7 @@ class CRUDController implements ContainerAwareInterface
                     $newObject = $this->admin->create($submittedObject);
 
                     if ($this->isXmlHttpRequest()) {
-                        return $this->renderJson([
-                            'result' => 'ok',
-                            'objectId' => $this->admin->getNormalizedIdentifier($newObject),
-                            'objectName' => $this->escapeHtml($this->admin->toString($newObject)),
-                        ], 200, []);
+                        return $this->handleXmlHttpRequestSuccessResponse($newObject);
                     }
 
                     $this->addFlash(
@@ -1609,5 +1601,19 @@ class CRUDController implements ContainerAwareInterface
             'result' => 'error',
             'errors' => $errors,
         ], 400);
+    }
+
+    /**
+     * @param object $object
+     *
+     * @return JsonResponse
+     */
+    private function handleXmlHttpRequestSuccessResponse($object): JsonResponse
+    {
+        return $this->renderJson([
+            'result'     => 'ok',
+            'objectId'   => $this->admin->getNormalizedIdentifier($object),
+            'objectName' => $this->escapeHtml($this->admin->toString($object)),
+        ], 200);
     }
 }

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1608,6 +1608,6 @@ class CRUDController implements ContainerAwareInterface
         return $this->renderJson([
             'result' => 'error',
             'errors' => $errors,
-        ], 400, []);
+        ], 400);
     }
 }

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1594,6 +1594,7 @@ class CRUDController implements ContainerAwareInterface
     {
         if ('application/json' !== $request->headers->get('Accept')) {
             @trigger_error('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json`', E_USER_DEPRECATED);
+
             return null;
         }
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -32,6 +32,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -389,15 +390,7 @@ class CRUDController implements ContainerAwareInterface
             // show an error message if the form failed validation
             if (!$isFormValid) {
                 if ($this->isXmlHttpRequest()) {
-                    $errors = [];
-                    foreach ($form->getErrors(true) as $error) {
-                        $errors[] = $error->getMessage();
-                    }
-
-                    return $this->renderJson([
-                        'result' => 'error',
-                        'errors' => $errors
-                    ], 400, []);
+                    return $this->handleXmlHttpRequestErrorResponse($form);
                 }
 
                 $this->addFlash(
@@ -657,15 +650,7 @@ class CRUDController implements ContainerAwareInterface
             // show an error message if the form failed validation
             if (!$isFormValid) {
                 if ($this->isXmlHttpRequest()) {
-                    $errors = [];
-                    foreach ($form->getErrors(true) as $error) {
-                        $errors[] = $error->getMessage();
-                    }
-
-                    return $this->renderJson([
-                        'result' => 'error',
-                        'errors' => $errors
-                    ], 400, []);
+                    return $this->handleXmlHttpRequestErrorResponse($form);
                 }
 
                 $this->addFlash(
@@ -1611,5 +1596,18 @@ class CRUDController implements ContainerAwareInterface
         }
 
         $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
+    }
+
+    private function handleXmlHttpRequestErrorResponse(FormInterface $form): Response
+    {
+        $errors = [];
+        foreach ($form->getErrors(true) as $error) {
+            $errors[] = $error->getMessage();
+        }
+
+        return $this->renderJson([
+            'result' => 'error',
+            'errors' => $errors
+        ], 400, []);
     }
 }

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -1753,7 +1753,7 @@ class CRUDControllerTest extends TestCase
             ->method('all')
             ->willReturn(['field' => 'fielddata']);
 
-        $this->admin->expects($this->once())
+        $this->admin
             ->method('getNormalizedIdentifier')
             ->with($this->equalTo($object))
             ->willReturn('foo_normalized');
@@ -1815,9 +1815,64 @@ class CRUDControllerTest extends TestCase
 
         $this->request->setMethod('POST');
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
+        $this->request->headers->set('Accept', 'application/json');
 
         $this->assertInstanceOf(JsonResponse::class, $response = $this->controller->editAction(null, $this->request));
         $this->assertJsonStringEqualsJsonString('{"result":"error","errors":["Form error message"]}', $response->getContent());
+    }
+
+    /**
+     * @legacy
+     * @expectedDeprecation In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json`
+     */
+    public function testEditActionAjaxErrorWithoutAcceptApplicationJson(): void
+    {
+        $object = new \stdClass();
+
+        $this->admin->expects($this->once())
+            ->method('getObject')
+            ->willReturn($object);
+
+        $this->admin->expects($this->once())
+            ->method('checkAccess')
+            ->with($this->equalTo('edit'))
+            ->willReturn(true);
+
+        $form = $this->createMock(Form::class);
+
+        $this->admin->expects($this->once())
+            ->method('getForm')
+            ->willReturn($form);
+
+        $form->expects($this->once())
+            ->method('isSubmitted')
+            ->willReturn(true);
+
+        $form->expects($this->once())
+            ->method('isValid')
+            ->willReturn(false);
+
+        $form->expects($this->once())
+            ->method('all')
+            ->willReturn(['field' => 'fielddata']);
+
+        $this->request->setMethod('POST');
+        $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
+
+        $formView = $this->createMock(FormView::class);
+        $form
+            ->method('createView')
+            ->willReturn($formView);
+
+        $this->assertInstanceOf(Response::class, $response = $this->controller->editAction(null, $this->request));
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('@SonataAdmin/ajax_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame('edit', $this->parameters['action']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
+        $this->assertSame($object, $this->parameters['object']);
+        $this->assertSame(['sonata_flash_error' => [0 => null]], $this->session->getFlashBag()->all());
+        $this->assertSame('@SonataAdmin/CRUD/edit.html.twig', $this->template);
     }
 
     /**
@@ -2526,9 +2581,68 @@ class CRUDControllerTest extends TestCase
 
         $this->request->setMethod('POST');
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
+        $this->request->headers->set('Accept', 'application/json');
 
         $this->assertInstanceOf(JsonResponse::class, $response = $this->controller->createAction($this->request));
         $this->assertJsonStringEqualsJsonString('{"result":"error","errors":["Form error message"]}', $response->getContent());
+    }
+
+    /**
+     * @legacy
+     * @expectedDeprecation In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json`
+     */
+    public function testCreateActionAjaxErrorWithoutAcceptApplicationJson(): void
+    {
+        $this->admin->expects($this->once())
+            ->method('checkAccess')
+            ->with($this->equalTo('create'))
+            ->willReturn(true);
+
+        $object = new \stdClass();
+
+        $this->admin->expects($this->once())
+            ->method('getNewInstance')
+            ->willReturn($object);
+
+        $form = $this->createMock(Form::class);
+
+        $this->admin->expects($this->any())
+            ->method('getClass')
+            ->willReturn('stdClass');
+
+        $this->admin->expects($this->once())
+            ->method('getForm')
+            ->willReturn($form);
+
+        $form->expects($this->once())
+            ->method('all')
+            ->willReturn(['field' => 'fielddata']);
+
+        $form->expects($this->once())
+            ->method('isSubmitted')
+            ->willReturn(true);
+
+        $form->expects($this->once())
+            ->method('isValid')
+            ->willReturn(false);
+
+        $this->request->setMethod('POST');
+        $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
+
+        $formView = $this->createMock(FormView::class);
+        $form
+            ->method('createView')
+            ->willReturn($formView);
+
+        $this->assertInstanceOf(Response::class, $response = $this->controller->createAction($this->request));
+        $this->assertSame($this->admin, $this->parameters['admin']);
+        $this->assertSame('@SonataAdmin/ajax_layout.html.twig', $this->parameters['base_template']);
+        $this->assertSame($this->pool, $this->parameters['admin_pool']);
+        $this->assertSame('create', $this->parameters['action']);
+        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
+        $this->assertSame($object, $this->parameters['object']);
+        $this->assertSame(['sonata_flash_error' => [0 => null]], $this->session->getFlashBag()->all());
+        $this->assertSame('@SonataAdmin/CRUD/edit.html.twig', $this->template);
     }
 
     public function testCreateActionWithPreview(): void

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -2514,27 +2514,21 @@ class CRUDControllerTest extends TestCase
             ->method('isValid')
             ->willReturn(false);
 
+        $formError = $this->createMock(FormError::class);
+        $formError->expects($this->atLeastOnce())
+            ->method('getMessage')
+            ->willReturn('Form error message');
+
+        $form->expects($this->once())
+            ->method('getErrors')
+            ->with(true)
+            ->willReturn([$formError]);
+
         $this->request->setMethod('POST');
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $formView = $this->createMock(FormView::class);
-
-        $form->expects($this->any())
-            ->method('createView')
-            ->willReturn($formView);
-
-        $this->assertInstanceOf(Response::class, $this->controller->createAction($this->request));
-
-        $this->assertSame($this->admin, $this->parameters['admin']);
-        $this->assertSame('@SonataAdmin/ajax_layout.html.twig', $this->parameters['base_template']);
-        $this->assertSame($this->pool, $this->parameters['admin_pool']);
-
-        $this->assertSame('create', $this->parameters['action']);
-        $this->assertInstanceOf(FormView::class, $this->parameters['form']);
-        $this->assertSame($object, $this->parameters['object']);
-
-        $this->assertSame([], $this->session->getFlashBag()->all());
-        $this->assertSame('@SonataAdmin/CRUD/edit.html.twig', $this->template);
+        $this->assertInstanceOf(JsonResponse::class, $response = $this->controller->createAction($this->request));
+        $this->assertJsonStringEqualsJsonString('{"result":"error","errors":["Form error message"]}', $response->getContent());
     }
 
     public function testCreateActionWithPreview(): void


### PR DESCRIPTION
## Subject

Adding error-response for XHR requests

Current behaviour: when submitting form with AJAX (XHR) and if error occurs HTML will be returned instead of JSON.

I am targeting this branch, because features (BC?)

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
Added JSON response from edit/create action when form is invalid.

```

## To do
    
- [x] Update the tests
