### PR TITLE
Form base block prefix

### DIFF
--- a/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -90,7 +90,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             $baseName = str_replace('.', '_', $view->parent->vars['sonata_admin_code']);
 
             $baseType = $blockPrefixes[\count($blockPrefixes) - 2];
-            $blockSuffix = preg_replace('#^_([a-z0-9]{14})_(.++)$#', '$2', array_pop($blockPrefixes));
+            $blockSuffix = preg_replace('#^_([a-z0-9]{14})_(.++)$#', '$2', end($blockPrefixes));
 
             $blockPrefixes[] = sprintf('%s_%s', $baseName, $baseType);
             $blockPrefixes[] = sprintf('%s_%s_%s_%s', $baseName, $baseType, $view->parent->vars['name'], $view->vars['name']);
@@ -122,7 +122,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             $blockPrefixes = $view->vars['block_prefixes'];
             $baseName = str_replace('.', '_', $sonataAdmin['admin']->getCode());
             $baseType = $blockPrefixes[\count($blockPrefixes) - 2];
-            $blockSuffix = preg_replace('#^_([a-z0-9]{14})_(.++)$#', '$2', array_pop($blockPrefixes));
+            $blockSuffix = preg_replace('#^_([a-z0-9]{14})_(.++)$#', '$2', end($blockPrefixes));
 
             $blockPrefixes[] = sprintf('%s_%s', $baseName, $baseType);
             $blockPrefixes[] = sprintf('%s_%s_%s', $baseName, $sonataAdmin['name'], $baseType);

--- a/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -96,7 +96,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             $blockPrefixes[] = sprintf('%s_%s_%s_%s', $baseName, $baseType, $view->parent->vars['name'], $view->vars['name']);
             $blockPrefixes[] = sprintf('%s_%s_%s_%s', $baseName, $baseType, $view->parent->vars['name'], $blockSuffix);
 
-            $view->vars['block_prefixes'] = $blockPrefixes;
+            $view->vars['block_prefixes'] = array_unique($blockPrefixes);
             $view->vars['sonata_admin_enabled'] = true;
             $view->vars['sonata_admin'] = [
                 'admin' => false,
@@ -132,7 +132,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
                 $blockPrefixes[] = $sonataAdmin['block_name'];
             }
 
-            $view->vars['block_prefixes'] = $blockPrefixes;
+            $view->vars['block_prefixes'] = array_unique($blockPrefixes);
             $view->vars['sonata_admin_enabled'] = true;
             $view->vars['sonata_admin'] = $sonataAdmin;
             $view->vars['sonata_admin_code'] = $sonataAdmin['admin']->getCode();


### PR DESCRIPTION
## Subject

I am targeting this branch, because FormTypeFieldExtension removes basic Symfony block prefix for field in collection.

Closes #4506

## Changelog

```markdown
### Fixed
Fixed removing last element in form `block_prefixes` because of `array_pop` 
which was used to fetch last element in order to modify it
```