### PR TITLE
Autocomplete improvements & new customization options

### DIFF
--- a/Controller/HelperController.php
+++ b/Controller/HelperController.php
@@ -404,8 +404,11 @@ class HelperController
                 'label' => $label,
             );
 
-            if (is_callable($resultItemCallback)) {
-                $resultItemCallback($admin, $entity, $item);
+            if ($resultItemCallback !== null) {
+                if (!is_callable($resultItemCallback)) {
+                    throw new \RuntimeException('Option "result_item_callback" does not contain callable function.');
+                }
+                call_user_func_array($resultItemCallback, array($admin, $entity, &$item));
             }
 
             $items[] = $item;

--- a/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -12,20 +12,30 @@
 namespace Sonata\AdminBundle\Form\DataTransformer;
 
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
+use Symfony\Component\Form\ChoiceList\LegacyChoiceListAdapter;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 class ModelsToArrayTransformer implements DataTransformerInterface
 {
+    /**
+     * @var ModelChoiceList
+     */
     protected $choiceList;
 
     /**
-     * @param \Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList $choiceList
+     * @param ModelChoiceList|LegacyChoiceListAdapter $choiceList
      */
-    public function __construct(ModelChoiceList $choiceList)
+    public function __construct($choiceList)
     {
-        $this->choiceList = $choiceList;
+        if ($choiceList instanceof LegacyChoiceListAdapter && $choiceList->getAdaptedList() instanceof ModelChoiceList) {
+            $this->choiceList = $choiceList->getAdaptedList();
+        } elseif ($choiceList instanceof ModelChoiceList) {
+            $this->choiceList = $choiceList;
+        } else {
+            new \InvalidArgumentException('Argument 1 passed to '.__CLASS__.'::'.__METHOD__.' must be an instance of Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList, instance of '.get_class($choiceList).' given');
+        }
     }
 
     /**

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -281,7 +281,7 @@ file that was distributed with this source code.
                 minimumInputLength: {{ minimum_input_length }},
                 multiple: {{ multiple ? 'true' : 'false' }},
                 ajax: {
-                    url:  "{{ url ?: url(route.name, route.parameters|default([])) }}",
+                    url:  "{{ url ?: url(route.name, route.parameters|default([]))|e('js') }}",
                     dataType: 'json',
                     quietMillis: 100,
                     data: function (term, page) { // page is the one-based page number tracked by Select2

--- a/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/Tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -14,12 +14,14 @@ namespace Sonata\AdminBundle\Form\DataTransformer;
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity;
+use Symfony\Component\Form\ChoiceList\LegacyChoiceListAdapter;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
 class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
 {
+    private $choiceList;
     private $modelChoiceList;
 
     private $modelManager;
@@ -29,6 +31,13 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
         $this->modelChoiceList = $this->getMockBuilder('Sonata\AdminBundle\Form\ChoiceList\ModelChoiceList')
             ->disableOriginalConstructor()
             ->getMock();
+
+        // Symfony < 2.7 BC
+        if (class_exists('Symfony\Component\Form\ChoiceList\LegacyChoiceListAdapter')) {
+            $this->choiceList = new LegacyChoiceListAdapter($this->modelChoiceList);
+        } else {
+            $this->choiceList = $this->modelChoiceList;
+        }
 
         $this->modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
 
@@ -47,7 +56,7 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransform($expected, $collection, $identifiers)
     {
-        $transformer = new ModelsToArrayTransformer($this->modelChoiceList);
+        $transformer = new ModelsToArrayTransformer($this->choiceList);
 
         $this->modelChoiceList->expects($this->any())
             ->method('getIdentifierValues')
@@ -89,7 +98,7 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException', 'Expected argument of type "\ArrayAccess", "NULL" given');
 
-        $transformer = new ModelsToArrayTransformer($this->modelChoiceList);
+        $transformer = new ModelsToArrayTransformer($this->choiceList);
 
         $this->modelManager->expects($this->any())
             ->method('getModelCollectionInstance')
@@ -102,7 +111,7 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException', 'Expected argument of type "array", "integer" given');
 
-        $transformer = new ModelsToArrayTransformer($this->modelChoiceList);
+        $transformer = new ModelsToArrayTransformer($this->choiceList);
 
         $this->modelManager->expects($this->any())
             ->method('getModelCollectionInstance')
@@ -116,7 +125,7 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testReverseTransformEmpty($keys)
     {
-        $transformer = new ModelsToArrayTransformer($this->modelChoiceList);
+        $transformer = new ModelsToArrayTransformer($this->choiceList);
 
         $this->modelManager->expects($this->any())
             ->method('getModelCollectionInstance')
@@ -135,7 +144,7 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testReverseTransform()
     {
-        $transformer = new ModelsToArrayTransformer($this->modelChoiceList);
+        $transformer = new ModelsToArrayTransformer($this->choiceList);
 
         $this->modelManager->expects($this->any())
             ->method('getModelCollectionInstance')
@@ -175,7 +184,7 @@ class ModelsToArrayTransformerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\Form\Exception\TransformationFailedException', 'The entities with keys "nonexistent" could not be found');
 
-        $transformer = new ModelsToArrayTransformer($this->modelChoiceList);
+        $transformer = new ModelsToArrayTransformer($this->choiceList);
 
         $this->modelManager->expects($this->any())
             ->method('getModelCollectionInstance')


### PR DESCRIPTION
This PR adds extra functionality to sonata_type_model_autocomplete, fixes few glitches & extends customization options:

- Added callback with possibility to modify each individual item in response.
- Removed form type check in HelperController: it made impossible to extend sonata_type_model_autocomplete without writing own controller with copying whole retrieveAutocompleteItemsAction method in case of extending it.
- Added way to customize any autocomplete select2 properties in js via adding sonata_type_model_autocomplete_select2_options_js block before initializing select2 element. Reason to do this is because select2 doesn't allow modification of several options after it has been initialized, you can only destroy it and initialize again from scratch.
- Make autocomplete item list independent of filters set in corresponding list via removing it's filters. Otherwise, if you set filter in, let's say, product list, and you're using product autocomplete elsewhere, it returns only products that match that filter, which is confusing.
- Set error bubbling to false - prevent passing error to parent form elements, which occurs by default for compound form types.