### PR TITLE
Add the basic doctrine metadata

### DIFF
--- a/docs/getting_started/creating_an_admin.rst
+++ b/docs/getting_started/creating_an_admin.rst
@@ -14,7 +14,7 @@ For the rest of the tutorial, you'll need some sort of model. In this tutorial,
     // src/Entity/BlogPost.php
 
     /**
-     * @ORM\Entity
+     * ... configure your entity be handled by an ORM
      */
     class BlogPost
     {
@@ -54,7 +54,7 @@ For the rest of the tutorial, you'll need some sort of model. In this tutorial,
     use Doctrine\Common\Collections\ArrayCollection;
 
     /**
-     * @ORM\Entity
+     * ...
      */
     class Category
     {

--- a/docs/getting_started/creating_an_admin.rst
+++ b/docs/getting_started/creating_an_admin.rst
@@ -13,7 +13,9 @@ For the rest of the tutorial, you'll need some sort of model. In this tutorial,
 
     // src/Entity/BlogPost.php
 
-    // ...
+    /**
+     * @ORM\Entity
+     */
     class BlogPost
     {
         // ...
@@ -51,6 +53,9 @@ For the rest of the tutorial, you'll need some sort of model. In this tutorial,
 
     use Doctrine\Common\Collections\ArrayCollection;
 
+    /**
+     * @ORM\Entity
+     */
     class Category
     {
         // ...
@@ -87,7 +92,8 @@ After this, create the schema for these entities:
 .. note::
 
     This article assumes you have basic knowledge of the Doctrine2 ORM and
-    you've set up a database correctly.
+    you've set up a database correctly. You can learn more on Doctrine entities
+    int the [Databases and the Doctrine ORM](https://symfony.com/doc/current/doctrine.html) chapter.
 
 Step 1: Create an Admin Class
 -----------------------------

--- a/docs/getting_started/creating_an_admin.rst
+++ b/docs/getting_started/creating_an_admin.rst
@@ -13,9 +13,6 @@ For the rest of the tutorial, you'll need some sort of model. In this tutorial,
 
     // src/Entity/BlogPost.php
 
-    /**
-     * ... configure your entity be handled by an ORM
-     */
     class BlogPost
     {
         // ...
@@ -53,9 +50,6 @@ For the rest of the tutorial, you'll need some sort of model. In this tutorial,
 
     use Doctrine\Common\Collections\ArrayCollection;
 
-    /**
-     * ...
-     */
     class Category
     {
         // ...
@@ -93,7 +87,9 @@ After this, create the schema for these entities:
 
     This article assumes you have basic knowledge of the Doctrine2 ORM and
     you've set up a database correctly. You can learn more on Doctrine entities
-    int the [Databases and the Doctrine ORM](https://symfony.com/doc/current/doctrine.html) chapter.
+    int the `Databases and the Doctrine ORM`_ chapter.
+
+.. _`Databases and the Doctrine ORM`: https://symfony.com/doc/current/doctrine.html
 
 Step 1: Create an Admin Class
 -----------------------------

--- a/docs/getting_started/creating_an_admin.rst
+++ b/docs/getting_started/creating_an_admin.rst
@@ -87,7 +87,7 @@ After this, create the schema for these entities:
 
     This article assumes you have basic knowledge of the Doctrine2 ORM and
     you've set up a database correctly. You can learn more on Doctrine entities
-    int the `Databases and the Doctrine ORM`_ chapter.
+    in the `Databases and the Doctrine ORM`_ chapter.
 
 .. _`Databases and the Doctrine ORM`: https://symfony.com/doc/current/doctrine.html
 


### PR DESCRIPTION
## Subject

To make things simpler, I suggest that we add the basic Doctrine metadata on the class level just like it has been done on the class properties.

I also added a reference to the Doctrine documentation page.

Adding the $id might be nice, but as least now if you execute the `doctrine:schema:create` command, you will get a nice error message to tell you that something is wrong in your entity. Until now, the only message on a fresh install was that no entity was found.. how frustrating.

I added this on the current master branch but I think we might also push it to the next release as people starting with Symfony will likely use the 5 branch.
