### PR TITLE
Export choices as const

### DIFF
--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -34,6 +34,12 @@ class ChoiceType extends AbstractType
 
     public const TYPE_EQUAL = 3;
 
+    public const CHOICES = [
+        'label_type_contains' => self::TYPE_CONTAINS,
+        'label_type_not_contains' => self::TYPE_NOT_CONTAINS,
+        'label_type_equals' => self::TYPE_EQUAL,
+    ];
+
     /**
      * NEXT_MAJOR: remove this property.
      *
@@ -65,17 +71,11 @@ class ChoiceType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choices = [
-            'label_type_contains' => self::TYPE_CONTAINS,
-            'label_type_not_contains' => self::TYPE_NOT_CONTAINS,
-            'label_type_equals' => self::TYPE_EQUAL,
-        ];
         $operatorChoices = [];
 
         if (HiddenType::class !== $options['operator_type']) {
             $operatorChoices['choice_translation_domain'] = 'SonataAdminBundle';
-
-            $operatorChoices['choices'] = $choices;
+            $operatorChoices['choices'] = self::CHOICES;
         }
 
         $builder

--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -34,10 +34,13 @@ class ChoiceType extends AbstractType
 
     public const TYPE_EQUAL = 3;
 
-    public const CHOICES = [
-        'label_type_contains' => self::TYPE_CONTAINS,
-        'label_type_not_contains' => self::TYPE_NOT_CONTAINS,
-        'label_type_equals' => self::TYPE_EQUAL,
+    public const OPERATOR_OPTIONS = [
+        'choices' => [
+            'label_type_contains' => self::TYPE_CONTAINS,
+            'label_type_not_contains' => self::TYPE_NOT_CONTAINS,
+            'label_type_equals' => self::TYPE_EQUAL,
+        ],
+        'choice_translation_domain' => 'SonataAdminBundle',
     ];
 
     /**
@@ -74,8 +77,7 @@ class ChoiceType extends AbstractType
         $operatorChoices = [];
 
         if (HiddenType::class !== $options['operator_type']) {
-            $operatorChoices['choice_translation_domain'] = 'SonataAdminBundle';
-            $operatorChoices['choices'] = self::CHOICES;
+            $operatorChoices = self::OPERATOR_OPTIONS;
         }
 
         $builder

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -31,9 +31,12 @@ class DateRangeType extends AbstractType
     public const TYPE_BETWEEN = 1;
     public const TYPE_NOT_BETWEEN = 2;
 
-    public const CHOICES = [
-        'label_date_type_between' => self::TYPE_BETWEEN,
-        'label_date_type_not_between' => self::TYPE_NOT_BETWEEN,
+    public const OPERATOR_OPTIONS = [
+        'choices' => [
+            'label_date_type_between' => self::TYPE_BETWEEN,
+            'label_date_type_not_between' => self::TYPE_NOT_BETWEEN,
+        ],
+        'choice_translation_domain' => 'SonataAdminBundle',
     ];
 
     /**
@@ -67,12 +70,8 @@ class DateRangeType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choiceOptions = [
-            'required' => false,
-        ];
-
-        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-        $choiceOptions['choices'] = self::CHOICES;
+        $choiceOptions = self::OPERATOR_OPTIONS;
+        $choiceOptions['required'] = false;
 
         $builder
             ->add('type', FormChoiceType::class, $choiceOptions)

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -31,6 +31,11 @@ class DateRangeType extends AbstractType
     public const TYPE_BETWEEN = 1;
     public const TYPE_NOT_BETWEEN = 2;
 
+    public const CHOICES = [
+        'label_date_type_between' => self::TYPE_BETWEEN,
+        'label_date_type_not_between' => self::TYPE_NOT_BETWEEN,
+    ];
+
     /**
      * NEXT_MAJOR: remove this property.
      *
@@ -62,17 +67,12 @@ class DateRangeType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choices = [
-            'label_date_type_between' => self::TYPE_BETWEEN,
-            'label_date_type_not_between' => self::TYPE_NOT_BETWEEN,
-        ];
         $choiceOptions = [
             'required' => false,
         ];
 
         $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-
-        $choiceOptions['choices'] = $choices;
+        $choiceOptions['choices'] = self::CHOICES;
 
         $builder
             ->add('type', FormChoiceType::class, $choiceOptions)

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -31,6 +31,11 @@ class DateTimeRangeType extends AbstractType
     public const TYPE_BETWEEN = 1;
     public const TYPE_NOT_BETWEEN = 2;
 
+    public const CHOICES = [
+        'label_date_type_between' => self::TYPE_BETWEEN,
+        'label_date_type_not_between' => self::TYPE_NOT_BETWEEN,
+    ];
+
     /**
      * NEXT_MAJOR: remove this property.
      *
@@ -62,17 +67,12 @@ class DateTimeRangeType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choices = [
-            'label_date_type_between' => self::TYPE_BETWEEN,
-            'label_date_type_not_between' => self::TYPE_NOT_BETWEEN,
-        ];
         $choiceOptions = [
             'required' => false,
         ];
 
         $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-
-        $choiceOptions['choices'] = $choices;
+        $choiceOptions['choices'] = self::CHOICES;
 
         $builder
             ->add('type', FormChoiceType::class, $choiceOptions)

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -31,9 +31,12 @@ class DateTimeRangeType extends AbstractType
     public const TYPE_BETWEEN = 1;
     public const TYPE_NOT_BETWEEN = 2;
 
-    public const CHOICES = [
-        'label_date_type_between' => self::TYPE_BETWEEN,
-        'label_date_type_not_between' => self::TYPE_NOT_BETWEEN,
+    public const OPERATOR_OPTIONS = [
+        'choices' => [
+            'label_date_type_between' => self::TYPE_BETWEEN,
+            'label_date_type_not_between' => self::TYPE_NOT_BETWEEN,
+        ],
+        'choice_translation_domain' => 'SonataAdminBundle',
     ];
 
     /**
@@ -67,12 +70,8 @@ class DateTimeRangeType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choiceOptions = [
-            'required' => false,
-        ];
-
-        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-        $choiceOptions['choices'] = self::CHOICES;
+        $choiceOptions = self::OPERATOR_OPTIONS;
+        $choiceOptions['required'] = false;
 
         $builder
             ->add('type', FormChoiceType::class, $choiceOptions)

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -42,14 +42,17 @@ class DateTimeType extends AbstractType
 
     public const TYPE_NOT_NULL = 7;
 
-    public const CHOICES = [
-        'label_date_type_equal' => self::TYPE_EQUAL,
-        'label_date_type_greater_equal' => self::TYPE_GREATER_EQUAL,
-        'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
-        'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
-        'label_date_type_less_than' => self::TYPE_LESS_THAN,
-        'label_date_type_null' => self::TYPE_NULL,
-        'label_date_type_not_null' => self::TYPE_NOT_NULL,
+    public const OPERATOR_OPTIONS = [
+        'choices' => [
+            'label_date_type_equal' => self::TYPE_EQUAL,
+            'label_date_type_greater_equal' => self::TYPE_GREATER_EQUAL,
+            'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
+            'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
+            'label_date_type_less_than' => self::TYPE_LESS_THAN,
+            'label_date_type_null' => self::TYPE_NULL,
+            'label_date_type_not_null' => self::TYPE_NOT_NULL,
+        ],
+        'choice_translation_domain' => 'SonataAdminBundle',
     ];
 
     /**
@@ -83,12 +86,8 @@ class DateTimeType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choiceOptions = [
-            'required' => false,
-        ];
-
-        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-        $choiceOptions['choices'] = self::CHOICES;
+        $choiceOptions = self::OPERATOR_OPTIONS;
+        $choiceOptions['required'] = false;
 
         $builder
             ->add('type', FormChoiceType::class, $choiceOptions)

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -42,6 +42,16 @@ class DateTimeType extends AbstractType
 
     public const TYPE_NOT_NULL = 7;
 
+    public const CHOICES = [
+        'label_date_type_equal' => self::TYPE_EQUAL,
+        'label_date_type_greater_equal' => self::TYPE_GREATER_EQUAL,
+        'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
+        'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
+        'label_date_type_less_than' => self::TYPE_LESS_THAN,
+        'label_date_type_null' => self::TYPE_NULL,
+        'label_date_type_not_null' => self::TYPE_NOT_NULL,
+    ];
+
     /**
      * NEXT_MAJOR: remove this property.
      *
@@ -73,22 +83,12 @@ class DateTimeType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choices = [
-            'label_date_type_equal' => self::TYPE_EQUAL,
-            'label_date_type_greater_equal' => self::TYPE_GREATER_EQUAL,
-            'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
-            'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
-            'label_date_type_less_than' => self::TYPE_LESS_THAN,
-            'label_date_type_null' => self::TYPE_NULL,
-            'label_date_type_not_null' => self::TYPE_NOT_NULL,
-        ];
         $choiceOptions = [
             'required' => false,
         ];
 
         $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-
-        $choiceOptions['choices'] = $choices;
+        $choiceOptions['choices'] = self::CHOICES;
 
         $builder
             ->add('type', FormChoiceType::class, $choiceOptions)

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -42,6 +42,16 @@ class DateType extends AbstractType
 
     public const TYPE_NOT_NULL = 7;
 
+    public const CHOICES = [
+        'label_date_type_equal' => self::TYPE_EQUAL,
+        'label_date_type_greater_equal' => self::TYPE_GREATER_EQUAL,
+        'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
+        'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
+        'label_date_type_less_than' => self::TYPE_LESS_THAN,
+        'label_date_type_null' => self::TYPE_NULL,
+        'label_date_type_not_null' => self::TYPE_NOT_NULL,
+    ];
+
     /**
      * NEXT_MAJOR: remove this property.
      *
@@ -73,22 +83,12 @@ class DateType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choices = [
-            'label_date_type_equal' => self::TYPE_EQUAL,
-            'label_date_type_greater_equal' => self::TYPE_GREATER_EQUAL,
-            'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
-            'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
-            'label_date_type_less_than' => self::TYPE_LESS_THAN,
-            'label_date_type_null' => self::TYPE_NULL,
-            'label_date_type_not_null' => self::TYPE_NOT_NULL,
-        ];
         $choiceOptions = [
             'required' => false,
         ];
 
         $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-
-        $choiceOptions['choices'] = $choices;
+        $choiceOptions['choices'] = self::CHOICES;
 
         $builder
             ->add('type', FormChoiceType::class, $choiceOptions)

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -42,14 +42,17 @@ class DateType extends AbstractType
 
     public const TYPE_NOT_NULL = 7;
 
-    public const CHOICES = [
-        'label_date_type_equal' => self::TYPE_EQUAL,
-        'label_date_type_greater_equal' => self::TYPE_GREATER_EQUAL,
-        'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
-        'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
-        'label_date_type_less_than' => self::TYPE_LESS_THAN,
-        'label_date_type_null' => self::TYPE_NULL,
-        'label_date_type_not_null' => self::TYPE_NOT_NULL,
+    public const OPERATOR_OPTIONS = [
+        'choices' => [
+            'label_date_type_equal' => self::TYPE_EQUAL,
+            'label_date_type_greater_equal' => self::TYPE_GREATER_EQUAL,
+            'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
+            'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
+            'label_date_type_less_than' => self::TYPE_LESS_THAN,
+            'label_date_type_null' => self::TYPE_NULL,
+            'label_date_type_not_null' => self::TYPE_NOT_NULL,
+        ],
+        'choice_translation_domain' => 'SonataAdminBundle',
     ];
 
     /**
@@ -83,12 +86,8 @@ class DateType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choiceOptions = [
-            'required' => false,
-        ];
-
-        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-        $choiceOptions['choices'] = self::CHOICES;
+        $choiceOptions = self::OPERATOR_OPTIONS;
+        $choiceOptions['required'] = false;
 
         $builder
             ->add('type', FormChoiceType::class, $choiceOptions)

--- a/src/Form/Type/Filter/NumberType.php
+++ b/src/Form/Type/Filter/NumberType.php
@@ -38,6 +38,14 @@ class NumberType extends AbstractType
 
     public const TYPE_LESS_THAN = 5;
 
+    public const CHOICES = [
+        'label_type_equal' => self::TYPE_EQUAL,
+        'label_type_greater_equal' => self::TYPE_GREATER_EQUAL,
+        'label_type_greater_than' => self::TYPE_GREATER_THAN,
+        'label_type_less_equal' => self::TYPE_LESS_EQUAL,
+        'label_type_less_than' => self::TYPE_LESS_THAN,
+    ];
+
     /**
      * NEXT_MAJOR: remove this property.
      *
@@ -69,20 +77,12 @@ class NumberType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choices = [
-            'label_type_equal' => self::TYPE_EQUAL,
-            'label_type_greater_equal' => self::TYPE_GREATER_EQUAL,
-            'label_type_greater_than' => self::TYPE_GREATER_THAN,
-            'label_type_less_equal' => self::TYPE_LESS_EQUAL,
-            'label_type_less_than' => self::TYPE_LESS_THAN,
-        ];
         $choiceOptions = [
             'required' => false,
         ];
 
         $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-
-        $choiceOptions['choices'] = $choices;
+        $choiceOptions['choices'] = self::CHOICES;
 
         $builder
             ->add('type', FormChoiceType::class, $choiceOptions)

--- a/src/Form/Type/Filter/NumberType.php
+++ b/src/Form/Type/Filter/NumberType.php
@@ -38,12 +38,15 @@ class NumberType extends AbstractType
 
     public const TYPE_LESS_THAN = 5;
 
-    public const CHOICES = [
-        'label_type_equal' => self::TYPE_EQUAL,
-        'label_type_greater_equal' => self::TYPE_GREATER_EQUAL,
-        'label_type_greater_than' => self::TYPE_GREATER_THAN,
-        'label_type_less_equal' => self::TYPE_LESS_EQUAL,
-        'label_type_less_than' => self::TYPE_LESS_THAN,
+    public const OPERATOR_OPTIONS = [
+        'choices' => [
+            'label_type_equal' => self::TYPE_EQUAL,
+            'label_type_greater_equal' => self::TYPE_GREATER_EQUAL,
+            'label_type_greater_than' => self::TYPE_GREATER_THAN,
+            'label_type_less_equal' => self::TYPE_LESS_EQUAL,
+            'label_type_less_than' => self::TYPE_LESS_THAN,
+        ],
+        'choice_translation_domain' => 'SonataAdminBundle',
     ];
 
     /**
@@ -77,12 +80,8 @@ class NumberType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choiceOptions = [
-            'required' => false,
-        ];
-
-        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-        $choiceOptions['choices'] = self::CHOICES;
+        $choiceOptions = self::OPERATOR_OPTIONS;
+        $choiceOptions['required'] = false;
 
         $builder
             ->add('type', FormChoiceType::class, $choiceOptions)


### PR DESCRIPTION
## Subject

I am targeting this branch, because there is no breaking changes.

In the following of https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/934#issuecomment-518019569 I'd like to expose the choices as public const to use it when creating custom filter.

## Changelog

```markdown

### Changed
Create const for form choices in Filter classes
```
