### PR TITLE
Fixes incompatible $registry argument in GenerateObjectAclCommand class when using DoctrineBundle:^2.0

### DIFF
--- a/src/Command/GenerateObjectAclCommand.php
+++ b/src/Command/GenerateObjectAclCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Command;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Util\ObjectAclManipulatorInterface;
@@ -50,14 +51,34 @@ class GenerateObjectAclCommand extends QuestionableCommand
     private $aclObjectManipulators = [];
 
     /**
-     * @var RegistryInterface
+     * @var RegistryInterface|ManagerRegistry|null
      */
     private $registry;
 
-    public function __construct(Pool $pool, array $aclObjectManipulators, RegistryInterface $registry = null)
+    /**
+     * @param RegistryInterface|ManagerRegistry|null $registry
+     */
+    public function __construct(Pool $pool, array $aclObjectManipulators, $registry = null)
     {
         $this->pool = $pool;
         $this->aclObjectManipulators = $aclObjectManipulators;
+        if (null !== $registry && (!$registry instanceof RegistryInterface && !$registry instanceof ManagerRegistry)) {
+            if (!$registry instanceof ManagerRegistry) {
+                @trigger_error(sprintf(
+                    "Passing an object that doesn't implement %s as argument 3 to %s() is deprecated since sonata-project/admin-bundle 3.x.",
+                    ManagerRegistry::class,
+                    __METHOD__
+                ), E_USER_DEPRECATED);
+            }
+
+            throw new \TypeError(sprintf(
+                'Argument 3 passed to %s() must be either an instance of %s or %s, %s given.',
+                __METHOD__,
+                RegistryInterface::class,
+                ManagerRegistry::class,
+                \is_object($registry) ? \get_class($registry) : \gettype($registry)
+            ));
+        }
         $this->registry = $registry;
 
         parent::__construct();
@@ -156,12 +177,14 @@ class GenerateObjectAclCommand extends QuestionableCommand
         if ('' === $this->userEntityClass) {
             if ($input->getOption('user_entity')) {
                 list($userBundle, $userEntity) = Validators::validateEntityName($input->getOption('user_entity'));
-                $this->userEntityClass = $this->registry->getEntityNamespace($userBundle).'\\'.$userEntity;
             } else {
                 list($userBundle, $userEntity) = $this->askAndValidate($input, $output, 'Please enter the User Entity shortcut name: ', '', 'Sonata\AdminBundle\Command\Validators::validateEntityName');
-
-                // Entity exists?
+            }
+            // Entity exists?
+            if ($this->registry instanceof RegistryInterface) {
                 $this->userEntityClass = $this->registry->getEntityNamespace($userBundle).'\\'.$userEntity;
+            } else {
+                $this->userEntityClass = $this->registry->getAliasNamespace($userBundle).'\\'.$userEntity;
             }
         }
 


### PR DESCRIPTION
Since I cannot contribute to @Metabor's fork, a new PR for fixing the comments

See https://github.com/sonata-project/SonataAdminBundle/pull/5758
Fixes https://github.com/sonata-project/SonataAdminBundle/issues/5757