### PR TITLE
Change some test calls from isInstanceOf to assertInstanceOf

### DIFF
--- a/tests/Action/AppendFormFieldElementActionTest.php
+++ b/tests/Action/AppendFormFieldElementActionTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Twig\Environment;
 
@@ -113,10 +114,9 @@ final class AppendFormFieldElementActionTest extends TestCase
         $renderer->setTheme($formView, $formView)->shouldBeCalled();
         $renderer->searchAndRenderBlock($formView, 'widget')->willReturn('block');
 
-        $action = $this->action;
-        $response = $action($request);
+        $response = ($this->action)($request);
 
-        $this->isInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame($response->getContent(), 'block');
     }
 

--- a/tests/Action/GetShortObjectDescriptionActionTest.php
+++ b/tests/Action/GetShortObjectDescriptionActionTest.php
@@ -73,8 +73,7 @@ final class GetShortObjectDescriptionActionTest extends TestCase
         $this->pool->getInstance('sonata.post.admin')->willReturn(null);
         $this->admin->setRequest(Argument::type(Request::class))->shouldNotBeCalled();
 
-        $action = $this->action;
-        $action($request);
+        ($this->action)($request);
     }
 
     public function testGetShortObjectDescriptionActionObjectDoesNotExist(): void
@@ -91,8 +90,7 @@ final class GetShortObjectDescriptionActionTest extends TestCase
         $this->admin->setUniqid('asdasd123')->shouldBeCalled();
         $this->admin->getObject(42)->willReturn(false);
 
-        $action = $this->action;
-        $action($request);
+        ($this->action)($request);
     }
 
     public function testGetShortObjectDescriptionActionEmptyObjectId(): void
@@ -107,10 +105,7 @@ final class GetShortObjectDescriptionActionTest extends TestCase
         $this->admin->setUniqid('asdasd123')->shouldBeCalled();
         $this->admin->getObject(null)->willReturn(false);
 
-        $action = $this->action;
-        $response = $action($request);
-
-        $this->assertInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, ($this->action)($request));
     }
 
     public function testGetShortObjectDescriptionActionObject(): void
@@ -128,8 +123,7 @@ final class GetShortObjectDescriptionActionTest extends TestCase
         $this->admin->getTemplate('short_object_description')->willReturn('template');
         $this->admin->toString($object)->willReturn('bar');
 
-        $action = $this->action;
-        $response = $action($request);
+        $response = ($this->action)($request);
 
         $this->assertSame('renderedTemplate', $response->getContent());
     }
@@ -148,8 +142,7 @@ final class GetShortObjectDescriptionActionTest extends TestCase
         $this->admin->id(false)->willReturn('');
         $this->admin->toString(false)->willReturn('');
 
-        $action = $this->action;
-        $response = $action($request);
+        $response = ($this->action)($request);
 
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertSame('{"result":{"id":"","label":""}}', $response->getContent());
@@ -171,8 +164,7 @@ final class GetShortObjectDescriptionActionTest extends TestCase
         $this->admin->getTemplate('short_object_description')->willReturn('template');
         $this->admin->toString($object)->willReturn('bar');
 
-        $action = $this->action;
-        $response = $action($request);
+        $response = ($this->action)($request);
 
         $this->assertSame('{"result":{"id":42,"label":"bar"}}', $response->getContent());
     }

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -28,6 +28,7 @@ use Sonata\DatagridBundle\Datagrid\DatagridInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormConfigInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 final class RetrieveAutocompleteItemsActionTest extends TestCase
@@ -69,8 +70,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $this->admin->hasAccess('create')->willReturn(false);
         $this->admin->hasAccess('edit')->willReturn(false);
 
-        $action = $this->action;
-        $action($request);
+        ($this->action)($request);
     }
 
     public function testRetrieveAutocompleteItemsActionDisabledFormelememt(): void
@@ -97,8 +97,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $fieldDescription->getTargetEntity()->willReturn(Foo::class);
         $fieldDescription->getName()->willReturn('barField');
 
-        $action = $this->action;
-        $action($request);
+        ($this->action)($request);
     }
 
     public function testRetrieveAutocompleteItemsTooShortSearchString(): void
@@ -125,10 +124,9 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $fieldDescription->getName()->willReturn('barField');
         $fieldDescription->getAssociationAdmin()->willReturn($targetAdmin->reveal());
 
-        $action = $this->action;
-        $response = $action($request);
+        $response = ($this->action)($request);
 
-        $this->isInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertSame('{"status":"KO","message":"Too short search string."}', $response->getContent());
     }
@@ -158,10 +156,9 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $datagrid->getFilter('foo')->willReturn($filter);
         $datagrid->setValue('foo', null, 'sonata')->shouldBeCalled();
 
-        $action = $this->action;
-        $response = $action($request);
+        $response = ($this->action)($request);
 
-        $this->isInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
     }
@@ -191,10 +188,9 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $datagrid->setValue('entity__property', null, 'sonata')->shouldBeCalled();
         $datagrid->setValue('entity2__property2', null, 'sonata')->shouldBeCalled();
 
-        $action = $this->action;
-        $response = $action($request);
+        $response = ($this->action)($request);
 
-        $this->isInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
     }
@@ -217,10 +213,9 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $datagrid->getFilter('entity.property')->willReturn($filter);
         $datagrid->setValue('entity__property', null, 'sonata')->shouldBeCalled();
 
-        $action = $this->action;
-        $response = $action($request);
+        $response = ($this->action)($request);
 
-        $this->isInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
     }

--- a/tests/Action/RetrieveFormFieldElementActionTest.php
+++ b/tests/Action/RetrieveFormFieldElementActionTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 
 final class RetrieveFormFieldElementActionTest extends TestCase
@@ -107,10 +108,9 @@ final class RetrieveFormFieldElementActionTest extends TestCase
         $renderer->setTheme($formView, $formView)->shouldBeCalled();
         $renderer->searchAndRenderBlock($formView, 'widget')->willReturn('block');
 
-        $action = $this->action;
-        $response = $action($request);
+        $response = ($this->action)($request);
 
-        $this->isInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame($response->getContent(), 'block');
     }
 

--- a/tests/Action/SearchActionTest.php
+++ b/tests/Action/SearchActionTest.php
@@ -30,8 +30,8 @@ class SearchActionTest extends TestCase
 {
     private $container;
     private $pool;
-    private $action;
     private $searchHandler;
+    private $action;
     private $templating;
     private $breadcrumbsBuilder;
 

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -128,8 +128,8 @@ final class SetObjectFieldValueActionTest extends TestCase
         $fieldDescription->getValue(Argument::cetera())->willReturn('some value');
 
         $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
-        $action = $this->action;
-        $response = $action($request);
+
+        $response = ($this->action)($request);
 
         $this->assertSame(200, $response->getStatusCode());
     }
@@ -182,8 +182,8 @@ final class SetObjectFieldValueActionTest extends TestCase
         $modelManager->find(\get_class($associationObject), 1)->willReturn($associationObject);
 
         $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
-        $action = $this->action;
-        $response = $action($request);
+
+        $response = ($this->action)($request);
 
         $this->assertSame(200, $response->getStatusCode());
     }
@@ -215,8 +215,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $fieldDescription->getOption('editable')->willReturn(true);
         $fieldDescription->getType()->willReturn('boolean');
 
-        $action = $this->action;
-        $response = $action($request);
+        $response = ($this->action)($request);
 
         $this->assertSame(400, $response->getStatusCode());
         $this->assertSame(json_encode("error1\nerror2"), $response->getContent());

--- a/tests/Admin/AdminHelperTest.php
+++ b/tests/Admin/AdminHelperTest.php
@@ -57,7 +57,7 @@ class AdminHelperTest extends TestCase
         $formBuilder->add($childFormBuilder);
 
         $this->assertNull($this->helper->getChildFormBuilder($formBuilder, 'foo'));
-        $this->isInstanceOf(FormBuilder::class, $this->helper->getChildFormBuilder($formBuilder, 'test_elementId'));
+        $this->assertInstanceOf(FormBuilder::class, $this->helper->getChildFormBuilder($formBuilder, 'test_elementId'));
     }
 
     public function testGetChildFormView(): void
@@ -65,10 +65,11 @@ class AdminHelperTest extends TestCase
         $formView = new FormView();
         $formView->vars['id'] = 'test';
         $child = new FormView($formView);
+        $formView->children[] = $child;
         $child->vars['id'] = 'test_elementId';
 
         $this->assertNull($this->helper->getChildFormView($formView, 'foo'));
-        $this->isInstanceOf(FormView::class, $this->helper->getChildFormView($formView, 'test_elementId'));
+        $this->assertInstanceOf(FormView::class, $this->helper->getChildFormView($formView, 'test_elementId'));
     }
 
     public function testAddNewInstance(): void

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -87,7 +87,7 @@ class BaseFieldDescriptionTest extends TestCase
 
         $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $description->setAdmin($admin);
-        $this->isInstanceOf(AdminInterface::class, $description->getAdmin());
+        $this->assertInstanceOf(AdminInterface::class, $description->getAdmin());
 
         $associationAdmin = $this->getMockForAbstractClass(AdminInterface::class);
         $associationAdmin->expects($this->once())->method('setParentFieldDescription');
@@ -95,11 +95,11 @@ class BaseFieldDescriptionTest extends TestCase
         $this->assertFalse($description->hasAssociationAdmin());
         $description->setAssociationAdmin($associationAdmin);
         $this->assertTrue($description->hasAssociationAdmin());
-        $this->isInstanceOf(AdminInterface::class, $description->getAssociationAdmin());
+        $this->assertInstanceOf(AdminInterface::class, $description->getAssociationAdmin());
 
         $parent = $this->getMockForAbstractClass(AdminInterface::class);
         $description->setParent($parent);
-        $this->isInstanceOf(AdminInterface::class, $description->getParent());
+        $this->assertInstanceOf(AdminInterface::class, $description->getParent());
     }
 
     public function testGetValue(): void

--- a/tests/Admin/FieldDescriptionCollectionTest.php
+++ b/tests/Admin/FieldDescriptionCollectionTest.php
@@ -39,8 +39,8 @@ class FieldDescriptionCollectionTest extends TestCase
         $this->assertCount(2, $collection->getElements());
         $this->assertCount(2, $collection);
 
-        $this->isInstanceOf(FieldDescriptionInterface::class, $collection['title']);
-        $this->isInstanceOf(FieldDescriptionInterface::class, $collection->get('title'));
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $collection['title']);
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $collection->get('title'));
 
         $collection->remove('title');
         $this->assertFalse($collection->has('title'));

--- a/tests/Controller/CoreControllerTest.php
+++ b/tests/Controller/CoreControllerTest.php
@@ -28,7 +28,6 @@ use Symfony\Component\HttpFoundation\Response;
 class CoreControllerTest extends TestCase
 {
     /**
-     * @doesNotPerformAssertions
      * @group legacy
      */
     public function testdashboardActionStandardRequest(): void
@@ -75,11 +74,10 @@ class CoreControllerTest extends TestCase
         $controller = new CoreController();
         $controller->setContainer($container);
 
-        $this->isInstanceOf(Response::class, $controller->dashboardAction());
+        $this->assertInstanceOf(Response::class, $controller->dashboardAction());
     }
 
     /**
-     * @doesNotPerformAssertions
      * @group legacy
      */
     public function testdashboardActionAjaxLayout(): void
@@ -122,6 +120,6 @@ class CoreControllerTest extends TestCase
 
         $response = $controller->dashboardAction($request);
 
-        $this->isInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
     }
 }

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -319,7 +319,7 @@ class HelperControllerTest extends TestCase
 
         $response = $this->controller->appendFormFieldElementAction($request);
 
-        $this->isInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame($response->getContent(), 'block');
     }
 
@@ -358,7 +358,7 @@ class HelperControllerTest extends TestCase
 
         $response = $this->controller->retrieveFormFieldElementAction($request);
 
-        $this->isInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame($response->getContent(), 'block');
     }
 
@@ -462,7 +462,7 @@ class HelperControllerTest extends TestCase
 
         $response = $this->controller->retrieveAutocompleteItemsAction($request);
 
-        $this->isInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertSame('{"status":"KO","message":"Too short search string."}', $response->getContent());
     }
@@ -487,7 +487,7 @@ class HelperControllerTest extends TestCase
 
         $response = $this->controller->retrieveAutocompleteItemsAction($request);
 
-        $this->isInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
     }
@@ -519,7 +519,7 @@ class HelperControllerTest extends TestCase
 
         $response = $this->controller->retrieveAutocompleteItemsAction($request);
 
-        $this->isInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
     }
@@ -544,7 +544,7 @@ class HelperControllerTest extends TestCase
 
         $response = $this->controller->retrieveAutocompleteItemsAction($request);
 
-        $this->isInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
I realised that there were some calls to `isInstanceOf` instead of `assertInstanceOf`. `isInstanceOf` is a constraint which just requires one parameter and does not perform an assertion. I didn't add something to the changelog as this is not useful to the end user.


I am targeting this branch, because these changes are BC.

