### PR TITLE
Prevent installing Doctrine bundle 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         "twig/twig": "^2.10"
     },
     "conflict": {
+        "doctrine/doctrine-bundle": ">=2",
         "jms/di-extra-bundle": "<1.9",
         "sonata-project/media-bundle": "<3.7",
         "sonata-project/user-bundle": "<3.3"


### PR DESCRIPTION
## Subject

We rely on a `doctrine` service defined in that bundle, which means we
have a dependency on the bundle that cannot be seen by just examining
php code like composer-require-checker does.
That dependency is optional though, because not everyone is using the
ORM or ACLs. Using the conflict section is the best way to prevent
installation of version 2 while still not requiring installation of
version 3.
The error might be quite easy to fix, but the conflict I added should
stay, and just be modified to `>=3` when the error is fixed.

See:
- https://github.com/doctrine/DoctrineBundle/blob/d1f8a28fb45b6ff0b59f88df393575a4f89c3b66/Resources/config/dbal.xml#L67
- https://github.com/sonata-project/SonataAdminBundle/blob/3ab3cca373f76304149aa2ba0ef7da7d34c998b6/src/Resources/config/commands.xml#L20-L24


<!-- Describe your Pull Request content here -->

I am targeting this branch, because this is BC.

Refs #5757 (it fixes the crash, but the reported bug will still have to be fixed when allowing the new version of the bundle)

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- crash when using the command that generates ACLs
- crash when using `bin/console list` or just `bin/console`
```
