### PR TITLE
Revert to trully unique uniqid

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1933,7 +1933,7 @@ EOT;
     public function getUniqid()
     {
         if (!$this->uniqid) {
-            $this->uniqid = 's'.substr(md5($this->getBaseCodeRoute()), 0, 10);
+            $this->uniqid = 's'.uniqid();
         }
 
         return $this->uniqid;

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -668,33 +668,6 @@ class AdminTest extends TestCase
         $this->assertSame($uniqid, $admin->getUniqid());
     }
 
-    public function testUniqidConsistency(): void
-    {
-        $admin = $this->getMockForAbstractClass(AbstractAdmin::class, [
-            'sonata.abstract.admin',
-            'AbstractBundle\Entity\Foo',
-            'SonataAbstractBundle:FooAdmin',
-        ]);
-        $admin->initialize();
-
-        $uniqid = $admin->getUniqid();
-        $admin->setUniqid(null);
-
-        $this->assertSame($uniqid, $admin->getUniqid());
-
-        $parentAdmin = $this->getMockForAbstractClass(AbstractAdmin::class, [
-            'sonata.abstract.parent.admin',
-            'AbstractBundle\Entity\Bar',
-            'SonataAbstractBundle:BarAdmin',
-        ]);
-        $parentAdmin->initialize();
-
-        $admin->setParent($parentAdmin);
-        $admin->setUniqid(null);
-
-        $this->assertNotSame($uniqid, $admin->getUniqid());
-    }
-
     public function testToString(): void
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');


### PR DESCRIPTION
## Subject
I am targeting this branch, because it's a BC fix.
Should fix https://github.com/sonata-project/SonataAdminBundle/issues/5398

SonataPage compose feature is broken if you add 2 blocks of same kind
Each fields using this value through javascript are broken if they exist twice in the page

Closes #5398

## Changelog

```markdown
### Fixed
- Revert to trully unique uniqid for admins
```