### PR TITLE
abstract-admin: Fixed method buildTabMenu to comply with it's interface

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1405,10 +1405,13 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return $this->datagrid;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function buildTabMenu($action, AdminInterface $childAdmin = null)
     {
         if ($this->loaded['tab_menu']) {
-            return;
+            return $this->menu;
         }
 
         $this->loaded['tab_menu'] = true;
@@ -1429,6 +1432,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         }
 
         $this->menu = $menu;
+
+        return $this->menu;
     }
 
     public function buildSideMenu($action, AdminInterface $childAdmin = null)

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1405,9 +1405,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return $this->datagrid;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function buildTabMenu($action, AdminInterface $childAdmin = null)
     {
         if ($this->loaded['tab_menu']) {


### PR DESCRIPTION
## Subject

<!-- Describe your Pull Request content here -->
I am targeting this branch, because it's fix and it's BC.


Method \Sonata\AdminBundle\Admin\AbstractAdmin::buildTabMenu returns void, but in interface that class implementing it's returning value described as `ItemInterface|bool`, so i fixed it by returning expected value.

## Changelog
```markdown
### Fixed
- Changed returning values of method \Sonata\AdminBundle\Admin\AbstractAdmin::buildTabMenu to comply it's interface 
```

