### PR TITLE
Trigger deprecation when using a string name as filter type

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,24 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated the use of string names to reference filters in favor of the FQCN of the filter.
+
+Before:
+```php
+$datagridMapper
+    ->add('field', 'filter_type')
+;
+```
+
+After:
+```php
+use App\Filter\FilterType;
+
+$datagridMapper
+    ->add('field', FilterType::class)
+;
+```
+
 UPGRADE FROM 3.51 to 3.52
 =========================
 

--- a/src/Filter/FilterFactory.php
+++ b/src/Filter/FilterFactory.php
@@ -51,6 +51,14 @@ class FilterFactory implements FilterFactoryInterface
 
         if ($id) {
             $filter = $this->container->get($id);
+
+            if ($filter && !class_exists($type)) {
+                @trigger_error(
+                    'Referencing a filter by name ('.$type.') is deprecated since version 3.x and will be removed in 4.0.'
+                    .' Use the fully-qualified type class name instead ('.\get_class($filter).')',
+                    E_USER_DEPRECATED
+                );
+            }
         } elseif (class_exists($type)) {
             $filter = new $type();
         } else {

--- a/tests/Filter/FilterFactoryTest.php
+++ b/tests/Filter/FilterFactoryTest.php
@@ -90,6 +90,27 @@ class FilterFactoryTest extends TestCase
         $container = $this->getMockForAbstractClass(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
+            ->with('my.filter.id')
+            ->willReturn($filter);
+
+        $fqcn = \get_class($filter);
+
+        $filter = new FilterFactory($container, [$fqcn => 'my.filter.id']);
+        $filter->create('test', $fqcn);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testCreateFilterWithTypeName(): void
+    {
+        $filter = $this->getMockForAbstractClass(FilterInterface::class);
+        $filter->expects($this->once())
+            ->method('initialize');
+
+        $container = $this->getMockForAbstractClass(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
             ->willReturn($filter);
 
         $filter = new FilterFactory($container, ['mytype' => 'mytype']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Trigger a deprecation notice when using old string names in filters.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- The use of string names to reference filters
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
