### PR TITLE
Allow to use FQCN and strings names in filters

### DIFF
--- a/src/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
@@ -35,6 +35,11 @@ class AddFilterTypeCompilerPass implements CompilerPassInterface
             $serviceDefinition->setPublic(true); // Temporary fix until we can support service locators
 
             $types[$serviceDefinition->getClass()] = $id;
+
+            // NEXT_MAJOR: Remove this loop, only FQCN will be supported
+            foreach ($attributes as $eachTag) {
+                $types[$eachTag['alias']] = $id;
+            }
         }
 
         $definition->replaceArgument(1, $types);

--- a/tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
@@ -71,7 +71,9 @@ class AddFilterTypeCompilerPassTest extends TestCase
         $this->filterFactory->expects($this->once())
             ->method('replaceArgument')
             ->with(1, $this->equalTo([
+                'foo_filter_alias' => 'acme.demo.foo_filter',
                 'Acme\Filter\FooFilter' => 'acme.demo.foo_filter',
+                'bar_filter_alias' => 'acme.demo.bar_filter',
                 'Acme\Filter\BarFilter' => 'acme.demo.bar_filter',
             ]));
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Since I removed that piece of code and the ORM/MongoDB/PHPCR are not updated accordingly, I think the best solution is to restore the ability of using string names. I'll try to trigger deprecations when using them and then remove completely in next major version.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5781

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Ability of using string names and FQCNs to define filter types
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
