### PR TITLE
Remove extending from Controller in Dashboard and Search actions

### DIFF
--- a/src/Action/DashboardAction.php
+++ b/src/Action/DashboardAction.php
@@ -16,11 +16,13 @@ namespace Sonata\AdminBundle\Action;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
-final class DashboardAction extends Controller
+
+final class DashboardAction
 {
     /**
      * @var array
@@ -41,17 +43,23 @@ final class DashboardAction extends Controller
      * @var Pool
      */
     private $pool;
+    /**
+     * @var Environment
+     */
+    private $templatingEngine;
 
     public function __construct(
         array $dashboardBlocks,
         BreadcrumbsBuilderInterface $breadcrumbsBuilder,
         TemplateRegistryInterface $templateRegistry,
-        Pool $pool
+        Pool $pool,
+        EngineInterface $templatingEngine
     ) {
         $this->dashboardBlocks = $dashboardBlocks;
         $this->breadcrumbsBuilder = $breadcrumbsBuilder;
         $this->templateRegistry = $templateRegistry;
         $this->pool = $pool;
+        $this->templatingEngine = $templatingEngine;
     }
 
     public function __invoke(Request $request): Response
@@ -80,6 +88,6 @@ final class DashboardAction extends Controller
             $parameters['breadcrumbs_builder'] = $this->breadcrumbsBuilder;
         }
 
-        return $this->render($this->templateRegistry->getTemplate('dashboard'), $parameters);
+        return new Response($this->templatingEngine->render($this->templateRegistry->getTemplate('dashboard'), $parameters));
     }
 }

--- a/src/Action/DashboardAction.php
+++ b/src/Action/DashboardAction.php
@@ -19,8 +19,6 @@ use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Templating\EngineInterface;
-use Twig\Environment;
-
 
 final class DashboardAction
 {
@@ -44,22 +42,22 @@ final class DashboardAction
      */
     private $pool;
     /**
-     * @var Environment
+     * @var EngineInterface
      */
-    private $templatingEngine;
+    private $templateEngine;
 
     public function __construct(
         array $dashboardBlocks,
         BreadcrumbsBuilderInterface $breadcrumbsBuilder,
         TemplateRegistryInterface $templateRegistry,
         Pool $pool,
-        EngineInterface $templatingEngine
+        EngineInterface $templateEngine
     ) {
         $this->dashboardBlocks = $dashboardBlocks;
         $this->breadcrumbsBuilder = $breadcrumbsBuilder;
         $this->templateRegistry = $templateRegistry;
         $this->pool = $pool;
-        $this->templatingEngine = $templatingEngine;
+        $this->templateEngine = $templateEngine;
     }
 
     public function __invoke(Request $request): Response
@@ -88,6 +86,6 @@ final class DashboardAction
             $parameters['breadcrumbs_builder'] = $this->breadcrumbsBuilder;
         }
 
-        return new Response($this->templatingEngine->render($this->templateRegistry->getTemplate('dashboard'), $parameters));
+        return new Response($this->templateEngine->render($this->templateRegistry->getTemplate('dashboard'), $parameters));
     }
 }

--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -48,34 +48,32 @@ final class SearchAction
     /**
      * @var EngineInterface
      */
-    private $templatingEngine;
+    private $templateEngine;
 
     public function __construct(
         Pool $pool,
         SearchHandler $searchHandler,
         TemplateRegistryInterface $templateRegistry,
         BreadcrumbsBuilderInterface $breadcrumbsBuilder,
-        EngineInterface $templatingEngine
+        EngineInterface $templateEngine
     ) {
         $this->pool = $pool;
         $this->searchHandler = $searchHandler;
         $this->templateRegistry = $templateRegistry;
         $this->breadcrumbsBuilder = $breadcrumbsBuilder;
-        $this->templatingEngine = $templatingEngine;
+        $this->templateEngine = $templateEngine;
     }
 
     /**
      * The search action first render an empty page, if the query is set, then the template generates
      * some ajax request to retrieve results for each admin. The Ajax query returns a JSON response.
      *
-     * @param Request $request
-     *
      * @return JsonResponse|Response
      */
     public function __invoke(Request $request): Response
     {
         if (!$request->get('admin') || !$request->isXmlHttpRequest()) {
-            return new Response($this->templatingEngine->render($this->templateRegistry->getTemplate('search'), [
+            return new Response($this->templateEngine->render($this->templateRegistry->getTemplate('search'), [
                 'base_template' => $request->isXmlHttpRequest() ?
                     $this->templateRegistry->getTemplate('ajax') :
                     $this->templateRegistry->getTemplate('layout'),

--- a/tests/Action/DashboardActionTest.php
+++ b/tests/Action/DashboardActionTest.php
@@ -53,23 +53,9 @@ class DashboardActionTest extends TestCase
             [],
             $breadcrumbsBuilder,
             $templateRegistry->reveal(),
-            $pool
+            $pool,
+            $templating
         );
-        $values = [
-            'templating' => $templating,
-            'request_stack' => $requestStack,
-        ];
-        $dashboardAction->setContainer($container);
-
-        $container->expects($this->any())->method('get')->willReturnCallback(static function ($id) use ($values) {
-            return $values[$id];
-        });
-
-        $container->expects($this->any())
-            ->method('has')
-            ->willReturnCallback(static function ($id) {
-                return 'templating' === $id;
-            });
 
         $this->isInstanceOf(Response::class, $dashboardAction($request));
     }
@@ -101,24 +87,9 @@ class DashboardActionTest extends TestCase
             [],
             $breadcrumbsBuilder,
             $templateRegistry->reveal(),
-            $pool
+            $pool,
+            $templating
         );
-        $dashboardAction->setContainer($container);
-        $values = [
-            'templating' => $templating,
-            'request_stack' => $requestStack,
-        ];
-        $dashboardAction->setContainer($container);
-
-        $container->expects($this->any())->method('get')->willReturnCallback(static function ($id) use ($values) {
-            return $values[$id];
-        });
-
-        $container->expects($this->any())
-            ->method('has')
-            ->willReturnCallback(static function ($id) {
-                return 'templating' === $id;
-            });
 
         $this->isInstanceOf(Response::class, $dashboardAction($request));
     }

--- a/tests/Action/DashboardActionTest.php
+++ b/tests/Action/DashboardActionTest.php
@@ -21,15 +21,13 @@ use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
 class DashboardActionTest extends TestCase
 {
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testdashboardActionStandardRequest()
+    private $action;
+
+    protected function setUp(): void
     {
         $container = $this->createMock(ContainerInterface::class);
 
@@ -42,55 +40,30 @@ class DashboardActionTest extends TestCase
         $pool->setTemplateRegistry($templateRegistry->reveal());
 
         $templating = $this->createMock(EngineInterface::class);
-        $request = new Request();
-
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
 
         $breadcrumbsBuilder = $this->getMockForAbstractClass(BreadcrumbsBuilderInterface::class);
 
-        $dashboardAction = new DashboardAction(
+        $this->action = new DashboardAction(
             [],
             $breadcrumbsBuilder,
             $templateRegistry->reveal(),
             $pool,
             $templating
         );
-
-        $this->isInstanceOf(Response::class, $dashboardAction($request));
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    public function testdashboardActionStandardRequest()
+    {
+        $request = new Request();
+
+        $this->assertInstanceOf(Response::class, ($this->action)($request));
+    }
+
     public function testDashboardActionAjaxLayout(): void
     {
-        $container = $this->createMock(ContainerInterface::class);
-
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->getTemplate('ajax')->willReturn('ajax.html');
-        $templateRegistry->getTemplate('dashboard')->willReturn('dashboard.html');
-        $templateRegistry->getTemplate('layout')->willReturn('layout.html');
-        $breadcrumbsBuilder = $this->getMockForAbstractClass(BreadcrumbsBuilderInterface::class);
-
-        $pool = new Pool($container, 'title', 'logo.png');
-        $pool->setTemplateRegistry($templateRegistry->reveal());
-
-        $templating = $this->createMock(EngineInterface::class);
         $request = new Request();
         $request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
-
-        $dashboardAction = new DashboardAction(
-            [],
-            $breadcrumbsBuilder,
-            $templateRegistry->reveal(),
-            $pool,
-            $templating
-        );
-
-        $this->isInstanceOf(Response::class, $dashboardAction($request));
+        $this->assertInstanceOf(Response::class, ($this->action)($request));
     }
 }

--- a/tests/Action/SearchActionTest.php
+++ b/tests/Action/SearchActionTest.php
@@ -46,16 +46,15 @@ class SearchActionTest extends TestCase
 
         $this->breadcrumbsBuilder = $this->createMock(BreadcrumbsBuilderInterface::class);
         $this->searchHandler = $this->createMock(SearchHandler::class);
+        $this->templating = $this->prophesize(EngineInterface::class);
 
         $this->action = new SearchAction(
             $this->pool,
             $this->searchHandler,
             $templateRegistry,
-            $this->breadcrumbsBuilder
+            $this->breadcrumbsBuilder,
+            $this->templating->reveal()
         );
-        $this->action->setContainer($this->container);
-        $this->templating = $this->prophesize(EngineInterface::class);
-        $this->container->set('templating', $this->templating->reveal());
     }
 
     public function testGlobalPage(): void

--- a/tests/Action/SearchActionTest.php
+++ b/tests/Action/SearchActionTest.php
@@ -31,6 +31,7 @@ class SearchActionTest extends TestCase
     private $container;
     private $pool;
     private $action;
+    private $searchHandler;
     private $templating;
     private $breadcrumbsBuilder;
 
@@ -75,9 +76,7 @@ class SearchActionTest extends TestCase
             'groups' => [],
         ], null)->willReturn(new Response());
 
-        // NEXT_MAJOR: simplify this when dropping php 5
-        $action = $this->action;
-        $this->assertInstanceOf(Response::class, $action($request));
+        $this->assertInstanceOf(Response::class, ($this->action)($request));
     }
 
     public function testAjaxCall(): void
@@ -88,8 +87,6 @@ class SearchActionTest extends TestCase
         $request = new Request(['admin' => 'foo']);
         $request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        // NEXT_MAJOR: simplify this when dropping php 5
-        $action = $this->action;
-        $this->assertInstanceOf(JsonResponse::class, $action($request));
+        $this->assertInstanceOf(JsonResponse::class, ($this->action)($request));
     }
 }

--- a/tests/Controller/CoreControllerTest.php
+++ b/tests/Controller/CoreControllerTest.php
@@ -56,12 +56,11 @@ class CoreControllerTest extends TestCase
                 [],
                 $breadcrumbsBuilder,
                 $templateRegistry->reveal(),
-                $pool
+                $pool,
+                $templating
             ),
-            'templating' => $templating,
             'request_stack' => $requestStack,
         ];
-        $dashboardAction->setContainer($container);
 
         $container->expects($this->any())->method('get')->willReturnCallback(static function ($id) use ($values) {
             return $values[$id];
@@ -108,22 +107,15 @@ class CoreControllerTest extends TestCase
                 [],
                 $breadcrumbsBuilder,
                 $templateRegistry->reveal(),
-                $pool
+                $pool,
+                $templating
             ),
-            'templating' => $templating,
             'request_stack' => $requestStack,
         ];
-        $dashboardAction->setContainer($container);
 
         $container->expects($this->any())->method('get')->willReturnCallback(static function ($id) use ($values) {
             return $values[$id];
         });
-
-        $container->expects($this->any())
-            ->method('has')
-            ->willReturnCallback(static function ($id) {
-                return 'templating' === $id;
-            });
 
         $controller = new CoreController();
         $controller->setContainer($container);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I cherry-picked the commits from https://github.com/sonata-project/SonataAdminBundle/pull/5510 that just remove extending from Controller from the actions which are `final`.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Removed extending from `Controller` in `DashboardAction` and `SearchAction` in favor of DI.
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
