### PR TITLE
Add OperatorType

### DIFF
--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -29,17 +29,17 @@ use Symfony\Component\Translation\TranslatorInterface;
 class ChoiceType extends AbstractType
 {
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use ContainsOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use ContainsOperatorType::TYPE_CONTAINS instead
      */
     public const TYPE_CONTAINS = 1;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use ContainsOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use ContainsOperatorType::TYPE_NOT_CONTAINS instead
      */
     public const TYPE_NOT_CONTAINS = 2;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use ContainsOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use ContainsOperatorType::TYPE_EQUAL instead
      */
     public const TYPE_EQUAL = 3;
 

--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
+use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -28,10 +28,19 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class ChoiceType extends AbstractType
 {
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use ContainsOperatorType const instead
+     */
     public const TYPE_CONTAINS = 1;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use ContainsOperatorType const instead
+     */
     public const TYPE_NOT_CONTAINS = 2;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use ContainsOperatorType const instead
+     */
     public const TYPE_EQUAL = 3;
 
     /**
@@ -65,21 +74,8 @@ class ChoiceType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choices = [
-            'label_type_contains' => self::TYPE_CONTAINS,
-            'label_type_not_contains' => self::TYPE_NOT_CONTAINS,
-            'label_type_equals' => self::TYPE_EQUAL,
-        ];
-        $operatorChoices = [];
-
-        if (HiddenType::class !== $options['operator_type']) {
-            $operatorChoices['choice_translation_domain'] = 'SonataAdminBundle';
-
-            $operatorChoices['choices'] = $choices;
-        }
-
         $builder
-            ->add('type', $options['operator_type'], array_merge(['required' => false], $options['operator_options'], $operatorChoices))
+            ->add('type', $options['operator_type'], array_merge(['required' => false], $options['operator_options']))
             ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
         ;
     }
@@ -99,7 +95,7 @@ class ChoiceType extends AbstractType
         $resolver->setDefaults([
             'field_type' => FormChoiceType::class,
             'field_options' => [],
-            'operator_type' => FormChoiceType::class,
+            'operator_type' => ContainsOperatorType::class,
             'operator_options' => [],
         ]);
     }

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
+use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
 use Sonata\CoreBundle\Form\Type\DateRangeType as FormDateRangeType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -28,7 +28,14 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class DateRangeType extends AbstractType
 {
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateRangeOperatorType const instead
+     */
     public const TYPE_BETWEEN = 1;
+
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateRangeOperatorType const instead
+     */
     public const TYPE_NOT_BETWEEN = 2;
 
     /**
@@ -62,20 +69,8 @@ class DateRangeType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choices = [
-            'label_date_type_between' => self::TYPE_BETWEEN,
-            'label_date_type_not_between' => self::TYPE_NOT_BETWEEN,
-        ];
-        $choiceOptions = [
-            'required' => false,
-        ];
-
-        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-
-        $choiceOptions['choices'] = $choices;
-
         $builder
-            ->add('type', FormChoiceType::class, $choiceOptions)
+            ->add('type', DateRangeOperatorType::class, ['required' => false])
             ->add('value', $options['field_type'], $options['field_options'])
         ;
     }

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -29,12 +29,12 @@ use Symfony\Component\Translation\TranslatorInterface;
 class DateRangeType extends AbstractType
 {
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateRangeOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateRangeOperatorType::TYPE_BETWEEN instead
      */
     public const TYPE_BETWEEN = 1;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateRangeOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateRangeOperatorType::TYPE_NOT_BETWEEN instead
      */
     public const TYPE_NOT_BETWEEN = 2;
 

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
+use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
 use Sonata\CoreBundle\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -28,7 +28,14 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class DateTimeRangeType extends AbstractType
 {
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateRangeOperatorType const instead
+     */
     public const TYPE_BETWEEN = 1;
+
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateRangeOperatorType const instead
+     */
     public const TYPE_NOT_BETWEEN = 2;
 
     /**
@@ -62,20 +69,8 @@ class DateTimeRangeType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choices = [
-            'label_date_type_between' => self::TYPE_BETWEEN,
-            'label_date_type_not_between' => self::TYPE_NOT_BETWEEN,
-        ];
-        $choiceOptions = [
-            'required' => false,
-        ];
-
-        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-
-        $choiceOptions['choices'] = $choices;
-
         $builder
-            ->add('type', FormChoiceType::class, $choiceOptions)
+            ->add('type', DateRangeOperatorType::class, ['required' => false])
             ->add('value', $options['field_type'], $options['field_options'])
         ;
     }

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -29,12 +29,12 @@ use Symfony\Component\Translation\TranslatorInterface;
 class DateTimeRangeType extends AbstractType
 {
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateRangeOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateRangeOperatorType::TYPE_BETWEEN instead
      */
     public const TYPE_BETWEEN = 1;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateRangeOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateRangeOperatorType::TYPE_NOT_BETWEEN instead
      */
     public const TYPE_NOT_BETWEEN = 2;
 

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
+use Sonata\AdminBundle\Form\Type\Operator\DateOperatorType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType as FormDateTimeType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -28,18 +28,39 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class DateTimeType extends AbstractType
 {
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_GREATER_EQUAL = 1;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_GREATER_THAN = 2;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_EQUAL = 3;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_LESS_EQUAL = 4;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_LESS_THAN = 5;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_NULL = 6;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_NOT_NULL = 7;
 
     /**
@@ -73,25 +94,8 @@ class DateTimeType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choices = [
-            'label_date_type_equal' => self::TYPE_EQUAL,
-            'label_date_type_greater_equal' => self::TYPE_GREATER_EQUAL,
-            'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
-            'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
-            'label_date_type_less_than' => self::TYPE_LESS_THAN,
-            'label_date_type_null' => self::TYPE_NULL,
-            'label_date_type_not_null' => self::TYPE_NOT_NULL,
-        ];
-        $choiceOptions = [
-            'required' => false,
-        ];
-
-        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-
-        $choiceOptions['choices'] = $choices;
-
         $builder
-            ->add('type', FormChoiceType::class, $choiceOptions)
+            ->add('type', DateOperatorType::class, ['required' => false])
             ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
         ;
     }

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -29,37 +29,37 @@ use Symfony\Component\Translation\TranslatorInterface;
 class DateTimeType extends AbstractType
 {
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_GREATER_EQUAL instead
      */
     public const TYPE_GREATER_EQUAL = 1;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_GREATER_THAN instead
      */
     public const TYPE_GREATER_THAN = 2;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_EQUAL instead
      */
     public const TYPE_EQUAL = 3;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_LESS_EQUAL instead
      */
     public const TYPE_LESS_EQUAL = 4;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_LESS_THAN instead
      */
     public const TYPE_LESS_THAN = 5;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_NULL instead
      */
     public const TYPE_NULL = 6;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_NOT_NULL instead
      */
     public const TYPE_NOT_NULL = 7;
 

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -29,37 +29,37 @@ use Symfony\Component\Translation\TranslatorInterface;
 class DateType extends AbstractType
 {
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_GREATER_EQUAL instead
      */
     public const TYPE_GREATER_EQUAL = 1;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_GREATER_THAN instead
      */
     public const TYPE_GREATER_THAN = 2;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_EQUAL instead
      */
     public const TYPE_EQUAL = 3;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_LESS_EQUAL instead
      */
     public const TYPE_LESS_EQUAL = 4;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_LESS_THAN instead
      */
     public const TYPE_LESS_THAN = 5;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_NULL instead
      */
     public const TYPE_NULL = 6;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use DateOperatorType::TYPE_NOT_NULL instead
      */
     public const TYPE_NOT_NULL = 7;
 

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
+use Sonata\AdminBundle\Form\Type\Operator\DateOperatorType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateType as FormDateType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -28,18 +28,39 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class DateType extends AbstractType
 {
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_GREATER_EQUAL = 1;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_GREATER_THAN = 2;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_EQUAL = 3;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_LESS_EQUAL = 4;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_LESS_THAN = 5;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_NULL = 6;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use DateOperatorType const instead
+     */
     public const TYPE_NOT_NULL = 7;
 
     /**
@@ -73,25 +94,8 @@ class DateType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choices = [
-            'label_date_type_equal' => self::TYPE_EQUAL,
-            'label_date_type_greater_equal' => self::TYPE_GREATER_EQUAL,
-            'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
-            'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
-            'label_date_type_less_than' => self::TYPE_LESS_THAN,
-            'label_date_type_null' => self::TYPE_NULL,
-            'label_date_type_not_null' => self::TYPE_NOT_NULL,
-        ];
-        $choiceOptions = [
-            'required' => false,
-        ];
-
-        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-
-        $choiceOptions['choices'] = $choices;
-
         $builder
-            ->add('type', FormChoiceType::class, $choiceOptions)
+            ->add('type', DateOperatorType::class, ['required' => false])
             ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
         ;
     }

--- a/src/Form/Type/Filter/NumberType.php
+++ b/src/Form/Type/Filter/NumberType.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
+use Sonata\AdminBundle\Form\Type\Operator\NumberOperatorType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType as FormNumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -28,14 +28,29 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class NumberType extends AbstractType
 {
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use NumberOperatorType const instead
+     */
     public const TYPE_GREATER_EQUAL = 1;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use NumberOperatorType const instead
+     */
     public const TYPE_GREATER_THAN = 2;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use NumberOperatorType const instead
+     */
     public const TYPE_EQUAL = 3;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use NumberOperatorType const instead
+     */
     public const TYPE_LESS_EQUAL = 4;
 
+    /**
+     * @deprecated since 3.x, to be removed with 4.0: Use NumberOperatorType const instead
+     */
     public const TYPE_LESS_THAN = 5;
 
     /**
@@ -69,23 +84,8 @@ class NumberType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choices = [
-            'label_type_equal' => self::TYPE_EQUAL,
-            'label_type_greater_equal' => self::TYPE_GREATER_EQUAL,
-            'label_type_greater_than' => self::TYPE_GREATER_THAN,
-            'label_type_less_equal' => self::TYPE_LESS_EQUAL,
-            'label_type_less_than' => self::TYPE_LESS_THAN,
-        ];
-        $choiceOptions = [
-            'required' => false,
-        ];
-
-        $choiceOptions['choice_translation_domain'] = 'SonataAdminBundle';
-
-        $choiceOptions['choices'] = $choices;
-
         $builder
-            ->add('type', FormChoiceType::class, $choiceOptions)
+            ->add('type', NumberOperatorType::class, ['required' => false])
             ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
         ;
     }

--- a/src/Form/Type/Filter/NumberType.php
+++ b/src/Form/Type/Filter/NumberType.php
@@ -29,27 +29,27 @@ use Symfony\Component\Translation\TranslatorInterface;
 class NumberType extends AbstractType
 {
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use NumberOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use NumberOperatorType::TYPE_GREATER_EQUAL instead
      */
     public const TYPE_GREATER_EQUAL = 1;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use NumberOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use NumberOperatorType::TYPE_GREATER_THAN instead
      */
     public const TYPE_GREATER_THAN = 2;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use NumberOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use NumberOperatorType::TYPE_EQUAL instead
      */
     public const TYPE_EQUAL = 3;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use NumberOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use NumberOperatorType::TYPE_LESS_EQUAL instead
      */
     public const TYPE_LESS_EQUAL = 4;
 
     /**
-     * @deprecated since 3.x, to be removed with 4.0: Use NumberOperatorType const instead
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use NumberOperatorType::TYPE_LESS_THAN instead
      */
     public const TYPE_LESS_THAN = 5;
 

--- a/src/Form/Type/Operator/ContainsOperatorType.php
+++ b/src/Form/Type/Operator/ContainsOperatorType.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Form\Type\Operator;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ContainsOperatorType extends AbstractType
+{
+    public const TYPE_CONTAINS = 1;
+    public const TYPE_NOT_CONTAINS = 2;
+    public const TYPE_EQUAL = 3;
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'choice_translation_domain' => 'SonataAdminBundle',
+            'choices' => [
+                'label_type_contains' => self::TYPE_CONTAINS,
+                'label_type_not_contains' => self::TYPE_NOT_CONTAINS,
+                'label_type_equals' => self::TYPE_EQUAL,
+            ],
+        ]);
+    }
+
+    public function getParent()
+    {
+        return FormChoiceType::class;
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'sonata_type_operator_contains';
+    }
+}

--- a/src/Form/Type/Operator/DateOperatorType.php
+++ b/src/Form/Type/Operator/DateOperatorType.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Form\Type\Operator;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class DateOperatorType extends AbstractType
+{
+    public const TYPE_GREATER_EQUAL = 1;
+    public const TYPE_GREATER_THAN = 2;
+    public const TYPE_EQUAL = 3;
+    public const TYPE_LESS_EQUAL = 4;
+    public const TYPE_LESS_THAN = 5;
+    public const TYPE_NULL = 6;
+    public const TYPE_NOT_NULL = 7;
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'choice_translation_domain' => 'SonataAdminBundle',
+            'choices' => [
+                'label_date_type_equal' => self::TYPE_EQUAL,
+                'label_date_type_greater_equal' => self::TYPE_GREATER_EQUAL,
+                'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
+                'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
+                'label_date_type_less_than' => self::TYPE_LESS_THAN,
+                'label_date_type_null' => self::TYPE_NULL,
+                'label_date_type_not_null' => self::TYPE_NOT_NULL,
+            ],
+        ]);
+    }
+
+    public function getParent()
+    {
+        return FormChoiceType::class;
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'sonata_type_operator_date';
+    }
+}

--- a/src/Form/Type/Operator/DateRangeOperatorType.php
+++ b/src/Form/Type/Operator/DateRangeOperatorType.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Form\Type\Operator;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class DateRangeOperatorType extends AbstractType
+{
+    public const TYPE_BETWEEN = 1;
+    public const TYPE_NOT_BETWEEN = 2;
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'choice_translation_domain' => 'SonataAdminBundle',
+            'choices' => [
+                'label_date_type_between' => self::TYPE_BETWEEN,
+                'label_date_type_not_between' => self::TYPE_NOT_BETWEEN,
+            ],
+        ]);
+    }
+
+    public function getParent()
+    {
+        return FormChoiceType::class;
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'sonata_type_operator_date_range';
+    }
+}

--- a/src/Form/Type/Operator/EqualOperatorType.php
+++ b/src/Form/Type/Operator/EqualOperatorType.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Form\Type\Operator;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class EqualOperatorType extends AbstractType
+{
+    public const TYPE_YES = 1;
+    public const TYPE_NO = 2;
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'choice_translation_domain' => 'SonataAdminBundle',
+            'choices' => [
+                'label_type_yes' => self::TYPE_YES,
+                'label_type_no' => self::TYPE_NO,
+            ],
+        ]);
+    }
+
+    public function getParent()
+    {
+        return FormChoiceType::class;
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'sonata_type_operator_equal';
+    }
+}

--- a/src/Form/Type/Operator/NumberOperatorType.php
+++ b/src/Form/Type/Operator/NumberOperatorType.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Form\Type\Operator;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class NumberOperatorType extends AbstractType
+{
+    public const TYPE_GREATER_EQUAL = 1;
+    public const TYPE_GREATER_THAN = 2;
+    public const TYPE_EQUAL = 3;
+    public const TYPE_LESS_EQUAL = 4;
+    public const TYPE_LESS_THAN = 5;
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults($defaultOptions = [
+            'choice_translation_domain' => 'SonataAdminBundle',
+            'choices' => [
+                'label_type_equal' => self::TYPE_EQUAL,
+                'label_type_greater_equal' => self::TYPE_GREATER_EQUAL,
+                'label_type_greater_than' => self::TYPE_GREATER_THAN,
+                'label_type_less_equal' => self::TYPE_LESS_EQUAL,
+                'label_type_less_than' => self::TYPE_LESS_THAN,
+            ],
+        ]);
+    }
+
+    public function getParent()
+    {
+        return FormChoiceType::class;
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'sonata_type_operator_number';
+    }
+}

--- a/tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
+++ b/tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Form\Widget;
 
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
+use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as SymfonyChoiceType;
 use Symfony\Component\Form\FormTypeGuesserInterface;
 use Symfony\Component\Form\Tests\Fixtures\TestExtension;
@@ -31,7 +32,7 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
     public function testDefaultValueRendering(): void
     {
         $choice = $this->factory->create(
-            $this->getParentClass(),
+            $this->getChoiceClass(),
             null,
             $this->getDefaultOption()
         );
@@ -55,14 +56,9 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
         );
     }
 
-    protected function getParentClass()
-    {
-        return ChoiceType::class;
-    }
-
     protected function getChoiceClass()
     {
-        return SymfonyChoiceType::class;
+        return ChoiceType::class;
     }
 
     protected function getExtensions()
@@ -81,7 +77,7 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
         $type = new ChoiceType($mock);
         $extension->addType($type);
 
-        if (!$extension->hasType($this->getParentClass())) {
+        if (!$extension->hasType($this->getChoiceClass())) {
             $reflection = new \ReflectionClass($extension);
             $property = $reflection->getProperty('types');
             $property->setAccessible(true);
@@ -95,9 +91,9 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
 
     protected function getDefaultOption()
     {
-        return ['field_type' => $this->getChoiceClass(),
+        return ['field_type' => SymfonyChoiceType::class,
              'field_options' => [],
-             'operator_type' => $this->getChoiceClass(),
+             'operator_type' => ContainsOperatorType::class,
              'operator_options' => [],
         ];
     }


### PR DESCRIPTION
## Subject

<!-- Describe your Pull Request content here -->
Another proposal for my issue (cf https://github.com/sonata-project/SonataAdminBundle/pull/5739) I try to solve

When using CallbackFilter, you may want to use the same operator than the ones Sonata offer in ChoiceFilter, NumberFilter, ... That's why I split these filter to create the OperatorType.

I am targeting this branch, because it's a new feature.

Usage:
```
->add(
    'fooFilter',
    CallbackFilter::class,
    [
        'callback' => [$this, 'myCallback'],
        'operator_type' => ContainsOperatorType::class,
    ],
```

## Changelog

```markdown
### Added
- Added OperatorType usable in CallbackFilter
```
