### PR TITLE
Autocomplete customization remake

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Run PHP-CS-Fixer
-              uses: docker://oskarstark/php-cs-fixer-ga:2.17.2
+              uses: docker://oskarstark/php-cs-fixer-ga:2.18.0
               with:
                   args: --ansi --verbose --diff --dry-run
 

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -27,7 +27,7 @@ jobs:
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: 8.0
                   coverage: none
                   tools: composer:v2
 
@@ -51,7 +51,7 @@ jobs:
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: 8.0
                   coverage: none
                   tools: composer:v2
 
@@ -62,4 +62,4 @@ jobs:
                   composer-options: "--prefer-dist --prefer-stable"
 
             - name: Psalm
-              run: vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc) --shepherd --php-version=7.4
+              run: vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc) --shepherd --php-version=8.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,11 +36,11 @@ jobs:
                       dependencies: lowest
                       allowed-to-fail: false
                       variant: normal
-                    - php-version: '7.4'
+                    - php-version: '8.0'
                       dependencies: highest
                       allowed-to-fail: false
                       variant: 'symfony/symfony:"4.4.*"'
-                    - php-version: '7.4'
+                    - php-version: '8.0'
                       dependencies: highest
                       allowed-to-fail: false
                       variant: 'sonata-project/block-bundle:"3.*"'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,7 @@ jobs:
                 php-version:
                     - '7.3'
                     - '7.4'
+                    - '8.0'
                 dependencies: [highest]
                 allowed-to-fail: [false]
                 variant: [normal]
@@ -34,10 +35,6 @@ jobs:
                     - php-version: '7.3'
                       dependencies: lowest
                       allowed-to-fail: false
-                      variant: normal
-                    - php-version: '8.0'
-                      dependencies: highest
-                      allowed-to-fail: true
                       variant: normal
                     - php-version: '7.4'
                       dependencies: highest
@@ -61,10 +58,6 @@ jobs:
 
             - name: Add PHPUnit matcher
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-            - name: Configuration required for PHP 8.0
-              if: matrix.php-version == '8.0'
-              run: composer config platform.php 7.4.99
 
             - name: Install variant
               if: matrix.variant != 'normal'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.88.0](https://github.com/sonata-project/SonataAdminBundle/compare/3.87.0...3.88.0) - 2021-01-18
+### Added
+- [[#6767](https://github.com/sonata-project/SonataAdminBundle/pull/6767)] Allow PHP 8 ([@VincentLanglet](https://github.com/VincentLanglet))
+- [[#6766](https://github.com/sonata-project/SonataAdminBundle/pull/6766)] Added `Sonata\AdminBundle\Templating\MutableTemplateRegistryAwareInterface::setTemplate()` ([@wbloszyk](https://github.com/wbloszyk))
+- [[#6766](https://github.com/sonata-project/SonataAdminBundle/pull/6766)] Added `Sonata\AdminBundle\Templating\MutableTemplateRegistryAwareInterface::setTemplates()` ([@wbloszyk](https://github.com/wbloszyk))
+- [[#6769](https://github.com/sonata-project/SonataAdminBundle/pull/6769)] Translation file for `bs` (Bosnian) ([@tambait](https://github.com/tambait))
+- [[#6769](https://github.com/sonata-project/SonataAdminBundle/pull/6769)] Translation files for `sr_Latn` & `sr_Cyrl` (Serbian Latin & Cyrillic script) ([@tambait](https://github.com/tambait))
+
+### Fixed
+- [[#6772](https://github.com/sonata-project/SonataAdminBundle/pull/6772)] Fixed using admin maker command having a default controller service ([@franmomu](https://github.com/franmomu))
+
+### Removed
+- [[#6766](https://github.com/sonata-project/SonataAdminBundle/pull/6766)] Removed deprecations for `Sonata\AdminBundle\Admin\AbstractAdmin::setTemplate()` ([@wbloszyk](https://github.com/wbloszyk))
+- [[#6766](https://github.com/sonata-project/SonataAdminBundle/pull/6766)] Removed deprecations for `Sonata\AdminBundle\Admin\AbstractAdmin::setTemplates()` ([@wbloszyk](https://github.com/wbloszyk))
+
 ## [3.87.0](https://github.com/sonata-project/SonataAdminBundle/compare/3.86.0...3.87.0) - 2021-01-12
 ### Added
 - [[#6676](https://github.com/sonata-project/SonataAdminBundle/pull/6676)] Added `Sonata\AdminBundle\Twig\Extension\SecurityExtension` ([@tambait](https://github.com/tambait))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,7 +289,7 @@ The `NEXT_MAJOR` tag SHOULD also be used for deprecations, it will be searched f
 You have three ways to deprecate things.
 
 For class definitions and properties, use the `@deprecated` tag.
-For methods, use the `@deprecated` tag and trigger a deprecation with `@trigger_error('...', E_USER_DEPRECATED)`:
+For methods, use the `@deprecated` tag and trigger a deprecation with `@trigger_error('...', \E_USER_DEPRECATED)`:
 
 ```php
 /**
@@ -320,7 +320,7 @@ final class StillUsedClass
         @trigger_error(sprintf(
             'Method %s() is deprecated since sonata-project/foo-lib 42.x and will be removed in version 43.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         echo "But this is not Gotham here.";
     }
@@ -348,7 +348,7 @@ you **MUST** still trigger a deprecation message (and add a `NEXT_MAJOR` comment
 if (/* some condition showing the user is using the legacy way */) {
     @trigger_error(
         'This is deprecated since sonata-project/bar-bundle 42.x and will not be supported in version 43.0.',
-        E_USER_DEPRECATED
+        \E_USER_DEPRECATED
     );
 } else {
     // new way of doing things

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "symfony/browser-kit": "^4.4 || ^5.1",
         "symfony/css-selector": "^4.4 || ^5.1",
         "symfony/filesystem": "^4.4 || ^5.1",
-        "symfony/maker-bundle": "^1.17",
+        "symfony/maker-bundle": "^1.25",
         "symfony/phpunit-bridge": "^5.1.8",
         "symfony/yaml": "^4.4 || ^5.1",
         "vimeo/psalm": "^4.3.2"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "doctrine/collections": "^1.6",
         "doctrine/common": "^2.7 || ^3.0",

--- a/src/Action/GetShortObjectDescriptionAction.php
+++ b/src/Action/GetShortObjectDescriptionAction.php
@@ -67,7 +67,7 @@ final class GetShortObjectDescriptionAction
             @trigger_error(
                 'Trying to get a short object description for a non found object is deprecated'
                 .' since sonata-project/admin-bundle 3.76 and will be throw a 404 in version 4.0.',
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
             //throw new NotFoundHttpException(sprintf('Could not find subject for id "%s"', $objectId));
 

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -68,7 +68,7 @@ final class RetrieveAutocompleteItemsAction
             $reqParamPageNumber = $filterAutocomplete->getFieldOption('req_param_name_page_number', '_page');
             $toStringCallback = $filterAutocomplete->getFieldOption('to_string_callback');
             $targetAdminAccessAction = $filterAutocomplete->getFieldOption('target_admin_access_action', 'list');
-            $resultItemCallback = $filterAutocomplete->getFieldOption('response_item_callback');
+            $responseItemCallback = $filterAutocomplete->getFieldOption('response_item_callback');
         } else {
             // create/edit form
             $fieldDescription = $this->retrieveFormFieldDescription($admin, $request->get('field'));

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -156,7 +156,7 @@ final class RetrieveAutocompleteItemsAction
             @trigger_error(sprintf(
                 'Not implementing "%s::getCurrentPageResults()" is deprecated since sonata-project/admin-bundle 3.87 and will fail in 4.0.',
                 PagerInterface::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             $results = $pager->getResults();
         }

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -68,7 +68,7 @@ final class RetrieveAutocompleteItemsAction
             $reqParamPageNumber = $filterAutocomplete->getFieldOption('req_param_name_page_number', '_page');
             $toStringCallback = $filterAutocomplete->getFieldOption('to_string_callback');
             $targetAdminAccessAction = $filterAutocomplete->getFieldOption('target_admin_access_action', 'list');
-            $responseItemCallback = $filterAutocomplete->getFieldOption('response_item_callback');
+            $resultItemCallback = $filterAutocomplete->getFieldOption('response_item_callback');
         } else {
             // create/edit form
             $fieldDescription = $this->retrieveFormFieldDescription($admin, $request->get('field'));
@@ -88,7 +88,7 @@ final class RetrieveAutocompleteItemsAction
             $reqParamPageNumber = $formAutocompleteConfig->getAttribute('req_param_name_page_number');
             $toStringCallback = $formAutocompleteConfig->getAttribute('to_string_callback');
             $targetAdminAccessAction = $formAutocompleteConfig->getAttribute('target_admin_access_action');
-            $responseItemCallback = $formAutocompleteConfig->getAttribute('response_item_callback');
+            $resultItemCallback = $formAutocompleteConfig->getAttribute('response_item_callback');
         }
 
         $searchText = $request->get('q', '');

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -88,7 +88,7 @@ final class RetrieveAutocompleteItemsAction
             $reqParamPageNumber = $formAutocompleteConfig->getAttribute('req_param_name_page_number');
             $toStringCallback = $formAutocompleteConfig->getAttribute('to_string_callback');
             $targetAdminAccessAction = $formAutocompleteConfig->getAttribute('target_admin_access_action');
-            $resultItemCallback = $formAutocompleteConfig->getAttribute('response_item_callback');
+            $responseItemCallback = $formAutocompleteConfig->getAttribute('response_item_callback');
         }
 
         $searchText = $request->get('q', '');
@@ -175,12 +175,12 @@ final class RetrieveAutocompleteItemsAction
             }
 
             $item = [
-                'id'    => $admin->id($model),
+                'id' => $admin->id($model),
                 'label' => $label,
             ];
 
             if (\is_callable($responseItemCallback)) {
-                \call_user_func($responseItemCallback, $admin, $entity, $item);
+                \call_user_func($responseItemCallback, $admin, $model, $item);
             }
 
             $items[] = $item;

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -105,7 +105,6 @@ final class RetrieveAutocompleteItemsAction
 
         $targetAdmin->setFilterPersister(null);
         $datagrid = $targetAdmin->getDatagrid();
-        $this->clearDatagridFilters($datagrid);
 
         if (null !== $callback) {
             if (!\is_callable($callback)) {
@@ -251,15 +250,5 @@ final class RetrieveAutocompleteItemsAction
         }
 
         return $fieldDescription;
-    }
-
-    /**
-     * @param DatagridInterface $datagrid
-     */
-    private function clearDatagridFilters(DatagridInterface $datagrid)
-    {
-        foreach ($datagrid->getFilters() as $filter) {
-            $datagrid->setValue($filter->getName(), null, null);
-        }
     }
 }

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -17,7 +17,6 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
-use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -180,8 +179,8 @@ final class RetrieveAutocompleteItemsAction
                 'label' => $label,
             ];
 
-            if (is_callable($resultItemCallback)) {
-                call_user_func($resultItemCallback, $admin, $entity, $item);
+            if (\is_callable($resultItemCallback)) {
+                \call_user_func($resultItemCallback, $admin, $entity, $item);
             }
 
             $items[] = $item;

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -68,7 +68,7 @@ final class RetrieveAutocompleteItemsAction
             $reqParamPageNumber = $filterAutocomplete->getFieldOption('req_param_name_page_number', '_page');
             $toStringCallback = $filterAutocomplete->getFieldOption('to_string_callback');
             $targetAdminAccessAction = $filterAutocomplete->getFieldOption('target_admin_access_action', 'list');
-            $resultItemCallback = $filterAutocomplete->getFieldOption('response_item_callback');
+            $responseItemCallback = $filterAutocomplete->getFieldOption('response_item_callback');
         } else {
             // create/edit form
             $fieldDescription = $this->retrieveFormFieldDescription($admin, $request->get('field'));
@@ -88,7 +88,7 @@ final class RetrieveAutocompleteItemsAction
             $reqParamPageNumber = $formAutocompleteConfig->getAttribute('req_param_name_page_number');
             $toStringCallback = $formAutocompleteConfig->getAttribute('to_string_callback');
             $targetAdminAccessAction = $formAutocompleteConfig->getAttribute('target_admin_access_action');
-            $resultItemCallback = $formAutocompleteConfig->getAttribute('response_item_callback');
+            $responseItemCallback = $formAutocompleteConfig->getAttribute('response_item_callback');
         }
 
         $searchText = $request->get('q', '');
@@ -179,8 +179,8 @@ final class RetrieveAutocompleteItemsAction
                 'label' => $label,
             ];
 
-            if (\is_callable($resultItemCallback)) {
-                \call_user_func($resultItemCallback, $admin, $entity, $item);
+            if (\is_callable($responseItemCallback)) {
+                \call_user_func($responseItemCallback, $admin, $entity, $item);
             }
 
             $items[] = $item;

--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -114,7 +114,7 @@ final class SearchAction
                 @trigger_error(sprintf(
                     'Not implementing "%s::getCurrentPageResults()" is deprecated since sonata-project/admin-bundle 3.87 and will fail in 4.0.',
                     PagerInterface::class
-                ), E_USER_DEPRECATED);
+                ), \E_USER_DEPRECATED);
 
                 $pageResults = $pager->getResults();
             }
@@ -135,7 +135,7 @@ final class SearchAction
                 @trigger_error(sprintf(
                     'Not implementing "%s::countResults()" is deprecated since sonata-project/admin-bundle 3.86 and will fail in 4.0.',
                     'Sonata\AdminBundle\Datagrid\PagerInterface'
-                ), E_USER_DEPRECATED);
+                ), \E_USER_DEPRECATED);
                 $total = (int) $pager->getNbResults();
             }
         }

--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -84,7 +84,7 @@ final class SetObjectFieldValueAction
                 DataTransformerResolverInterface::class,
                 __METHOD__,
                 \TypeError::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             $resolver = new DataTransformerResolver();
         }
 
@@ -95,7 +95,7 @@ final class SetObjectFieldValueAction
                 .' 3.82 and will throw a \TypeError error in version 4.0. You must pass an instance of %s instead.',
                 __METHOD__,
                 PropertyAccessorInterface::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             $propertyAccessor = $pool->getPropertyAccessor();
         }

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -506,7 +506,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             .' and won\'t be possible in 4.0.',
             __METHOD__,
             DataSourceInterface::class
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->getModelManager()->getDataSourceIterator($datagrid, $fields);
     }
@@ -520,7 +520,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             @trigger_error(sprintf(
                 'The %s method is deprecated since version 3.82 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
     }
 
@@ -626,7 +626,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             @trigger_error(sprintf(
                 'The %s method is deprecated since version 3.82 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
     }
 
@@ -819,7 +819,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             @trigger_error(sprintf(
                 'Calling "%s" when $this->parentAssociationMapping is string is deprecated since sonata-project/admin-bundle 3.75 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $this->parentAssociationMapping[$code] = $value;
@@ -989,7 +989,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         @trigger_error(sprintf(
             'Method "%s" is deprecated since sonata-project/admin-bundle 3.30 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (!\in_array($subClass, $this->subClasses, true)) {
             $this->subClasses[] = $subClass;
@@ -1024,7 +1024,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 .' Use %s::hasActiveSubClass() to know if there is an active subclass.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare string as return type
             // throw new \LogicException(sprintf(
             //    'Admin "%s" has no active subclass.',
@@ -1046,7 +1046,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 .' Use %s::hasActiveSubClass() to know if there is an active subclass.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare string as return type
             // throw new \LogicException(sprintf(
             //    'Admin "%s" has no active subclass.',
@@ -1065,7 +1065,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 .' Use %s::hasActiveSubClass() to know if there is an active subclass.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare string as return type
             // throw new \LogicException(sprintf(
             //    'Admin "%s" has no active subclass.',
@@ -1272,7 +1272,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 .' and will throw an exception in 4.0. Use %s::setSubject() to set the subject.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             // NEXT_MAJOR : remove the previous `trigger_error()` call and uncomment the following exception
             // throw new \LogicException(sprintf(
             //    'Admin "%s" has no subject.',
@@ -1377,7 +1377,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             @trigger_error(sprintf(
                 'The $context argument of %s is deprecated since 3.3, to be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $query = $this->getModelManager()->createQuery($this->getClass());
@@ -1492,7 +1492,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         @trigger_error(sprintf(
             'The %s method is deprecated since version 3.34 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $this->persistFilters = $persist;
     }
@@ -1509,7 +1509,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         @trigger_error(sprintf(
             'The method %s is deprecated since sonata-project/admin-bundle 3.67 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $this->maxPerPage = $maxPerPage;
     }
@@ -1549,7 +1549,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 'Returning other type than array in method %s() is deprecated since sonata-project/admin-bundle 3.65.'
                 .' It will return only array in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         return $this->formGroups;
@@ -1589,7 +1589,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 'Returning other type than array in method %s() is deprecated since sonata-project/admin-bundle 3.65.'
                 .' It will return only array in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         return $this->formTabs;
@@ -1607,7 +1607,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 'Returning other type than array in method %s() is deprecated since sonata-project/admin-bundle 3.65.'
                 .' It will return only array in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         return $this->showTabs;
@@ -1625,7 +1625,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 'Returning other type than array in method %s() is deprecated since sonata-project/admin-bundle 3.65.'
                 .' It will return only array in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         return $this->showGroups;
@@ -1658,7 +1658,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 .' Use %s::hasParentFieldDescription() to know if there is a parent field description.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare FieldDescriptionInterface as return type
             // throw new \LogicException(sprintf(
             //    'Admin "%s" has no parent field description.',
@@ -1686,7 +1686,7 @@ This is deprecated since 3.5 and will no longer be supported in 4.0.
 EOT;
 
             // NEXT_MAJOR : throw an exception instead
-            @trigger_error(sprintf($message, \get_class($subject), $this->getClass()), E_USER_DEPRECATED);
+            @trigger_error(sprintf($message, \get_class($subject), $this->getClass()), \E_USER_DEPRECATED);
         }
 
         $this->subject = $subject;
@@ -1700,7 +1700,7 @@ EOT;
                 .' and will throw an exception in 4.0. Use %s::hasSubject() to know if there is a subject.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and update the return type
             // throw new \LogicException(sprintf(
             //    'Admin "%s" has no subject.',
@@ -1744,7 +1744,7 @@ EOT;
                 .' Use %s::hasFormFieldDescription() to know if there is a form field description.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare FieldDescriptionInterface as return type
             // throw new \LogicException(sprintf(
             //    'Admin "%s" has no form field description for the field %s.',
@@ -1817,7 +1817,7 @@ EOT;
                 .' Use %s::hasFormFieldDescription() to know if there is a show field description.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare FieldDescriptionInterface as return type
             // throw new \LogicException(sprintf(
             //    'Admin "%s" has no show field description for the field %s.',
@@ -1867,7 +1867,7 @@ EOT;
                 __METHOD__,
                 __CLASS__,
                 $name
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare FieldDescriptionInterface as return type
             // throw new \LogicException(sprintf(
             //    'Admin "%s" has no list field description for %s.',
@@ -1909,7 +1909,7 @@ EOT;
                 .' Use %s::hasFilterFieldDescription() to know if there is a filter field description.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare FieldDescriptionInterface as return type
             // throw new \LogicException(sprintf(
             //    'Admin "%s" has no filter field description for the field %s.',
@@ -1975,7 +1975,7 @@ EOT;
         } else {
             @trigger_error(
                 'Calling "addChild" without second argument is deprecated since sonata-project/admin-bundle 3.35 and will not be allowed in 4.0.',
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
         }
     }
@@ -1998,7 +1998,7 @@ EOT;
                 .' and will throw an exception in 4.0. Use %s::hasChild() to know if the child exists.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare AdminInterface as return type
             // throw new \LogicException(sprintf(
             //    'Admin "%s" has no child for the code %s.',
@@ -2025,7 +2025,7 @@ EOT;
                 .' and will throw an exception in 4.0. Use %s::isChild() to know if there is a parent.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare AdminInterface as return type
             // throw new \LogicException(sprintf(
             //    'Admin "%s" has no parent.',
@@ -2119,7 +2119,7 @@ EOT;
                 'Calling %s() when no classname label is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no classname label. Did you forgot to initialize the admin ?',
 //                static::class
@@ -2168,7 +2168,7 @@ EOT;
             .' Use %s::getBreadcrumbs instead.',
             __METHOD__,
             BreadcrumbsBuilder::class
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->getBreadcrumbsBuilder()->getBreadcrumbs($this, $action);
     }
@@ -2187,7 +2187,7 @@ EOT;
         @trigger_error(sprintf(
             'The %s method is deprecated since version 3.2 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (isset($this->breadcrumbs[$action])) {
             return $this->breadcrumbs[$action];
@@ -2208,7 +2208,7 @@ EOT;
             'The %s method is deprecated since version 3.2 and will be removed in 4.0.'
             .' Use the sonata.admin.breadcrumbs_builder service instead.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
         if (null === $this->breadcrumbsBuilder) {
             $this->breadcrumbsBuilder = new BreadcrumbsBuilder(
                 $this->getConfigurationPool()->getContainer('sonata_deprecation_mute')->getParameter('sonata.admin.configuration.breadcrumbs')
@@ -2229,7 +2229,7 @@ EOT;
             'The %s method is deprecated since version 3.2 and will be removed in 4.0.'
             .' Use the sonata.admin.breadcrumbs_builder service instead.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
         $this->breadcrumbsBuilder = $value;
 
         return $this;
@@ -2252,7 +2252,7 @@ EOT;
             .' Use %s::isCurrentChild() instead.',
             __METHOD__,
             __CLASS__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->currentChild;
     }
@@ -2290,7 +2290,7 @@ EOT;
         @trigger_error(sprintf(
             'The %s method is deprecated since version 3.9 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $domain = $domain ?: $this->getTranslationDomain();
 
@@ -2316,7 +2316,7 @@ EOT;
         @trigger_error(sprintf(
             'The %s method is deprecated since version 3.9 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $domain = $domain ?: $this->getTranslationDomain();
 
@@ -2379,7 +2379,7 @@ EOT;
         @trigger_error(sprintf(
             'The %s is deprecated since 3.24 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $this->baseCodeRoute = $baseCodeRoute;
     }
@@ -2507,7 +2507,7 @@ EOT;
                 .' Only object will be allowed in version 4.0.',
                 \gettype($object),
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             return '';
         }
@@ -2536,7 +2536,7 @@ EOT;
         @trigger_error(sprintf(
             'The method %s is deprecated since sonata-project/admin-bundle 3.67 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $this->perPageOptions = $options;
     }
@@ -2826,7 +2826,7 @@ EOT;
         @trigger_error(sprintf(
             'Method "%s" is deprecated since sonata-project/admin-bundle 3.76.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $filter = $this->getFilterParameters();
         $default = $this->getDefaultFilterValues();
@@ -2870,7 +2870,7 @@ EOT;
                 .' Use %s::hasTemplateRegistry() to know if the template registry is set.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
         //if (false === $this->hasTemplateRegistry()) {
         //    throw new \LogicException(sprintf('Unable to find the template registry for admin `%s`.', static::class));
@@ -3128,7 +3128,7 @@ EOT;
             @trigger_error(sprintf(
                 'The %s method is deprecated since version 3.82 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $admin = $this;

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -828,7 +828,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     /**
      * Returns the baseRoutePattern used to generate the routing information.
      *
-     * @throws \RuntimeException
+     * @throws \RuntimeException // NEXT_MAJOR: Remove this tag
      *
      * @return string the baseRoutePattern used to generate the routing information
      */
@@ -844,6 +844,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 preg_match(self::CLASS_REGEX, $this->class, $matches);
 
                 if (!$matches) {
+                    // NEXT_MAJOR: Throw \LogicException instead
                     throw new \RuntimeException(sprintf(
                         'Please define a default `baseRoutePattern` value for the admin class `%s`',
                         static::class
@@ -864,6 +865,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             preg_match(self::CLASS_REGEX, $this->class, $matches);
 
             if (!$matches) {
+                // NEXT_MAJOR: Throw \LogicException instead
                 throw new \RuntimeException(sprintf(
                     'Please define a default `baseRoutePattern` value for the admin class `%s`',
                     static::class
@@ -884,7 +886,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     /**
      * Returns the baseRouteName used to generate the routing information.
      *
-     * @throws \RuntimeException
+     * @throws \RuntimeException // NEXT_MAJOR: Remove this tag
      *
      * @return string the baseRouteName used to generate the routing information
      */
@@ -900,6 +902,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 preg_match(self::CLASS_REGEX, $this->class, $matches);
 
                 if (!$matches) {
+                    // NEXT_MAJOR: Throw \LogicException instead
                     throw new \RuntimeException(sprintf(
                         'Cannot automatically determine base route name,'
                         .' please define a default `baseRouteName` value for the admin class `%s`',
@@ -920,6 +923,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             preg_match(self::CLASS_REGEX, $this->class, $matches);
 
             if (!$matches) {
+                // NEXT_MAJOR: Throw \LogicException instead
                 throw new \RuntimeException(sprintf(
                     'Cannot automatically determine base route name,'
                     .' please define a default `baseRouteName` value for the admin class `%s`',
@@ -955,12 +959,14 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     {
         if ($this->hasActiveSubClass()) {
             if ($this->hasParentFieldDescription()) {
+                // NEXT_MAJOR: Throw \LogicException instead
                 throw new \RuntimeException('Feature not implemented: an embedded admin cannot have subclass');
             }
 
             $subClass = $this->getRequest()->query->get('subclass');
 
             if (!$this->hasSubClass($subClass)) {
+                // NEXT_MAJOR: Throw \LogicException instead
                 throw new \RuntimeException(sprintf('Subclass "%s" is not defined.', $subClass));
             }
 
@@ -1955,6 +1961,7 @@ EOT;
         }
 
         if ($parentAdmin->getCode() === $child->getCode()) {
+            // NEXT_MAJOR: Throw \LogicException instead
             throw new \RuntimeException(sprintf(
                 'Circular reference detected! The child admin `%s` is already in the parent tree of the `%s` admin.',
                 $child->getCode(),
@@ -2136,6 +2143,7 @@ EOT;
         foreach ($this->getExtensions() as $extension) {
             $params = $extension->getPersistentParameters($this);
 
+            // NEXT_MAJOR: Remove this check, since return typehint is added
             if (!\is_array($params)) {
                 throw new \RuntimeException(sprintf(
                     'The %s::getPersistentParameters must return an array',
@@ -2583,10 +2591,6 @@ EOT;
 
     public function setListMode($mode)
     {
-        if (!$this->hasRequest()) {
-            throw new \RuntimeException(sprintf('No request attached to the current admin: %s', $this->getCode()));
-        }
-
         $this->getRequest()->getSession()->set(sprintf('%s.list_mode', $this->getCode()), $mode);
     }
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1195,11 +1195,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         $this->templateRegistry = $templateRegistry;
     }
 
-    /**
-     * @deprecated since sonata-project/admin-bundle 3.76, will be dropped in 4.0. Use TemplateRegistry services instead
-     *
-     * @param array<string, string> $templates
-     */
     public function setTemplates(array $templates)
     {
         // NEXT_MAJOR: Remove this line
@@ -1208,12 +1203,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         $this->getTemplateRegistry()->setTemplates($templates);
     }
 
-    /**
-     * @deprecated since sonata-project/admin-bundle 3.76, will be dropped in 4.0. Use TemplateRegistry services instead
-     *
-     * @param string $name
-     * @param string $template
-     */
     public function setTemplate($name, $template)
     {
         // NEXT_MAJOR: Remove this line

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -70,7 +70,7 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
             @trigger_error(sprintf(
                 'The %s method is deprecated since version 3.82 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
     }
 

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -16,7 +16,7 @@ namespace Sonata\AdminBundle\Admin;
 @trigger_error(sprintf(
     'The %1$s\Admin class is deprecated since version 3.1 and will be removed in 4.0. Use %1$s\AbstractAdmin instead.',
     __NAMESPACE__
-), E_USER_DEPRECATED);
+), \E_USER_DEPRECATED);
 
 /**
  * NEXT_MAJOR: remove this class.

--- a/src/Admin/AdminExtension.php
+++ b/src/Admin/AdminExtension.php
@@ -17,7 +17,7 @@ namespace Sonata\AdminBundle\Admin;
     'The %1$s\AdminExtension class is deprecated since version 3.1 and will be removed in 4.0.'
     .' Use %1$s\AbstractAdminExtension instead.',
     __NAMESPACE__
-), E_USER_DEPRECATED);
+), \E_USER_DEPRECATED);
 
 /**
  * NEXT_MAJOR: remove this class.

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -76,7 +76,7 @@ class AdminHelper
                 Pool::class,
                 __METHOD__,
                 PropertyAccessorInterface::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             $this->pool = $poolOrPropertyAccessor;
             $this->propertyAccessor = $poolOrPropertyAccessor->getPropertyAccessor();
@@ -294,7 +294,7 @@ class AdminHelper
             .' Use %s::addInstance() instead.',
             __METHOD__,
             ObjectManipulator::class
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $instance = $fieldDescription->getAssociationAdmin()->getNewInstance();
 
@@ -320,7 +320,7 @@ class AdminHelper
             'The %s method is deprecated since 3.1 and will be removed in 4.0. Use %s::classify() instead.',
             __METHOD__,
             Inflector::class
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return InflectorFactory::create()->build()->classify($property);
     }
@@ -391,7 +391,7 @@ class AdminHelper
                 .' Use %s::getModelClassName() instead.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $element = array_shift($elements);

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -153,7 +153,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
                 'Omitting the argument 1 for "%s()" or passing other type than "string" is deprecated'.
                 ' since sonata-project/admin-bundle 3.78. It will accept only string in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         } else {
             $this->setName($name);
 
@@ -197,7 +197,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
                 'The %s() method is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will become private in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $this->fieldName = $fieldName;
@@ -255,7 +255,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
                 .' and the option will be removed in 4.0.'
                 .' Use Symfony Form "help" option instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             $this->setHelp($options['help'], 'sonata_deprecation_mute');
             unset($options['help']);
@@ -290,7 +290,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
                 'Returning other type than string or null in method %s() is deprecated since'
                 .' sonata-project/admin-bundle 3.65. It will return only those types in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         return $this->template;
@@ -321,7 +321,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
                     __METHOD__,
                     __CLASS__
                 ),
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
             // NEXT_MAJOR : remove the previous `trigger_error()` call, uncomment the following exception and declare AdminInterface as return type
             // throw new \LogicException(sprintf('%s has no parent.', static::class));
@@ -367,7 +367,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
                     __METHOD__,
                     __CLASS__
                 ),
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
             // NEXT_MAJOR : remove the previous `trigger_error()` call, uncomment the following exception and declare AdminInterface as return type
             // throw new \LogicException(sprintf('%s has no association admin.', static::class));
@@ -483,7 +483,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
                     __METHOD__,
                     __CLASS__
                 ),
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
             // NEXT_MAJOR : remove the previous `trigger_error()` call, uncomment the following exception and declare AdminInterface as return type
             // throw new \LogicException(sprintf('%s has no admin.', static::class));
@@ -525,7 +525,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         @trigger_error(sprintf(
             'The "%s()" method is deprecated since version 3.83 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $this->mappingType = $mappingType;
     }
@@ -554,7 +554,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
             'The %s method is deprecated since 3.1 and will be removed in 4.0. Use %s::classify() instead.',
             __METHOD__,
             Inflector::class
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return InflectorFactory::create()->build()->classify($property);
     }
@@ -575,7 +575,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
                 'The "%s()" method is deprecated since sonata-project/admin-bundle 3.74 and will be removed in version 4.0.'
                 .' Use Symfony Form "help" option instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $this->help = $help;
@@ -595,7 +595,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
                 'The "%s()" method is deprecated since sonata-project/admin-bundle 3.74 and will be removed in version 4.0.'
                 .' Use Symfony Form "help" option instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         return $this->help;
@@ -609,7 +609,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
                 'Returning other type than string, false or null in method %s() is deprecated since'
                 .' sonata-project/admin-bundle 3.65. It will return only those types in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         return $label;

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -155,7 +155,7 @@ class Pool
                 .' sonata-project/admin-bundle 3.86 and will throw "%s" exception in 4.0.',
                 __METHOD__,
                 \TypeError::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             $this->title = $titleOrAdminServiceIds;
         }
@@ -169,7 +169,7 @@ class Pool
                 .' sonata-project/admin-bundle 3.86 and will throw "%s" exception in 4.0.',
                 __METHOD__,
                 \TypeError::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             $this->titleLogo = $logoTitleOrAdminGroups;
         }
@@ -187,7 +187,7 @@ class Pool
                 'Passing an "%s" instance as argument 4 to "%s()" is deprecated since sonata-project/admin-bundle 3.82.',
                 PropertyAccessorInterface::class,
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         // NEXT_MAJOR: Remove next line.
@@ -218,7 +218,7 @@ class Pool
         @trigger_error(sprintf(
             'Method "%s()" is deprecated since sonata-project/admin-bundle 3.83 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $groups = $this->adminGroups;
 
@@ -247,7 +247,7 @@ class Pool
         @trigger_error(sprintf(
             'Method "%s()" is deprecated since sonata-project/admin-bundle 3.83 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return isset($this->adminGroups[$group]);
     }
@@ -313,7 +313,7 @@ class Pool
         @trigger_error(sprintf(
             'Method "%s()" is deprecated since sonata-project/admin-bundle 3.83 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (!isset($this->adminGroups[$group])) {
             throw new \InvalidArgumentException(sprintf('Group "%s" not found in admin pool.', $group));
@@ -354,7 +354,7 @@ class Pool
                 __METHOD__,
                 $class,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement,
             // uncomment the following exception and declare AdminInterface as return type
@@ -417,7 +417,7 @@ class Pool
                 .' sonata-project/admin-bundle 3.51 and will cause a %s in 4.0.',
                 __METHOD__,
                 \TypeError::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             return false;
 
@@ -441,7 +441,7 @@ class Pool
                     'Passing an invalid admin code as argument 1 for %s() is deprecated since'
                     .' sonata-project/admin-bundle 3.50 and will throw an exception in 4.0.',
                     __METHOD__
-                ), E_USER_DEPRECATED);
+                ), \E_USER_DEPRECATED);
 
                 // NEXT_MAJOR : throw `\InvalidArgumentException` instead
             }
@@ -451,7 +451,7 @@ class Pool
                     'Passing an invalid admin hierarchy inside argument 1 for %s() is deprecated since'
                     .' sonata-project/admin-bundle 3.51 and will throw an exception in 4.0.',
                     __METHOD__
-                ), E_USER_DEPRECATED);
+                ), \E_USER_DEPRECATED);
 
                 // NEXT_MAJOR : remove the previous `trigger_error()` call, uncomment the following exception and declare AdminInterface as return type
                 // throw new \InvalidArgumentException(sprintf(
@@ -549,7 +549,7 @@ class Pool
             @trigger_error(sprintf(
                 'Method "%s()" is deprecated since sonata-project/admin-bundle 3.77 and will be removed in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         return $this->container;
@@ -572,7 +572,7 @@ class Pool
             @trigger_error(sprintf(
                 'Method "%s()" is deprecated since sonata-project/admin-bundle 3.86 and will be removed in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $this->adminGroups = $adminGroups;
@@ -600,7 +600,7 @@ class Pool
             @trigger_error(sprintf(
                 'Method "%s()" is deprecated since sonata-project/admin-bundle 3.86 and will be removed in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $this->adminServiceIds = $adminServiceIds;
@@ -632,7 +632,7 @@ class Pool
             @trigger_error(sprintf(
                 'Method "%s()" is deprecated since sonata-project/admin-bundle 3.86 and will be removed in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $this->adminClasses = $adminClasses;
@@ -705,7 +705,7 @@ class Pool
             .' Use "%s::getLogo()" instead.',
             __METHOD__,
             SonataConfiguration::class
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->titleLogo;
     }
@@ -724,7 +724,7 @@ class Pool
             .' Use "%s::getTitle()" instead.',
             __METHOD__,
             SonataConfiguration::class
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->title;
     }
@@ -746,7 +746,7 @@ class Pool
             .' Use "%s::getOption()" instead.',
             __METHOD__,
             SonataConfiguration::class
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (isset($this->options[$name])) {
             return $this->options[$name];
@@ -763,7 +763,7 @@ class Pool
         @trigger_error(sprintf(
             'The "%s" method is deprecated since version 3.82 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (null === $this->propertyAccessor) {
             $this->propertyAccessor = PropertyAccess::createPropertyAccessor();

--- a/src/Block/AdminListBlockService.php
+++ b/src/Block/AdminListBlockService.php
@@ -83,7 +83,7 @@ class AdminListBlockService extends AbstractBlockService
                 null === $poolOrTemplating ? 'null' : EngineInterface::class,
                 __METHOD__,
                 Pool::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             if (!$templateRegistryOrPool instanceof Pool) {
                 throw new \TypeError(sprintf(

--- a/src/Block/AdminSearchBlockService.php
+++ b/src/Block/AdminSearchBlockService.php
@@ -89,7 +89,7 @@ class AdminSearchBlockService extends AbstractBlockService
                     'Not passing a string as argument 4 to %s() is deprecated since sonata-project/admin-bundle 3.81'
                     .' and will throw a \TypeError in version 4.0.',
                     __METHOD__
-                ), E_USER_DEPRECATED);
+                ), \E_USER_DEPRECATED);
             }
 
             $this->pool = $poolOrTemplating;
@@ -102,7 +102,7 @@ class AdminSearchBlockService extends AbstractBlockService
                 null === $poolOrTemplating ? 'null' : EngineInterface::class,
                 __METHOD__,
                 Pool::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             if (!$searchHandlerOrPool instanceof Pool) {
                 throw new \TypeError(sprintf(

--- a/src/Block/AdminStatsBlockService.php
+++ b/src/Block/AdminStatsBlockService.php
@@ -61,7 +61,7 @@ class AdminStatsBlockService extends AbstractBlockService
                 null === $poolOrTemplating ? 'null' : EngineInterface::class,
                 __METHOD__,
                 Pool::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             if (null === $pool) {
                 throw new \TypeError(sprintf(

--- a/src/Command/CreateClassCacheCommand.php
+++ b/src/Command/CreateClassCacheCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 @trigger_error(sprintf(
     'The %s\CreateClassCacheCommand class is deprecated since version 3.39.0 and will be removed in 4.0.',
     __NAMESPACE__
-), E_USER_DEPRECATED);
+), \E_USER_DEPRECATED);
 
 /**
  * NEXT_MAJOR: Remove this class.

--- a/src/Command/GenerateObjectAclCommand.php
+++ b/src/Command/GenerateObjectAclCommand.php
@@ -71,7 +71,7 @@ class GenerateObjectAclCommand extends QuestionableCommand
             @trigger_error(sprintf(
                 'Passing a third argument to %s() is deprecated since sonata-project/admin-bundle 3.77.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             if (!$registry instanceof RegistryInterface && !$registry instanceof ManagerRegistry) {
                 throw new \TypeError(sprintf(
@@ -196,7 +196,7 @@ class GenerateObjectAclCommand extends QuestionableCommand
             @trigger_error(
                 'Option "user_entity" is deprecated since sonata-project/admin-bundle 3.69 and will be removed in version 4.0.'
                 .' Use "user_model" option instead.',
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
 
             if (null === $input->getOption('user_model')) {
@@ -225,7 +225,7 @@ class GenerateObjectAclCommand extends QuestionableCommand
                 .' Use %s::getUserModelClass() instead.',
                 __METHOD__,
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         if ('' === $this->userEntityClass) {
@@ -247,7 +247,7 @@ class GenerateObjectAclCommand extends QuestionableCommand
                     .' sonata-project/admin-bundle 3.77 and will throw an exception in 4.0.'
                     .' Pass a fully qualified class name instead (e.g. App\Model\User).',
                     $userModelFromInput
-                ), E_USER_DEPRECATED);
+                ), \E_USER_DEPRECATED);
 
 //                throw new \InvalidArgumentException(sprintf(
 //                    'The "user_model" name be a fully qualified class name'

--- a/src/Command/Validators.php
+++ b/src/Command/Validators.php
@@ -59,7 +59,7 @@ class Validators
             'Method "%s()" is deprecated since sonata-project/admin-bundle 3.78'
             .' and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $model = str_replace('/', '\\', $shortcut);
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -105,7 +105,7 @@ class CRUDController implements ContainerAwareInterface
         @trigger_error(sprintf(
             'Method %1$s::render has been renamed to %1$s::renderWithExtraParams.',
             __CLASS__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->renderWithExtraParams($view, $parameters, $response);
     }
@@ -296,7 +296,7 @@ class CRUDController implements ContainerAwareInterface
                 .' sonata-project/admin-bundle 3.62 and will be removed in 4.0,'
                 .' use `AdminInterface::getIdParameter()` instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         // the key used to lookup the template
@@ -465,7 +465,7 @@ class CRUDController implements ContainerAwareInterface
                 'Override %1$s::getBatchActions method is deprecated since version 3.2.'
                 .' Use %1$s::configureBatchActions instead. The method will be final in 4.0.',
                 AbstractAdmin::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
         $batchActions = $this->admin->getBatchActions();
         if (!\array_key_exists($action, $batchActions)) {
@@ -687,7 +687,7 @@ class CRUDController implements ContainerAwareInterface
                 .' sonata-project/admin-bundle 3.62 and will be removed in 4.0,'
                 .' use `AdminInterface::getIdParameter()` instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $request = $this->getRequest();
@@ -741,7 +741,7 @@ class CRUDController implements ContainerAwareInterface
                 .' sonata-project/admin-bundle 3.62 and will be removed in 4.0,'
                 .' use `AdminInterface::getIdParameter()` instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $request = $this->getRequest();
@@ -927,7 +927,7 @@ class CRUDController implements ContainerAwareInterface
         if (!$this->has('sonata.admin.admin_exporter')) {
             @trigger_error(
                 'Not registering the exporter bundle is deprecated since version 3.14. You must register it to be able to use the export action in 4.0.',
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
             $allowedExportFormats = (array) $this->admin->getExportFormats();
 
@@ -980,7 +980,7 @@ class CRUDController implements ContainerAwareInterface
                 .' sonata-project/admin-bundle 3.62 and will be removed in 4.0,'
                 .' use `AdminInterface::getIdParameter()` instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         if (!$this->admin->isAclEnabled()) {
@@ -993,7 +993,7 @@ class CRUDController implements ContainerAwareInterface
                 'Not configuring "acl_user_manager" and using ACL security handler is deprecated since'
                 .' sonata-project/admin-bundle 3.78 and will not work on 4.0. You MUST specify the service name'
                 .' under "sonata_admin.security.acl_user_manager" option.',
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
         }
 
@@ -1195,7 +1195,7 @@ class CRUDController implements ContainerAwareInterface
             .', to be removed in 4.0. Use `%s::getMethod()` instead.',
             __METHOD__,
             Request::class
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->getRequest()->getMethod();
     }
@@ -1210,7 +1210,7 @@ class CRUDController implements ContainerAwareInterface
                 'The "%s()" method is deprecated since sonata-project/admin-bundle version 3.86 and will be'
                 .' removed in 4.0 version.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $request = $this->getRequest();
@@ -1490,7 +1490,7 @@ class CRUDController implements ContainerAwareInterface
      */
     protected function escapeHtml($s)
     {
-        return htmlspecialchars((string) $s, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        return htmlspecialchars((string) $s, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
     }
 
     /**
@@ -1605,7 +1605,7 @@ class CRUDController implements ContainerAwareInterface
                 implode('", "', $request->getAcceptableContentTypes()),
                 $request->getMethod(),
                 $request->getUri()
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             return null;
         }
@@ -1633,7 +1633,7 @@ class CRUDController implements ContainerAwareInterface
                 implode('", "', $request->getAcceptableContentTypes()),
                 $request->getMethod(),
                 $request->getUri()
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         return $this->renderJson([
@@ -1672,7 +1672,7 @@ class CRUDController implements ContainerAwareInterface
             // NEXT_MAJOR: make this exception
             @trigger_error(
                 'Accessing a child that isn\'t connected to a given parent is deprecated since sonata-project/admin-bundle 3.34 and won\'t be allowed in 4.0.',
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
         }
     }

--- a/src/Controller/CoreController.php
+++ b/src/Controller/CoreController.php
@@ -19,7 +19,7 @@ namespace Sonata\AdminBundle\Controller;
     'The %1$s\CoreController class is deprecated since version 3.36 and will be removed in 4.0.'
     .' Use %1$s\SearchAction or %1$s\DashboardAction instead.',
     __NAMESPACE__
-), E_USER_DEPRECATED);
+), \E_USER_DEPRECATED);
 
 use Sonata\AdminBundle\Action\DashboardAction;
 use Sonata\AdminBundle\Action\SearchAction;
@@ -80,7 +80,7 @@ class CoreController extends Controller
             .' Inject the %s into the actions instead.',
             __METHOD__,
             Request::class
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->getCurrentRequest();
     }

--- a/src/Controller/HelperController.php
+++ b/src/Controller/HelperController.php
@@ -34,7 +34,7 @@ use Twig\Environment;
     'The %s\HelperController class is deprecated since version 3.38.0 and will be removed in 4.0.'
     .' Use actions inside Sonata\AdminBundle\Action instead.',
     __NAMESPACE__
-), E_USER_DEPRECATED);
+), \E_USER_DEPRECATED);
 
 /**
  * NEXT_MAJOR: remove this class.
@@ -92,7 +92,7 @@ class HelperController
                 DataTransformerResolverInterface::class,
                 __METHOD__,
                 \TypeError::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             $resolver = new DataTransformerResolver();
         }
 

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -108,7 +108,7 @@ class Datagrid implements DatagridInterface
                 @trigger_error(sprintf(
                     'Not implementing "%s::getCurrentPageResults()" is deprecated since sonata-project/admin-bundle 3.87 and will fail in 4.0.',
                     PagerInterface::class
-                ), E_USER_DEPRECATED);
+                ), \E_USER_DEPRECATED);
 
                 $this->results = $this->pager->getResults();
             }
@@ -191,7 +191,7 @@ class Datagrid implements DatagridInterface
                 'Passing a nonexistent filter name as argument 1 to %s() is deprecated since'
                 .' sonata-project/admin-bundle 3.52 and will throw an exception in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare FilterInterface as return type
             // throw new \InvalidArgumentException(sprintf(

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -110,7 +110,7 @@ class ListMapper extends BaseMapper
             if (isset($fieldDescriptionOptions['actions']['view'])) {
                 @trigger_error(
                     'Inline action "view" is deprecated since version 2.2.4 and will be removed in 4.0. Use inline action "show" instead.',
-                    E_USER_DEPRECATED
+                    \E_USER_DEPRECATED
                 );
 
                 $fieldDescriptionOptions['actions']['show'] = $fieldDescriptionOptions['actions']['view'];
@@ -122,7 +122,7 @@ class ListMapper extends BaseMapper
         if (\array_key_exists('identifier', $fieldDescriptionOptions) && !\is_bool($fieldDescriptionOptions['identifier'])) {
             @trigger_error(
                 'Passing a non boolean value for the "identifier" option is deprecated since sonata-project/admin-bundle 3.51 and will throw an exception in 4.0.',
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
 
             $fieldDescriptionOptions['identifier'] = (bool) $fieldDescriptionOptions['identifier'];
@@ -167,7 +167,7 @@ class ListMapper extends BaseMapper
         if (isset($fieldDescriptionOptions['header_style'])) {
             @trigger_error(
                 'The "header_style" option is deprecated, please, use "header_class" option instead.',
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
         }
 

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -152,7 +152,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->currentMaxLink;
     }
@@ -171,7 +171,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->maxRecordLimit;
     }
@@ -190,7 +190,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $this->maxRecordLimit = $limit;
     }
@@ -238,7 +238,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
             @trigger_error(sprintf(
                 'Not implementing "%s::countResults()" is deprecated since sonata-project/admin-bundle 3.86 and will fail in 4.0.',
                 'Sonata\AdminBundle\Datagrid\PagerInterface'
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             $countResults = (int) $this->getNbResults();
         }
@@ -260,7 +260,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->cursor;
     }
@@ -279,7 +279,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if ($pos < 1) {
             $this->cursor = 1;
@@ -308,7 +308,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $this->setCursor($pos);
 
@@ -329,7 +329,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->retrieveObject($this->cursor);
     }
@@ -348,7 +348,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if ($this->cursor + 1 > $this->nbResults) {
             return null;
@@ -371,7 +371,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if ($this->cursor - 1 < 1) {
             return null;
@@ -394,7 +394,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (0 === $this->page) {
             return 1;
@@ -414,7 +414,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
             'Method %s is deprecated since version 3.11 and will be removed in 4.0,'
             .' please use getFirstIndex() instead.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->getFirstIndex();
     }
@@ -433,7 +433,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (0 === $this->page) {
             return $this->nbResults;
@@ -456,7 +456,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
             'Method %s is deprecated since version 3.11 and will be removed in 4.0,'
             .' please use getLastIndex() instead.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->getLastIndex();
     }
@@ -473,7 +473,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.86 and will be removed in 4.0. Use countResults() instead.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->nbResults;
     }
@@ -598,7 +598,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
             @trigger_error(sprintf(
                 'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         return $this->parameters;
@@ -621,7 +621,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->parameters[$name] ?? $default;
     }
@@ -642,7 +642,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return isset($this->parameters[$name]);
     }
@@ -662,7 +662,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $this->parameters[$name] = $value;
     }
@@ -677,7 +677,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (!$this->isIteratorInitialized()) {
             $this->initializeIterator();
@@ -696,7 +696,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (!$this->isIteratorInitialized()) {
             $this->initializeIterator();
@@ -715,7 +715,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (!$this->isIteratorInitialized()) {
             $this->initializeIterator();
@@ -737,7 +737,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (!$this->isIteratorInitialized()) {
             $this->initializeIterator();
@@ -759,7 +759,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (!$this->isIteratorInitialized()) {
             $this->initializeIterator();
@@ -778,7 +778,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->getNbResults();
     }
@@ -793,7 +793,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $vars = get_object_vars($this);
         unset($vars['query']);
@@ -811,7 +811,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $array = unserialize($serialized);
 
@@ -832,7 +832,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->countColumn;
     }
@@ -849,7 +849,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->countColumn = $countColumn;
     }
@@ -883,7 +883,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.86 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $this->nbResults = $nb;
     }
@@ -917,7 +917,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return null !== $this->results;
     }
@@ -937,7 +937,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
             @trigger_error(sprintf(
                 'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         if (method_exists($this, 'getCurrentPageResults')) {
@@ -946,7 +946,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
             @trigger_error(sprintf(
                 'Not implementing "%s::getCurrentPageResults()" is deprecated since sonata-project/admin-bundle 3.87 and will fail in 4.0.',
                 PagerInterface::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             $results = $this->getResults();
         }
@@ -975,7 +975,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
             @trigger_error(sprintf(
                 'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $this->results = null;
@@ -998,7 +998,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $queryForRetrieve = clone $this->getQuery();
         $queryForRetrieve

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -71,7 +71,7 @@ class SimplePager extends Pager
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.86 and will be removed in 4.0. Use countResults() instead.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->countResults();
     }
@@ -119,7 +119,7 @@ class SimplePager extends Pager
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/admin-bundle 3.87 and will be removed in 4.0. Use getCurrentPageResults() instead.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (null !== $this->results) {
             return $this->results;
@@ -213,7 +213,7 @@ class SimplePager extends Pager
             @trigger_error(sprintf(
                 'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         parent::resetIterator('sonata_deprecation_mute');

--- a/src/DependencyInjection/AbstractSonataAdminExtension.php
+++ b/src/DependencyInjection/AbstractSonataAdminExtension.php
@@ -126,7 +126,7 @@ abstract class AbstractSonataAdminExtension extends Extension
                 FieldDescriptionInterface::TYPE_INTEGER => '@SonataIntl/CRUD/show_decimal.html.twig',
                 /* NEXT_MAJOR: Remove this line. */
                 TemplateRegistry::TYPE_DECIMAL => '@SonataIntl/CRUD/show_decimal.html.twig',
-                FieldDescriptionInterface::TYPE_FLOAT => '@SonataIntl/CRUD/list_decimal.html.twig',
+                FieldDescriptionInterface::TYPE_FLOAT => '@SonataIntl/CRUD/show_decimal.html.twig',
                 FieldDescriptionInterface::TYPE_CURRENCY => '@SonataIntl/CRUD/show_currency.html.twig',
                 FieldDescriptionInterface::TYPE_PERCENT => '@SonataIntl/CRUD/show_percent.html.twig',
             ]);

--- a/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
+++ b/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
@@ -216,7 +216,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Passing other type than string as argument 1 for method %s() is deprecated since'
                 .' sonata-project/admin-bundle 3.65. It will accept only string in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
         $this->code = $code;
 
@@ -225,7 +225,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Passing other type than string as argument 2 for method %s() is deprecated since'
                 .' sonata-project/admin-bundle 3.65. It will accept only string in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
         $this->class = $class;
 
@@ -234,7 +234,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Passing other type than string as argument 3 for method %s() is deprecated since'
                 .' sonata-project/admin-bundle 3.84. It will accept only string in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
         $this->baseControllerName = $baseControllerName;
     }
@@ -311,7 +311,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Calling %s() when no manager type is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no manager type.',
 //                static::class
@@ -384,7 +384,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Calling %s() when no model manager is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no model manager.',
 //                static::class
@@ -413,7 +413,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Calling %s() when no data source is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no data source.',
 //                static::class
@@ -442,7 +442,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Calling %s() when no form contractor is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no form contractor.',
 //                static::class
@@ -471,7 +471,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Calling %s() when no show builder is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no show builder.',
 //                static::class
@@ -500,7 +500,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Calling %s() when no list build is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no list builder.',
 //                static::class
@@ -529,7 +529,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Calling %s() when no datagrid builder is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no datagrid builder.',
 //                static::class
@@ -558,7 +558,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Calling %s() when no translator is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no translator.',
 //                static::class
@@ -588,7 +588,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                     'Calling %s() when no pool is set is deprecated since sonata-project/admin-bundle 3.84'
                     .' and will throw a LogicException in 4.0',
                     __METHOD__,
-                ), E_USER_DEPRECATED);
+                ), \E_USER_DEPRECATED);
             }
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no pool.',
@@ -618,7 +618,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Calling %s() when no route generator is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no route generator.',
 //                static::class
@@ -656,7 +656,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
         @trigger_error(sprintf(
             'The %s method is deprecated since version 3.83 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->validator;
     }
@@ -680,7 +680,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Calling %s() when no security handler is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no security handler.',
 //                static::class
@@ -709,7 +709,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Calling %s() when no security handler is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no security handler.',
 //                static::class
@@ -738,7 +738,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Calling %s() when no route builder is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no route builder.',
 //                static::class
@@ -767,7 +767,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
                 'Calling %s() when no label translator strategy is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 //            throw new \LogicException(sprintf(
 //                'Admin "%s" has no label translator strategy.',
 //                static::class

--- a/src/DependencyInjection/Compiler/AdminMakerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminMakerCompilerPass.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class AdminMakerCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('sonata.admin.maker')) {
+            return;
+        }
+
+        if (!$container->hasParameter('sonata.admin.configuration.default_controller')) {
+            return;
+        }
+
+        $defaultController = $container->getParameter('sonata.admin.configuration.default_controller');
+
+        if (!$container->hasDefinition($defaultController)) {
+            return;
+        }
+
+        $adminMaker = $container->getDefinition('sonata.admin.maker');
+        $controllerDefinition = $container->getDefinition($defaultController);
+
+        $adminMaker->replaceArgument(2, $controllerDefinition->getClass());
+    }
+}

--- a/src/DependencyInjection/Compiler/CheckAclUserManagerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/CheckAclUserManagerCompilerPass.php
@@ -47,7 +47,7 @@ final class CheckAclUserManagerCompilerPass implements CompilerPassInterface
                 .' is deprecated since sonata-project/admin-bundle 3.78 and will throw an "%s" exception in 4.0.',
                 AdminAclUserManagerInterface::class,
                 \InvalidArgumentException::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
     }
 }

--- a/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -150,7 +150,7 @@ class ExtensionCompilerPass implements CompilerPassInterface
 
             @trigger_error(
                 sprintf('The admin "%s" does not have a valid manager.', $admin->getClass()),
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
         }
 
@@ -170,7 +170,7 @@ class ExtensionCompilerPass implements CompilerPassInterface
                     $admin->getClass(),
                     \is_object($class) ? \get_class($class) : \gettype($class)
                 ),
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
         }
 

--- a/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
@@ -56,7 +56,7 @@ final class ModelManagerCompilerPass implements CompilerPassInterface
                     .' sonata-project/admin-bundle 3.60.',
                     self::MANAGER_TAG,
                     $id
-                ), E_USER_DEPRECATED);
+                ), \E_USER_DEPRECATED);
 
                 $definition->addTag(self::MANAGER_TAG);
             }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -272,7 +272,7 @@ CASESENSITIVE;
                                                     } elseif (null === $items[$key]['route']) {
                                                         @trigger_error(
                                                             'Passing a null route is deprecated since sonata-project/admin-bundle 3.77.',
-                                                            E_USER_DEPRECATED
+                                                            \E_USER_DEPRECATED
                                                         );
                                                     }
 
@@ -282,7 +282,7 @@ CASESENSITIVE;
                                                     } elseif (null === $items[$key]['label']) {
                                                         @trigger_error(
                                                             'Passing a null label is deprecated since sonata-project/admin-bundle 3.77.',
-                                                            E_USER_DEPRECATED
+                                                            \E_USER_DEPRECATED
                                                         );
 
                                                         $items[$key]['label'] = '';

--- a/src/EventListener/AssetsInstallCommandListener.php
+++ b/src/EventListener/AssetsInstallCommandListener.php
@@ -47,7 +47,7 @@ final class AssetsInstallCommandListener
                 'Not passing the project directory to the constructor of %s is deprecated since Symfony 4.3'
                 .' and will not be supported in 5.0.',
                 __CLASS__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $this->filesystem = $filesystem;

--- a/src/Export/Exporter.php
+++ b/src/Export/Exporter.php
@@ -30,7 +30,7 @@ if (class_exists(CoreExporter::class)) {
                 'The %s\Exporter class is deprecated since version 3.14 and will be removed in 4.0.'
                 .' Use \Sonata\Exporter\Exporter instead',
                 __NAMESPACE__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
     }
 } else {

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -201,7 +201,7 @@ abstract class Filter implements FilterInterface
         @trigger_error(sprintf(
             'Method %s() is deprecated since sonata-project/admin-bundle 3.84 and will be removed in version 4.0.',
             __METHOD__,
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $this->value = $value;
     }
@@ -218,7 +218,7 @@ abstract class Filter implements FilterInterface
         @trigger_error(sprintf(
             'Method %s() is deprecated since sonata-project/admin-bundle 3.84 and will be removed in version 4.0.',
             __METHOD__,
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->value;
     }

--- a/src/Filter/FilterFactory.php
+++ b/src/Filter/FilterFactory.php
@@ -58,7 +58,7 @@ class FilterFactory implements FilterFactoryInterface
                     .' Use the fully-qualified type class name instead (%s)',
                     $type,
                     \get_class($filter)
-                ), E_USER_DEPRECATED);
+                ), \E_USER_DEPRECATED);
             }
         } elseif (class_exists($type)) {
             $filter = new $type();

--- a/src/Form/ChoiceList/ModelChoiceLoader.php
+++ b/src/Form/ChoiceList/ModelChoiceLoader.php
@@ -104,7 +104,7 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
                     @trigger_error(
                         'Passing a query which is not supported by the model manager is deprecated since'
                         .' sonata-project/admin-bundle 3.76 and will throw an exception in version 4.0.',
-                        E_USER_DEPRECATED
+                        \E_USER_DEPRECATED
                     );
                     // throw new \InvalidArgumentException('The model manager does not support the query.');
                 }

--- a/src/Form/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Form/DataTransformer/BooleanToStringTransformer.php
@@ -40,6 +40,6 @@ final class BooleanToStringTransformer implements DataTransformerInterface
 
     public function reverseTransform($value): bool
     {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        return filter_var($value, \FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -44,7 +44,7 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
     protected $className;
 
     /**
-     * @var string
+     * @var string|string[]
      */
     protected $property;
 
@@ -59,13 +59,14 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
     protected $toStringCallback;
 
     /**
-     * @param string        $className
-     * @param string        $property
-     * @param bool          $multiple
-     * @param callable|null $toStringCallback
+     * @param string          $className
+     * @param string|string[] $property
+     * @param bool            $multiple
+     * @param callable|null   $toStringCallback
      *
+     * @phpstan-template P
      * @phpstan-param class-string<T> $className
-     * @phpstan-param null|callable(object, string): string $toStringCallback
+     * @phpstan-param null|callable(object, P): string $toStringCallback
      */
     public function __construct(
         ModelManagerInterface $modelManager,

--- a/src/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/src/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -241,6 +241,6 @@ class ModelsToArrayTransformer implements DataTransformerInterface
         @trigger_error(sprintf(
             'Using the "%s::$choiceList" property is deprecated since version 3.12 and will be removed in 4.0.',
             __CLASS__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
     }
 }

--- a/src/Form/EventListener/MergeCollectionListener.php
+++ b/src/Form/EventListener/MergeCollectionListener.php
@@ -41,7 +41,7 @@ class MergeCollectionListener implements EventSubscriberInterface
                 'Passing argument 1 to %s() is deprecated since sonata-project/admin-bundle 3.75'
                 .' and will be ignored in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $this->modelManager = $modelManager;

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -162,7 +162,7 @@ class FormMapper extends BaseGroupedMapper
                     @trigger_error(
                         'Using HTML syntax within the "help" option and not setting the "help_html" option to "true" is deprecated'
                         .' since sonata-project/admin-bundle 3.74 and it will not work in version 4.0.',
-                        E_USER_DEPRECATED
+                        \E_USER_DEPRECATED
                     );
 
                     $options['help_html'] = true;
@@ -241,7 +241,7 @@ class FormMapper extends BaseGroupedMapper
             'The "%s()" method is deprecated since sonata-project/admin-bundle 3.74 and will be removed in version 4.0.'
             .' Use Symfony Form "help" option instead.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         foreach ($helps as $name => $help) {
             $this->addHelp($name, $help, 'sonata_deprecation_mute');
@@ -264,7 +264,7 @@ class FormMapper extends BaseGroupedMapper
                 'The "%s()" method is deprecated since sonata-project/admin-bundle 3.74 and will be removed in version 4.0.'
                 .' Use Symfony Form "help" option instead.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         if ($this->admin->hasFormFieldDescription($name)) {

--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -52,7 +52,7 @@ class AdminType extends AbstractType
                 'Passing argument 1 to %s() is deprecated since sonata-project/admin-bundle 3.72'
                 .' and will be ignored in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $this->adminHelper = $adminHelper;

--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -51,6 +51,7 @@ class ModelAutocompleteType extends AbstractType
         );
         $builder->setAttribute('to_string_callback', $options['to_string_callback']);
         $builder->setAttribute('target_admin_access_action', $options['target_admin_access_action']);
+        $builder->setAttribute('response_item_callback', $options['response_item_callback']);
 
         if ($options['multiple']) {
             $resizeListener = new ResizeFormListener(HiddenType::class, [], true, true, true);
@@ -108,10 +109,12 @@ class ModelAutocompleteType extends AbstractType
         $resolver->setDefaults([
             'attr' => [],
             'compound' => $compound,
+            'error_bubbling' => false,
             'model_manager' => null,
             'class' => null,
             'admin_code' => null,
             'callback' => null,
+            'response_item_callback' => null,
             'multiple' => false,
             'width' => '',
             'context' => '',

--- a/src/Form/Type/ModelTypeList.php
+++ b/src/Form/Type/ModelTypeList.php
@@ -17,7 +17,7 @@ namespace Sonata\AdminBundle\Form\Type;
     'The %s1$\ModelTypeList class is deprecated since version 3.5 and will be removed in 4.0.'
     .' Use %1$s\ModelListType instead.',
     __NAMESPACE__
-), E_USER_DEPRECATED);
+), \E_USER_DEPRECATED);
 
 /**
  * This type is used to render an hidden input text and 3 links

--- a/src/Maker/AdminMaker.php
+++ b/src/Maker/AdminMaker.php
@@ -232,7 +232,7 @@ final class AdminMaker extends AbstractMaker
 
             $io->writeln(sprintf(
                 '%sThe service "<info>%s</info>" has been appended to the file <info>"%s</info>".',
-                PHP_EOL,
+                \PHP_EOL,
                 $id,
                 realpath($file)
             ));
@@ -256,7 +256,7 @@ final class AdminMaker extends AbstractMaker
         $generator->writeChanges();
         $io->writeln(sprintf(
             '%sThe controller class "<info>%s</info>" has been generated under the file "<info>%s</info>".',
-            PHP_EOL,
+            \PHP_EOL,
             $controllerClassNameDetails->getShortName(),
             $controllerClassFullName
         ));
@@ -272,7 +272,7 @@ final class AdminMaker extends AbstractMaker
         $fields = $this->modelManager->getExportFields($this->modelClass);
         $fieldString = '';
         foreach ($fields as $field) {
-            $fieldString = $fieldString.sprintf('%12s', '')."->add('".$field."')".PHP_EOL;
+            $fieldString = $fieldString.sprintf('%12s', '')."->add('".$field."')".\PHP_EOL;
         }
 
         $fieldString .= sprintf('%12s', '');
@@ -287,7 +287,7 @@ final class AdminMaker extends AbstractMaker
 
         $io->writeln(sprintf(
             '%sThe admin class "<info>%s</info>" has been generated under the file "<info>%s</info>".',
-            PHP_EOL,
+            \PHP_EOL,
             $adminClassNameDetails->getShortName(),
             $adminClassFullName
         ));

--- a/src/Maker/AdminMaker.php
+++ b/src/Maker/AdminMaker.php
@@ -78,7 +78,7 @@ final class AdminMaker extends AbstractMaker
     private $defaultController;
 
     /**
-     * NEXT_MAJOR: Make $defaultController mandatory.
+     * NEXT_MAJOR: Make $modelManagers and $defaultController mandatory.
      *
      * @param string                               $projectDirectory
      * @param array<string, ModelManagerInterface> $modelManagers

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -362,7 +362,7 @@ abstract class BaseGroupedMapper extends BaseMapper
         @trigger_error(sprintf(
             '%s should be implemented and will be abstract in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return 'default';
     }

--- a/src/Menu/Matcher/Voter/AdminVoter.php
+++ b/src/Menu/Matcher/Voter/AdminVoter.php
@@ -54,7 +54,7 @@ class AdminVoter implements VoterInterface
             'The %s() method is deprecated since version 3.31. Pass a %s in the constructor instead.',
             __METHOD__,
             RequestStack::class
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $this->request = $request;
 

--- a/src/Menu/Provider/GroupMenuProvider.php
+++ b/src/Menu/Provider/GroupMenuProvider.php
@@ -63,7 +63,7 @@ class GroupMenuProvider implements MenuProviderInterface
                 'Passing no 3rd argument is deprecated since version 3.10 and will be mandatory in 4.0.'
                 .' Pass %s as 3rd argument.',
                 AuthorizationCheckerInterface::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         } elseif (!$checker instanceof AuthorizationCheckerInterface) {
             throw new \InvalidArgumentException(sprintf(
                 'Argument 3 must be an instance of %s',

--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -571,7 +571,7 @@ var Admin = {
         return '100%';
     },
 
-    setup_sortable_select2: function(subject, data, customOptions) {
+    setup_sortable_select2: function(subject, data, options) {
         var transformedData = [];
         for (var i = 0 ; i < data.length ; i++) {
             transformedData[i] = {id: data[i].data, text: data[i].label};
@@ -586,7 +586,7 @@ var Admin = {
             dropdownAutoWidth: true,
             data: transformedData,
             multiple: true
-        }, customOptions);
+        }, options);
 
         subject.select2(options);
 

--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -571,7 +571,7 @@ var Admin = {
         return '100%';
     },
 
-    setup_sortable_select2: function(subject, data, options) {
+    setup_sortable_select2: function(subject, data, customOptions) {
         var transformedData = [];
         for (var i = 0 ; i < data.length ; i++) {
             transformedData[i] = {id: data[i].data, text: data[i].label};
@@ -586,7 +586,7 @@ var Admin = {
             dropdownAutoWidth: true,
             data: transformedData,
             multiple: true
-        }, options);
+        }, customOptions);
 
         subject.select2(options);
 

--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -571,13 +571,13 @@ var Admin = {
         return '100%';
     },
 
-    setup_sortable_select2: function(subject, data) {
+    setup_sortable_select2: function(subject, data, customOptions) {
         var transformedData = [];
         for (var i = 0 ; i < data.length ; i++) {
             transformedData[i] = {id: data[i].data, text: data[i].label};
         }
 
-        subject.select2({
+        var options = Object.assign({
             width: function(){
                 // Select2 v3 and v4 BC. If window.Select2 is defined, then the v3 is installed.
                 // NEXT_MAJOR: Remove Select2 v3 support.
@@ -586,7 +586,9 @@ var Admin = {
             dropdownAutoWidth: true,
             data: transformedData,
             multiple: true
-        });
+        }, customOptions);
+
+        subject.select2(options);
 
         subject.select2("container").find("ul.select2-choices").sortable({
             containment: 'parent',

--- a/src/Resources/translations/SonataAdminBundle.bs.xliff
+++ b/src/Resources/translations/SonataAdminBundle.bs.xliff
@@ -1,0 +1,507 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+        <body>
+            <trans-unit id="sonata_administration">
+                <source>sonata_administration</source>
+                <target>Administracija</target>
+            </trans-unit>
+            <trans-unit id="action_delete">
+                <source>action_delete</source>
+                <target>Obriši</target>
+            </trans-unit>
+            <trans-unit id="btn_batch">
+                <source>btn_batch</source>
+                <target>OK</target>
+            </trans-unit>
+            <trans-unit id="btn_create">
+                <source>btn_create</source>
+                <target>Sačuvaj</target>
+            </trans-unit>
+            <trans-unit id="btn_create_and_edit_again">
+                <source>btn_create_and_edit_again</source>
+                <target>Sačuvaj</target>
+            </trans-unit>
+            <trans-unit id="btn_create_and_create_a_new_one">
+                <source>btn_create_and_create_a_new_one</source>
+                <target>Sačuvaj i dodaj još jedan zapis</target>
+            </trans-unit>
+            <trans-unit id="btn_create_and_return_to_list">
+                <source>btn_create_and_return_to_list</source>
+                <target>Sačuvaj i idi na listu zapisa</target>
+            </trans-unit>
+            <trans-unit id="btn_filter">
+                <source>btn_filter</source>
+                <target>Filtriraj</target>
+            </trans-unit>
+            <trans-unit id="btn_advanced_filters">
+                <source>btn_advanced_filters</source>
+                <target>Napredni filteri</target>
+            </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Ažuriraj</target>
+            </trans-unit>
+            <trans-unit id="btn_update_and_edit_again">
+                <source>btn_update_and_edit_again</source>
+                <target>Ažuriraj</target>
+            </trans-unit>
+            <trans-unit id="btn_update_and_return_to_list">
+                <source>btn_update_and_return_to_list</source>
+                <target>Ažuriraj i zatvori</target>
+            </trans-unit>
+            <trans-unit id="link_delete">
+                <source>link_delete</source>
+                <target>Obriši</target>
+            </trans-unit>
+            <trans-unit id="link_action_create">
+                <source>link_action_create</source>
+                <target>Novi zapis</target>
+            </trans-unit>
+            <trans-unit id="link_action_list">
+                <source>link_action_list</source>
+                <target>Lista zapisa</target>
+            </trans-unit>
+            <trans-unit id="link_action_show">
+                <source>link_action_show</source>
+                <target>Prikaži</target>
+            </trans-unit>
+            <trans-unit id="link_action_edit">
+                <source>link_action_edit</source>
+                <target>Promjeni</target>
+            </trans-unit>
+            <trans-unit id="link_add">
+                <source>link_add</source>
+                <target>Novi zapis</target>
+            </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Promjeni</target>
+            </trans-unit>
+            <trans-unit id="link_list">
+                <source>link_list</source>
+                <target>Lista zapisa</target>
+            </trans-unit>
+            <trans-unit id="link_reset_filter">
+                <source>link_reset_filter</source>
+                <target>Resetuj</target>
+            </trans-unit>
+            <trans-unit id="title_create">
+                <source>title_create</source>
+                <target>Novi zapis</target>
+            </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>Prikaži "%name%"</target>
+            </trans-unit>
+            <trans-unit id="title_dashboard">
+                <source>title_dashboard</source>
+                <target>Kontrolna tabla</target>
+            </trans-unit>
+            <trans-unit id="title_edit">
+                <source>title_edit</source>
+                <target>Promjeni "%name%"</target>
+            </trans-unit>
+            <trans-unit id="title_list">
+                <source>title_list</source>
+                <target>Lista zapisa</target>
+            </trans-unit>
+            <trans-unit id="link_next_pager">
+                <source>link_next_pager</source>
+                <target>Sledeća</target>
+            </trans-unit>
+            <trans-unit id="link_previous_pager">
+                <source>link_previous_pager</source>
+                <target>Prethodna</target>
+            </trans-unit>
+            <trans-unit id="link_first_pager">
+                <source>link_first_pager</source>
+                <target>Prva</target>
+            </trans-unit>
+            <trans-unit id="link_last_pager">
+                <source>link_last_pager</source>
+                <target>Poslednja</target>
+            </trans-unit>
+            <trans-unit id="Admin">
+                <source>Admin</source>
+                <target>Administracija</target>
+            </trans-unit>
+            <trans-unit id="link_expand">
+                <source>link_expand</source>
+                <target>proširi/skupi</target>
+            </trans-unit>
+            <trans-unit id="no_result">
+                <source>no_result</source>
+                <target>Nema rezultata</target>
+            </trans-unit>
+            <trans-unit id="confirm_msg">
+                <source>confirm_msg</source>
+                <target>Da li ste sigurni?</target>
+            </trans-unit>
+            <trans-unit id="action_edit">
+                <source>action_edit</source>
+                <target>Promjeni</target>
+            </trans-unit>
+            <trans-unit id="action_show">
+                <source>action_show</source>
+                <target>Prikaži</target>
+            </trans-unit>
+            <trans-unit id="all_elements">
+                <source>all_elements</source>
+                <target>Ukupno</target>
+            </trans-unit>
+            <trans-unit id="flash_batch_empty">
+                <source>flash_batch_empty</source>
+                <target>Akcija je prekinuta jer ništa nije izabrano.</target>
+            </trans-unit>
+            <trans-unit id="flash_create_success">
+                <source>flash_create_success</source>
+                <target>Novi zapis "%name%" je uspješno sačuvan.</target>
+            </trans-unit>
+            <trans-unit id="flash_create_error">
+                <source>flash_create_error</source>
+                <target>Došlo je do greške tokom kreiranja "%name%".</target>
+            </trans-unit>
+            <trans-unit id="flash_edit_success">
+                <source>flash_edit_success</source>
+                <target>Zapis "%name%" je uspješno ažuriran.</target>
+            </trans-unit>
+            <trans-unit id="flash_edit_error">
+                <source>flash_edit_error</source>
+                <target>Došlo je do greške tokom ažuriranja "%name%".</target>
+            </trans-unit>
+            <trans-unit id="flash_lock_error">
+                <source>flash_lock_error</source>
+                <target>Drugi korisnik je promjenio "%name%". Molim %link_start%kliknite ovde%link_end% da biste ponovo učitali stranicu i sačuvali izmjene.</target>
+            </trans-unit>
+            <trans-unit id="flash_batch_delete_success">
+                <source>flash_batch_delete_success</source>
+                <target>Izabrani zapisi su uspješno obrisani.</target>
+            </trans-unit>
+            <trans-unit id="flash_batch_no_elements_processed">
+                <source>flash_batch_no_elements_processed</source>
+                <target>Nije obrađen nijedan element.</target>
+            </trans-unit>
+            <trans-unit id="flash_batch_delete_error">
+                <source>flash_batch_delete_error</source>
+                <target>Došlo je do greške tokom brisanja izabranih zapisa.</target>
+            </trans-unit>
+            <trans-unit id="flash_delete_error">
+                <source>flash_delete_error</source>
+                <target>Došlo je do greške tokom brisanja "%name%".</target>
+            </trans-unit>
+            <trans-unit id="flash_delete_success">
+                <source>flash_delete_success</source>
+                <target>Zapis "%name%" je uspješno obrisan.</target>
+            </trans-unit>
+            <trans-unit id="form_not_available">
+                <source>form_not_available</source>
+                <target>Obrazac nije dostupan.</target>
+            </trans-unit>
+            <trans-unit id="link_breadcrumb_dashboard">
+                <source>link_breadcrumb_dashboard</source>
+                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+            </trans-unit>
+            <trans-unit id="title_delete">
+                <source>title_delete</source>
+                <target>Potvrdite brisanje</target>
+            </trans-unit>
+            <trans-unit id="message_delete_confirmation">
+                <source>message_delete_confirmation</source>
+                <target>Da li sigurno želite da obrišete "%object%"?</target>
+            </trans-unit>
+            <trans-unit id="btn_delete">
+                <source>btn_delete</source>
+                <target>Da, obriši</target>
+            </trans-unit>
+            <trans-unit id="title_batch_confirmation">
+                <source>title_batch_confirmation</source>
+                <target>Potvrdite grupnu akciju "%action%"</target>
+            </trans-unit>
+            <trans-unit id="message_batch_confirmation">
+                <source>message_batch_confirmation</source>
+                <target>Da li sigurno želite da izvršite ovu akciju za izabrane zapise?|Da li sigurno želite da izvršite ovu akciju nad %count% zapisa?</target>
+            </trans-unit>
+            <trans-unit id="message_batch_all_confirmation">
+                <source>message_batch_all_confirmation</source>
+                <target>Da li sigurno želite da izvršite ovu akciju nad svim zapisima?</target>
+            </trans-unit>
+            <trans-unit id="btn_execute_batch_action">
+                <source>btn_execute_batch_action</source>
+                <target>Da, izvrši</target>
+            </trans-unit>
+            <trans-unit id="label_type_yes">
+                <source>label_type_yes</source>
+                <target>da</target>
+            </trans-unit>
+            <trans-unit id="label_type_no">
+                <source>label_type_no</source>
+                <target>ne</target>
+            </trans-unit>
+            <trans-unit id="label_type_contains">
+                <source>label_type_contains</source>
+                <target>sadrži</target>
+            </trans-unit>
+            <trans-unit id="label_type_not_contains">
+                <source>label_type_not_contains</source>
+                <target>ne sadrži</target>
+            </trans-unit>
+            <trans-unit id="label_type_equals">
+                <source>label_type_equals</source>
+                <target>jednako</target>
+            </trans-unit>
+            <trans-unit id="label_type_not_equals">
+                <source>label_type_not_equals</source>
+                <target>nije jednako</target>
+            </trans-unit>
+            <trans-unit id="label_type_equal">
+                <source>label_type_equal</source>
+                <target>=</target>
+            </trans-unit>
+            <trans-unit id="label_type_greater_equal">
+                <source>label_type_greater_equal</source>
+                <target>&gt;=</target>
+            </trans-unit>
+            <trans-unit id="label_type_greater_than">
+                <source>label_type_greater_than</source>
+                <target>&gt;</target>
+            </trans-unit>
+            <trans-unit id="label_type_less_equal">
+                <source>label_type_less_equal</source>
+                <target>&lt;=</target>
+            </trans-unit>
+            <trans-unit id="label_type_less_than">
+                <source>label_type_less_than</source>
+                <target>&lt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_equal">
+                <source>label_date_type_equal</source>
+                <target>=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_greater_equal">
+                <source>label_date_type_greater_equal</source>
+                <target>&gt;=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_greater_than">
+                <source>label_date_type_greater_than</source>
+                <target>&gt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_less_equal">
+                <source>label_date_type_less_equal</source>
+                <target>&lt;=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_less_than">
+                <source>label_date_type_less_than</source>
+                <target>&lt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_null">
+                <source>label_date_type_null</source>
+                <target>je prazan</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_not_null">
+                <source>label_date_type_not_null</source>
+                <target>nije prazan</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_between">
+                <source>label_date_type_between</source>
+                <target>u periodu</target>
+            </trans-unit>
+            <trans-unit id="label_date_not_between">
+                <source>label_date_type_not_between</source>
+                <target>nije u periodu</target>
+            </trans-unit>
+            <trans-unit id="label_filters">
+                <source>label_filters</source>
+                <target>Filteri</target>
+            </trans-unit>
+            <trans-unit id="delete_or">
+                <source>delete_or</source>
+                <target>ili</target>
+            </trans-unit>
+            <trans-unit id="link_action_history">
+                <source>link_action_history</source>
+                <target>Revizije</target>
+            </trans-unit>
+            <trans-unit id="td_action">
+                <source>td_action</source>
+                <target>Akcije</target>
+            </trans-unit>
+            <trans-unit id="td_compare">
+                <source>td_compare</source>
+                <target>Uporedi</target>
+            </trans-unit>
+            <trans-unit id="td_revision">
+                <source>td_revision</source>
+                <target>Revizije</target>
+            </trans-unit>
+            <trans-unit id="td_timestamp">
+                <source>td_timestamp</source>
+                <target>Datum</target>
+            </trans-unit>
+            <trans-unit id="td_username">
+                <source>td_username</source>
+                <target>Autor/ka</target>
+            </trans-unit>
+            <trans-unit id="td_role">
+                <source>td_role</source>
+                <target>Uloga</target>
+            </trans-unit>
+            <trans-unit id="label_view_revision">
+                <source>label_view_revision</source>
+                <target>Prikaži reviziju</target>
+            </trans-unit>
+            <trans-unit id="label_compare_revision">
+                <source>label_compare_revision</source>
+                <target>Uporedi reviziju</target>
+            </trans-unit>
+            <trans-unit id="list_results_count_prefix">
+                <source>list_results_count_prefix</source>
+                <target>barem</target>
+            </trans-unit>
+            <trans-unit id="list_results_count">
+                <source>list_results_count</source>
+                <target>%count% rezultat|%count% rezultata|%count% rezultata</target>
+            </trans-unit>
+            <trans-unit id="label_export_download">
+                <source>label_export_download</source>
+                <target>Preuzmi</target>
+            </trans-unit>
+            <trans-unit id="export_format_json">
+                <source>export_format_json</source>
+                <target>JSON</target>
+            </trans-unit>
+            <trans-unit id="export_format_xml">
+                <source>export_format_xml</source>
+                <target>XML</target>
+            </trans-unit>
+            <trans-unit id="export_format_csv">
+                <source>export_format_csv</source>
+                <target>CSV</target>
+            </trans-unit>
+            <trans-unit id="export_format_xls">
+                <source>export_format_xls</source>
+                <target>XLS</target>
+            </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Učitavam podatke...</target>
+            </trans-unit>
+            <trans-unit id="btn_preview">
+                <source>btn_preview</source>
+                <target>Pregledaj</target>
+            </trans-unit>
+            <trans-unit id="btn_preview_approve">
+                <source>btn_preview_approve</source>
+                <target>Odobri</target>
+            </trans-unit>
+            <trans-unit id="btn_preview_decline">
+                <source>btn_preview_decline</source>
+                <target>Odbij</target>
+            </trans-unit>
+            <trans-unit id="label_per_page">
+                <source>label_per_page</source>
+                <target>Po stranici</target>
+            </trans-unit>
+            <trans-unit id="list_select">
+                <source>list_select</source>
+                <target>Izaberi</target>
+            </trans-unit>
+            <trans-unit id="confirm_exit">
+                <source>confirm_exit</source>
+                <target>Neke izmjene nisu sačuvane.</target>
+            </trans-unit>
+            <trans-unit id="link_edit_acl">
+                <source>link_edit_acl</source>
+                <target>Izmjeni listu za kontrolu pristupa (ACL)</target>
+            </trans-unit>
+            <trans-unit id="btn_update_acl">
+                <source>btn_update_acl</source>
+                <target>Ažuriraj listu za kontrolu pristupa (ACL)</target>
+            </trans-unit>
+            <trans-unit id="flash_acl_update_success">
+                <source>flash_acl_edit_success</source>
+                <target>Lista za kontorlu pristupa (ACL) je uspješno ažurirana.</target>
+            </trans-unit>
+            <trans-unit id="link_action_acl">
+                <source>link_action_acl</source>
+                <target>Lista za kontrolu pristupa (ACL)</target>
+            </trans-unit>
+            <trans-unit id="short_object_description_placeholder">
+                <source>short_object_description_placeholder</source>
+                <target>Ništa nije izabrano</target>
+            </trans-unit>
+            <trans-unit id="title_search_results">
+                <source>title_search_results</source>
+                <target>Rezultati pretraživanja: %query%</target>
+            </trans-unit>
+            <trans-unit id="search_placeholder">
+                <source>search_placeholder</source>
+                <target>Traži</target>
+            </trans-unit>
+            <trans-unit id="no_results_found">
+                <source>no_results_found</source>
+                <target>nije pronađen nijedan rezultat</target>
+            </trans-unit>
+            <trans-unit id="add_new_entry">
+                <source>add_new_entry</source>
+                <target>dodaj novi zapis</target>
+            </trans-unit>
+            <trans-unit id="link_actions">
+                <source>link_actions</source>
+                <target>Akcije</target>
+            </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>Javascript je onemogućen u Vašem internet pretraživaču. Neke funkcije neće raditi ispravno.</target>
+            </trans-unit>
+            <trans-unit id="message_form_group_empty">
+                <source>message_form_group_empty</source>
+                <target>Nema dostupnih polja.</target>
+            </trans-unit>
+            <trans-unit id="link_filters">
+                <source>link_filters</source>
+                <target>Filteri</target>
+            </trans-unit>
+            <trans-unit id="stats_view_more">
+                <source>stats_view_more</source>
+                <target>Pogledaj više</target>
+            </trans-unit>
+            <trans-unit id="title_select_subclass">
+                <source>title_select_subclass</source>
+                <target>Izaberite tip objekta</target>
+            </trans-unit>
+            <trans-unit id="no_subclass_available">
+                <source>no_subclass_available</source>
+                <target>Nije dostupan nijedan tip objekta</target>
+            </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>nepoznato</target>
+            </trans-unit>
+            <trans-unit id="read_more">
+                <source>read_more</source>
+                <target>Opširnije</target>
+            </trans-unit>
+            <trans-unit id="read_less">
+                <source>read_less</source>
+                <target>Zatvori</target>
+            </trans-unit>
+            <trans-unit id="toggle_navigation">
+                <source>toggle_navigation</source>
+                <target>Uključi/isključi navigaciju</target>
+            </trans-unit>
+            <trans-unit id="label_type_starts_with">
+                <source>label_type_starts_with</source>
+                <target>počinje sa</target>
+            </trans-unit>
+            <trans-unit id="label_type_ends_with">
+                <source>label_type_ends_with</source>
+                <target>završava se sa</target>
+            </trans-unit>
+            <trans-unit id="go_to_first_page">
+                <source>go_to_first_page</source>
+                <target>Idi na prvu stranicu</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Resources/translations/SonataAdminBundle.sr_Cyrl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.sr_Cyrl.xliff
@@ -1,0 +1,507 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+        <body>
+            <trans-unit id="sonata_administration">
+                <source>sonata_administration</source>
+                <target>Администрација</target>
+            </trans-unit>
+            <trans-unit id="action_delete">
+                <source>action_delete</source>
+                <target>Обриши</target>
+            </trans-unit>
+            <trans-unit id="btn_batch">
+                <source>btn_batch</source>
+                <target>ОК</target>
+            </trans-unit>
+            <trans-unit id="btn_create">
+                <source>btn_create</source>
+                <target>Сачувај</target>
+            </trans-unit>
+            <trans-unit id="btn_create_and_edit_again">
+                <source>btn_create_and_edit_again</source>
+                <target>Сачувај</target>
+            </trans-unit>
+            <trans-unit id="btn_create_and_create_a_new_one">
+                <source>btn_create_and_create_a_new_one</source>
+                <target>Сачувај и додај још један запис</target>
+            </trans-unit>
+            <trans-unit id="btn_create_and_return_to_list">
+                <source>btn_create_and_return_to_list</source>
+                <target>Сачувај и иди на листу записа</target>
+            </trans-unit>
+            <trans-unit id="btn_filter">
+                <source>btn_filter</source>
+                <target>Филтрирај</target>
+            </trans-unit>
+            <trans-unit id="btn_advanced_filters">
+                <source>btn_advanced_filters</source>
+                <target>Напредни филтери</target>
+            </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Ажурирај</target>
+            </trans-unit>
+            <trans-unit id="btn_update_and_edit_again">
+                <source>btn_update_and_edit_again</source>
+                <target>Ажурирај</target>
+            </trans-unit>
+            <trans-unit id="btn_update_and_return_to_list">
+                <source>btn_update_and_return_to_list</source>
+                <target>Ажурирај и затвори</target>
+            </trans-unit>
+            <trans-unit id="link_delete">
+                <source>link_delete</source>
+                <target>Обриши</target>
+            </trans-unit>
+            <trans-unit id="link_action_create">
+                <source>link_action_create</source>
+                <target>Нови запис</target>
+            </trans-unit>
+            <trans-unit id="link_action_list">
+                <source>link_action_list</source>
+                <target>Листа записа</target>
+            </trans-unit>
+            <trans-unit id="link_action_show">
+                <source>link_action_show</source>
+                <target>Прикажи</target>
+            </trans-unit>
+            <trans-unit id="link_action_edit">
+                <source>link_action_edit</source>
+                <target>Промени</target>
+            </trans-unit>
+            <trans-unit id="link_add">
+                <source>link_add</source>
+                <target>Нови запис</target>
+            </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Промени</target>
+            </trans-unit>
+            <trans-unit id="link_list">
+                <source>link_list</source>
+                <target>Листа записа</target>
+            </trans-unit>
+            <trans-unit id="link_reset_filter">
+                <source>link_reset_filter</source>
+                <target>Ресетуј</target>
+            </trans-unit>
+            <trans-unit id="title_create">
+                <source>title_create</source>
+                <target>Нови запис</target>
+            </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>Прикажи "%name%"</target>
+            </trans-unit>
+            <trans-unit id="title_dashboard">
+                <source>title_dashboard</source>
+                <target>Контролна табла</target>
+            </trans-unit>
+            <trans-unit id="title_edit">
+                <source>title_edit</source>
+                <target>Промени "%name%"</target>
+            </trans-unit>
+            <trans-unit id="title_list">
+                <source>title_list</source>
+                <target>Листа записа</target>
+            </trans-unit>
+            <trans-unit id="link_next_pager">
+                <source>link_next_pager</source>
+                <target>Следећа</target>
+            </trans-unit>
+            <trans-unit id="link_previous_pager">
+                <source>link_previous_pager</source>
+                <target>Претходна</target>
+            </trans-unit>
+            <trans-unit id="link_first_pager">
+                <source>link_first_pager</source>
+                <target>Прва</target>
+            </trans-unit>
+            <trans-unit id="link_last_pager">
+                <source>link_last_pager</source>
+                <target>Последња</target>
+            </trans-unit>
+            <trans-unit id="Admin">
+                <source>Admin</source>
+                <target>Администрација</target>
+            </trans-unit>
+            <trans-unit id="link_expand">
+                <source>link_expand</source>
+                <target>прошири/скупи</target>
+            </trans-unit>
+            <trans-unit id="no_result">
+                <source>no_result</source>
+                <target>Нема резултата</target>
+            </trans-unit>
+            <trans-unit id="confirm_msg">
+                <source>confirm_msg</source>
+                <target>Да ли сте сигурни?</target>
+            </trans-unit>
+            <trans-unit id="action_edit">
+                <source>action_edit</source>
+                <target>Промени</target>
+            </trans-unit>
+            <trans-unit id="action_show">
+                <source>action_show</source>
+                <target>Прикажи</target>
+            </trans-unit>
+            <trans-unit id="all_elements">
+                <source>all_elements</source>
+                <target>Укупно</target>
+            </trans-unit>
+            <trans-unit id="flash_batch_empty">
+                <source>flash_batch_empty</source>
+                <target>Акција је прекинута јер ништа није изабрано.</target>
+            </trans-unit>
+            <trans-unit id="flash_create_success">
+                <source>flash_create_success</source>
+                <target>Нови запис "%name%" је успешно сачуван.</target>
+            </trans-unit>
+            <trans-unit id="flash_create_error">
+                <source>flash_create_error</source>
+                <target>Дошло је до грешке током креирања "%name%".</target>
+            </trans-unit>
+            <trans-unit id="flash_edit_success">
+                <source>flash_edit_success</source>
+                <target>Запис "%name%" је успешно ажуриран.</target>
+            </trans-unit>
+            <trans-unit id="flash_edit_error">
+                <source>flash_edit_error</source>
+                <target>Дошло је до грешке током ажурирања "%name%".</target>
+            </trans-unit>
+            <trans-unit id="flash_lock_error">
+                <source>flash_lock_error</source>
+                <target>Други корисник је променио "%name%". Молим %link_start%кликните овде%link_end% да бисте поново учитали страницу и сачували измене.</target>
+            </trans-unit>
+            <trans-unit id="flash_batch_delete_success">
+                <source>flash_batch_delete_success</source>
+                <target>Изабрани записи су успешно обрисани.</target>
+            </trans-unit>
+            <trans-unit id="flash_batch_no_elements_processed">
+                <source>flash_batch_no_elements_processed</source>
+                <target>Није обрађен ниједан елемент.</target>
+            </trans-unit>
+            <trans-unit id="flash_batch_delete_error">
+                <source>flash_batch_delete_error</source>
+                <target>Дошло је до грешке током брисања изабраних записа.</target>
+            </trans-unit>
+            <trans-unit id="flash_delete_error">
+                <source>flash_delete_error</source>
+                <target>Дошло је до грешке током брисања "%name%".</target>
+            </trans-unit>
+            <trans-unit id="flash_delete_success">
+                <source>flash_delete_success</source>
+                <target>Запис "%name%" је успешно обрисан.</target>
+            </trans-unit>
+            <trans-unit id="form_not_available">
+                <source>form_not_available</source>
+                <target>Образац није доступан.</target>
+            </trans-unit>
+            <trans-unit id="link_breadcrumb_dashboard">
+                <source>link_breadcrumb_dashboard</source>
+                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+            </trans-unit>
+            <trans-unit id="title_delete">
+                <source>title_delete</source>
+                <target>Потврдите брисање</target>
+            </trans-unit>
+            <trans-unit id="message_delete_confirmation">
+                <source>message_delete_confirmation</source>
+                <target>Да ли сигурно желите да обришете "%object%"?</target>
+            </trans-unit>
+            <trans-unit id="btn_delete">
+                <source>btn_delete</source>
+                <target>Да, обриши</target>
+            </trans-unit>
+            <trans-unit id="title_batch_confirmation">
+                <source>title_batch_confirmation</source>
+                <target>Потврдите групну акцију "%action%"</target>
+            </trans-unit>
+            <trans-unit id="message_batch_confirmation">
+                <source>message_batch_confirmation</source>
+                <target>Да ли сигурно желите да извршите ову акцију за изабране записе?|Да ли сигурно желите да извршите ову акцију над %count% записа?</target>
+            </trans-unit>
+            <trans-unit id="message_batch_all_confirmation">
+                <source>message_batch_all_confirmation</source>
+                <target>Да ли сигурно желите да извршите ову акцију над свим записима?</target>
+            </trans-unit>
+            <trans-unit id="btn_execute_batch_action">
+                <source>btn_execute_batch_action</source>
+                <target>Да, изврши</target>
+            </trans-unit>
+            <trans-unit id="label_type_yes">
+                <source>label_type_yes</source>
+                <target>да</target>
+            </trans-unit>
+            <trans-unit id="label_type_no">
+                <source>label_type_no</source>
+                <target>нe</target>
+            </trans-unit>
+            <trans-unit id="label_type_contains">
+                <source>label_type_contains</source>
+                <target>садржи</target>
+            </trans-unit>
+            <trans-unit id="label_type_not_contains">
+                <source>label_type_not_contains</source>
+                <target>не садржи</target>
+            </trans-unit>
+            <trans-unit id="label_type_equals">
+                <source>label_type_equals</source>
+                <target>једнако</target>
+            </trans-unit>
+            <trans-unit id="label_type_not_equals">
+                <source>label_type_not_equals</source>
+                <target>није једнако</target>
+            </trans-unit>
+            <trans-unit id="label_type_equal">
+                <source>label_type_equal</source>
+                <target>=</target>
+            </trans-unit>
+            <trans-unit id="label_type_greater_equal">
+                <source>label_type_greater_equal</source>
+                <target>&gt;=</target>
+            </trans-unit>
+            <trans-unit id="label_type_greater_than">
+                <source>label_type_greater_than</source>
+                <target>&gt;</target>
+            </trans-unit>
+            <trans-unit id="label_type_less_equal">
+                <source>label_type_less_equal</source>
+                <target>&lt;=</target>
+            </trans-unit>
+            <trans-unit id="label_type_less_than">
+                <source>label_type_less_than</source>
+                <target>&lt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_equal">
+                <source>label_date_type_equal</source>
+                <target>=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_greater_equal">
+                <source>label_date_type_greater_equal</source>
+                <target>&gt;=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_greater_than">
+                <source>label_date_type_greater_than</source>
+                <target>&gt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_less_equal">
+                <source>label_date_type_less_equal</source>
+                <target>&lt;=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_less_than">
+                <source>label_date_type_less_than</source>
+                <target>&lt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_null">
+                <source>label_date_type_null</source>
+                <target>је празан</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_not_null">
+                <source>label_date_type_not_null</source>
+                <target>није празан</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_between">
+                <source>label_date_type_between</source>
+                <target>у периоду</target>
+            </trans-unit>
+            <trans-unit id="label_date_not_between">
+                <source>label_date_type_not_between</source>
+                <target>није у периоду</target>
+            </trans-unit>
+            <trans-unit id="label_filters">
+                <source>label_filters</source>
+                <target>Филтери</target>
+            </trans-unit>
+            <trans-unit id="delete_or">
+                <source>delete_or</source>
+                <target>или</target>
+            </trans-unit>
+            <trans-unit id="link_action_history">
+                <source>link_action_history</source>
+                <target>Ревизије</target>
+            </trans-unit>
+            <trans-unit id="td_action">
+                <source>td_action</source>
+                <target>Акције</target>
+            </trans-unit>
+            <trans-unit id="td_compare">
+                <source>td_compare</source>
+                <target>Упореди</target>
+            </trans-unit>
+            <trans-unit id="td_revision">
+                <source>td_revision</source>
+                <target>Ревизије</target>
+            </trans-unit>
+            <trans-unit id="td_timestamp">
+                <source>td_timestamp</source>
+                <target>Датум</target>
+            </trans-unit>
+            <trans-unit id="td_username">
+                <source>td_username</source>
+                <target>Аутор/ка</target>
+            </trans-unit>
+            <trans-unit id="td_role">
+                <source>td_role</source>
+                <target>Улога</target>
+            </trans-unit>
+            <trans-unit id="label_view_revision">
+                <source>label_view_revision</source>
+                <target>Прикажи ревизију</target>
+            </trans-unit>
+            <trans-unit id="label_compare_revision">
+                <source>label_compare_revision</source>
+                <target>Упореди ревизију</target>
+            </trans-unit>
+            <trans-unit id="list_results_count_prefix">
+                <source>list_results_count_prefix</source>
+                <target>барем</target>
+            </trans-unit>
+            <trans-unit id="list_results_count">
+                <source>list_results_count</source>
+                <target>%count% резултат|%count% резултата|%count% резултата</target>
+            </trans-unit>
+            <trans-unit id="label_export_download">
+                <source>label_export_download</source>
+                <target>Преузми</target>
+            </trans-unit>
+            <trans-unit id="export_format_json">
+                <source>export_format_json</source>
+                <target>JSON</target>
+            </trans-unit>
+            <trans-unit id="export_format_xml">
+                <source>export_format_xml</source>
+                <target>XML</target>
+            </trans-unit>
+            <trans-unit id="export_format_csv">
+                <source>export_format_csv</source>
+                <target>CSV</target>
+            </trans-unit>
+            <trans-unit id="export_format_xls">
+                <source>export_format_xls</source>
+                <target>XLS</target>
+            </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Учитавам податке...</target>
+            </trans-unit>
+            <trans-unit id="btn_preview">
+                <source>btn_preview</source>
+                <target>Прегледај</target>
+            </trans-unit>
+            <trans-unit id="btn_preview_approve">
+                <source>btn_preview_approve</source>
+                <target>Одобри</target>
+            </trans-unit>
+            <trans-unit id="btn_preview_decline">
+                <source>btn_preview_decline</source>
+                <target>Одбиј</target>
+            </trans-unit>
+            <trans-unit id="label_per_page">
+                <source>label_per_page</source>
+                <target>По страници</target>
+            </trans-unit>
+            <trans-unit id="list_select">
+                <source>list_select</source>
+                <target>Изабери</target>
+            </trans-unit>
+            <trans-unit id="confirm_exit">
+                <source>confirm_exit</source>
+                <target>Неке измене нису сачуване.</target>
+            </trans-unit>
+            <trans-unit id="link_edit_acl">
+                <source>link_edit_acl</source>
+                <target>Измени листу за контролу приступа (ACL)</target>
+            </trans-unit>
+            <trans-unit id="btn_update_acl">
+                <source>btn_update_acl</source>
+                <target>Ажурирај листу за контролу приступа (ACL)</target>
+            </trans-unit>
+            <trans-unit id="flash_acl_update_success">
+                <source>flash_acl_edit_success</source>
+                <target>Листа за конторлу приступа (ACL) је успешно ажурирана.</target>
+            </trans-unit>
+            <trans-unit id="link_action_acl">
+                <source>link_action_acl</source>
+                <target>Листа за контролу приступа (ACL)</target>
+            </trans-unit>
+            <trans-unit id="short_object_description_placeholder">
+                <source>short_object_description_placeholder</source>
+                <target>Ништа није изабрано</target>
+            </trans-unit>
+            <trans-unit id="title_search_results">
+                <source>title_search_results</source>
+                <target>Резултати претраживања: %query%</target>
+            </trans-unit>
+            <trans-unit id="search_placeholder">
+                <source>search_placeholder</source>
+                <target>Тражи</target>
+            </trans-unit>
+            <trans-unit id="no_results_found">
+                <source>no_results_found</source>
+                <target>није пронађен ниједан резултат</target>
+            </trans-unit>
+            <trans-unit id="add_new_entry">
+                <source>add_new_entry</source>
+                <target>додај нови запис</target>
+            </trans-unit>
+            <trans-unit id="link_actions">
+                <source>link_actions</source>
+                <target>Акције</target>
+            </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>Javascript је онемогућен у Вашем интернет претраживачу. Неке функције неће радити исправно.</target>
+            </trans-unit>
+            <trans-unit id="message_form_group_empty">
+                <source>message_form_group_empty</source>
+                <target>Нема доступних поља.</target>
+            </trans-unit>
+            <trans-unit id="link_filters">
+                <source>link_filters</source>
+                <target>Филтери</target>
+            </trans-unit>
+            <trans-unit id="stats_view_more">
+                <source>stats_view_more</source>
+                <target>Погледај више</target>
+            </trans-unit>
+            <trans-unit id="title_select_subclass">
+                <source>title_select_subclass</source>
+                <target>Изаберите тип објекта</target>
+            </trans-unit>
+            <trans-unit id="no_subclass_available">
+                <source>no_subclass_available</source>
+                <target>Није доступан ниједан тип објекта</target>
+            </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>непознато</target>
+            </trans-unit>
+            <trans-unit id="read_more">
+                <source>read_more</source>
+                <target>Опширније</target>
+            </trans-unit>
+            <trans-unit id="read_less">
+                <source>read_less</source>
+                <target>Затвори</target>
+            </trans-unit>
+            <trans-unit id="toggle_navigation">
+                <source>toggle_navigation</source>
+                <target>Укључи/искључи навигацију</target>
+            </trans-unit>
+            <trans-unit id="label_type_starts_with">
+                <source>label_type_starts_with</source>
+                <target>почиње са</target>
+            </trans-unit>
+            <trans-unit id="label_type_ends_with">
+                <source>label_type_ends_with</source>
+                <target>завршава се са</target>
+            </trans-unit>
+            <trans-unit id="go_to_first_page">
+                <source>go_to_first_page</source>
+                <target>Иди на прву страницу</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Resources/translations/SonataAdminBundle.sr_Latn.xliff
+++ b/src/Resources/translations/SonataAdminBundle.sr_Latn.xliff
@@ -1,0 +1,507 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" datatype="plaintext" original="SonataAdminBundle.en.xliff">
+        <body>
+            <trans-unit id="sonata_administration">
+                <source>sonata_administration</source>
+                <target>Administracija</target>
+            </trans-unit>
+            <trans-unit id="action_delete">
+                <source>action_delete</source>
+                <target>Obriši</target>
+            </trans-unit>
+            <trans-unit id="btn_batch">
+                <source>btn_batch</source>
+                <target>OK</target>
+            </trans-unit>
+            <trans-unit id="btn_create">
+                <source>btn_create</source>
+                <target>Sačuvaj</target>
+            </trans-unit>
+            <trans-unit id="btn_create_and_edit_again">
+                <source>btn_create_and_edit_again</source>
+                <target>Sačuvaj</target>
+            </trans-unit>
+            <trans-unit id="btn_create_and_create_a_new_one">
+                <source>btn_create_and_create_a_new_one</source>
+                <target>Sačuvaj i dodaj još jedan zapis</target>
+            </trans-unit>
+            <trans-unit id="btn_create_and_return_to_list">
+                <source>btn_create_and_return_to_list</source>
+                <target>Sačuvaj i idi na listu zapisa</target>
+            </trans-unit>
+            <trans-unit id="btn_filter">
+                <source>btn_filter</source>
+                <target>Filtriraj</target>
+            </trans-unit>
+            <trans-unit id="btn_advanced_filters">
+                <source>btn_advanced_filters</source>
+                <target>Napredni filteri</target>
+            </trans-unit>
+            <trans-unit id="btn_update">
+                <source>btn_update</source>
+                <target>Ažuriraj</target>
+            </trans-unit>
+            <trans-unit id="btn_update_and_edit_again">
+                <source>btn_update_and_edit_again</source>
+                <target>Ažuriraj</target>
+            </trans-unit>
+            <trans-unit id="btn_update_and_return_to_list">
+                <source>btn_update_and_return_to_list</source>
+                <target>Ažuriraj i zatvori</target>
+            </trans-unit>
+            <trans-unit id="link_delete">
+                <source>link_delete</source>
+                <target>Obriši</target>
+            </trans-unit>
+            <trans-unit id="link_action_create">
+                <source>link_action_create</source>
+                <target>Novi zapis</target>
+            </trans-unit>
+            <trans-unit id="link_action_list">
+                <source>link_action_list</source>
+                <target>Lista zapisa</target>
+            </trans-unit>
+            <trans-unit id="link_action_show">
+                <source>link_action_show</source>
+                <target>Prikaži</target>
+            </trans-unit>
+            <trans-unit id="link_action_edit">
+                <source>link_action_edit</source>
+                <target>Promeni</target>
+            </trans-unit>
+            <trans-unit id="link_add">
+                <source>link_add</source>
+                <target>Novi zapis</target>
+            </trans-unit>
+            <trans-unit id="link_edit">
+                <source>link_edit</source>
+                <target>Promeni</target>
+            </trans-unit>
+            <trans-unit id="link_list">
+                <source>link_list</source>
+                <target>Lista zapisa</target>
+            </trans-unit>
+            <trans-unit id="link_reset_filter">
+                <source>link_reset_filter</source>
+                <target>Resetuj</target>
+            </trans-unit>
+            <trans-unit id="title_create">
+                <source>title_create</source>
+                <target>Novi zapis</target>
+            </trans-unit>
+            <trans-unit id="title_show">
+                <source>title_show</source>
+                <target>Prikaži "%name%"</target>
+            </trans-unit>
+            <trans-unit id="title_dashboard">
+                <source>title_dashboard</source>
+                <target>Kontrolna tabla</target>
+            </trans-unit>
+            <trans-unit id="title_edit">
+                <source>title_edit</source>
+                <target>Promeni "%name%"</target>
+            </trans-unit>
+            <trans-unit id="title_list">
+                <source>title_list</source>
+                <target>Lista zapisa</target>
+            </trans-unit>
+            <trans-unit id="link_next_pager">
+                <source>link_next_pager</source>
+                <target>Sledeća</target>
+            </trans-unit>
+            <trans-unit id="link_previous_pager">
+                <source>link_previous_pager</source>
+                <target>Prethodna</target>
+            </trans-unit>
+            <trans-unit id="link_first_pager">
+                <source>link_first_pager</source>
+                <target>Prva</target>
+            </trans-unit>
+            <trans-unit id="link_last_pager">
+                <source>link_last_pager</source>
+                <target>Poslednja</target>
+            </trans-unit>
+            <trans-unit id="Admin">
+                <source>Admin</source>
+                <target>Administracija</target>
+            </trans-unit>
+            <trans-unit id="link_expand">
+                <source>link_expand</source>
+                <target>proširi/skupi</target>
+            </trans-unit>
+            <trans-unit id="no_result">
+                <source>no_result</source>
+                <target>Nema rezultata</target>
+            </trans-unit>
+            <trans-unit id="confirm_msg">
+                <source>confirm_msg</source>
+                <target>Da li ste sigurni?</target>
+            </trans-unit>
+            <trans-unit id="action_edit">
+                <source>action_edit</source>
+                <target>Promeni</target>
+            </trans-unit>
+            <trans-unit id="action_show">
+                <source>action_show</source>
+                <target>Prikaži</target>
+            </trans-unit>
+            <trans-unit id="all_elements">
+                <source>all_elements</source>
+                <target>Ukupno</target>
+            </trans-unit>
+            <trans-unit id="flash_batch_empty">
+                <source>flash_batch_empty</source>
+                <target>Akcija je prekinuta jer ništa nije izabrano.</target>
+            </trans-unit>
+            <trans-unit id="flash_create_success">
+                <source>flash_create_success</source>
+                <target>Novi zapis "%name%" je uspešno sačuvan.</target>
+            </trans-unit>
+            <trans-unit id="flash_create_error">
+                <source>flash_create_error</source>
+                <target>Došlo je do greške tokom kreiranja "%name%".</target>
+            </trans-unit>
+            <trans-unit id="flash_edit_success">
+                <source>flash_edit_success</source>
+                <target>Zapis "%name%" je uspešno ažuriran.</target>
+            </trans-unit>
+            <trans-unit id="flash_edit_error">
+                <source>flash_edit_error</source>
+                <target>Došlo je do greške tokom ažuriranja "%name%".</target>
+            </trans-unit>
+            <trans-unit id="flash_lock_error">
+                <source>flash_lock_error</source>
+                <target>Drugi korisnik je promenio "%name%". Molim %link_start%kliknite ovde%link_end% da biste ponovo učitali stranicu i sačuvali izmene.</target>
+            </trans-unit>
+            <trans-unit id="flash_batch_delete_success">
+                <source>flash_batch_delete_success</source>
+                <target>Izabrani zapisi su uspešno obrisani.</target>
+            </trans-unit>
+            <trans-unit id="flash_batch_no_elements_processed">
+                <source>flash_batch_no_elements_processed</source>
+                <target>Nije obrađen nijedan element.</target>
+            </trans-unit>
+            <trans-unit id="flash_batch_delete_error">
+                <source>flash_batch_delete_error</source>
+                <target>Došlo je do greške tokom brisanja izabranih zapisa.</target>
+            </trans-unit>
+            <trans-unit id="flash_delete_error">
+                <source>flash_delete_error</source>
+                <target>Došlo je do greške tokom brisanja "%name%".</target>
+            </trans-unit>
+            <trans-unit id="flash_delete_success">
+                <source>flash_delete_success</source>
+                <target>Zapis "%name%" je uspešno obrisan.</target>
+            </trans-unit>
+            <trans-unit id="form_not_available">
+                <source>form_not_available</source>
+                <target>Obrazac nije dostupan.</target>
+            </trans-unit>
+            <trans-unit id="link_breadcrumb_dashboard">
+                <source>link_breadcrumb_dashboard</source>
+                <target><![CDATA[<i class="fa fa-home"></i>]]></target>
+            </trans-unit>
+            <trans-unit id="title_delete">
+                <source>title_delete</source>
+                <target>Potvrdite brisanje</target>
+            </trans-unit>
+            <trans-unit id="message_delete_confirmation">
+                <source>message_delete_confirmation</source>
+                <target>Da li sigurno želite da obrišete "%object%"?</target>
+            </trans-unit>
+            <trans-unit id="btn_delete">
+                <source>btn_delete</source>
+                <target>Da, obriši</target>
+            </trans-unit>
+            <trans-unit id="title_batch_confirmation">
+                <source>title_batch_confirmation</source>
+                <target>Potvrdite grupnu akciju "%action%"</target>
+            </trans-unit>
+            <trans-unit id="message_batch_confirmation">
+                <source>message_batch_confirmation</source>
+                <target>Da li sigurno želite da izvršite ovu akciju za izabrane zapise?|Da li sigurno želite da izvršite ovu akciju nad %count% zapisa?</target>
+            </trans-unit>
+            <trans-unit id="message_batch_all_confirmation">
+                <source>message_batch_all_confirmation</source>
+                <target>Da li sigurno želite da izvršite ovu akciju nad svim zapisima?</target>
+            </trans-unit>
+            <trans-unit id="btn_execute_batch_action">
+                <source>btn_execute_batch_action</source>
+                <target>Da, izvrši</target>
+            </trans-unit>
+            <trans-unit id="label_type_yes">
+                <source>label_type_yes</source>
+                <target>da</target>
+            </trans-unit>
+            <trans-unit id="label_type_no">
+                <source>label_type_no</source>
+                <target>ne</target>
+            </trans-unit>
+            <trans-unit id="label_type_contains">
+                <source>label_type_contains</source>
+                <target>sadrži</target>
+            </trans-unit>
+            <trans-unit id="label_type_not_contains">
+                <source>label_type_not_contains</source>
+                <target>ne sadrži</target>
+            </trans-unit>
+            <trans-unit id="label_type_equals">
+                <source>label_type_equals</source>
+                <target>jednako</target>
+            </trans-unit>
+            <trans-unit id="label_type_not_equals">
+                <source>label_type_not_equals</source>
+                <target>nije jednako</target>
+            </trans-unit>
+            <trans-unit id="label_type_equal">
+                <source>label_type_equal</source>
+                <target>=</target>
+            </trans-unit>
+            <trans-unit id="label_type_greater_equal">
+                <source>label_type_greater_equal</source>
+                <target>&gt;=</target>
+            </trans-unit>
+            <trans-unit id="label_type_greater_than">
+                <source>label_type_greater_than</source>
+                <target>&gt;</target>
+            </trans-unit>
+            <trans-unit id="label_type_less_equal">
+                <source>label_type_less_equal</source>
+                <target>&lt;=</target>
+            </trans-unit>
+            <trans-unit id="label_type_less_than">
+                <source>label_type_less_than</source>
+                <target>&lt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_equal">
+                <source>label_date_type_equal</source>
+                <target>=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_greater_equal">
+                <source>label_date_type_greater_equal</source>
+                <target>&gt;=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_greater_than">
+                <source>label_date_type_greater_than</source>
+                <target>&gt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_less_equal">
+                <source>label_date_type_less_equal</source>
+                <target>&lt;=</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_less_than">
+                <source>label_date_type_less_than</source>
+                <target>&lt;</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_null">
+                <source>label_date_type_null</source>
+                <target>je prazan</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_not_null">
+                <source>label_date_type_not_null</source>
+                <target>nije prazan</target>
+            </trans-unit>
+            <trans-unit id="label_date_type_between">
+                <source>label_date_type_between</source>
+                <target>u periodu</target>
+            </trans-unit>
+            <trans-unit id="label_date_not_between">
+                <source>label_date_type_not_between</source>
+                <target>nije u periodu</target>
+            </trans-unit>
+            <trans-unit id="label_filters">
+                <source>label_filters</source>
+                <target>Filteri</target>
+            </trans-unit>
+            <trans-unit id="delete_or">
+                <source>delete_or</source>
+                <target>ili</target>
+            </trans-unit>
+            <trans-unit id="link_action_history">
+                <source>link_action_history</source>
+                <target>Revizije</target>
+            </trans-unit>
+            <trans-unit id="td_action">
+                <source>td_action</source>
+                <target>Akcije</target>
+            </trans-unit>
+            <trans-unit id="td_compare">
+                <source>td_compare</source>
+                <target>Uporedi</target>
+            </trans-unit>
+            <trans-unit id="td_revision">
+                <source>td_revision</source>
+                <target>Revizije</target>
+            </trans-unit>
+            <trans-unit id="td_timestamp">
+                <source>td_timestamp</source>
+                <target>Datum</target>
+            </trans-unit>
+            <trans-unit id="td_username">
+                <source>td_username</source>
+                <target>Autor/ka</target>
+            </trans-unit>
+            <trans-unit id="td_role">
+                <source>td_role</source>
+                <target>Uloga</target>
+            </trans-unit>
+            <trans-unit id="label_view_revision">
+                <source>label_view_revision</source>
+                <target>Prikaži reviziju</target>
+            </trans-unit>
+            <trans-unit id="label_compare_revision">
+                <source>label_compare_revision</source>
+                <target>Uporedi reviziju</target>
+            </trans-unit>
+            <trans-unit id="list_results_count_prefix">
+                <source>list_results_count_prefix</source>
+                <target>barem</target>
+            </trans-unit>
+            <trans-unit id="list_results_count">
+                <source>list_results_count</source>
+                <target>%count% rezultat|%count% rezultata|%count% rezultata</target>
+            </trans-unit>
+            <trans-unit id="label_export_download">
+                <source>label_export_download</source>
+                <target>Preuzmi</target>
+            </trans-unit>
+            <trans-unit id="export_format_json">
+                <source>export_format_json</source>
+                <target>JSON</target>
+            </trans-unit>
+            <trans-unit id="export_format_xml">
+                <source>export_format_xml</source>
+                <target>XML</target>
+            </trans-unit>
+            <trans-unit id="export_format_csv">
+                <source>export_format_csv</source>
+                <target>CSV</target>
+            </trans-unit>
+            <trans-unit id="export_format_xls">
+                <source>export_format_xls</source>
+                <target>XLS</target>
+            </trans-unit>
+            <trans-unit id="loading_information">
+                <source>loading_information</source>
+                <target>Učitavam podatke...</target>
+            </trans-unit>
+            <trans-unit id="btn_preview">
+                <source>btn_preview</source>
+                <target>Pregledaj</target>
+            </trans-unit>
+            <trans-unit id="btn_preview_approve">
+                <source>btn_preview_approve</source>
+                <target>Odobri</target>
+            </trans-unit>
+            <trans-unit id="btn_preview_decline">
+                <source>btn_preview_decline</source>
+                <target>Odbij</target>
+            </trans-unit>
+            <trans-unit id="label_per_page">
+                <source>label_per_page</source>
+                <target>Po stranici</target>
+            </trans-unit>
+            <trans-unit id="list_select">
+                <source>list_select</source>
+                <target>Izaberi</target>
+            </trans-unit>
+            <trans-unit id="confirm_exit">
+                <source>confirm_exit</source>
+                <target>Neke izmene nisu sačuvane.</target>
+            </trans-unit>
+            <trans-unit id="link_edit_acl">
+                <source>link_edit_acl</source>
+                <target>Izmeni listu za kontrolu pristupa (ACL)</target>
+            </trans-unit>
+            <trans-unit id="btn_update_acl">
+                <source>btn_update_acl</source>
+                <target>Ažuriraj listu za kontrolu pristupa (ACL)</target>
+            </trans-unit>
+            <trans-unit id="flash_acl_update_success">
+                <source>flash_acl_edit_success</source>
+                <target>Lista za kontorlu pristupa (ACL) je uspešno ažurirana.</target>
+            </trans-unit>
+            <trans-unit id="link_action_acl">
+                <source>link_action_acl</source>
+                <target>Lista za kontrolu pristupa (ACL)</target>
+            </trans-unit>
+            <trans-unit id="short_object_description_placeholder">
+                <source>short_object_description_placeholder</source>
+                <target>Ništa nije izabrano</target>
+            </trans-unit>
+            <trans-unit id="title_search_results">
+                <source>title_search_results</source>
+                <target>Rezultati pretraživanja: %query%</target>
+            </trans-unit>
+            <trans-unit id="search_placeholder">
+                <source>search_placeholder</source>
+                <target>Traži</target>
+            </trans-unit>
+            <trans-unit id="no_results_found">
+                <source>no_results_found</source>
+                <target>nije pronađen nijedan rezultat</target>
+            </trans-unit>
+            <trans-unit id="add_new_entry">
+                <source>add_new_entry</source>
+                <target>dodaj novi zapis</target>
+            </trans-unit>
+            <trans-unit id="link_actions">
+                <source>link_actions</source>
+                <target>Akcije</target>
+            </trans-unit>
+            <trans-unit id="noscript_warning">
+                <source>noscript_warning</source>
+                <target>Javascript je onemogućen u Vašem internet pretraživaču. Neke funkcije neće raditi ispravno.</target>
+            </trans-unit>
+            <trans-unit id="message_form_group_empty">
+                <source>message_form_group_empty</source>
+                <target>Nema dostupnih polja.</target>
+            </trans-unit>
+            <trans-unit id="link_filters">
+                <source>link_filters</source>
+                <target>Filteri</target>
+            </trans-unit>
+            <trans-unit id="stats_view_more">
+                <source>stats_view_more</source>
+                <target>Pogledaj više</target>
+            </trans-unit>
+            <trans-unit id="title_select_subclass">
+                <source>title_select_subclass</source>
+                <target>Izaberite tip objekta</target>
+            </trans-unit>
+            <trans-unit id="no_subclass_available">
+                <source>no_subclass_available</source>
+                <target>Nije dostupan nijedan tip objekta</target>
+            </trans-unit>
+            <trans-unit id="label_unknown_user">
+                <source>label_unknown_user</source>
+                <target>nepoznato</target>
+            </trans-unit>
+            <trans-unit id="read_more">
+                <source>read_more</source>
+                <target>Opširnije</target>
+            </trans-unit>
+            <trans-unit id="read_less">
+                <source>read_less</source>
+                <target>Zatvori</target>
+            </trans-unit>
+            <trans-unit id="toggle_navigation">
+                <source>toggle_navigation</source>
+                <target>Uključi/isključi navigaciju</target>
+            </trans-unit>
+            <trans-unit id="label_type_starts_with">
+                <source>label_type_starts_with</source>
+                <target>počinje sa</target>
+            </trans-unit>
+            <trans-unit id="label_type_ends_with">
+                <source>label_type_ends_with</source>
+                <target>završava se sa</target>
+            </trans-unit>
+            <trans-unit id="go_to_first_page">
+                <source>go_to_first_page</source>
+                <target>Idi na prvu stranicu</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -577,7 +577,11 @@ file that was distributed with this source code.
 
     <script>
         jQuery(document).ready(function() {
-            Admin.setup_sortable_select2(jQuery('#{{ id }}'), {{ form.vars.choices|json_encode|raw }});
+            var options = {};
+
+            {% block sonata_type_model_autocomplete_select2_options_js %}{% endblock %}
+
+            Admin.setup_sortable_select2(jQuery('#{{ id }}'), {{ form.vars.choices|json_encode|raw }}, options);
         });
     </script>
 {% endblock %}

--- a/src/Route/RouteCollection.php
+++ b/src/Route/RouteCollection.php
@@ -335,7 +335,7 @@ class RouteCollection implements RouteCollectionInterface
                     'Element resolved by code "%s" is not instance of "%s"; This is deprecated since sonata-project/admin-bundle 3.75 and will be removed in 4.0.',
                     $code,
                     Route::class
-                ), E_USER_DEPRECATED);
+                ), \E_USER_DEPRECATED);
                 // NEXT_MAJOR : remove the previous `trigger_error()` and throw exception
             }
 

--- a/src/Search/SearchHandler.php
+++ b/src/Search/SearchHandler.php
@@ -54,7 +54,7 @@ class SearchHandler
                 .' It will accept only bool in version 4.0.',
                 Pool::class,
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             $this->pool = $deprecatedPoolOrCaseSensitive;
             $this->caseSensitive = $caseSensitive;

--- a/src/SonataAdminBundle.php
+++ b/src/SonataAdminBundle.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle;
 use Mopa\Bundle\BootstrapBundle\Form\Type\TabType;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\Compiler\AdminMakerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AdminSearchCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
@@ -57,6 +58,7 @@ class SonataAdminBundle extends Bundle
         $container->addCompilerPass(new ModelManagerCompilerPass());
         $container->addCompilerPass(new ObjectAclManipulatorCompilerPass());
         $container->addCompilerPass(new TwigStringExtensionCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
+        $container->addCompilerPass(new AdminMakerCompilerPass());
 
         $this->registerFormMapping();
     }

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -53,7 +53,7 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
             'Passing a nonexistent template name as argument 1 to %s() is deprecated since'
             .' sonata-project/admin-bundle 3.52 and will throw an exception in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare string as return type
         // throw new \InvalidArgumentException(sprintf(

--- a/src/Templating/MutableTemplateRegistry.php
+++ b/src/Templating/MutableTemplateRegistry.php
@@ -22,7 +22,9 @@ final class MutableTemplateRegistry extends AbstractTemplateRegistry implements 
     // public function setTemplates(array $templates): void
     public function setTemplates(array $templates)
     {
+        //NEXT_MAJOR: merge arrays and update the doc https://github.com/sonata-project/SonataAdminBundle/blob/3.x/docs/reference/templates.rst
         $this->templates = $templates;
+        //$this->templates = $templates + $this->templates;
     }
 
     // NEXT_MAJOR: change method declaration for new one

--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -30,4 +30,23 @@ interface MutableTemplateRegistryAwareInterface
 
     // NEXT_MAJOR: uncomment this method in 4.0
     //public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void;
+
+    /**
+     * NEXT_MAJOR: remove this method declaration with docblock and uncomment code below.
+     *
+     * @param string $name
+     * @param string $template
+     */
+    public function setTemplate($name, $template);
+
+    //public function setTemplate(string $name, string $template);
+
+    /**
+     * NEXT_MAJOR: remove this method declaration and uncomment code below.
+     *
+     * @param array<string, string> $templates
+     */
+    public function setTemplates(array $templates);
+
+    //public function setTemplates(array $templates): void;
 }

--- a/src/Templating/TemplateRegistry.php
+++ b/src/Templating/TemplateRegistry.php
@@ -32,7 +32,7 @@ final class TemplateRegistry extends AbstractTemplateRegistry implements Mutable
         @trigger_error(sprintf(
             'Method "%s()" is deprecated since sonata-project/admin-bundle 3.39 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
     }
 
     /**
@@ -47,6 +47,6 @@ final class TemplateRegistry extends AbstractTemplateRegistry implements Mutable
         @trigger_error(sprintf(
             'Method "%s()" is deprecated since sonata-project/admin-bundle 3.39 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
     }
 }

--- a/src/Twig/Extension/RenderElementExtension.php
+++ b/src/Twig/Extension/RenderElementExtension.php
@@ -159,7 +159,7 @@ final class RenderElementExtension extends AbstractExtension
                     .' since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.',
                     $fieldDescription->getName(),
                 ),
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
 
             $value = null;
@@ -203,7 +203,7 @@ final class RenderElementExtension extends AbstractExtension
                     .' since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.',
                     $fieldDescription->getName(),
                 ),
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
 
             $baseValue = null;
@@ -219,7 +219,7 @@ final class RenderElementExtension extends AbstractExtension
                     .' since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.',
                     $fieldDescription->getName(),
                 ),
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
 
             $compareValue = null;
@@ -276,7 +276,7 @@ final class RenderElementExtension extends AbstractExtension
             if ($method) {
                 @trigger_error(
                     'Option "associated_tostring" is deprecated since version 2.3 and will be removed in 4.0. Use "associated_property" instead.',
-                    E_USER_DEPRECATED
+                    \E_USER_DEPRECATED
                 );
             } else {
                 $method = '__toString';
@@ -325,7 +325,7 @@ final class RenderElementExtension extends AbstractExtension
                 'Relying on default template loading on field template loading exception is deprecated since 3.1'
                 .' and will be removed in 4.0. A %s exception will be thrown instead',
                 LoaderError::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
             $template = $environment->load($defaultTemplate);
 
             if (null !== $this->logger) {
@@ -380,7 +380,7 @@ final class RenderElementExtension extends AbstractExtension
                         .' since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.',
                         $fieldDescription->getName(),
                     ),
-                    E_USER_DEPRECATED
+                    \E_USER_DEPRECATED
                 );
 
                 $value = null;

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -146,14 +146,14 @@ class SonataAdminExtension extends AbstractExtension
         if (null === $translator) {
             @trigger_error(
                 'The $translator parameter will be required field with the 4.0 release.',
-                E_USER_DEPRECATED
+                \E_USER_DEPRECATED
             );
         } else {
             if (!$translator instanceof TranslatorInterface) {
                 @trigger_error(sprintf(
                     'The $translator parameter should be an instance of "%s" and will be mandatory in 4.0.',
                     TranslatorInterface::class
-                ), E_USER_DEPRECATED);
+                ), \E_USER_DEPRECATED);
             }
 
             if (!$translator instanceof TranslatorInterface && !$translator instanceof LegacyTranslationInterface) {
@@ -189,7 +189,7 @@ class SonataAdminExtension extends AbstractExtension
                 __METHOD__,
                 PropertyAccessorInterface::class,
                 AuthorizationCheckerInterface::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             $this->securityChecker = $propertyAccessorOrSecurityChecker;
             $this->propertyAccessor = $pool->getPropertyAccessor();
@@ -199,7 +199,7 @@ class SonataAdminExtension extends AbstractExtension
                 .' 3.82 and will throw a \TypeError error in version 4.0. You must pass an instance of "%s" instead.',
                 __METHOD__,
                 PropertyAccessorInterface::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             $this->propertyAccessor = $pool->getPropertyAccessor();
             $this->securityChecker = $securityChecker;
@@ -367,7 +367,7 @@ class SonataAdminExtension extends AbstractExtension
             @trigger_error(sprintf(
                 'The %s method is deprecated in favor of RenderElementExtension::renderListElement since version 3.87 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         if (null === $this->renderElementExtension) {
@@ -391,7 +391,7 @@ class SonataAdminExtension extends AbstractExtension
         @trigger_error(sprintf(
             'The %s method is deprecated since version 3.33 and will be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         $content = $template->render($parameters);
 
@@ -443,7 +443,7 @@ EOT;
             'The %s() method is deprecated since sonata-project/admin-bundle 3.73 and will be removed in version 4.0.'
             .' There is no replacement.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         if (isset($params['loop']) && $object instanceof \ArrayAccess) {
             throw new \RuntimeException('remove the loop requirement');
@@ -464,7 +464,7 @@ EOT;
                         .' since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.',
                         $fieldDescription->getName(),
                     ),
-                    E_USER_DEPRECATED
+                    \E_USER_DEPRECATED
                 );
             }
         }
@@ -491,7 +491,7 @@ EOT;
             @trigger_error(sprintf(
                 'The %s method is deprecated in favor of RenderElementExtension::renderViewElement since version 3.87 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         if (null === $this->renderElementExtension) {
@@ -522,7 +522,7 @@ EOT;
             @trigger_error(sprintf(
                 'The %s method is deprecated in favor of RenderElementExtension::renderViewElementCompare since version 3.87 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
         if (null === $this->renderElementExtension) {
             $this->renderElementExtension = new RenderElementExtension($this->propertyAccessor, $this->templateRegistries, $this->logger);
@@ -548,7 +548,7 @@ EOT;
             @trigger_error(sprintf(
                 'The %s method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.87 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         if (null === $this->renderElementExtension) {
@@ -592,7 +592,7 @@ EOT;
             @trigger_error(sprintf(
                 'The %s method is deprecated in favor of XEditableExtension::setXEditableTypeMapping since version 3.87 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         $this->xEditableTypeMapping = $xEditableTypeMapping;
@@ -611,7 +611,7 @@ EOT;
             @trigger_error(sprintf(
                 'The %s method is deprecated in favor of XEditableExtension::getXEditableType since version 3.87 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         return $this->xEditableTypeMapping[$type] ?? false;
@@ -636,7 +636,7 @@ EOT;
             @trigger_error(sprintf(
                 'The %s method is deprecated in favor of XEditableExtension::getXEditableChoices since version 3.87 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         if (null === $this->xEditableExtension) {
@@ -662,7 +662,7 @@ EOT;
             @trigger_error(sprintf(
                 'The %s method is deprecated in favor of CanonicalizeExtension::getCanonicalizedLocaleForMoment since version 3.87 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         if (null === $this->canonicalizeExtension) {
@@ -690,7 +690,7 @@ EOT;
             @trigger_error(sprintf(
                 'The %s method is deprecated in favor of CanonicalizeExtension::getCanonicalizedLocaleForSelect2 since version 3.87 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         if (null === $this->canonicalizeExtension) {
@@ -719,7 +719,7 @@ EOT;
             @trigger_error(sprintf(
                 'The %s method is deprecated in favor of SecurityExtension::isGrantedAffirmative since version 3.87 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         if (null === $this->securityExtension) {
@@ -749,7 +749,7 @@ EOT;
             @trigger_error(sprintf(
                 'The %s method is deprecated in favor of RenderElementExtension::getTemplate since version 3.87 and will be removed in 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         return $this->renderElementExtension->getTemplate($fieldDescription, $defaultTemplate, $$environment);

--- a/src/Twig/Extension/StringExtension.php
+++ b/src/Twig/Extension/StringExtension.php
@@ -75,7 +75,7 @@ final class StringExtension extends AbstractExtension
         @trigger_error(
             'The "sonata_truncate" twig filter is deprecated'
             .' since sonata-project/admin-bundle 3.69 and will be removed in 4.0. Use "u.truncate" instead.',
-            E_USER_DEPRECATED
+            \E_USER_DEPRECATED
         );
 
         if ($this->legacyExtension instanceof TextExtension) {

--- a/src/Twig/GlobalVariables.php
+++ b/src/Twig/GlobalVariables.php
@@ -59,7 +59,7 @@ class GlobalVariables
                 'Using an instance of %s is deprecated since version 3.5 and will be removed in 4.0. Use %s instead.',
                 ContainerInterface::class,
                 Pool::class
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
 
             $adminPool = $adminPool->get('sonata.admin.pool');
         }
@@ -82,7 +82,7 @@ class GlobalVariables
             @trigger_error(sprintf(
                 'Method "%s()" is deprecated since sonata-project/admin-bundle 3.83 and will be removed in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         return $this->adminPool;
@@ -101,7 +101,7 @@ class GlobalVariables
         @trigger_error(sprintf(
             'Method "%s()" is deprecated since sonata-project/admin-bundle 3.83 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         [$action, $code] = $this->getCodeAction($code, $action);
 
@@ -122,7 +122,7 @@ class GlobalVariables
         @trigger_error(sprintf(
             'Method "%s()" is deprecated since sonata-project/admin-bundle 3.83 and will be removed in version 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         [$action, $code] = $this->getCodeAction($code, $action);
 
@@ -135,7 +135,7 @@ class GlobalVariables
             'Method "%s()" is deprecated since sonata-project/admin-bundle 3.83 and will be removed in version 4.0.'
             .' Use "sonata_config.getOption(\'mosaic_background\')" instead.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return $this->mosaicBackground;
     }

--- a/src/Util/AdminObjectAclData.php
+++ b/src/Util/AdminObjectAclData.php
@@ -191,7 +191,7 @@ class AdminObjectAclData
     {
         @trigger_error(
             'setForm() is deprecated since version 3.0 and will be removed in 4.0. Use setAclUsersForm() instead.',
-            E_USER_DEPRECATED
+            \E_USER_DEPRECATED
         );
 
         return $this->setAclUsersForm($form);
@@ -210,7 +210,7 @@ class AdminObjectAclData
     {
         @trigger_error(
             'getForm() is deprecated since version 3.0 and will be removed in 4.0. Use getAclUsersForm() instead.',
-            E_USER_DEPRECATED
+            \E_USER_DEPRECATED
         );
 
         return $this->getAclUsersForm();

--- a/src/Util/AdminObjectAclManipulator.php
+++ b/src/Util/AdminObjectAclManipulator.php
@@ -84,7 +84,7 @@ class AdminObjectAclManipulator
     {
         @trigger_error(
             'createForm() is deprecated since version 3.0 and will be removed in 4.0. Use createAclUsersForm() instead.',
-            E_USER_DEPRECATED
+            \E_USER_DEPRECATED
         );
 
         return $this->createAclUsersForm($data);
@@ -153,7 +153,7 @@ class AdminObjectAclManipulator
     {
         @trigger_error(
             'updateAcl() is deprecated since version 3.0 and will be removed in 4.0. Use updateAclUsers() instead.',
-            E_USER_DEPRECATED
+            \E_USER_DEPRECATED
         );
 
         $this->updateAclUsers($data);

--- a/src/Util/FormBuilderIterator.php
+++ b/src/Util/FormBuilderIterator.php
@@ -63,7 +63,7 @@ class FormBuilderIterator extends \RecursiveArrayIterator
                 'Passing other type than string or null as argument 2 for method %s() is deprecated since'
                 .' sonata-project/admin-bundle 3.84. It will accept only string and null in version 4.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            ), \E_USER_DEPRECATED);
         }
 
         // NEXT_MAJOR: Remove next line.

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -292,6 +292,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             ['req_param_name_page_number', null, '_page'],
             ['to_string_callback', null, null],
             ['target_admin_access_action', null, 'list'],
+            ['response_string_callback', null, null],
         ]);
     }
 
@@ -312,6 +313,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             ['items_per_page', null, 10],
             ['req_param_name_page_number', null, '_page'],
             ['target_admin_access_action', null, 'list'],
+            ['response_string_callback', null, null],
         ]);
     }
 
@@ -332,6 +334,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             ['items_per_page', null, 10],
             ['req_param_name_page_number', null, '_page'],
             ['target_admin_access_action', null, 'list'],
+            ['response_string_callback', null, null],
         ]);
     }
 }

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -388,7 +388,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $dataTransformer = new CallbackTransformer(static function ($value): string {
             return (string) (int) $value;
         }, static function ($value): bool {
-            return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+            return filter_var($value, \FILTER_VALIDATE_BOOLEAN);
         });
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
@@ -447,7 +447,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         }, static function ($value) use (&$isOverridden): bool {
             $isOverridden = true;
 
-            return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+            return filter_var($value, \FILTER_VALIDATE_BOOLEAN);
         });
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);

--- a/tests/App/Admin/FooAdmin.php
+++ b/tests/App/Admin/FooAdmin.php
@@ -23,7 +23,7 @@ use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Tests\App\Model\Foo;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
-final class FooAdmin extends AbstractAdmin
+class FooAdmin extends AbstractAdmin
 {
     public function getNewInstance()
     {

--- a/tests/App/Admin/FooAdminWithCustomController.php
+++ b/tests/App/Admin/FooAdminWithCustomController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Admin;
+
+class FooAdminWithCustomController extends FooAdmin
+{
+    protected $baseRoutePattern = 'tests/app/foo-with-custom-controller';
+    protected $baseRouteName = 'admin_foo_with_custom_controller';
+}

--- a/tests/App/Controller/CustomCRUDController.php
+++ b/tests/App/Controller/CustomCRUDController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Controller;
+
+use Sonata\AdminBundle\Controller\CRUDController;
+
+class CustomCRUDController extends CRUDController
+{
+}

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -162,7 +162,7 @@ final class ModelManager implements ModelManagerInterface
         @trigger_error(sprintf(
             'Method %s() is deprecated since sonata-project/admin-bundle 3.66. To be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return [];
     }
@@ -220,7 +220,7 @@ final class ModelManager implements ModelManagerInterface
         @trigger_error(sprintf(
             'Method %s() is deprecated since sonata-project/admin-bundle 3.66. To be removed in 4.0.',
             __METHOD__
-        ), E_USER_DEPRECATED);
+        ), \E_USER_DEPRECATED);
 
         return [];
     }

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -38,7 +38,12 @@ services:
         class: Sonata\AdminBundle\Tests\App\Exporter\DataSource
 
     Sonata\AdminBundle\Tests\App\Admin\FooAdmin:
-        arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
+        arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, Sonata\AdminBundle\Controller\CRUDController]
+        tags:
+            - {name: sonata.admin, manager_type: test, label: Foo}
+
+    Sonata\AdminBundle\Tests\App\Admin\FooAdminWithCustomController:
+        arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, Sonata\AdminBundle\Tests\App\Controller\CustomCRUDController]
         tags:
             - {name: sonata.admin, manager_type: test, label: Foo}
 

--- a/tests/Command/ExplainAdminCommandTest.php
+++ b/tests/Command/ExplainAdminCommandTest.php
@@ -208,7 +208,7 @@ class ExplainAdminCommandTest extends TestCase
         $commandTester->execute(['command' => $command->getName(), 'admin' => 'acme.admin.foo']);
 
         $this->assertSame(sprintf(
-            str_replace("\n", PHP_EOL, file_get_contents(sprintf('%s/../Fixtures/Command/explain_admin.txt', __DIR__))),
+            str_replace("\n", \PHP_EOL, file_get_contents(sprintf('%s/../Fixtures/Command/explain_admin.txt', __DIR__))),
             \get_class($this->admin),
             \get_class($modelManager),
             \get_class($formBuilder),
@@ -260,7 +260,7 @@ class ExplainAdminCommandTest extends TestCase
         $this->assertSame(sprintf(
             str_replace(
                 "\n",
-                PHP_EOL,
+                \PHP_EOL,
                 file_get_contents(sprintf('%s/../Fixtures/Command/explain_admin_empty_validator.txt', __DIR__))
             ),
             \get_class($this->admin),

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -660,6 +660,7 @@ class HelperControllerTest extends TestCase
             ['req_param_name_page_number', null, '_page'],
             ['to_string_callback', null, null],
             ['target_admin_access_action', null, 'list'],
+            ['response_string_callback', null, null],
         ]);
     }
 
@@ -682,6 +683,7 @@ class HelperControllerTest extends TestCase
             ['req_param_name_page_number', null, '_page'],
             ['to_string_callback', null, null],
             ['target_admin_access_action', null, 'list'],
+            ['response_string_callback', null, null],
         ]);
     }
 
@@ -704,6 +706,7 @@ class HelperControllerTest extends TestCase
             ['req_param_name_page_number', null, '_page'],
             ['to_string_callback', null, null],
             ['target_admin_access_action', null, 'list'],
+            ['response_string_callback', null, null],
         ]);
     }
 

--- a/tests/DependencyInjection/Compiler/AdminMakerCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AdminMakerCompilerPassTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\AdminBundle\Controller\CRUDController;
+use Sonata\AdminBundle\DependencyInjection\Compiler\AdminMakerCompilerPass;
+use Sonata\AdminBundle\Maker\AdminMaker;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class AdminMakerCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testDoesNothingWithoutAdminMaker(): void
+    {
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sonata.admin.maker');
+    }
+
+    public function testDoesNothingWithoutDefaultControllerParameter(): void
+    {
+        $definition = new Definition(AdminMaker::class);
+        $definition->setArguments([
+            'dir',
+            [],
+            CRUDController::class,
+        ]);
+        $this->container->setDefinition('sonata.admin.maker', $definition);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sonata.admin.maker',
+            2,
+            CRUDController::class
+        );
+    }
+
+    public function testDoesNothingWithoutDefaultControllerNotBeingAService(): void
+    {
+        $definition = new Definition(AdminMaker::class);
+        $definition->setArguments([
+            'dir',
+            [],
+            CRUDController::class,
+        ]);
+        $this->container->setDefinition('sonata.admin.maker', $definition);
+
+        $this->container->setParameter('sonata.admin.configuration.default_controller', CRUDController::class);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sonata.admin.maker',
+            2,
+            CRUDController::class
+        );
+    }
+
+    public function testReplacesTheServiceArgumentWithClassName(): void
+    {
+        $definition = new Definition(AdminMaker::class);
+        $definition->setArguments([
+            'dir',
+            [],
+            'sonata.admin.controller.crud',
+        ]);
+        $this->container->setDefinition('sonata.admin.maker', $definition);
+
+        $definition = new Definition(CRUDController::class);
+        $this->container->setDefinition('sonata.admin.controller.crud', $definition);
+
+        $this->container->setParameter('sonata.admin.configuration.default_controller', 'sonata.admin.controller.crud');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sonata.admin.maker',
+            2,
+            CRUDController::class
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new AdminMakerCompilerPass());
+    }
+}

--- a/tests/Form/DataTransformer/BooleanToStringTransformerTest.php
+++ b/tests/Form/DataTransformer/BooleanToStringTransformerTest.php
@@ -63,7 +63,7 @@ final class BooleanToStringTransformerTest extends TestCase
             // invalid values
             ['foo', false],
             [new \DateTime(), false],
-            [PHP_INT_MAX, false],
+            [\PHP_INT_MAX, false],
         ];
     }
 

--- a/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
@@ -311,4 +311,33 @@ class ModelToIdPropertyTransformerTest extends TestCase
 
         $transformer->transform($collection);
     }
+
+    public function testTransformWithMultipleProperties(): void
+    {
+        $properties = ['bar', 'baz'];
+
+        $transformer = new ModelToIdPropertyTransformer(
+            $this->modelManager,
+            Foo::class,
+            $properties,
+            false,
+            function ($model, $property) use ($properties) {
+                $this->assertSame($properties, $property);
+
+                return 'nice_label';
+            }
+        );
+
+        $model = new Foo();
+        $this->modelManager->expects($this->once())
+            ->method('getIdentifierValues')
+            ->willReturn([123])
+        ;
+
+        $value = $transformer->transform($model);
+        $this->assertSame([
+            123,
+            '_labels' => ['nice_label'],
+        ], $value);
+    }
 }

--- a/tests/Form/DataTransformerResolverTest.php
+++ b/tests/Form/DataTransformerResolverTest.php
@@ -76,7 +76,7 @@ final class DataTransformerResolverTest extends TestCase
         $customDataTransformer = new CallbackTransformer(static function ($value): string {
             return (string) (int) $value;
         }, static function ($value): bool {
-            return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+            return filter_var($value, \FILTER_VALIDATE_BOOLEAN);
         });
         $this->fieldDescription->method('getOption')->with('data_transformer')->willReturn($customDataTransformer);
         $this->fieldDescription->method('getType')->willReturn($fieldType);
@@ -181,7 +181,7 @@ final class DataTransformerResolverTest extends TestCase
         $customDataTransformer = new CallbackTransformer(static function ($value): string {
             return (string) (int) $value;
         }, static function ($value): bool {
-            return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+            return filter_var($value, \FILTER_VALIDATE_BOOLEAN);
         });
 
         $this->fieldDescription->method('getType')->willReturn($fieldType);
@@ -204,7 +204,7 @@ final class DataTransformerResolverTest extends TestCase
         $customDataTransformer = new CallbackTransformer(static function ($value): string {
             return (string) (int) $value;
         }, static function ($value): bool {
-            return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+            return filter_var($value, \FILTER_VALIDATE_BOOLEAN);
         });
 
         $this->fieldDescription->method('getType')->willReturn($fieldType);

--- a/tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -65,6 +65,7 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $this->assertSame('_per_page', $options['req_param_name_items_per_page']);
 
         $this->assertSame('list', $options['target_admin_access_action']);
+        $this->assertSame(null, $options['response_item_callback']);
 
         $this->assertSame('', $options['container_css_class']);
         $this->assertSame('', $options['dropdown_css_class']);

--- a/tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -65,7 +65,7 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $this->assertSame('_per_page', $options['req_param_name_items_per_page']);
 
         $this->assertSame('list', $options['target_admin_access_action']);
-        $this->assertSame(null, $options['response_item_callback']);
+        $this->assertNull($options['response_item_callback']);
 
         $this->assertSame('', $options['container_css_class']);
         $this->assertSame('', $options['dropdown_css_class']);

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -40,6 +40,14 @@ final class CRUDControllerTest extends WebTestCase
         $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }
 
+    public function testCustomControllerList(): void
+    {
+        $client = static::createClient();
+        $client->request(Request::METHOD_GET, '/admin/tests/app/foo-with-custom-controller/list');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+    }
+
     public function testCreate(): void
     {
         $client = static::createClient();
@@ -64,6 +72,14 @@ final class CRUDControllerTest extends WebTestCase
         $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }
 
+    public function testCustomControllerCreate(): void
+    {
+        $client = static::createClient();
+        $client->request(Request::METHOD_GET, '/admin/tests/app/foo-with-custom-controller/create');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+    }
+
     public function testShow(): void
     {
         $client = static::createClient();
@@ -84,6 +100,14 @@ final class CRUDControllerTest extends WebTestCase
         $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }
 
+    public function testCustomControllerShow(): void
+    {
+        $client = static::createClient();
+        $client->request(Request::METHOD_GET, '/admin/tests/app/foo-with-custom-controller/test_id/show');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+    }
+
     public function testEdit(): void
     {
         $client = static::createClient();
@@ -100,6 +124,14 @@ final class CRUDControllerTest extends WebTestCase
     {
         $client = static::createClient();
         $client->request(Request::METHOD_GET, '/admin/empty/test_id/edit');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+    }
+
+    public function testCustomControllerEdit(): void
+    {
+        $client = static::createClient();
+        $client->request(Request::METHOD_GET, '/admin/tests/app/foo-with-custom-controller/test_id/edit');
 
         $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -32,22 +32,6 @@ final class CRUDControllerTest extends WebTestCase
         );
     }
 
-    public function testEmptyList(): void
-    {
-        $client = static::createClient();
-        $client->request(Request::METHOD_GET, '/admin/empty/list');
-
-        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
-    }
-
-    public function testCustomControllerList(): void
-    {
-        $client = static::createClient();
-        $client->request(Request::METHOD_GET, '/admin/tests/app/foo-with-custom-controller/list');
-
-        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
-    }
-
     public function testCreate(): void
     {
         $client = static::createClient();
@@ -64,22 +48,6 @@ final class CRUDControllerTest extends WebTestCase
         );
     }
 
-    public function testEmptyCreate(): void
-    {
-        $client = static::createClient();
-        $client->request(Request::METHOD_GET, '/admin/empty/create');
-
-        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
-    }
-
-    public function testCustomControllerCreate(): void
-    {
-        $client = static::createClient();
-        $client->request(Request::METHOD_GET, '/admin/tests/app/foo-with-custom-controller/create');
-
-        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
-    }
-
     public function testShow(): void
     {
         $client = static::createClient();
@@ -90,22 +58,6 @@ final class CRUDControllerTest extends WebTestCase
             1,
             $crawler->filter('td:contains("foo_name")')->count()
         );
-    }
-
-    public function testEmptyShow(): void
-    {
-        $client = static::createClient();
-        $client->request(Request::METHOD_GET, '/admin/empty/test_id/show');
-
-        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
-    }
-
-    public function testCustomControllerShow(): void
-    {
-        $client = static::createClient();
-        $client->request(Request::METHOD_GET, '/admin/tests/app/foo-with-custom-controller/test_id/show');
-
-        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }
 
     public function testEdit(): void
@@ -120,20 +72,29 @@ final class CRUDControllerTest extends WebTestCase
         );
     }
 
-    public function testEmptyEdit(): void
+    /**
+     * @dataProvider urlIsSuccessfulDataProvider
+     */
+    public function testUrlIsSuccessful(string $url): void
     {
         $client = static::createClient();
-        $client->request(Request::METHOD_GET, '/admin/empty/test_id/edit');
+        $client->request(Request::METHOD_GET, $url);
 
         $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }
 
-    public function testCustomControllerEdit(): void
+    public function urlIsSuccessfulDataProvider(): iterable
     {
-        $client = static::createClient();
-        $client->request(Request::METHOD_GET, '/admin/tests/app/foo-with-custom-controller/test_id/edit');
-
-        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        return [
+            ['/admin/empty/list'],
+            ['/admin/empty/create'],
+            ['/admin/empty/test_id/show'],
+            ['/admin/empty/test_id/edit'],
+            ['/admin/tests/app/foo-with-custom-controller/list'],
+            ['/admin/tests/app/foo-with-custom-controller/create'],
+            ['/admin/tests/app/foo-with-custom-controller/test_id/show'],
+            ['/admin/tests/app/foo-with-custom-controller/test_id/edit'],
+        ];
     }
 
     protected static function getKernelClass()

--- a/tests/Maker/AdminMakerTest.php
+++ b/tests/Maker/AdminMakerTest.php
@@ -22,6 +22,7 @@ use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\Util\AutoloaderUtil;
 use Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -131,7 +132,11 @@ class AdminMakerTest extends TestCase
         );
         $fileManager->setIO($this->io);
 
-        $this->generator = new Generator($fileManager, 'Sonata\AdminBundle\Tests');
+        $this->generator = new Generator(
+            $fileManager,
+            'Sonata\AdminBundle\Tests',
+            new PhpCompatUtil($fileManager)
+        );
         $maker->generate($this->input, $this->io, $this->generator);
     }
 }

--- a/tests/SonataAdminBundleTest.php
+++ b/tests/SonataAdminBundleTest.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Tests;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\Compiler\AdminMakerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AdminSearchCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
@@ -36,7 +37,7 @@ class SonataAdminBundleTest extends TestCase
     {
         $containerBuilder = $this->createMock(ContainerBuilder::class);
 
-        $containerBuilder->expects($this->exactly(8))
+        $containerBuilder->expects($this->exactly(9))
             ->method('addCompilerPass')
             ->willReturnCallback(function (CompilerPassInterface $pass, $type = PassConfig::TYPE_BEFORE_OPTIMIZATION): void {
                 if ($pass instanceof AddDependencyCallsCompilerPass) {
@@ -71,8 +72,12 @@ class SonataAdminBundleTest extends TestCase
                     return;
                 }
 
+                if ($pass instanceof AdminMakerCompilerPass) {
+                    return;
+                }
+
                 $this->fail(sprintf(
-                    'CompilerPass is not one of the expected types. Expects "%s", "%s", "%s", "%s", "%s", "%s" or "%s", but got "%s".',
+                    'CompilerPass is not one of the expected types. Expects "%s", "%s", "%s", "%s", "%s", "%s", "%s" or "%s", but got "%s".',
                     AddDependencyCallsCompilerPass::class,
                     AddFilterTypeCompilerPass::class,
                     AdminSearchCompilerPass::class,
@@ -81,6 +86,7 @@ class SonataAdminBundleTest extends TestCase
                     ModelManagerCompilerPass::class,
                     ObjectAclManipulatorCompilerPass::class,
                     TwigStringExtensionCompilerPass::class,
+                    AdminMakerCompilerPass::class,
                     \get_class($pass)
                 ));
             });

--- a/tests/SonataAdminBundleTest.php
+++ b/tests/SonataAdminBundleTest.php
@@ -24,8 +24,6 @@ use Sonata\AdminBundle\DependencyInjection\Compiler\ModelManagerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ObjectAclManipulatorCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
 use Sonata\AdminBundle\SonataAdminBundle;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -39,57 +37,18 @@ class SonataAdminBundleTest extends TestCase
 
         $containerBuilder->expects($this->exactly(9))
             ->method('addCompilerPass')
-            ->willReturnCallback(function (CompilerPassInterface $pass, $type = PassConfig::TYPE_BEFORE_OPTIMIZATION): void {
-                if ($pass instanceof AddDependencyCallsCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof AddFilterTypeCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof AdminSearchCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof ExtensionCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof GlobalVariablesCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof ModelManagerCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof ObjectAclManipulatorCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof TwigStringExtensionCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof AdminMakerCompilerPass) {
-                    return;
-                }
-
-                $this->fail(sprintf(
-                    'CompilerPass is not one of the expected types. Expects "%s", "%s", "%s", "%s", "%s", "%s", "%s" or "%s", but got "%s".',
-                    AddDependencyCallsCompilerPass::class,
-                    AddFilterTypeCompilerPass::class,
-                    AdminSearchCompilerPass::class,
-                    ExtensionCompilerPass::class,
-                    GlobalVariablesCompilerPass::class,
-                    ModelManagerCompilerPass::class,
-                    ObjectAclManipulatorCompilerPass::class,
-                    TwigStringExtensionCompilerPass::class,
-                    AdminMakerCompilerPass::class,
-                    \get_class($pass)
-                ));
-            });
+            ->withConsecutive(
+                [new AddDependencyCallsCompilerPass()],
+                [new AddFilterTypeCompilerPass()],
+                [new AdminSearchCompilerPass()],
+                [new ExtensionCompilerPass()],
+                [new GlobalVariablesCompilerPass()],
+                [new ModelManagerCompilerPass()],
+                [new ObjectAclManipulatorCompilerPass()],
+                [new TwigStringExtensionCompilerPass()],
+                [new AdminMakerCompilerPass()],
+            )
+        ;
 
         $bundle = new SonataAdminBundle();
         $bundle->build($containerBuilder);

--- a/tests/Templating/MutableTemplateRegistryTest.php
+++ b/tests/Templating/MutableTemplateRegistryTest.php
@@ -44,7 +44,9 @@ final class MutableTemplateRegistryTest extends TestCase
         ];
 
         $this->templateRegistry->setTemplates($templates);
+        // NEXT_MAJOR: remove this first assert and uncomment second
         $this->assertSame($templates, $this->templateRegistry->getTemplates());
+        //$this->assertSame($templates + ['list' => '@FooAdmin/CRUD/list.html.twig'], $this->templateRegistry->getTemplates());
     }
 
     /**

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -2524,7 +2524,7 @@ EOT
      */
     private function buildTwigLikeUrl(array $url): string
     {
-        return htmlspecialchars(http_build_query($url, '', '&', PHP_QUERY_RFC3986));
+        return htmlspecialchars(http_build_query($url, '', '&', \PHP_QUERY_RFC3986));
     }
 
     private function removeExtraWhitespace(string $string): string

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -3326,7 +3326,7 @@ EOT
      */
     private function buildTwigLikeUrl(array $url): string
     {
-        return htmlspecialchars(http_build_query($url, '', '&', PHP_QUERY_RFC3986));
+        return htmlspecialchars(http_build_query($url, '', '&', \PHP_QUERY_RFC3986));
     }
 
     private function removeExtraWhitespace(string $string): string

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 /*
  * fix encoding issue while running text on different host with different locale configuration
  */
-setlocale(LC_ALL, 'en_US.UTF-8');
+setlocale(\LC_ALL, 'en_US.UTF-8');
 
 require_once __DIR__.'/../vendor/autoload.php';
 


### PR DESCRIPTION
## Autocomplete customizations

I am targeting this branch, because this PR adds extra functionality to sonata_type_model_autocomplete, fixes few glitches & extends customization options.

## Changelog
```markdown
### Added
- A callback with a possibility to modify each individual item in the response.
- A way to customize any autocomplete select2 properties in js via adding sonata_type_model_autocomplete_select2_options_js block before initializing select2 element because select2 doesn't allow modification of several options after it has been initialized, you can only destroy it and initialize again from scratch.
- Set error bubbling to false - prevent passing error to parent form elements, which occurs by default for compound form types.

### Changed
- The autocomplete item list is now independent of filters set in the corresponding list via removing its filters. Before these changes, it returned only items that matched the selected filter.