### PR TITLE
Warning: Illegal offset type in isset or empty

### DIFF
--- a/src/Resources/views/CRUD/list_choice.html.twig
+++ b/src/Resources/views/CRUD/list_choice.html.twig
@@ -46,7 +46,7 @@ file that was distributed with this source code.
                     {% set choice = val %}
                 {% endif %}
                 {% if field_description.options.catalogue is defined %}
-                    {% set result = result ~ choice %}
+                    {% set result = result ~ choice|trans({}, field_description.options.catalogue) %}
                 {% else %}
                     {% set result = result ~ choice|trans({}, field_description.options.catalogue) %}
                 {% endif %}

--- a/src/Resources/views/CRUD/list_choice.html.twig
+++ b/src/Resources/views/CRUD/list_choice.html.twig
@@ -40,14 +40,15 @@ file that was distributed with this source code.
                     {% set result = result ~ delimiter %}
                 {% endif %}
 
-                {% if field_description.options.choices[val] is defined %}
-                    {% if field_description.options.catalogue is not defined %}
-                        {% set result = result ~ field_description.options.choices[val] %}
-                    {% else %}
-                        {% set result = result ~ field_description.options.choices[val]|trans({}, field_description.options.catalogue) %}
-                    {% endif %}
+                {% if val in field_description.options.choices|keys %}
+                    {% set choice = field_description.options.choices[val] %}
                 {% else %}
-                    {% set result = result ~ val %}
+                    {% set choice = val %}
+                {% endif %}
+                {% if field_description.options.catalogue is not defined %}
+                    {% set result = result ~ choice %}
+                {% else %}
+                    {% set result = result ~ choice|trans({}, field_description.options.catalogue) %}
                 {% endif %}
             {% endfor %}
 

--- a/src/Resources/views/CRUD/list_choice.html.twig
+++ b/src/Resources/views/CRUD/list_choice.html.twig
@@ -48,7 +48,7 @@ file that was distributed with this source code.
                 {% if field_description.options.catalogue is defined %}
                     {% set result = result ~ choice|trans({}, field_description.options.catalogue) %}
                 {% else %}
-                    {% set result = result ~ choice|trans({}, field_description.options.catalogue) %}
+                    {% set result = result ~ choice %}
                 {% endif %}
             {% endfor %}
 

--- a/src/Resources/views/CRUD/list_choice.html.twig
+++ b/src/Resources/views/CRUD/list_choice.html.twig
@@ -45,7 +45,7 @@ file that was distributed with this source code.
                 {% else %}
                     {% set choice = val %}
                 {% endif %}
-                {% if field_description.options.catalogue is not defined %}
+                {% if field_description.options.catalogue is defined %}
                     {% set result = result ~ choice %}
                 {% else %}
                     {% set result = result ~ choice|trans({}, field_description.options.catalogue) %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fix error in `src/Resources/views/CRUD/list_choice.html.twig` at line `43` if use list of ValueObject as values for entity.

```
Warning: Illegal offset type in isset or empty
```


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

This condition is failed if `val` is object:

```twig
{% if field_description.options.choices[val] is defined %}
```

Related #5767

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix error of using list ValueObject as editable field in list fields.
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
