### PR TITLE
Apply iftrue and iffalse to tab and allow nested conditions

### DIFF
--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -58,7 +58,7 @@ class FormMapper extends BaseGroupedMapper
      */
     public function add($name, $type = null, array $options = [], array $fieldDescriptionOptions = [])
     {
-        if (null !== $this->apply && !$this->apply) {
+        if (!$this->shouldApply()) {
             return $this;
         }
 

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -33,9 +33,9 @@ abstract class BaseGroupedMapper extends BaseMapper
     protected $currentTab;
 
     /**
-     * @var bool|null
+     * @var array
      */
-    protected $apply;
+    protected $apply = [];
 
     /**
      * Add new group or tab (if parameter "tab=true" is available in options).
@@ -48,7 +48,7 @@ abstract class BaseGroupedMapper extends BaseMapper
      */
     public function with($name, array $options = [])
     {
-        if (null !== $this->apply && !$this->apply) {
+        if (!$this->shouldApply()) {
             return $this;
         }
 
@@ -163,17 +163,11 @@ abstract class BaseGroupedMapper extends BaseMapper
      *
      * @param bool $bool
      *
-     * @throws \LogicException
-     *
      * @return $this
      */
     public function ifTrue($bool)
     {
-        if (null !== $this->apply) {
-            throw new \LogicException('Cannot nest ifTrue or ifFalse call');
-        }
-
-        $this->apply = (true === $bool);
+        $this->apply[] = true === $bool;
 
         return $this;
     }
@@ -183,17 +177,11 @@ abstract class BaseGroupedMapper extends BaseMapper
      *
      * @param bool $bool
      *
-     * @throws \LogicException
-     *
      * @return $this
      */
     public function ifFalse($bool)
     {
-        if (null !== $this->apply) {
-            throw new \LogicException('Cannot nest ifTrue or ifFalse call');
-        }
-
-        $this->apply = (false === $bool);
+        $this->apply[] = false === $bool;
 
         return $this;
     }
@@ -203,7 +191,7 @@ abstract class BaseGroupedMapper extends BaseMapper
      */
     public function ifEnd()
     {
-        $this->apply = null;
+        array_pop($this->apply);
 
         return $this;
     }
@@ -229,7 +217,7 @@ abstract class BaseGroupedMapper extends BaseMapper
      */
     public function end()
     {
-        if (null !== $this->apply && !$this->apply) {
+        if (!$this->shouldApply()) {
             return $this;
         }
 
@@ -313,5 +301,19 @@ abstract class BaseGroupedMapper extends BaseMapper
         }
 
         return $this->currentGroup;
+    }
+
+    /**
+     * Check if all apply conditions are respected.
+     */
+    protected function shouldApply(): bool
+    {
+        foreach ($this->apply as $condition) {
+            if (!$condition) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -48,6 +48,10 @@ abstract class BaseGroupedMapper extends BaseMapper
      */
     public function with($name, array $options = [])
     {
+        if (null !== $this->apply && !$this->apply) {
+            return $this;
+        }
+
         /*
          * The current implementation should work with the following workflow:
          *
@@ -225,6 +229,10 @@ abstract class BaseGroupedMapper extends BaseMapper
      */
     public function end()
     {
+        if (null !== $this->apply && !$this->apply) {
+            return $this;
+        }
+
         if (null !== $this->currentGroup) {
             $this->currentGroup = null;
         } elseif (null !== $this->currentTab) {

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -33,7 +33,7 @@ abstract class BaseGroupedMapper extends BaseMapper
     protected $currentTab;
 
     /**
-     * @var array
+     * @var bool[]
      */
     protected $apply = [];
 
@@ -306,14 +306,8 @@ abstract class BaseGroupedMapper extends BaseMapper
     /**
      * Check if all apply conditions are respected.
      */
-    protected function shouldApply(): bool
+    final protected function shouldApply(): bool
     {
-        foreach ($this->apply as $condition) {
-            if (!$condition) {
-                return false;
-            }
-        }
-
-        return true;
+        return !\in_array(false, $this->apply, true);
     }
 }

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -49,7 +49,7 @@ class ShowMapper extends BaseGroupedMapper
      */
     public function add($name, $type = null, array $fieldDescriptionOptions = [])
     {
-        if (null !== $this->apply && !$this->apply) {
+        if (!$this->shouldApply()) {
             return $this;
         }
 

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -300,56 +300,80 @@ class FormMapperTest extends TestCase
 
     public function testIfTrueNested(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+        $this->formMapper
+            ->ifTrue(true)
+                ->ifTrue(true)
+                    ->add('fooName')
+                ->ifEnd()
+            ->ifEnd()
+        ;
 
-        $this->formMapper->ifTrue(true);
-        $this->formMapper->ifTrue(true);
+        $this->assertTrue($this->formMapper->has('fooName'));
     }
 
     public function testIfFalseNested(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+        $this->formMapper
+            ->ifFalse(false)
+                ->ifFalse(false)
+                    ->add('fooName')
+                ->ifEnd()
+            ->ifEnd()
+        ;
 
-        $this->formMapper->ifFalse(false);
-        $this->formMapper->ifFalse(false);
+        $this->assertTrue($this->formMapper->has('fooName'));
     }
 
     public function testIfCombinationNested(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+        $this->formMapper
+            ->ifTrue(true)
+                ->ifFalse(false)
+                    ->add('fooName')
+                ->ifEnd()
+            ->ifEnd()
+        ;
 
-        $this->formMapper->ifTrue(true);
-        $this->formMapper->ifFalse(false);
+        $this->assertTrue($this->formMapper->has('fooName'));
     }
 
     public function testIfFalseCombinationNested2(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+        $this->formMapper
+            ->ifFalse(false)
+                ->ifTrue(true)
+                    ->add('fooName')
+                ->ifEnd()
+            ->ifEnd()
+        ;
 
-        $this->formMapper->ifFalse(false);
-        $this->formMapper->ifTrue(true);
+        $this->assertTrue($this->formMapper->has('fooName'));
     }
 
     public function testIfFalseCombinationNested3(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+        $this->formMapper
+            ->ifFalse(true)
+                ->ifTrue(false)
+                    ->add('fooName')
+                ->ifEnd()
+            ->ifEnd()
+        ;
 
-        $this->formMapper->ifFalse(true);
-        $this->formMapper->ifTrue(false);
+        $this->assertFalse($this->formMapper->has('fooName'));
     }
 
     public function testIfFalseCombinationNested4(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+        $this->formMapper
+            ->ifTrue(false)
+                ->ifFalse(true)
+                    ->add('fooName')
+                ->ifEnd()
+            ->ifEnd()
+        ;
 
-        $this->formMapper->ifTrue(false);
-        $this->formMapper->ifFalse(true);
+        $this->assertFalse($this->formMapper->has('fooName'));
     }
 
     public function testAddAcceptFormBuilder(): void

--- a/tests/Mapper/BaseGroupedMapperTest.php
+++ b/tests/Mapper/BaseGroupedMapperTest.php
@@ -171,6 +171,30 @@ class BaseGroupedMapperTest extends TestCase
         $this->assertFalse($this->baseGroupedMapper->hasOpenTab(), '->hasOpenTab() returns false when all tabs are closed');
     }
 
+    public function testIfTrueApply(): void
+    {
+        $this->baseGroupedMapper->ifTrue(true)->tab('fooTab')->ifEnd();
+        $this->assertTrue($this->baseGroupedMapper->hasOpenTab());
+    }
+
+    public function testIfTrueNotApply(): void
+    {
+        $this->baseGroupedMapper->ifTrue(false)->tab('fooTab')->ifEnd();
+        $this->assertFalse($this->baseGroupedMapper->hasOpenTab());
+    }
+
+    public function testIfFalseApply(): void
+    {
+        $this->baseGroupedMapper->ifFalse(false)->tab('fooTab')->ifEnd();
+        $this->assertTrue($this->baseGroupedMapper->hasOpenTab());
+    }
+
+    public function testIfFalseNotApply(): void
+    {
+        $this->baseGroupedMapper->ifFalse(true)->tab('fooTab')->ifEnd();
+        $this->assertFalse($this->baseGroupedMapper->hasOpenTab());
+    }
+
     public function testEndException(): void
     {
         $this->expectException(\LogicException::class);

--- a/tests/Show/ShowMapperTest.php
+++ b/tests/Show/ShowMapperTest.php
@@ -299,56 +299,80 @@ class ShowMapperTest extends TestCase
 
     public function testIfTrueNested(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+        $this->showMapper
+            ->ifTrue(true)
+                ->ifTrue(true)
+                    ->add('fooName')
+                ->ifEnd()
+            ->ifEnd()
+        ;
 
-        $this->showMapper->ifTrue(true);
-        $this->showMapper->ifTrue(true);
+        $this->assertTrue($this->showMapper->has('fooName'));
     }
 
     public function testIfFalseNested(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+        $this->showMapper
+            ->ifFalse(false)
+                ->ifFalse(false)
+                    ->add('fooName')
+                ->ifEnd()
+            ->ifEnd()
+        ;
 
-        $this->showMapper->ifFalse(false);
-        $this->showMapper->ifFalse(false);
+        $this->assertTrue($this->showMapper->has('fooName'));
     }
 
     public function testIfCombinationNested(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+        $this->showMapper
+            ->ifTrue(true)
+                ->ifFalse(false)
+                    ->add('fooName')
+                ->ifEnd()
+            ->ifEnd()
+        ;
 
-        $this->showMapper->ifTrue(true);
-        $this->showMapper->ifFalse(false);
+        $this->assertTrue($this->showMapper->has('fooName'));
     }
 
     public function testIfFalseCombinationNested2(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+        $this->showMapper
+            ->ifFalse(false)
+                ->ifTrue(true)
+                    ->add('fooName')
+                ->ifEnd()
+            ->ifEnd()
+        ;
 
-        $this->showMapper->ifFalse(false);
-        $this->showMapper->ifTrue(true);
+        $this->assertTrue($this->showMapper->has('fooName'));
     }
 
     public function testIfFalseCombinationNested3(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+        $this->showMapper
+            ->ifFalse(true)
+                ->ifTrue(false)
+                    ->add('fooName')
+                ->ifEnd()
+            ->ifEnd()
+        ;
 
-        $this->showMapper->ifFalse(true);
-        $this->showMapper->ifTrue(false);
+        $this->assertFalse($this->showMapper->has('fooName'));
     }
 
     public function testIfFalseCombinationNested4(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot nest ifTrue or ifFalse call');
+        $this->showMapper
+            ->ifTrue(false)
+                ->ifFalse(true)
+                    ->add('fooName')
+                ->ifEnd()
+            ->ifEnd()
+        ;
 
-        $this->showMapper->ifTrue(false);
-        $this->showMapper->ifFalse(true);
+        $this->assertFalse($this->showMapper->has('fooName'));
     }
 
     public function testAddRemove(): void

--- a/tests/Show/ShowMapperTest.php
+++ b/tests/Show/ShowMapperTest.php
@@ -187,10 +187,33 @@ class ShowMapperTest extends TestCase
         $this->assertSame('fooName', $fieldDescription->getOption('label'));
     }
 
+    public function testIfTrueApplyWithTab(): void
+    {
+        $this->showMapper->ifTrue(true);
+        $this->showMapper->tab('fooTab')->add('fooName')->end();
+        $this->showMapper->ifEnd();
+
+        $this->assertTrue($this->showMapper->has('fooName'));
+        $fieldDescription = $this->showMapper->get('fooName');
+
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $fieldDescription);
+        $this->assertSame('fooName', $fieldDescription->getName());
+        $this->assertSame('fooName', $fieldDescription->getOption('label'));
+    }
+
     public function testIfTrueNotApply(): void
     {
         $this->showMapper->ifTrue(false);
         $this->showMapper->add('fooName');
+        $this->showMapper->ifEnd();
+
+        $this->assertFalse($this->showMapper->has('fooName'));
+    }
+
+    public function testIfTrueNotApplyWithTab(): void
+    {
+        $this->showMapper->ifTrue(false);
+        $this->showMapper->tab('fooTab')->add('fooName')->end();
         $this->showMapper->ifEnd();
 
         $this->assertFalse($this->showMapper->has('fooName'));
@@ -226,10 +249,33 @@ class ShowMapperTest extends TestCase
         $this->assertSame('fooName', $fieldDescription->getOption('label'));
     }
 
+    public function testIfFalseApplyWithTab(): void
+    {
+        $this->showMapper->ifFalse(false);
+        $this->showMapper->tab('fooTab')->add('fooName')->end();
+        $this->showMapper->ifEnd();
+
+        $this->assertTrue($this->showMapper->has('fooName'));
+        $fieldDescription = $this->showMapper->get('fooName');
+
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $fieldDescription);
+        $this->assertSame('fooName', $fieldDescription->getName());
+        $this->assertSame('fooName', $fieldDescription->getOption('label'));
+    }
+
     public function testIfFalseNotApply(): void
     {
         $this->showMapper->ifFalse(true);
         $this->showMapper->add('fooName');
+        $this->showMapper->ifEnd();
+
+        $this->assertFalse($this->showMapper->has('fooName'));
+    }
+
+    public function testIfFalseNotApplyWithTab(): void
+    {
+        $this->showMapper->ifFalse(true);
+        $this->showMapper->tab('fooTab')->add('fooName')->end();
         $this->showMapper->ifEnd();
 
         $this->assertFalse($this->showMapper->has('fooName'));


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is a new feature.
Close https://github.com/sonata-project/SonataAdminBundle/issues/5775

## Changelog

```markdown
### Changed
IfTrue and IfFalse apply correctly to tab and with functions
Nested IfTrue and IfFalse works as expected and does not throws exception anymore.
```