### PR TITLE
Deprecate id param in Sonata Action

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -298,7 +298,10 @@ class CRUDController implements ContainerAwareInterface
     {
         if (isset(\func_get_args()[0])) {
             @trigger_error(
-                'The $id param will be remove in 4.0, use $this->admin->getIdParameter() instead',
+                sprintf(
+                    'Support for the "id" route param as argument 1 at `%s()` is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0, use `AdminInterface::getIdParameter()` instead.',
+                    __METHOD__
+                ),
                 E_USER_DEPRECATED
             );
         }
@@ -683,7 +686,10 @@ class CRUDController implements ContainerAwareInterface
     {
         if (isset(\func_get_args()[0])) {
             @trigger_error(
-                'The $id param will be remove in 4.0, use $this->admin->getIdParameter() instead',
+                sprintf(
+                    'Support for the "id" route param as argument 1 at `%s()` is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0, use `AdminInterface::getIdParameter()` instead.',
+                    __METHOD__
+                ),
                 E_USER_DEPRECATED
             );
         }
@@ -745,7 +751,10 @@ class CRUDController implements ContainerAwareInterface
     {
         if (isset(\func_get_args()[0])) {
             @trigger_error(
-                'The $id param will be remove in 4.0, use $this->admin->getIdParameter() instead',
+                sprintf(
+                    'Support for the "id" route param as argument 1 at `%s()` is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0, use `AdminInterface::getIdParameter()` instead.',
+                    __METHOD__
+                ),
                 E_USER_DEPRECATED
             );
         }
@@ -997,7 +1006,10 @@ class CRUDController implements ContainerAwareInterface
     {
         if (isset(\func_get_args()[0])) {
             @trigger_error(
-                'The $id param will be remove in 4.0, use $this->admin->getIdParameter() instead',
+                sprintf(
+                    'Support for the "id" route param as argument 1 at `%s()` is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0, use `AdminInterface::getIdParameter()` instead.',
+                    __METHOD__
+                ),
                 E_USER_DEPRECATED
             );
         }

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -215,6 +215,8 @@ class CRUDController implements ContainerAwareInterface
     public function deleteAction($id)
     {
         $request = $this->getRequest();
+
+        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
@@ -294,12 +296,13 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response|RedirectResponse
      */
-    public function editAction($id = null)
+    public function editAction($id = null) // NEXT_MAJOR: Remove the $id default value
     {
         $request = $this->getRequest();
         // the key used to lookup the template
         $templateKey = 'edit';
 
+        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
         $id = $request->get($this->admin->getIdParameter());
         $existingObject = $this->admin->getObject($id);
 
@@ -672,11 +675,12 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response
      */
-    public function showAction($id = null)
+    public function showAction($id = null) // NEXT_MAJOR: Remove the $id default value
     {
         $request = $this->getRequest();
-        $id = $request->get($this->admin->getIdParameter());
 
+        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
+        $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
         if (!$object) {
@@ -728,11 +732,12 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response
      */
-    public function historyAction($id = null)
+    public function historyAction($id = null) // NEXT_MAJOR: Remove the $id default value
     {
         $request = $this->getRequest();
-        $id = $request->get($this->admin->getIdParameter());
 
+        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
+        $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
         if (!$object) {
@@ -779,11 +784,12 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response
      */
-    public function historyViewRevisionAction($id = null, $revision = null)
+    public function historyViewRevisionAction($id = null, $revision = null) // NEXT_MAJOR: Remove the $id default value
     {
         $request = $this->getRequest();
-        $id = $request->get($this->admin->getIdParameter());
 
+        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
+        $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
         if (!$object) {
@@ -844,14 +850,14 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response
      */
-    public function historyCompareRevisionsAction($id = null, $base_revision = null, $compare_revision = null)
+    public function historyCompareRevisionsAction($id = null, $base_revision = null, $compare_revision = null) // NEXT_MAJOR: Remove the $id default value
     {
         $request = $this->getRequest();
 
         $this->admin->checkAccess('historyCompareRevisions');
 
+        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
         $id = $request->get($this->admin->getIdParameter());
-
         $object = $this->admin->getObject($id);
 
         if (!$object) {
@@ -977,7 +983,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response|RedirectResponse
      */
-    public function aclAction($id = null)
+    public function aclAction($id = null) // NEXT_MAJOR: Remove the $id default value
     {
         $request = $this->getRequest();
 
@@ -985,8 +991,8 @@ class CRUDController implements ContainerAwareInterface
             throw $this->createNotFoundException('ACL are not enabled for this admin');
         }
 
+        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
         $id = $request->get($this->admin->getIdParameter());
-
         $object = $this->admin->getObject($id);
 
         if (!$object) {

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -212,11 +212,9 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response|RedirectResponse
      */
-    public function deleteAction($id)
+    public function deleteAction($id) // NEXT_MAJOR: Remove the unused $id parameter
     {
         $request = $this->getRequest();
-
-        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
@@ -296,13 +294,12 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response|RedirectResponse
      */
-    public function editAction($id = null) // NEXT_MAJOR: Remove the $id default value
+    public function editAction($id = null) // NEXT_MAJOR: Remove the unused $id parameter
     {
-        $request = $this->getRequest();
         // the key used to lookup the template
         $templateKey = 'edit';
 
-        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
+        $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $existingObject = $this->admin->getObject($id);
 
@@ -675,11 +672,9 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response
      */
-    public function showAction($id = null) // NEXT_MAJOR: Remove the $id default value
+    public function showAction($id = null) // NEXT_MAJOR: Remove the unused $id parameter
     {
         $request = $this->getRequest();
-
-        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
@@ -732,11 +727,9 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response
      */
-    public function historyAction($id = null) // NEXT_MAJOR: Remove the $id default value
+    public function historyAction($id = null) // NEXT_MAJOR: Remove the unused $id parameter
     {
         $request = $this->getRequest();
-
-        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
@@ -784,11 +777,9 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response
      */
-    public function historyViewRevisionAction($id = null, $revision = null) // NEXT_MAJOR: Remove the $id default value
+    public function historyViewRevisionAction($id = null, $revision = null) // NEXT_MAJOR: Remove the unused $id parameter
     {
         $request = $this->getRequest();
-
-        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
@@ -850,13 +841,11 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response
      */
-    public function historyCompareRevisionsAction($id = null, $base_revision = null, $compare_revision = null) // NEXT_MAJOR: Remove the $id default value
+    public function historyCompareRevisionsAction($id = null, $base_revision = null, $compare_revision = null) // NEXT_MAJOR: Remove the unused $id parameter
     {
-        $request = $this->getRequest();
-
         $this->admin->checkAccess('historyCompareRevisions');
 
-        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
+        $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
@@ -983,15 +972,13 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response|RedirectResponse
      */
-    public function aclAction($id = null) // NEXT_MAJOR: Remove the $id default value
+    public function aclAction($id = null) // NEXT_MAJOR: Remove the unused $id parameter
     {
-        $request = $this->getRequest();
-
         if (!$this->admin->isAclEnabled()) {
             throw $this->createNotFoundException('ACL are not enabled for this admin');
         }
 
-        // NEXT_MAJOR: remove the next line and use the $id parameter of the function
+        $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -286,7 +286,7 @@ class CRUDController implements ContainerAwareInterface
     /**
      * Edit action.
      *
-     * @param int|string|null $id
+     * @param int|string|null $deprecatedId
      *
      * @throws NotFoundHttpException If the object does not exist
      * @throws \RuntimeException     If no editable field is defined
@@ -294,8 +294,15 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return Response|RedirectResponse
      */
-    public function editAction($id = null) // NEXT_MAJOR: Remove the unused $id parameter
+    public function editAction($deprecatedId = null) // NEXT_MAJOR: Remove the unused $id parameter
     {
+        if (isset(\func_get_args()[0])) {
+            @trigger_error(
+                'The $id param will be remove in 4.0, use $this->admin->getIdParameter() instead',
+                E_USER_DEPRECATED
+            );
+        }
+
         // the key used to lookup the template
         $templateKey = 'edit';
 
@@ -665,15 +672,22 @@ class CRUDController implements ContainerAwareInterface
     /**
      * Show action.
      *
-     * @param int|string|null $id
+     * @param int|string|null $deprecatedId
      *
      * @throws NotFoundHttpException If the object does not exist
      * @throws AccessDeniedException If access is not granted
      *
      * @return Response
      */
-    public function showAction($id = null) // NEXT_MAJOR: Remove the unused $id parameter
+    public function showAction($deprecatedId = null) // NEXT_MAJOR: Remove the unused $id parameter
     {
+        if (isset(\func_get_args()[0])) {
+            @trigger_error(
+                'The $id param will be remove in 4.0, use $this->admin->getIdParameter() instead',
+                E_USER_DEPRECATED
+            );
+        }
+
         $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
@@ -720,15 +734,22 @@ class CRUDController implements ContainerAwareInterface
     /**
      * Show history revisions for object.
      *
-     * @param int|string|null $id
+     * @param int|string|null $deprecatedId
      *
      * @throws AccessDeniedException If access is not granted
      * @throws NotFoundHttpException If the object does not exist or the audit reader is not available
      *
      * @return Response
      */
-    public function historyAction($id = null) // NEXT_MAJOR: Remove the unused $id parameter
+    public function historyAction($deprecatedId = null) // NEXT_MAJOR: Remove the unused $id parameter
     {
+        if (isset(\func_get_args()[0])) {
+            @trigger_error(
+                'The $id param will be remove in 4.0, use $this->admin->getIdParameter() instead',
+                E_USER_DEPRECATED
+            );
+        }
+
         $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
@@ -965,15 +986,22 @@ class CRUDController implements ContainerAwareInterface
     /**
      * Returns the Response object associated to the acl action.
      *
-     * @param int|string|null $id
+     * @param int|string|null $deprecatedId
      *
      * @throws AccessDeniedException If access is not granted
      * @throws NotFoundHttpException If the object does not exist or the ACL is not enabled
      *
      * @return Response|RedirectResponse
      */
-    public function aclAction($id = null) // NEXT_MAJOR: Remove the unused $id parameter
+    public function aclAction($deprecatedId = null) // NEXT_MAJOR: Remove the unused $id parameter
     {
+        if (isset(\func_get_args()[0])) {
+            @trigger_error(
+                'The $id param will be remove in 4.0, use $this->admin->getIdParameter() instead',
+                E_USER_DEPRECATED
+            );
+        }
+
         if (!$this->admin->isAclEnabled()) {
             throw $this->createNotFoundException('ACL are not enabled for this admin');
         }

--- a/src/Route/QueryStringBuilder.php
+++ b/src/Route/QueryStringBuilder.php
@@ -18,7 +18,11 @@ use Sonata\AdminBundle\Builder\RouteBuilderInterface;
 use Sonata\AdminBundle\Model\AuditManagerInterface;
 
 /**
+ * NEXT_MAJOR: remove this class.
+ *
  * @final since sonata-project/admin-bundle 3.52
+ *
+ * @deprecated since 3.x, to be removed with 4.0
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */

--- a/src/Route/QueryStringBuilder.php
+++ b/src/Route/QueryStringBuilder.php
@@ -22,7 +22,7 @@ use Sonata\AdminBundle\Model\AuditManagerInterface;
  *
  * @final since sonata-project/admin-bundle 3.52
  *
- * @deprecated since 3.x, to be removed with 4.0
+ * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */


### PR DESCRIPTION
## Subject

I am targeting this branch, because there is no breaking change.

Closes https://github.com/sonata-project/SonataAdminBundle/issues/5805

## Changelog
```markdown
### Deprecated
Deprecate id param of Sonata Action
```