### PR TITLE
Use LogicException instead of Runtime exception

### DIFF
--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -47,7 +47,7 @@ class DatagridMapper extends BaseMapper
      * @param string $fieldType
      * @param array  $fieldOptions
      *
-     * @throws \RuntimeException
+     * @throws \LogicException
      *
      * @return DatagridMapper
      */
@@ -72,7 +72,7 @@ class DatagridMapper extends BaseMapper
             $fieldDescription->mergeOptions($filterOptions);
         } elseif (\is_string($name)) {
             if ($this->admin->hasFilterFieldDescription($name)) {
-                throw new \RuntimeException(sprintf('Duplicate field name "%s" in datagrid mapper. Names should be unique.', $name));
+                throw new \LogicException(sprintf('Duplicate field name "%s" in datagrid mapper. Names should be unique.', $name));
             }
 
             if (!isset($filterOptions['field_name'])) {
@@ -85,7 +85,7 @@ class DatagridMapper extends BaseMapper
                 array_merge($filterOptions, $fieldDescriptionOptions)
             );
         } else {
-            throw new \RuntimeException(
+            throw new \LogicException(
                 'Unknown field name in datagrid mapper.'
                 .' Field name should be either of FieldDescriptionInterface interface or string.'
             );

--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -42,10 +42,10 @@ class DatagridMapper extends BaseMapper
     }
 
     /**
-     * @param string $name
-     * @param string $type
-     * @param string $fieldType
-     * @param array  $fieldOptions
+     * @param FieldDescriptionInterface|string $name
+     * @param string|null                      $type
+     * @param string|null                      $fieldType
+     * @param array|null                       $fieldOptions
      *
      * @throws \LogicException
      *
@@ -85,7 +85,7 @@ class DatagridMapper extends BaseMapper
                 array_merge($filterOptions, $fieldDescriptionOptions)
             );
         } else {
-            throw new \LogicException(
+            throw new \TypeError(
                 'Unknown field name in datagrid mapper.'
                 .' Field name should be either of FieldDescriptionInterface interface or string.'
             );

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -65,8 +65,8 @@ class ListMapper extends BaseMapper
     }
 
     /**
-     * @param string      $name
-     * @param string|null $type
+     * @param FieldDescriptionInterface|string $name
+     * @param string|null                      $type
      *
      * @throws \LogicException
      *
@@ -122,7 +122,7 @@ class ListMapper extends BaseMapper
                 $fieldDescriptionOptions
             );
         } else {
-            throw new \LogicException(
+            throw new \TypeError(
                 'Unknown field name in list mapper. '
                 .'Field name should be either of FieldDescriptionInterface interface or string.'
             );

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -68,7 +68,7 @@ class ListMapper extends BaseMapper
      * @param string      $name
      * @param string|null $type
      *
-     * @throws \RuntimeException
+     * @throws \LogicException
      *
      * @return $this
      */
@@ -110,7 +110,7 @@ class ListMapper extends BaseMapper
             $fieldDescription->mergeOptions($fieldDescriptionOptions);
         } elseif (\is_string($name)) {
             if ($this->admin->hasListFieldDescription($name)) {
-                throw new \RuntimeException(sprintf(
+                throw new \LogicException(sprintf(
                     'Duplicate field name "%s" in list mapper. Names should be unique.',
                     $name
                 ));
@@ -122,7 +122,7 @@ class ListMapper extends BaseMapper
                 $fieldDescriptionOptions
             );
         } else {
-            throw new \RuntimeException(
+            throw new \LogicException(
                 'Unknown field name in list mapper. '
                 .'Field name should be either of FieldDescriptionInterface interface or string.'
             );

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -52,7 +52,7 @@ class FormMapper extends BaseGroupedMapper
 
     /**
      * @param FormBuilderInterface|string $name
-     * @param string                      $type
+     * @param string|null                 $type
      *
      * @return $this
      */

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -42,7 +42,7 @@ abstract class BaseGroupedMapper extends BaseMapper
      *
      * @param string $name
      *
-     * @throws \RuntimeException
+     * @throws \LogicException
      *
      * @return $this
      */
@@ -94,12 +94,12 @@ abstract class BaseGroupedMapper extends BaseMapper
 
             if ($this->currentTab) {
                 if (isset($tabs[$this->currentTab]['auto_created']) && true === $tabs[$this->currentTab]['auto_created']) {
-                    throw new \RuntimeException('New tab was added automatically when you have added field or group. You should close current tab before adding new one OR add tabs before adding groups and fields.');
+                    throw new \LogicException('New tab was added automatically when you have added field or group. You should close current tab before adding new one OR add tabs before adding groups and fields.');
                 }
 
-                throw new \RuntimeException(sprintf('You should close previous tab "%s" with end() before adding new tab "%s".', $this->currentTab, $name));
+                throw new \LogicException(sprintf('You should close previous tab "%s" with end() before adding new tab "%s".', $this->currentTab, $name));
             } elseif ($this->currentGroup) {
-                throw new \RuntimeException(sprintf('You should open tab before adding new group "%s".', $name));
+                throw new \LogicException(sprintf('You should open tab before adding new group "%s".', $name));
             }
 
             if (!isset($tabs[$name])) {
@@ -114,7 +114,7 @@ abstract class BaseGroupedMapper extends BaseMapper
             $this->currentTab = $code;
         } else {
             if ($this->currentGroup) {
-                throw new \RuntimeException(sprintf('You should close previous group "%s" with end() before adding new tab "%s".', $this->currentGroup, $name));
+                throw new \LogicException(sprintf('You should close previous group "%s" with end() before adding new tab "%s".', $this->currentGroup, $name));
             }
 
             if (!$this->currentTab) {
@@ -159,14 +159,14 @@ abstract class BaseGroupedMapper extends BaseMapper
      *
      * @param bool $bool
      *
-     * @throws \RuntimeException
+     * @throws \LogicException
      *
      * @return $this
      */
     public function ifTrue($bool)
     {
         if (null !== $this->apply) {
-            throw new \RuntimeException('Cannot nest ifTrue or ifFalse call');
+            throw new \LogicException('Cannot nest ifTrue or ifFalse call');
         }
 
         $this->apply = (true === $bool);
@@ -179,14 +179,14 @@ abstract class BaseGroupedMapper extends BaseMapper
      *
      * @param bool $bool
      *
-     * @throws \RuntimeException
+     * @throws \LogicException
      *
      * @return $this
      */
     public function ifFalse($bool)
     {
         if (null !== $this->apply) {
-            throw new \RuntimeException('Cannot nest ifTrue or ifFalse call');
+            throw new \LogicException('Cannot nest ifTrue or ifFalse call');
         }
 
         $this->apply = (false === $bool);
@@ -219,7 +219,7 @@ abstract class BaseGroupedMapper extends BaseMapper
     /**
      * Close the current group or tab.
      *
-     * @throws \RuntimeException
+     * @throws \LogicException
      *
      * @return $this
      */
@@ -230,7 +230,7 @@ abstract class BaseGroupedMapper extends BaseMapper
         } elseif (null !== $this->currentTab) {
             $this->currentTab = null;
         } else {
-            throw new \RuntimeException('No open tabs or groups, you cannot use end()');
+            throw new \LogicException('No open tabs or groups, you cannot use end()');
         }
 
         return $this;

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -40,8 +40,8 @@ class ShowMapper extends BaseGroupedMapper
     }
 
     /**
-     * @param mixed $name
-     * @param mixed $type
+     * @param FieldDescriptionInterface|string $name
+     * @param string|null                      $type
      *
      * @throws \LogicException
      *
@@ -71,7 +71,10 @@ class ShowMapper extends BaseGroupedMapper
                 throw new \LogicException(sprintf('Duplicate field name "%s" in show mapper. Names should be unique.', $name));
             }
         } else {
-            throw new \LogicException('invalid state');
+            throw new \TypeError(
+                'Unknown field name in show mapper. '
+                .'Field name should be either of FieldDescriptionInterface interface or string.'
+            );
         }
 
         if (!$fieldDescription->getLabel() && false !== $fieldDescription->getOption('label')) {

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -43,7 +43,7 @@ class ShowMapper extends BaseGroupedMapper
      * @param mixed $name
      * @param mixed $type
      *
-     * @throws \RuntimeException
+     * @throws \LogicException
      *
      * @return $this
      */
@@ -68,10 +68,10 @@ class ShowMapper extends BaseGroupedMapper
                     $fieldDescriptionOptions
                 );
             } else {
-                throw new \RuntimeException(sprintf('Duplicate field name "%s" in show mapper. Names should be unique.', $name));
+                throw new \LogicException(sprintf('Duplicate field name "%s" in show mapper. Names should be unique.', $name));
             }
         } else {
-            throw new \RuntimeException('invalid state');
+            throw new \LogicException('invalid state');
         }
 
         if (!$fieldDescription->getLabel() && false !== $fieldDescription->getOption('label')) {

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -205,7 +205,7 @@ class DatagridMapperTest extends TestCase
 
     public function testAddException(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(
             'Unknown field name in datagrid mapper. Field name should be either of FieldDescriptionInterface interface or string'
         );
@@ -228,7 +228,7 @@ class DatagridMapperTest extends TestCase
                 return false;
             });
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Duplicate field name "fooName" in datagrid mapper. Names should be unique.');
 
         $this->datagridMapper->add('fooName');

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -205,7 +205,7 @@ class DatagridMapperTest extends TestCase
 
     public function testAddException(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(\TypeError::class);
         $this->expectExceptionMessage(
             'Unknown field name in datagrid mapper. Field name should be either of FieldDescriptionInterface interface or string'
         );

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -271,7 +271,7 @@ class ListMapperTest extends TestCase
 
     public function testAddWrongTypeException(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(\TypeError::class);
         $this->expectExceptionMessage(
             'Unknown field name in list mapper. Field name should be either of FieldDescriptionInterface interface or string.'
         );

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -262,7 +262,7 @@ class ListMapperTest extends TestCase
                 return false;
             });
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Duplicate field name "fooName" in list mapper. Names should be unique.');
 
         $this->listMapper->add('fooName');
@@ -271,7 +271,7 @@ class ListMapperTest extends TestCase
 
     public function testAddWrongTypeException(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(
             'Unknown field name in list mapper. Field name should be either of FieldDescriptionInterface interface or string.'
         );

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -300,7 +300,7 @@ class FormMapperTest extends TestCase
 
     public function testIfTrueNested(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
 
         $this->formMapper->ifTrue(true);
@@ -309,7 +309,7 @@ class FormMapperTest extends TestCase
 
     public function testIfFalseNested(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
 
         $this->formMapper->ifFalse(false);
@@ -318,7 +318,7 @@ class FormMapperTest extends TestCase
 
     public function testIfCombinationNested(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
 
         $this->formMapper->ifTrue(true);
@@ -327,7 +327,7 @@ class FormMapperTest extends TestCase
 
     public function testIfFalseCombinationNested2(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
 
         $this->formMapper->ifFalse(false);
@@ -336,7 +336,7 @@ class FormMapperTest extends TestCase
 
     public function testIfFalseCombinationNested3(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
 
         $this->formMapper->ifFalse(true);
@@ -345,7 +345,7 @@ class FormMapperTest extends TestCase
 
     public function testIfFalseCombinationNested4(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
 
         $this->formMapper->ifTrue(false);

--- a/tests/Mapper/BaseGroupedMapperTest.php
+++ b/tests/Mapper/BaseGroupedMapperTest.php
@@ -135,7 +135,7 @@ class BaseGroupedMapperTest extends TestCase
 
     public function testGroupNotClosedException(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('You should close previous group "fooGroup1" with end() before adding new tab "fooGroup2".');
 
         $this->baseGroupedMapper->with('fooGroup1');
@@ -144,7 +144,7 @@ class BaseGroupedMapperTest extends TestCase
 
     public function testGroupInTabException(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('New tab was added automatically when you have added field or group. You should close current tab before adding new one OR add tabs before adding groups and fields.');
 
         $this->baseGroupedMapper->with('fooGroup');
@@ -153,7 +153,7 @@ class BaseGroupedMapperTest extends TestCase
 
     public function testTabInTabException(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('You should close previous tab "fooTab" with end() before adding new tab "barTab".');
 
         $this->baseGroupedMapper->tab('fooTab');
@@ -173,7 +173,7 @@ class BaseGroupedMapperTest extends TestCase
 
     public function testEndException(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('No open tabs or groups, you cannot use end()');
 
         $this->baseGroupedMapper->end();

--- a/tests/Show/ShowMapperTest.php
+++ b/tests/Show/ShowMapperTest.php
@@ -320,8 +320,8 @@ class ShowMapperTest extends TestCase
 
     public function testAddException(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('invalid state');
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Unknown field name in show mapper. Field name should be either of FieldDescriptionInterface interface or string.');
 
         $this->showMapper->add(12345);
     }

--- a/tests/Show/ShowMapperTest.php
+++ b/tests/Show/ShowMapperTest.php
@@ -253,7 +253,7 @@ class ShowMapperTest extends TestCase
 
     public function testIfTrueNested(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
 
         $this->showMapper->ifTrue(true);
@@ -262,7 +262,7 @@ class ShowMapperTest extends TestCase
 
     public function testIfFalseNested(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
 
         $this->showMapper->ifFalse(false);
@@ -271,7 +271,7 @@ class ShowMapperTest extends TestCase
 
     public function testIfCombinationNested(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
 
         $this->showMapper->ifTrue(true);
@@ -280,7 +280,7 @@ class ShowMapperTest extends TestCase
 
     public function testIfFalseCombinationNested2(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
 
         $this->showMapper->ifFalse(false);
@@ -289,7 +289,7 @@ class ShowMapperTest extends TestCase
 
     public function testIfFalseCombinationNested3(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
 
         $this->showMapper->ifFalse(true);
@@ -298,7 +298,7 @@ class ShowMapperTest extends TestCase
 
     public function testIfFalseCombinationNested4(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
 
         $this->showMapper->ifTrue(false);
@@ -320,7 +320,7 @@ class ShowMapperTest extends TestCase
 
     public function testAddException(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('invalid state');
 
         $this->showMapper->add(12345);
@@ -329,7 +329,7 @@ class ShowMapperTest extends TestCase
     public function testAddDuplicateFieldNameException(): void
     {
         $name = 'name';
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(
             sprintf('Duplicate field %s "name" in show mapper. Names should be unique.', $name)
         );


### PR DESCRIPTION
## Subject

Actually, `$listMapper->add(...)` can throw a RuntimeException.
I don't think we expect the developper to try/catch this exception.
For me, it should be a LogicException, the InvalidArgumentException seems made for this.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Mapper methods now throw `LogicException` instead of `RuntimeException`
```