### PR TITLE
Require secure versions of symfony/http-foundation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/expression-language": "^3.4.30 || ^4.2",
         "symfony/form": "^2.8.18 || ^3.2.5 || ^4.0",
         "symfony/framework-bundle": "^3.4.30 || ^4.2",
-        "symfony/http-foundation": "^3.4.30 || ^4.2",
+        "symfony/http-foundation": "^3.4.35 || ^4.2.12",
         "symfony/http-kernel": "^3.4.30 || ^4.2",
         "symfony/options-resolver": "^3.4.30 || ^4.2",
         "symfony/property-access": "^3.4.30 || ^4.2",


### PR DESCRIPTION

Github keeps notifying us about
https://github.com/advisories/GHSA-xhh6-956q-4q69