### PR TITLE
Solve problem with different doctrine services

### DIFF
--- a/src/Command/GenerateObjectAclCommand.php
+++ b/src/Command/GenerateObjectAclCommand.php
@@ -64,7 +64,7 @@ class GenerateObjectAclCommand extends QuestionableCommand
     {
         $this->pool = $pool;
         $this->aclObjectManipulators = $aclObjectManipulators;
-        if (!(method_exists($registry, 'getAliasNamespace') || method_exists($this->registry, 'getEntityNamespace'))) {
+        if (!(method_exists($registry, 'getAliasNamespace') || method_exists($registry, 'getEntityNamespace'))) {
             throw new \InvalidArgumentException('$registy need to be either Symfony\Bridge\Doctrine\RegistryInterface or Doctrine\Common\Persistence\ManagerRegistry');
         }
         $this->registry = $registry;

--- a/src/Command/GenerateObjectAclCommand.php
+++ b/src/Command/GenerateObjectAclCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Command;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Util\ObjectAclManipulatorInterface;
@@ -50,14 +51,22 @@ class GenerateObjectAclCommand extends QuestionableCommand
     private $aclObjectManipulators = [];
 
     /**
-     * @var RegistryInterface
+     * @var RegistryInterface|ManagerRegistry|null
      */
     private $registry;
 
+    /**
+     * @param Pool $pool
+     * @param array $aclObjectManipulators
+     * @param RegistryInterface|ManagerRegistry|null $registry
+     */
     public function __construct(Pool $pool, array $aclObjectManipulators, $registry = null)
     {
         $this->pool = $pool;
         $this->aclObjectManipulators = $aclObjectManipulators;
+        if (!(method_exists($registry, 'getAliasNamespace') || method_exists($this->registry, 'getEntityNamespace'))) {
+            throw new \InvalidArgumentException('$registy need to be either Symfony\Bridge\Doctrine\RegistryInterface or Doctrine\Common\Persistence\ManagerRegistry');
+        }
         $this->registry = $registry;
 
         parent::__construct();

--- a/src/Command/GenerateObjectAclCommand.php
+++ b/src/Command/GenerateObjectAclCommand.php
@@ -56,8 +56,6 @@ class GenerateObjectAclCommand extends QuestionableCommand
     private $registry;
 
     /**
-     * @param Pool $pool
-     * @param array $aclObjectManipulators
      * @param RegistryInterface|ManagerRegistry|null $registry
      */
     public function __construct(Pool $pool, array $aclObjectManipulators, $registry = null)

--- a/src/Command/GenerateObjectAclCommand.php
+++ b/src/Command/GenerateObjectAclCommand.php
@@ -54,7 +54,7 @@ class GenerateObjectAclCommand extends QuestionableCommand
      */
     private $registry;
 
-    public function __construct(Pool $pool, array $aclObjectManipulators, RegistryInterface $registry = null)
+    public function __construct(Pool $pool, array $aclObjectManipulators, $registry = null)
     {
         $this->pool = $pool;
         $this->aclObjectManipulators = $aclObjectManipulators;
@@ -158,11 +158,13 @@ class GenerateObjectAclCommand extends QuestionableCommand
         if ('' === $this->userEntityClass) {
             if ($input->getOption('user_entity')) {
                 list($userBundle, $userEntity) = Validators::validateEntityName($input->getOption('user_entity'));
-                $this->userEntityClass = $this->registry->getEntityNamespace($userBundle).'\\'.$userEntity;
             } else {
                 list($userBundle, $userEntity) = $this->askAndValidate($input, $output, 'Please enter the User Entity shortcut name: ', '', 'Sonata\AdminBundle\Command\Validators::validateEntityName');
-
-                // Entity exists?
+            }
+            // Entity exists?
+            if (method_exists($this->registry, 'getAliasNamespace')) {
+                $this->userEntityClass = $this->registry->getAliasNamespace($userBundle).'\\'.$userEntity;
+            } else {
                 $this->userEntityClass = $this->registry->getEntityNamespace($userBundle).'\\'.$userEntity;
             }
         }


### PR DESCRIPTION
## Subject

Allow doctrine service to be either Symfony\Bridge\Doctrine\RegistryInterface or Doctrine\Common\Persistence\ManagerRegistry

I am targeting this branch, because change should work with Symfony version 4.4 and lower.

Closes #5757

## Changelog

### Changed
GenerateObjectAclCommand is now able to work with Symfony 4.4 doctrine service
