### PR TITLE
Add missing AbstractAdmin::createQuery() types documentation

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1381,6 +1381,11 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return $this->list;
     }
 
+    /**
+     * @param string $context
+     *
+     * @return ProxyQueryInterface
+     */
     public function createQuery($context = 'list')
     {
         if (\func_num_args() > 0) {


### PR DESCRIPTION
## Subject

This will help developers when altering queries, because the IDE will autocomplete properly and also static analysers like PHPStan will not complain (correctly).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it only adds type information/PHPDoc hence is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add AbstractAdmin::createQuery() type documentation.
```