### PR TITLE
feat(form-theme): add label_translation_parameters support

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -148,9 +148,9 @@ file that was distributed with this source code.
             {% if translation_domain is same as(false) %}
                 {{- label -}}
             {% elseif not sonata_admin.admin %}
-                {{- label|trans({}, translation_domain) -}}
+                {{- label|trans(label_translation_parameters|default({}), translation_domain) -}}
             {% else %}
-                {{ label|trans({}, sonata_admin.field_description.translationDomain ?: admin.translationDomain) }}
+                {{ label|trans(label_translation_parameters|default({}), sonata_admin.field_description.translationDomain ?: admin.translationDomain) }}
             {% endif %}
         </label>
     {% endif %}
@@ -187,7 +187,7 @@ file that was distributed with this source code.
                     {% if translation_domain is same as(false) %}
                         {{- label -}}
                     {% else %}
-                        {{- label|trans({}, translation_domain) -}}
+                        {{- label|trans(label_translation_parameters|default({}), translation_domain) -}}
                     {%- endif -%}
                 </span>
             {%- endif -%}


### PR DESCRIPTION
## Subject

Use the "label_translation_parameters" when translating form labels. This new feature was introduced in Symfony 4.3.

I am targeting this branch, because it adds support for a currently unsupported feature but in a backward compatible way.

## Changelog
```markdown
### Added
- Added support for the `label_translation_parameters` option in the form theme.
```
