### PR TITLE
Fix service definition for DashboardAction and SearchAction

### DIFF
--- a/src/Action/DashboardAction.php
+++ b/src/Action/DashboardAction.php
@@ -18,7 +18,7 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 final class DashboardAction
 {
@@ -41,23 +41,24 @@ final class DashboardAction
      * @var Pool
      */
     private $pool;
+
     /**
-     * @var EngineInterface
+     * @var Environment
      */
-    private $templateEngine;
+    private $twig;
 
     public function __construct(
         array $dashboardBlocks,
         BreadcrumbsBuilderInterface $breadcrumbsBuilder,
         TemplateRegistryInterface $templateRegistry,
         Pool $pool,
-        EngineInterface $templateEngine
+        Environment $twig
     ) {
         $this->dashboardBlocks = $dashboardBlocks;
         $this->breadcrumbsBuilder = $breadcrumbsBuilder;
         $this->templateRegistry = $templateRegistry;
         $this->pool = $pool;
-        $this->templateEngine = $templateEngine;
+        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response
@@ -86,6 +87,6 @@ final class DashboardAction
             $parameters['breadcrumbs_builder'] = $this->breadcrumbsBuilder;
         }
 
-        return new Response($this->templateEngine->render($this->templateRegistry->getTemplate('dashboard'), $parameters));
+        return new Response($this->twig->render($this->templateRegistry->getTemplate('dashboard'), $parameters));
     }
 }

--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 final class SearchAction
 {
@@ -45,23 +45,24 @@ final class SearchAction
      * @var BreadcrumbsBuilderInterface
      */
     private $breadcrumbsBuilder;
+
     /**
-     * @var EngineInterface
+     * @var Environment
      */
-    private $templateEngine;
+    private $twig;
 
     public function __construct(
         Pool $pool,
         SearchHandler $searchHandler,
         TemplateRegistryInterface $templateRegistry,
         BreadcrumbsBuilderInterface $breadcrumbsBuilder,
-        EngineInterface $templateEngine
+        Environment $twig
     ) {
         $this->pool = $pool;
         $this->searchHandler = $searchHandler;
         $this->templateRegistry = $templateRegistry;
         $this->breadcrumbsBuilder = $breadcrumbsBuilder;
-        $this->templateEngine = $templateEngine;
+        $this->twig = $twig;
     }
 
     /**
@@ -73,7 +74,7 @@ final class SearchAction
     public function __invoke(Request $request): Response
     {
         if (!$request->get('admin') || !$request->isXmlHttpRequest()) {
-            return new Response($this->templateEngine->render($this->templateRegistry->getTemplate('search'), [
+            return new Response($this->twig->render($this->templateRegistry->getTemplate('search'), [
                 'base_template' => $request->isXmlHttpRequest() ?
                     $this->templateRegistry->getTemplate('ajax') :
                     $this->templateRegistry->getTemplate('layout'),

--- a/src/Resources/config/actions.xml
+++ b/src/Resources/config/actions.xml
@@ -7,18 +7,14 @@
             <argument type="service" id="sonata.admin.breadcrumbs_builder"/>
             <argument type="service" id="sonata.admin.global_template_registry"/>
             <argument type="service" id="sonata.admin.pool"/>
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
+            <argument type="service" id="twig"/>
         </service>
         <service id="Sonata\AdminBundle\Action\SearchAction" class="Sonata\AdminBundle\Action\SearchAction" public="true">
             <argument type="service" id="sonata.admin.pool"/>
             <argument type="service" id="sonata.admin.search.handler"/>
             <argument type="service" id="sonata.admin.global_template_registry"/>
             <argument type="service" id="sonata.admin.breadcrumbs_builder"/>
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
+            <argument type="service" id="twig"/>
         </service>
         <service id="sonata.admin.action.append_form_field_element" class="Sonata\AdminBundle\Action\AppendFormFieldElementAction" public="true">
             <argument type="service" id="twig"/>

--- a/tests/Action/DashboardActionTest.php
+++ b/tests/Action/DashboardActionTest.php
@@ -18,10 +18,10 @@ use Sonata\AdminBundle\Action\DashboardAction;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
 
 class DashboardActionTest extends TestCase
 {
@@ -39,7 +39,7 @@ class DashboardActionTest extends TestCase
         $pool = new Pool($container, 'title', 'logo.png');
         $pool->setTemplateRegistry($templateRegistry->reveal());
 
-        $templating = $this->createMock(EngineInterface::class);
+        $twig = $this->createMock(Environment::class);
 
         $breadcrumbsBuilder = $this->getMockForAbstractClass(BreadcrumbsBuilderInterface::class);
 
@@ -48,7 +48,7 @@ class DashboardActionTest extends TestCase
             $breadcrumbsBuilder,
             $templateRegistry->reveal(),
             $pool,
-            $templating
+            $twig
         );
     }
 

--- a/tests/Action/SearchActionTest.php
+++ b/tests/Action/SearchActionTest.php
@@ -20,11 +20,11 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Search\SearchHandler;
 use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CleanAdmin;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
 
 class SearchActionTest extends TestCase
 {
@@ -32,7 +32,7 @@ class SearchActionTest extends TestCase
     private $pool;
     private $searchHandler;
     private $action;
-    private $templating;
+    private $twig;
     private $breadcrumbsBuilder;
 
     protected function setUp(): void
@@ -47,34 +47,27 @@ class SearchActionTest extends TestCase
 
         $this->breadcrumbsBuilder = $this->createMock(BreadcrumbsBuilderInterface::class);
         $this->searchHandler = $this->createMock(SearchHandler::class);
-        $this->templating = $this->prophesize(EngineInterface::class);
+        $this->twig = $this->prophesize(Environment::class);
 
         $this->action = new SearchAction(
             $this->pool,
             $this->searchHandler,
             $templateRegistry,
             $this->breadcrumbsBuilder,
-            $this->templating->reveal()
+            $this->twig->reveal()
         );
     }
 
     public function testGlobalPage(): void
     {
         $request = new Request(['q' => 'some search']);
-        $this->templating->render('search.html.twig', [
+        $this->twig->render('search.html.twig', [
             'base_template' => 'layout.html.twig',
             'breadcrumbs_builder' => $this->breadcrumbsBuilder,
             'admin_pool' => $this->pool,
             'query' => 'some search',
             'groups' => [],
         ])->willReturn(new Response());
-        $this->templating->renderResponse('search.html.twig', [
-            'base_template' => 'layout.html.twig',
-            'breadcrumbs_builder' => $this->breadcrumbsBuilder,
-            'admin_pool' => $this->pool,
-            'query' => 'some search',
-            'groups' => [],
-        ], null)->willReturn(new Response());
 
         $this->assertInstanceOf(Response::class, ($this->action)($request));
     }

--- a/tests/Controller/CoreControllerTest.php
+++ b/tests/Controller/CoreControllerTest.php
@@ -19,11 +19,11 @@ use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Controller\CoreController;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
 
 class CoreControllerTest extends TestCase
 {
@@ -42,7 +42,7 @@ class CoreControllerTest extends TestCase
         $pool = new Pool($container, 'title', 'logo.png');
         $pool->setTemplateRegistry($templateRegistry->reveal());
 
-        $templating = $this->createMock(EngineInterface::class);
+        $twig = $this->createMock(Environment::class);
         $request = new Request();
 
         $requestStack = new RequestStack();
@@ -56,7 +56,7 @@ class CoreControllerTest extends TestCase
                 $breadcrumbsBuilder,
                 $templateRegistry->reveal(),
                 $pool,
-                $templating
+                $twig
             ),
             'request_stack' => $requestStack,
         ];
@@ -93,7 +93,7 @@ class CoreControllerTest extends TestCase
         $pool = new Pool($container, 'title', 'logo.png');
         $pool->setTemplateRegistry($templateRegistry->reveal());
 
-        $templating = $this->createMock(EngineInterface::class);
+        $twig = $this->createMock(Environment::class);
         $request = new Request();
         $request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
@@ -106,7 +106,7 @@ class CoreControllerTest extends TestCase
                 $breadcrumbsBuilder,
                 $templateRegistry->reveal(),
                 $pool,
-                $templating
+                $twig
             ),
             'request_stack' => $requestStack,
         ];


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
I missed updating the service definition in https://github.com/sonata-project/SonataAdminBundle/pull/5723
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5725

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed `DashboardAction` and `SearchAction` service definitions
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
