### PR TITLE
5826 - Use constant for Request methods and Response http status codes

### DIFF
--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -20,6 +20,7 @@ use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 final class RetrieveAutocompleteItemsAction
@@ -96,7 +97,7 @@ final class RetrieveAutocompleteItemsAction
         $targetAdmin->checkAccess($targetAdminAccessAction);
 
         if (mb_strlen($searchText, 'UTF-8') < $minimumInputLength) {
-            return new JsonResponse(['status' => 'KO', 'message' => 'Too short search string.'], 403);
+            return new JsonResponse(['status' => 'KO', 'message' => 'Too short search string.'], Response::HTTP_FORBIDDEN);
         }
 
         $targetAdmin->setFilterPersister(null);

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -231,7 +231,7 @@ class CRUDController implements ContainerAwareInterface
             return $preResponse;
         }
 
-        if ('DELETE' === $this->getRestMethod()) {
+        if (Request::METHOD_DELETE === $this->getRestMethod()) {
             // check the csrf token
             $this->validateCsrfToken('sonata.delete');
 
@@ -241,7 +241,7 @@ class CRUDController implements ContainerAwareInterface
                 $this->admin->delete($object);
 
                 if ($this->isXmlHttpRequest()) {
-                    return $this->renderJson(['result' => 'ok'], 200, []);
+                    return $this->renderJson(['result' => 'ok'], Response::HTTP_OK, []);
                 }
 
                 $this->addFlash(
@@ -256,7 +256,7 @@ class CRUDController implements ContainerAwareInterface
                 $this->handleModelManagerException($e);
 
                 if ($this->isXmlHttpRequest()) {
-                    return $this->renderJson(['result' => 'error'], 200, []);
+                    return $this->renderJson(['result' => 'error'], Response::HTTP_OK, []);
                 }
 
                 $this->addFlash(
@@ -419,8 +419,8 @@ class CRUDController implements ContainerAwareInterface
         $request = $this->getRequest();
         $restMethod = $this->getRestMethod();
 
-        if ('POST' !== $restMethod) {
-            throw $this->createNotFoundException(sprintf('Invalid request type "%s", POST expected', $restMethod));
+        if (Request::METHOD_POST !== $restMethod) {
+            throw $this->createNotFoundException(sprintf('Invalid request method given "%s", %s expected', $restMethod, Request::METHOD_POST));
         }
 
         // check the csrf token
@@ -1011,7 +1011,7 @@ class CRUDController implements ContainerAwareInterface
         $aclUsersForm = $adminObjectAclManipulator->createAclUsersForm($adminObjectAclData);
         $aclRolesForm = $adminObjectAclManipulator->createAclRolesForm($adminObjectAclData);
 
-        if ('POST' === $request->getMethod()) {
+        if (Request::METHOD_POST === $request->getMethod()) {
             if ($request->request->has(AdminObjectAclManipulator::ACL_USERS_FORM_NAME)) {
                 $form = $aclUsersForm;
                 $updateMethod = 'updateAclUsers';
@@ -1079,7 +1079,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return JsonResponse with json encoded data
      */
-    protected function renderJson($data, $status = 200, $headers = [])
+    protected function renderJson($data, $status = Response::HTTP_OK, $headers = [])
     {
         return new JsonResponse($data, $status, $headers);
     }
@@ -1415,7 +1415,7 @@ class CRUDController implements ContainerAwareInterface
         }
 
         if (!$valid) {
-            throw new HttpException(400, 'The csrf token is not valid, CSRF attack?');
+            throw new HttpException(Response::HTTP_BAD_REQUEST, 'The csrf token is not valid, CSRF attack?');
         }
     }
 
@@ -1582,7 +1582,7 @@ class CRUDController implements ContainerAwareInterface
         return $this->renderJson([
             'result' => 'error',
             'errors' => $errors,
-        ], 400);
+        ], Response::HTTP_BAD_REQUEST);
     }
 
     /**
@@ -1598,6 +1598,6 @@ class CRUDController implements ContainerAwareInterface
             'result' => 'ok',
             'objectId' => $this->admin->getNormalizedIdentifier($object),
             'objectName' => $this->escapeHtml($this->admin->toString($object)),
-        ], 200);
+        ], Response::HTTP_OK);
     }
 }

--- a/tests/Action/AppendFormFieldElementActionTest.php
+++ b/tests/Action/AppendFormFieldElementActionTest.php
@@ -87,7 +87,7 @@ final class AppendFormFieldElementActionTest extends TestCase
             'field' => 'enabled',
             'value' => 1,
             'context' => 'list',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'POST']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST]);
 
         $modelManager = $this->prophesize(ModelManagerInterface::class);
         $formView = new FormView();

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -65,7 +65,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
 
         $request = new Request([
             'admin_code' => 'foo.admin',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $this->admin->hasAccess('create')->willReturn(false);
         $this->admin->hasAccess('edit')->willReturn(false);
@@ -82,7 +82,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $request = new Request([
             'admin_code' => 'foo.admin',
             'field' => 'barField',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
 
@@ -107,7 +107,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             'admin_code' => 'foo.admin',
             'field' => 'barField',
             'q' => 'so',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $targetAdmin = $this->prophesize(AbstractAdmin::class);
         $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
@@ -137,7 +137,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             'admin_code' => 'foo.admin',
             'field' => 'barField',
             'q' => 'sonata',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $this->configureFormConfig('barField');
 
@@ -162,7 +162,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             'admin_code' => 'foo.admin',
             'field' => 'barField',
             'q' => 'sonata',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $this->configureFormConfigComplexPropertyArray('barField');
         $datagrid = $this->configureAutocompleteItemsDatagrid();
@@ -194,7 +194,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             'admin_code' => 'foo.admin',
             'field' => 'barField',
             'q' => 'sonata',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $this->configureFormConfigComplexProperty('barField');
         $datagrid = $this->configureAutocompleteItemsDatagrid();

--- a/tests/Action/RetrieveFormFieldElementActionTest.php
+++ b/tests/Action/RetrieveFormFieldElementActionTest.php
@@ -80,7 +80,7 @@ final class RetrieveFormFieldElementActionTest extends TestCase
             'field' => 'enabled',
             'value' => 1,
             'context' => 'list',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'POST']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST]);
 
         $modelManager = $this->prophesize(ModelManagerInterface::class);
         $formView = new FormView();

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -25,6 +25,7 @@ use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\ConstraintViolation;
@@ -87,7 +88,7 @@ final class SetObjectFieldValueActionTest extends TestCase
             'field' => 'enabled',
             'value' => 1,
             'context' => 'list',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
         $pool = $this->prophesize(Pool::class);
@@ -122,7 +123,7 @@ final class SetObjectFieldValueActionTest extends TestCase
 
         $response = ($this->action)($request);
 
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     public function testSetObjectFieldValueActionOnARelationField(): void
@@ -135,7 +136,7 @@ final class SetObjectFieldValueActionTest extends TestCase
             'field' => 'bar',
             'value' => 1,
             'context' => 'list',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
         $modelManager = $this->prophesize(ModelManagerInterface::class);
@@ -175,7 +176,7 @@ final class SetObjectFieldValueActionTest extends TestCase
 
         $response = ($this->action)($request);
 
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     public function testSetObjectFieldValueActionWithViolations(): void
@@ -189,7 +190,7 @@ final class SetObjectFieldValueActionTest extends TestCase
             'field' => 'bar.enabled',
             'value' => 1,
             'context' => 'list',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
         $propertyAccessor = new PropertyAccessor();
@@ -207,7 +208,7 @@ final class SetObjectFieldValueActionTest extends TestCase
 
         $response = ($this->action)($request);
 
-        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
         $this->assertSame(json_encode("error1\nerror2"), $response->getContent());
     }
 
@@ -220,7 +221,7 @@ final class SetObjectFieldValueActionTest extends TestCase
             'field' => 'status',
             'value' => [1, 2],
             'context' => 'list',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
         $pool = $this->prophesize(Pool::class);
@@ -257,6 +258,6 @@ final class SetObjectFieldValueActionTest extends TestCase
 
         $response = ($this->action)($request);
 
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 }

--- a/tests/Block/AdminSearchBlockServiceTest.php
+++ b/tests/Block/AdminSearchBlockServiceTest.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Block\AdminSearchBlockService;
 use Sonata\AdminBundle\Search\SearchHandler;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
 use Sonata\BlockBundle\Test\FakeTemplating;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
@@ -76,6 +77,6 @@ class AdminSearchBlockServiceTest extends BlockServiceTestCase
         $response = $blockService->execute($blockContext);
 
         static::assertSame('', $response->getContent());
-        static::assertSame(204, $response->getStatusCode());
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
     }
 }

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3642,7 +3642,7 @@ class CRUDControllerTest extends TestCase
     public function testBatchActionWrongMethod(): void
     {
         $this->expectException(NotFoundHttpException::class);
-        $this->expectExceptionMessage('Invalid request type "GET", POST expected');
+        $this->expectExceptionMessage('Invalid request method given "GET", POST expected');
 
         $this->controller->batchAction();
     }

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -1168,7 +1168,7 @@ class CRUDControllerTest extends TestCase
             ->with('csrf_protection')
             ->willReturn(true);
 
-        $this->request->setMethod('DELETE');
+        $this->request->setMethod(Request::METHOD_DELETE);
 
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
@@ -1198,8 +1198,8 @@ class CRUDControllerTest extends TestCase
             ->with('csrf_protection')
             ->willReturn(true);
 
-        $this->request->setMethod('POST');
-        $this->request->request->set('_method', 'DELETE');
+        $this->request->setMethod(Request::METHOD_POST);
+        $this->request->request->set('_method', Request::METHOD_DELETE);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
@@ -1235,7 +1235,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertLoggerLogsModelManagerException($this->admin, 'delete');
 
-        $this->request->setMethod('DELETE');
+        $this->request->setMethod(Request::METHOD_DELETE);
 
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
@@ -1277,7 +1277,7 @@ class CRUDControllerTest extends TestCase
             ->method('isDebug')
             ->willReturn(true);
 
-        $this->request->setMethod('DELETE');
+        $this->request->setMethod(Request::METHOD_DELETE);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
         $this->controller->deleteAction(1);
@@ -1311,7 +1311,7 @@ class CRUDControllerTest extends TestCase
             ->with('csrf_protection')
             ->willReturn(true);
 
-        $this->request->setMethod('DELETE');
+        $this->request->setMethod(Request::METHOD_DELETE);
 
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
@@ -1345,8 +1345,8 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_delete_success', ['%name%' => $expectedToStringValue], 'SonataAdminBundle');
 
-        $this->request->setMethod('POST');
-        $this->request->request->set('_method', 'DELETE');
+        $this->request->setMethod(Request::METHOD_POST);
+        $this->request->request->set('_method', Request::METHOD_DELETE);
 
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
@@ -1387,8 +1387,8 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_delete_success', ['%name%' => $expectedToStringValue], 'SonataAdminBundle');
 
-        $this->request->setMethod('POST');
-        $this->request->request->set('_method', 'DELETE');
+        $this->request->setMethod(Request::METHOD_POST);
+        $this->request->request->set('_method', Request::METHOD_DELETE);
 
         $this->formBuilder->expects($this->once())
             ->method('getOption')
@@ -1416,7 +1416,7 @@ class CRUDControllerTest extends TestCase
             ->willReturn(true);
 
         //without POST request parameter "_method" should not be used as real REST method
-        $this->request->query->set('_method', 'DELETE');
+        $this->request->query->set('_method', Request::METHOD_DELETE);
 
         $this->assertInstanceOf(Response::class, $this->controller->deleteAction(1));
 
@@ -1457,7 +1457,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertLoggerLogsModelManagerException($this->admin, 'delete');
 
-        $this->request->setMethod('DELETE');
+        $this->request->setMethod(Request::METHOD_DELETE);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
         $this->formBuilder->expects($this->once())
@@ -1485,8 +1485,8 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('delete'))
             ->willReturn(true);
 
-        $this->request->setMethod('POST');
-        $this->request->request->set('_method', 'DELETE');
+        $this->request->setMethod(Request::METHOD_POST);
+        $this->request->request->set('_method', Request::METHOD_DELETE);
         $this->request->request->set('_sonata_csrf_token', 'CSRF-INVALID');
 
         $this->formBuilder->expects($this->once())
@@ -1515,8 +1515,8 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('delete'))
             ->willReturn(true);
 
-        $this->request->setMethod('POST');
-        $this->request->request->set('_method', 'DELETE');
+        $this->request->setMethod(Request::METHOD_POST);
+        $this->request->request->set('_method', Request::METHOD_DELETE);
 
         $this->formBuilder->expects($this->once())
             ->method('getOption')
@@ -1710,7 +1710,7 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_edit_success', ['%name%' => $expectedToStringValue], 'SonataAdminBundle');
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
 
         $response = $this->controller->editAction(null);
 
@@ -1760,7 +1760,7 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_edit_error', ['%name%' => $expectedToStringValue], 'SonataAdminBundle');
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
 
         $formView = $this->createMock(FormView::class);
 
@@ -1830,7 +1830,7 @@ class CRUDControllerTest extends TestCase
             ->method('toString')
             ->willReturn('foo');
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
         $response = $this->controller->editAction(null);
@@ -1881,7 +1881,7 @@ class CRUDControllerTest extends TestCase
             ->with(true)
             ->willReturn([$formError]);
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
         $this->request->headers->set('Accept', 'application/json');
 
@@ -1924,7 +1924,7 @@ class CRUDControllerTest extends TestCase
             ->method('all')
             ->willReturn(['field' => 'fielddata']);
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
         $formView = $this->createMock(FormView::class);
@@ -1991,7 +1991,7 @@ class CRUDControllerTest extends TestCase
         $form->expects($this->once())
             ->method('isSubmitted')
             ->willReturn(true);
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
 
         $formView = $this->createMock(FormView::class);
 
@@ -2055,7 +2055,7 @@ class CRUDControllerTest extends TestCase
             ->method('all')
             ->willReturn(['field' => 'fielddata']);
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('btn_preview', 'Preview');
 
         $this->assertInstanceOf(Response::class, $this->controller->editAction(null));
@@ -2111,7 +2111,7 @@ class CRUDControllerTest extends TestCase
         $form
             ->method('isSubmitted')
             ->willReturn(true);
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
 
         $this->admin
             ->method('update')
@@ -2328,7 +2328,7 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_create_success', ['%name%' => $expectedToStringValue], 'SonataAdminBundle');
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
 
         $response = $this->controller->createAction();
 
@@ -2386,7 +2386,7 @@ class CRUDControllerTest extends TestCase
             ->method('isValid')
             ->willReturn(true);
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
 
         $this->controller->createAction();
     }
@@ -2436,7 +2436,7 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_create_error', ['%name%' => $expectedToStringValue], 'SonataAdminBundle');
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
 
         $formView = $this->createMock(FormView::class);
 
@@ -2507,7 +2507,7 @@ class CRUDControllerTest extends TestCase
             ->method('getData')
             ->willReturn($object);
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
 
         $formView = $this->createMock(FormView::class);
 
@@ -2592,7 +2592,7 @@ class CRUDControllerTest extends TestCase
             ->method('toString')
             ->willReturn('foo');
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
         $response = $this->controller->createAction();
@@ -2647,7 +2647,7 @@ class CRUDControllerTest extends TestCase
             ->with(true)
             ->willReturn([$formError]);
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
         $this->request->headers->set('Accept', 'application/json');
 
@@ -2694,7 +2694,7 @@ class CRUDControllerTest extends TestCase
             ->method('isValid')
             ->willReturn(false);
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
         $formView = $this->createMock(FormView::class);
@@ -2758,7 +2758,7 @@ class CRUDControllerTest extends TestCase
             ->method('isValid')
             ->willReturn(true);
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('btn_preview', 'Preview');
 
         $this->assertInstanceOf(Response::class, $this->controller->createAction());
@@ -2833,7 +2833,7 @@ class CRUDControllerTest extends TestCase
 
         $response = $this->controller->exportAction($this->request);
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $this->assertSame([], $this->session->getFlashBag()->all());
     }
 
@@ -3140,7 +3140,7 @@ class CRUDControllerTest extends TestCase
             ->method('getSecurityHandler')
             ->willReturn($aclSecurityHandler);
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
 
         $this->assertInstanceOf(Response::class, $this->controller->aclAction(null));
 
@@ -3231,7 +3231,7 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_acl_edit_success', [], 'SonataAdminBundle');
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
 
         $response = $this->controller->aclAction(null);
 
@@ -3663,7 +3663,7 @@ class CRUDControllerTest extends TestCase
             ->method('getBatchActions')
             ->willReturn($batchActions);
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('data', json_encode(['action' => 'foo', 'idx' => ['123', '456'], 'all_elements' => false]));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
@@ -3677,7 +3677,7 @@ class CRUDControllerTest extends TestCase
 
     public function testBatchActionActionInvalidCsrfToken(): void
     {
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('data', json_encode(['action' => 'foo', 'idx' => ['123', '456'], 'all_elements' => false]));
         $this->request->request->set('_sonata_csrf_token', 'CSRF-INVALID');
 
@@ -3696,7 +3696,7 @@ class CRUDControllerTest extends TestCase
 
     public function testBatchActionActionWithDisabledCsrfProtection(): void
     {
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('data', json_encode(['action' => 'foo', 'idx' => ['123', '456'], 'all_elements' => false]));
 
         $this->formBuilder->expects($this->once())
@@ -3755,7 +3755,7 @@ class CRUDControllerTest extends TestCase
             ->method('getDatagrid')
             ->willReturn($datagrid);
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('data', json_encode(['action' => 'foo', 'idx' => ['123', '456'], 'all_elements' => false]));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
@@ -3813,7 +3813,7 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_batch_delete_success', [], 'SonataAdminBundle');
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('data', json_encode(['action' => 'delete', 'idx' => ['123', '456'], 'all_elements' => false]));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
@@ -3875,7 +3875,7 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_batch_delete_success', [], 'SonataAdminBundle');
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('action', 'delete');
         $this->request->request->set('idx', ['123', '456']);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
@@ -3907,7 +3907,7 @@ class CRUDControllerTest extends TestCase
 
         $data = ['action' => 'delete', 'idx' => ['123', '456'], 'all_elements' => false];
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('data', json_encode($data));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
@@ -3975,7 +3975,7 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_batch_empty', [], 'SonataAdminBundle');
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('action', 'foo');
         $this->request->request->set('idx', ['789']);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
@@ -4002,7 +4002,7 @@ class CRUDControllerTest extends TestCase
 
         $data = ['action' => 'delete', 'idx' => ['123', '456'], 'all_elements' => false];
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('data', json_encode($data));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
@@ -4056,7 +4056,7 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_foo_error', [], 'SonataAdminBundle');
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('action', 'foo');
         $this->request->request->set('idx', ['999']);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
@@ -4094,7 +4094,7 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_batch_empty', [], 'SonataAdminBundle');
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('action', 'delete');
         $this->request->request->set('idx', []);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
@@ -4153,7 +4153,7 @@ class CRUDControllerTest extends TestCase
             ->with('csrf_protection')
             ->willReturn(true);
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('action', 'bar');
         $this->request->request->set('idx', []);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
@@ -4211,7 +4211,7 @@ class CRUDControllerTest extends TestCase
 
         $this->expectTranslate('flash_batch_delete_success', [], 'SonataAdminBundle');
 
-        $this->request->setMethod('POST');
+        $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('data', json_encode(['action' => 'delete', 'idx' => ['123', '456'], 'all_elements' => false]));
         $this->request->request->set('foo', 'bar');
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -190,7 +190,7 @@ class HelperControllerTest extends TestCase
             'field' => 'enabled',
             'value' => 1,
             'context' => 'list',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
         $pool = $this->prophesize(Pool::class);
@@ -225,7 +225,7 @@ class HelperControllerTest extends TestCase
 
         $response = $this->controller->setObjectFieldValueAction($request);
 
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     public function testSetObjectFieldValueActionOnARelationField(): void
@@ -238,7 +238,7 @@ class HelperControllerTest extends TestCase
             'field' => 'bar',
             'value' => 1,
             'context' => 'list',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
         $modelManager = $this->prophesize(ModelManagerInterface::class);
@@ -278,7 +278,7 @@ class HelperControllerTest extends TestCase
 
         $response = $this->controller->setObjectFieldValueAction($request);
 
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     public function testAppendFormFieldElementAction(): void
@@ -290,7 +290,7 @@ class HelperControllerTest extends TestCase
             'field' => 'enabled',
             'value' => 1,
             'context' => 'list',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'POST']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST]);
 
         $modelManager = $this->prophesize(ModelManagerInterface::class);
         $formView = new FormView();
@@ -369,7 +369,7 @@ class HelperControllerTest extends TestCase
             'field' => 'bar.enabled',
             'value' => 1,
             'context' => 'list',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'POST', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
         $propertyAccessor = new PropertyAccessor();
@@ -387,7 +387,7 @@ class HelperControllerTest extends TestCase
 
         $response = $this->controller->setObjectFieldValueAction($request);
 
-        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
         $this->assertSame(json_encode("error1\nerror2"), $response->getContent());
     }
 
@@ -397,7 +397,7 @@ class HelperControllerTest extends TestCase
 
         $request = new Request([
             'admin_code' => 'foo.admin',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $this->admin->hasAccess('create')->willReturn(false);
         $this->admin->hasAccess('edit')->willReturn(false);
@@ -414,7 +414,7 @@ class HelperControllerTest extends TestCase
         $request = new Request([
             'admin_code' => 'foo.admin',
             'field' => 'barField',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
 
@@ -439,7 +439,7 @@ class HelperControllerTest extends TestCase
             'admin_code' => 'foo.admin',
             'field' => 'barField',
             'q' => 'so',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $targetAdmin = $this->prophesize(AbstractAdmin::class);
         $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
@@ -469,7 +469,7 @@ class HelperControllerTest extends TestCase
             'admin_code' => 'foo.admin',
             'field' => 'barField',
             'q' => 'sonata',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $this->configureFormConfig('barField');
 
@@ -494,7 +494,7 @@ class HelperControllerTest extends TestCase
             'admin_code' => 'foo.admin',
             'field' => 'barField',
             'q' => 'sonata',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $this->configureFormConfigComplexPropertyArray('barField');
         $datagrid = $this->configureAutocompleteItemsDatagrid();
@@ -526,7 +526,7 @@ class HelperControllerTest extends TestCase
             'admin_code' => 'foo.admin',
             'field' => 'barField',
             'q' => 'sonata',
-        ], [], [], [], [], ['REQUEST_METHOD' => 'GET', 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $this->configureFormConfigComplexProperty('barField');
         $datagrid = $this->configureAutocompleteItemsDatagrid();

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -15,15 +15,17 @@ namespace Sonata\AdminBundle\Tests\Functional\Controller;
 
 use Sonata\AdminBundle\Tests\App\AppKernel;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 final class CRUDControllerTest extends WebTestCase
 {
     public function testList(): void
     {
         $client = static::createClient();
-        $crawler = $client->request('GET', '/admin/tests/app/foo/list');
+        $crawler = $client->request(Request::METHOD_GET, '/admin/tests/app/foo/list');
 
-        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
         $this->assertSame(
             1,
             $crawler->filter('.sonata-ba-list-field:contains("foo_name")')->count()
@@ -33,9 +35,9 @@ final class CRUDControllerTest extends WebTestCase
     public function testCreate(): void
     {
         $client = static::createClient();
-        $crawler = $client->request('GET', '/admin/tests/app/foo/create');
+        $crawler = $client->request(Request::METHOD_GET, '/admin/tests/app/foo/create');
 
-        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
         $this->assertSame(
             1,
             $crawler->filter('.sonata-ba-collapsed-fields label:contains("Name")')->count()
@@ -45,9 +47,9 @@ final class CRUDControllerTest extends WebTestCase
     public function testShow(): void
     {
         $client = static::createClient();
-        $crawler = $client->request('GET', '/admin/tests/app/foo/test_id/show');
+        $crawler = $client->request(Request::METHOD_GET, '/admin/tests/app/foo/test_id/show');
 
-        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
         $this->assertSame(
             1,
             $crawler->filter('td:contains("foo_name")')->count()
@@ -57,9 +59,9 @@ final class CRUDControllerTest extends WebTestCase
     public function testEdit(): void
     {
         $client = static::createClient();
-        $crawler = $client->request('GET', '/admin/tests/app/foo/test_id/edit');
+        $crawler = $client->request(Request::METHOD_GET, '/admin/tests/app/foo/test_id/edit');
 
-        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
         $this->assertSame(
             1,
             $crawler->filter('.sonata-ba-collapsed-fields label:contains("Name")')->count()

--- a/tests/Functional/Controller/DashboardActionTest.php
+++ b/tests/Functional/Controller/DashboardActionTest.php
@@ -16,14 +16,15 @@ namespace Sonata\AdminBundle\Tests\Functional\Controller;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Tests\App\AppKernel;
 use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Component\HttpFoundation\Response;
 
 final class DashboardActionTest extends TestCase
 {
     public function testDashboard(): void
     {
         $client = new Client(new AppKernel());
-        $client->request('GET', '/admin/dashboard');
+        $client->request(Request::METHOD_GET, '/admin/dashboard');
 
-        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }
 }

--- a/tests/Functional/Controller/DashboardActionTest.php
+++ b/tests/Functional/Controller/DashboardActionTest.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Tests\Functional\Controller;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Tests\App\AppKernel;
 use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 final class DashboardActionTest extends TestCase

--- a/tests/Route/RouteCollectionTest.php
+++ b/tests/Route/RouteCollectionTest.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Tests\Route;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Route\RouteCollection;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Route;
 
 class RouteCollectionTest extends TestCase
@@ -155,8 +156,8 @@ class RouteCollectionTest extends TestCase
             'https',
         ];
         $methods = [
-            'GET',
-            'POST',
+            Request::METHOD_GET,
+            Request::METHOD_POST,
         ];
         $condition = "context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'";
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Use constant for Request methods and Response http status codes
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes can also be applied before 3.x because the Request and Response are part of this project for a while
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5826  
