### PR TITLE
Include the edit modal and related script only when needed

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
@@ -126,13 +126,11 @@ file that was distributed with this source code.
                             <i class="fa fa-plus-circle"></i>
                             {{ btn_add|trans({}, btn_catalogue) }}
                         </a>
+                        {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
+                        {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
                     {% endif %}
                 </span>
-
-                {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
             </div>
-
-            {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
         {% endif %}
     </div>
 {% endif %}

--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -76,10 +76,11 @@ file that was distributed with this source code.
             </div>
             {% endif %}
 
-            {% if sonata_admin.edit == 'list'
+            {% set display_btn_delete = sonata_admin.edit == 'list'
                 and sonata_admin.field_description.associationadmin.hasRoute('delete')
                 and sonata_admin.field_description.associationadmin.hasAccess('delete')
                 and btn_delete %}
+            {% if display_btn_delete %}
                 <a  href=""
                     onclick="return remove_selected_element_{{ id }}(this);"
                     class="btn btn-danger btn-sm sonata-ba-action"
@@ -89,10 +90,11 @@ file that was distributed with this source code.
                     {{ btn_delete|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}
+
+            {% if display_btn_list or display_btn_add or display_btn_delete %}
+                {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
+                {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
+            {% endif %}
         </div>
-
-        {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
     </div>
-
-    {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
 {% endif %}

--- a/src/Resources/views/CRUD/Association/edit_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many.html.twig
@@ -86,12 +86,10 @@ file that was distributed with this source code.
                         <i class="fa fa-plus-circle"></i>
                         {{ btn_add|trans({}, btn_catalogue) }}
                     </a>
+                    {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
+                    {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
                 {% endif %}
             </span>
-
-            {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
-
-            {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
         {% endif %}
     </div>
 {% endif %}

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -76,10 +76,11 @@ file that was distributed with this source code.
             </div>
             {% endif %}
 
-            {% if sonata_admin.edit == 'list'
+            {% set display_btn_delete = sonata_admin.edit == 'list'
                 and sonata_admin.field_description.associationadmin.hasRoute('delete')
                 and sonata_admin.field_description.associationadmin.hasAccess('delete')
                 and btn_delete %}
+            {% if display_btn_delete %}
                 <a  href=""
                     onclick="return remove_selected_element_{{ id }}(this);"
                     class="btn btn-danger btn-sm sonata-ba-action"
@@ -89,10 +90,11 @@ file that was distributed with this source code.
                     {{ btn_delete|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}
+
+            {% if display_btn_list or display_btn_add or display_btn_delete %}
+                {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
+                {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
+            {% endif %}
         </div>
-
-        {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
     </div>
-
-    {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
 {% endif %}

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -50,9 +50,9 @@ file that was distributed with this source code.
                     <i class="fa fa-plus-circle"></i>
                     {{ btn_add|trans({}, btn_catalogue) }}
                 </a>
+                {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
+                {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
             {% endif %}
-            {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
-            {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
         </div>
     {% endif %}
 


### PR DESCRIPTION
## Subject
Currently, the edit_modal and edit_many_script files are always included
even when there is no button displayed. That results in a heavier page.

I am targeting this branch, because the patch is backward compatible.

## Changelog

```markdown
### Changed
- Include the `edit_modal` and `edit_many_script` templates only if there is at least one displayed button that need them (instead of always include them).
```