### PR TITLE
Allow doctrine/doctrine-bundle 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "twig/twig": "^2.10"
     },
     "conflict": {
-        "doctrine/doctrine-bundle": ">=2",
+        "doctrine/doctrine-bundle": ">=3",
         "jms/di-extra-bundle": "<1.9",
         "sonata-project/media-bundle": "<3.7",
         "sonata-project/user-bundle": "<3.3"


### PR DESCRIPTION
Compatibility issues are supposed to be fixed since #5768 was fixed.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
-  compatibility with `doctrine/doctrine-bundle` 2
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
