### PR TITLE
Update RetrieveAutocompleteItemsAction.php

### DIFF
--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -88,7 +88,7 @@ final class RetrieveAutocompleteItemsAction
             $targetAdminAccessAction = $formAutocompleteConfig->getAttribute('target_admin_access_action');
         }
 
-        $searchText = $request->get('q');
+        $searchText = $request->get('q','');
 
         $targetAdmin = $fieldDescription->getAssociationAdmin();
 

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -88,7 +88,7 @@ final class RetrieveAutocompleteItemsAction
             $targetAdminAccessAction = $formAutocompleteConfig->getAttribute('target_admin_access_action');
         }
 
-        $searchText = $request->get('q','');
+        $searchText = $request->get('q', '');
 
         $targetAdmin = $fieldDescription->getAssociationAdmin();
 


### PR DESCRIPTION
fix for mb_strlen need string not null

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

I am targeting this branch, because BC.


## Changelog

```markdown
### Fixed
- stop calling `mb_strlen()` on null in `RetrieveAutocompleteItemsAction`
```