### PR TITLE
Fix: Logic inconsistency in base_list.html.twig prevents default boolean filter from being visible

### DIFF
--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -241,7 +241,6 @@ file that was distributed with this source code.
 
                 <ul class="dropdown-menu" role="menu">
                     {% for filter in admin.datagrid.filters|filter(filter => filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null) %}
-                        {% set filterActive = ((filter.isActive() or filter.options['show_filter']) and not admin.isDefaultFilter(filter.formName)) %}
                         <li>
                             <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
                                 <i class="fa {{ (filter.isActive() or filter.options['show_filter']) ? 'fa-check-square-o' : 'fa-square-o' }}"></i>{{ filter.label|trans({}, filter.translationDomain ?: admin.translationDomain) }}

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -267,7 +267,7 @@ file that was distributed with this source code.
                             <div class="col-sm-9">
                                 {% set withAdvancedFilter = false %}
                                 {% for filter in admin.datagrid.filters %}
-                                    {% set filterActive = ((filter.isActive() and filter.options['show_filter'] is null) or (filter.options['show_filter'] is same as(true))) and not admin.isDefaultFilter(filter.formName) %}
+                                    {% set filterActive = filter.isActive() or filter.options['show_filter'] %}
                                     {% set filterVisible = filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null %}
                                     <div class="form-group {% block sonata_list_filter_group_class %}{% endblock %}" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ filterVisible ? 'true' : 'false' }}" style="display: {% if filterActive %}block{% else %}none{% endif %}">
                                         {% if filter.label is not same as(false) %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

An inconsistency in twig logic in the `base_list.html.twig` template, means that a boolean filter with a default value set, does not display on initial page load.  Different logic is used in 2 places; one to tick the filter in the dropdown menu and one to display the field in the filter area. This PR brings these two conditions into sync.

I'm not sure this is the best solution. Things that concern me:
 - ~~Why does this only affect boolean?~~ actually affects all field types
 - Not sure why there is a `filterVisible` check in the second loop and not the first?
 - Why does this only occur when default filter values are set in `$datagridValues` but not if same values are passed in the URL?

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5744

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Logic inconsistency in base_list.html.twig prevents default boolean filter from being visible
### Removed
 - Unused variable in base_list.html.twig
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Screenshots

### Setup
This is my test entity and admin, before the patch and before I set any default filters.
![2019-11-17-132131_1025x332_scrot](https://user-images.githubusercontent.com/2304970/69008104-78f27780-093e-11ea-9f4e-c501914e691b.png)

### Before
I have now added a default filter in `$datagridValues`, you can see it is applied to the data and ticked in the dropdown, but missing from the filters area
![2019-11-17-132654_1027x407_scrot](https://user-images.githubusercontent.com/2304970/69008121-a9d2ac80-093e-11ea-9d83-8dc08cc91a90.png)

### After
This is with the PR applied, the filter is now showing as expected
![2019-11-17-132941_1027x405_scrot](https://user-images.githubusercontent.com/2304970/69008130-c8d13e80-093e-11ea-86d9-ddf1ca8a9d57.png)
