### PR TITLE
Drop SonataIntlBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,9 @@
         "symfony/twig-bundle": "^4.3",
         "symfony/validator": "^4.3",
         "twig/extensions": "^1.5",
-        "twig/twig": "^2.10"
+        "twig/extra-bundle": "^3.0",
+        "twig/intl-extra": "^3.0",
+        "twig/twig": "^2.12"
     },
     "conflict": {
         "doctrine/doctrine-bundle": ">=3",
@@ -66,7 +68,6 @@
     "require-dev": {
         "jms/translation-bundle": "^1.4",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
-        "sonata-project/intl-bundle": "^2.4",
         "symfony/browser-kit": "^4.3",
         "symfony/css-selector": "^4.3",
         "symfony/filesystem": "^4.3",

--- a/composer.json
+++ b/composer.json
@@ -77,9 +77,7 @@
     },
     "suggest": {
         "jms/translation-bundle": "Extract message keys from Admins",
-        "kunicmarko/sonata-auto-configure-bundle": "Auto configures Admin classes",
-        "sensio/generator-bundle": "Add sonata:admin:generate command",
-        "sonata-project/intl-bundle": "Add localized date and number into the list"
+        "kunicmarko/sonata-auto-configure-bundle": "Auto configures Admin classes"
     },
     "config": {
         "sort-packages": true

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@ The demo website can be found at http://demo.sonata-project.org.
    reference/console
    reference/troubleshooting
    reference/breadcrumbs
+   reference/internationalization
 
 .. toctree::
    :caption: Advanced Options

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -248,3 +248,6 @@ Full Configuration Options
             global_search:
                 show_empty_boxes: show
                 case_sensitive: true
+
+            # show localized information
+            use_intl_templates: false

--- a/docs/reference/internationalization.rst
+++ b/docs/reference/internationalization.rst
@@ -1,0 +1,18 @@
+Internationalization (I18N)
+===========================
+
+The admin comes with the ``use_intl_templates`` option that will load a set of templates that will
+display localized information.
+
+
+Configuration
+-------------
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/sonata_admin.yaml
+
+        sonata_admin:
+            use_intl_templates: true

--- a/src/DependencyInjection/AbstractSonataAdminExtension.php
+++ b/src/DependencyInjection/AbstractSonataAdminExtension.php
@@ -78,29 +78,28 @@ abstract class AbstractSonataAdminExtension extends Extension
             ],
         ];
 
-        // let's add some magic, only overwrite template if the SonataIntlBundle is enabled
-        $bundles = $container->getParameter('kernel.bundles');
-        if (isset($bundles['SonataIntlBundle'])) {
+        $useIntlTemplates = $container->getParameter('sonata.admin.configuration.use_intl_templates');
+        if ($useIntlTemplates) {
             $defaultConfig['templates']['types']['list'] = array_merge($defaultConfig['templates']['types']['list'], [
-                'date' => '@SonataIntl/CRUD/list_date.html.twig',
-                'datetime' => '@SonataIntl/CRUD/list_datetime.html.twig',
-                'smallint' => '@SonataIntl/CRUD/list_decimal.html.twig',
-                'bigint' => '@SonataIntl/CRUD/list_decimal.html.twig',
-                'integer' => '@SonataIntl/CRUD/list_decimal.html.twig',
-                'decimal' => '@SonataIntl/CRUD/list_decimal.html.twig',
-                'currency' => '@SonataIntl/CRUD/list_currency.html.twig',
-                'percent' => '@SonataIntl/CRUD/list_percent.html.twig',
+                'date' => '@SonataAdmin/CRUD/Intl/list_date.html.twig',
+                'datetime' => '@SonataAdmin/CRUD/Intl/list_datetime.html.twig',
+                'smallint' => '@SonataAdmin/CRUD/Intl/list_decimal.html.twig',
+                'bigint' => '@SonataAdmin/CRUD/Intl/list_decimal.html.twig',
+                'integer' => '@SonataAdmin/CRUD/Intl/list_decimal.html.twig',
+                'decimal' => '@SonataAdmin/CRUD/Intl/list_decimal.html.twig',
+                'currency' => '@SonataAdmin/CRUD/Intl/list_currency.html.twig',
+                'percent' => '@SonataAdmin/CRUD/Intl/list_percent.html.twig',
             ]);
 
             $defaultConfig['templates']['types']['show'] = array_merge($defaultConfig['templates']['types']['show'], [
-                'date' => '@SonataIntl/CRUD/show_date.html.twig',
-                'datetime' => '@SonataIntl/CRUD/show_datetime.html.twig',
-                'smallint' => '@SonataIntl/CRUD/show_decimal.html.twig',
-                'bigint' => '@SonataIntl/CRUD/show_decimal.html.twig',
-                'integer' => '@SonataIntl/CRUD/show_decimal.html.twig',
-                'decimal' => '@SonataIntl/CRUD/show_decimal.html.twig',
-                'currency' => '@SonataIntl/CRUD/show_currency.html.twig',
-                'percent' => '@SonataIntl/CRUD/show_percent.html.twig',
+                'date' => '@SonataAdmin/CRUD/Intl/show_date.html.twig',
+                'datetime' => '@SonataAdmin/CRUD/Intl/show_datetime.html.twig',
+                'smallint' => '@SonataAdmin/CRUD/Intl/show_decimal.html.twig',
+                'bigint' => '@SonataAdmin/CRUD/Intl/show_decimal.html.twig',
+                'integer' => '@SonataAdmin/CRUD/Intl/show_decimal.html.twig',
+                'decimal' => '@SonataAdmin/CRUD/Intl/show_decimal.html.twig',
+                'currency' => '@SonataAdmin/CRUD/Intl/show_currency.html.twig',
+                'percent' => '@SonataAdmin/CRUD/Intl/show_percent.html.twig',
             ]);
         }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -514,6 +514,11 @@ CASESENSITIVE;
                     ->info('Translate group label')
                 ->end()
 
+                ->booleanNode('use_intl_templates')
+                    ->defaultFalse()
+                    ->info('Whether localized information should be shown, it will replace some default templates')
+                ->end()
+
             ->end()
         ->end();
 

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -49,15 +49,6 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
             ]);
         }
 
-        if (isset($bundles['SonataIntlBundle'])) {
-            // integrate the SonataUserBundle if the bundle exists
-            array_unshift($configs, [
-                'templates' => [
-                    'history_revision_timestamp' => '@SonataIntl/CRUD/history_revision_timestamp.html.twig',
-                ],
-            ]);
-        }
-
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('twig.xml');
         $loader->load('core.xml');
@@ -93,6 +84,16 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
 
         if (false === $config['options']['lock_protection']) {
             $container->removeDefinition('sonata.admin.lock.extension');
+        }
+
+        $useIntlTemplates = $config['use_intl_templates'] || isset($bundles['SonataIntlBundle']);
+
+        $container->setParameter('sonata.admin.configuration.use_intl_templates', $useIntlTemplates);
+
+        if ($useIntlTemplates) {
+            if ('@SonataAdmin/CRUD/history_revision_timestamp.html.twig' === $config['templates']['history_revision_timestamp']) {
+                $config['templates']['history_revision_timestamp'] = '@SonataAdmin/CRUD/Intl/history_revision_timestamp.html.twig';
+            }
         }
 
         $container->setParameter('sonata.admin.configuration.global_search.empty_boxes', $config['global_search']['empty_boxes']);

--- a/src/Resources/views/CRUD/Intl/display_currency.html.twig
+++ b/src/Resources/views/CRUD/Intl/display_currency.html.twig
@@ -1,0 +1,22 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{%- apply spaceless %}
+    {%- if value is null -%}
+        &nbsp;
+    {%- else -%}
+        {% set currency = field_description.options.currency %}
+        {% set attributes = field_description.options.attributes|default({}) %}
+        {% set locale = field_description.options.locale|default(null) %}
+
+        {{ value|format_currency(currency, attributes, locale) }}
+    {%- endif -%}
+{% endapply -%}

--- a/src/Resources/views/CRUD/Intl/display_date.html.twig
+++ b/src/Resources/views/CRUD/Intl/display_date.html.twig
@@ -1,0 +1,26 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{%- apply spaceless %}
+    {%- if value is empty -%}
+        &nbsp;
+    {%- else -%}
+        {% set pattern = field_description.options.pattern|default('') %}
+        {% set calendar = field_description.options.calendar|default('') %}
+        {% set locale = field_description.options.locale|default(null) %}
+        {% set timezone = field_description.options.timezone|default(null) %}
+        {% set dateType = field_description.options.dateType|default(null) %}
+
+        <time datetime="{{ value|date('Y-m-d', 'UTC') }}" title="{{ value|date('Y-m-d', 'UTC') }}">
+            {{ value|format_date(dateType, pattern, timezone, calendar, locale) }}
+        </time>
+    {%- endif -%}
+{% endapply -%}

--- a/src/Resources/views/CRUD/Intl/display_datetime.html.twig
+++ b/src/Resources/views/CRUD/Intl/display_datetime.html.twig
@@ -1,0 +1,27 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{%- apply spaceless %}
+    {%- if value is empty -%}
+        &nbsp;
+    {%- else -%}
+        {% set pattern = field_description.options.pattern|default('') %}
+        {% set calendar = field_description.options.calendar|default('') %}
+        {% set locale = field_description.options.locale|default(null) %}
+        {% set timezone = field_description.options.timezone|default(null) %}
+        {% set dateType = field_description.options.dateType|default(null) %}
+        {% set timeType = field_description.options.timeType|default(null) %}
+
+        <time datetime="{{ value|date('c', 'UTC') }}" title="{{ value|date('c', 'UTC') }}">
+            {{ value|format_datetime(dateType, timeType, pattern, timezone, calendar, locale) }}
+        </time>
+    {%- endif -%}
+{% endapply -%}

--- a/src/Resources/views/CRUD/Intl/display_decimal.html.twig
+++ b/src/Resources/views/CRUD/Intl/display_decimal.html.twig
@@ -1,0 +1,22 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{%- apply spaceless %}
+    {%- if value is null -%}
+        &nbsp;
+    {%- else -%}
+        {% set attributes = field_description.options.attributes|default({}) %}
+        {% set locale = field_description.options.locale|default(null) %}
+        {% set type = field_description.options.type|default('default') %}
+
+        {{ value | format_number(attributes, 'decimal', type, locale) }}
+    {%- endif -%}
+{% endapply -%}

--- a/src/Resources/views/CRUD/Intl/display_percent.html.twig
+++ b/src/Resources/views/CRUD/Intl/display_percent.html.twig
@@ -1,0 +1,22 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{%- apply spaceless %}
+    {%- if value is null -%}
+        &nbsp;
+    {%- else -%}
+        {% set attributes = field_description.options.attributes|default({}) %}
+        {% set locale = field_description.options.locale|default(null) %}
+        {% set type = field_description.options.type|default('default') %}
+
+        {{ value | format_number(attributes, 'percent', type, locale) }}
+    {%- endif -%}
+{% endapply -%}

--- a/src/Resources/views/CRUD/Intl/history_revision_timestamp.html.twig
+++ b/src/Resources/views/CRUD/Intl/history_revision_timestamp.html.twig
@@ -1,0 +1,12 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{%- include '@SonataAdmin/CRUD/Intl/display_datetime.html.twig' with { value: revision.timestamp } -%}

--- a/src/Resources/views/CRUD/Intl/list_currency.html.twig
+++ b/src/Resources/views/CRUD/Intl/list_currency.html.twig
@@ -1,0 +1,16 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends admin.getTemplate('base_list_field') %}
+
+{% block field%}
+    {%- include '@SonataAdmin/CRUD/Intl/display_currency.html.twig' -%}
+{% endblock %}

--- a/src/Resources/views/CRUD/Intl/list_date.html.twig
+++ b/src/Resources/views/CRUD/Intl/list_date.html.twig
@@ -1,0 +1,16 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends admin.getTemplate('base_list_field') %}
+
+{% block field %}
+    {%- include '@SonataAdmin/CRUD/Intl/display_date.html.twig' -%}
+{% endblock %}

--- a/src/Resources/views/CRUD/Intl/list_datetime.html.twig
+++ b/src/Resources/views/CRUD/Intl/list_datetime.html.twig
@@ -1,0 +1,16 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends admin.getTemplate('base_list_field') %}
+
+{% block field %}
+    {%- include '@SonataAdmin/CRUD/Intl/display_datetime.html.twig' -%}
+{% endblock %}

--- a/src/Resources/views/CRUD/Intl/list_decimal.html.twig
+++ b/src/Resources/views/CRUD/Intl/list_decimal.html.twig
@@ -1,0 +1,16 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends admin.getTemplate('base_list_field') %}
+
+{% block field %}
+    {%- include '@SonataAdmin/CRUD/Intl/display_decimal.html.twig' -%}
+{% endblock %}

--- a/src/Resources/views/CRUD/Intl/list_percent.html.twig
+++ b/src/Resources/views/CRUD/Intl/list_percent.html.twig
@@ -1,0 +1,16 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends admin.getTemplate('base_list_field') %}
+
+{% block field %}
+    {%- include '@SonataAdmin/CRUD/Intl/display_percent.html.twig' -%}
+{% endblock %}

--- a/src/Resources/views/CRUD/Intl/show_currency.html.twig
+++ b/src/Resources/views/CRUD/Intl/show_currency.html.twig
@@ -1,0 +1,16 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
+
+{% block field %}
+    {%- include '@SonataAdmin/CRUD/Intl/display_currency.html.twig' -%}
+{% endblock %}

--- a/src/Resources/views/CRUD/Intl/show_date.html.twig
+++ b/src/Resources/views/CRUD/Intl/show_date.html.twig
@@ -1,0 +1,16 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
+
+{% block field %}
+    {%- include '@SonataAdmin/CRUD/Intl/display_date.html.twig' -%}
+{% endblock %}

--- a/src/Resources/views/CRUD/Intl/show_datetime.html.twig
+++ b/src/Resources/views/CRUD/Intl/show_datetime.html.twig
@@ -1,0 +1,16 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
+
+{% block field %}
+    {%- include '@SonataAdmin/CRUD/Intl/display_datetime.html.twig' -%}
+{% endblock %}

--- a/src/Resources/views/CRUD/Intl/show_decimal.html.twig
+++ b/src/Resources/views/CRUD/Intl/show_decimal.html.twig
@@ -1,0 +1,16 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
+
+{% block field %}
+    {%- include '@SonataAdmin/CRUD/Intl/display_decimal.html.twig' -%}
+{% endblock %}

--- a/src/Resources/views/CRUD/Intl/show_percent.html.twig
+++ b/src/Resources/views/CRUD/Intl/show_percent.html.twig
@@ -1,0 +1,16 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
+
+{% block field %}
+    {%- include '@SonataAdmin/CRUD/Intl/display_percent.html.twig' -%}
+{% endblock %}

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -309,11 +309,11 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
 
     public function testLoadIntlTemplate(): void
     {
-        $bundlesWithSonataIntlBundle = array_merge($this->container->getParameter('kernel.bundles'), ['SonataIntlBundle' => true]);
-        $this->container->setParameter('kernel.bundles', $bundlesWithSonataIntlBundle);
-        $this->load();
+        $this->load([
+            'use_intl_templates' => true,
+        ]);
         $templates = $this->container->getParameter('sonata.admin.configuration.templates');
-        $this->assertSame('@SonataIntl/CRUD/history_revision_timestamp.html.twig', $templates['history_revision_timestamp']);
+        $this->assertSame('@SonataAdmin/CRUD/Intl/history_revision_timestamp.html.twig', $templates['history_revision_timestamp']);
     }
 
     protected function getContainerExtensions(): array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

I was in the middle of dropping support of Symfony < 4.4 and adding support of 5 in `master` branch. The problem is that SonataIntlBundle doesn't support Symfony 5 and [looks like it's not easy because of SonataUserBundle](https://github.com/sonata-project/SonataIntlBundle/pull/278).

So I decided to [remove SonataIntlBundle dependency](https://github.com/sonata-project/SonataIntlBundle/issues/280). Right now [if the bundle is enabled, it will automatically load its templates to use localized information](https://github.com/sonata-project/SonataAdminBundle/search?q=SonataIntlBundle&unscoped_q=SonataIntlBundle). I basically copied the templates and then modified them to use `twig/intl-extra` functions.

This is not finished, I have to try it, but before going further, I would like to see if that's fine.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Import templates from SonataIntlBundle
### Removed
- Dropped SonataIntlBundle
```

## To do
    
- [x] Update the tests
- [x] Update the documentation