### PR TITLE
Remove JMSDiExtraBundle and SensioGeneratorBundle from dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,6 @@
     "require-dev": {
         "jms/translation-bundle": "^1.4",
         "matthiasnoback/symfony-dependency-injection-test": "^3.1",
-        "sensio/generator-bundle": "^3.1",
         "sonata-project/intl-bundle": "^2.4",
         "symfony/browser-kit": "^3.4 || ^4.2",
         "symfony/filesystem": "^3.4.30 || ^4.2",

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,6 @@
         "sonata-project/user-bundle": "<3.3"
     },
     "require-dev": {
-        "jms/di-extra-bundle": "^1.9",
         "jms/translation-bundle": "^1.4",
         "matthiasnoback/symfony-dependency-injection-test": "^3.1",
         "sensio/generator-bundle": "^3.1",

--- a/tests/Command/GenerateAdminCommandTest.php
+++ b/tests/Command/GenerateAdminCommandTest.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
+use Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Command\GenerateAdminCommand;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
@@ -63,6 +64,10 @@ class GenerateAdminCommandTest extends TestCase
 
     protected function setUp(): void
     {
+        if (!class_exists(SensioGeneratorBundle::class)) {
+            $this->markTestSkipped('Sensio Generator Bundle does not exist');
+        }
+
         // create temp dir
         $tempfile = tempnam(sys_get_temp_dir(), 'sonata_admin');
         if (file_exists($tempfile)) {

--- a/tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
@@ -14,11 +14,19 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
 
 use JMS\DiExtraBundle\Metadata\ClassMetadata;
+use JMS\DiExtraBundle\JMSDiExtraBundle;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Annotation\Admin;
 
 class AnnotationCompilerPassTest extends TestCase
 {
+    public function setUp(): void
+    {
+        if (!class_exists(JMSDiExtraBundle::class)) {
+            $this->markTestSkipped('JMS DiExtraBundle does not exist');
+        }
+    }
+
     /**
      * @group legacy
      *

--- a/tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AnnotationCompilerPassTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
 
-use JMS\DiExtraBundle\Metadata\ClassMetadata;
 use JMS\DiExtraBundle\JMSDiExtraBundle;
+use JMS\DiExtraBundle\Metadata\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Annotation\Admin;
 

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\DependencyInjection;
 
+use JMS\DiExtraBundle\JMSDiExtraBundle;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilder;
@@ -111,6 +112,10 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
      */
     public function testContainerCompileWithJMSDiExtraBundle(): void
     {
+        if (!class_exists(JMSDiExtraBundle::class)) {
+            $this->markTestSkipped('JMS DiExtraBundle does not exist');
+        }
+
         $this->container->setParameter('kernel.bundles', [
             'JMSDiExtraBundle' => true,
         ]);

--- a/tests/Fixtures/Form/TestExtension.php
+++ b/tests/Fixtures/Form/TestExtension.php
@@ -1,0 +1,53 @@
+<?php
+
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Form;
+
+use Symfony\Component\Form\FormExtensionInterface;
+use Symfony\Component\Form\FormTypeExtensionInterface;
+use Symfony\Component\Form\FormTypeGuesserInterface;
+use Symfony\Component\Form\FormTypeInterface;
+
+class TestExtension implements FormExtensionInterface
+{
+    private $types = [];
+    private $extensions = [];
+    private $guesser;
+    public function __construct(FormTypeGuesserInterface $guesser)
+    {
+        $this->guesser = $guesser;
+    }
+    public function addType(FormTypeInterface $type)
+    {
+        $this->types[\get_class($type)] = $type;
+    }
+    public function getType($name): FormTypeInterface
+    {
+        return isset($this->types[$name]) ? $this->types[$name] : null;
+    }
+    public function hasType($name): bool
+    {
+        return isset($this->types[$name]);
+    }
+    public function addTypeExtension(FormTypeExtensionInterface $extension)
+    {
+        foreach ($extension::getExtendedTypes() as $type) {
+            if (!isset($this->extensions[$type])) {
+                $this->extensions[$type] = [];
+            }
+            $this->extensions[$type][] = $extension;
+        }
+    }
+    public function getTypeExtensions($name): array
+    {
+        return isset($this->extensions[$name]) ? $this->extensions[$name] : [];
+    }
+    public function hasTypeExtensions($name): bool
+    {
+        return isset($this->extensions[$name]);
+    }
+    public function getTypeGuesser(): ?FormTypeGuesserInterface
+    {
+        return $this->guesser;
+    }
+}

--- a/tests/Fixtures/Util/StubFilesystemLoader.php
+++ b/tests/Fixtures/Util/StubFilesystemLoader.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Util;
+
+use Twig\Loader\FilesystemLoader;
+
+class StubFilesystemLoader extends FilesystemLoader
+{
+    protected function findTemplate($name, $throw = true)
+    {
+        // strip away bundle name
+        $parts = explode(':', $name);
+        return parent::findTemplate(end($parts), $throw);
+    }
+}

--- a/tests/Generator/AdminGeneratorTest.php
+++ b/tests/Generator/AdminGeneratorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Generator;
 
 use PHPUnit\Framework\TestCase;
+use Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle;
 use Sonata\AdminBundle\Generator\AdminGenerator;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\ModelAdmin;
@@ -41,6 +42,10 @@ class AdminGeneratorTest extends TestCase
      */
     protected function setUp(): void
     {
+        if (!class_exists(SensioGeneratorBundle::class)) {
+            $this->markTestSkipped('Sensio Generator Bundle does not exist');
+        }
+
         $this->adminGenerator = new AdminGenerator(
             $this->createModelManagerMock(),
             __DIR__.'/../../src/Resources/skeleton'

--- a/tests/Generator/ControllerGeneratorTest.php
+++ b/tests/Generator/ControllerGeneratorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Generator;
 
 use PHPUnit\Framework\TestCase;
+use Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle;
 use Sonata\AdminBundle\Generator\ControllerGenerator;
 use Sonata\AdminBundle\Tests\Fixtures\Controller\ModelAdminController;
 use Symfony\Component\Filesystem\Filesystem;
@@ -40,6 +41,10 @@ class ControllerGeneratorTest extends TestCase
      */
     protected function setUp(): void
     {
+        if (!class_exists(SensioGeneratorBundle::class)) {
+            $this->markTestSkipped('Sensio Generator Bundle does not exist');
+        }
+
         $this->controllerGenerator = new ControllerGenerator(__DIR__.'/../../src/Resources/skeleton');
         $this->bundleMock = $this->createBundleMock();
         $this->bundlePath = $this->bundleMock->getPath();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

I was thinking about adding support to Symfony 5, for this we have to: 
- Update `SonataCoreBundle` and `SonataBlockBundle`.
- Remove JMSDiExtraBundle and SensioGeneratorBundle (both deprecated).
- Probably do more things.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- JMSDiExtraBundle from `require-dev`
- SensioGeneratorBundle from `require-dev`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

So before going deeper, I thought about removing completely `SonataCoreBundle` dependency and allow `"sonata-project/block-bundle": "^3.18 || ^4.1"`, would that be ok?
