### PR TITLE
Toggle required attribute when using choice_field_mask_widget.

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -533,12 +533,16 @@ file that was distributed with this source code.
                 };
 
                 jQuery.each(allFields, function (i, field) {
-                    jQuery(controlGroupIdFunc(field)).hide();
+                    var fieldContainer = controlGroupIdFunc(field);
+                    jQuery(fieldContainer).hide();
+                    jQuery(fieldContainer).find('[required="required"]').attr('data-required', 'required').removeAttr("required");
                 });
 
                 if (map[val]) {
                     jQuery.each(map[val], function (i, field) {
-                        jQuery(controlGroupIdFunc(field)).show();
+                        var fieldContainer = controlGroupIdFunc(field);
+                        jQuery(fieldContainer).show();
+                        jQuery(fieldContainer).find('[data-required="required"]').attr("required", "required");
                     });
                 }
             }


### PR DESCRIPTION
## Subject
Add and remove the required attribute on fields shown or hidden by the choice mask field. At the moment you are unable to submit the form when one of the hidden fields is required. 

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix and backwards compatible.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5706 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
Fixed `choice_field_mask_widget` to add or remove the html5 required validation when showing or hiding fields. 
```

