### PR TITLE
fix Symfony 4.3+ EventDispatcher deprecations

### DIFF
--- a/src/Event/AbstractEvent.php
+++ b/src/Event/AbstractEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
+use Symfony\Contracts\EventDispatcher\Event as ContractsEvent;
+
+if (class_exists(LegacyEventDispatcherProxy::class)) {
+    /**
+     * @internal
+     */
+    abstract class AbstractEvent extends ContractsEvent
+    {
+    }
+} else {
+    /**
+     * @internal
+     */
+    abstract class AbstractEvent extends Event
+    {
+    }
+}

--- a/src/Event/AdminEventExtension.php
+++ b/src/Event/AdminEventExtension.php
@@ -38,89 +38,100 @@ class AdminEventExtension extends AbstractAdminExtension
 
     public function configureFormFields(FormMapper $form)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.form',
-            new ConfigureEvent($form->getAdmin(), $form, ConfigureEvent::TYPE_FORM)
+        EventDispatcherHelper::dispatch(
+            $this->eventDispatcher,
+            new ConfigureEvent($form->getAdmin(), $form, ConfigureEvent::TYPE_FORM),
+            'sonata.admin.event.configure.form'
         );
     }
 
     public function configureListFields(ListMapper $list)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.list',
-            new ConfigureEvent($list->getAdmin(), $list, ConfigureEvent::TYPE_LIST)
+        EventDispatcherHelper::dispatch(
+            $this->eventDispatcher,
+            new ConfigureEvent($list->getAdmin(), $list, ConfigureEvent::TYPE_LIST),
+            'sonata.admin.event.configure.list'
         );
     }
 
     public function configureDatagridFilters(DatagridMapper $filter)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.datagrid',
-            new ConfigureEvent($filter->getAdmin(), $filter, ConfigureEvent::TYPE_DATAGRID)
+        EventDispatcherHelper::dispatch(
+            $this->eventDispatcher,
+            new ConfigureEvent($filter->getAdmin(), $filter, ConfigureEvent::TYPE_DATAGRID),
+            'sonata.admin.event.configure.datagrid'
         );
     }
 
     public function configureShowFields(ShowMapper $show)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.show',
-            new ConfigureEvent($show->getAdmin(), $show, ConfigureEvent::TYPE_SHOW)
+        EventDispatcherHelper::dispatch(
+            $this->eventDispatcher,
+            new ConfigureEvent($show->getAdmin(), $show, ConfigureEvent::TYPE_SHOW),
+            'sonata.admin.event.configure.show'
         );
     }
 
     public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list')
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.query',
-            new ConfigureQueryEvent($admin, $query, $context)
+        EventDispatcherHelper::dispatch(
+            $this->eventDispatcher,
+            new ConfigureQueryEvent($admin, $query, $context),
+            'sonata.admin.event.configure.query'
         );
     }
 
     public function preUpdate(AdminInterface $admin, $object)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.pre_update',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_UPDATE)
+        EventDispatcherHelper::dispatch(
+            $this->eventDispatcher,
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_UPDATE),
+            'sonata.admin.event.persistence.pre_update'
         );
     }
 
     public function postUpdate(AdminInterface $admin, $object)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.post_update',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_UPDATE)
+        EventDispatcherHelper::dispatch(
+            $this->eventDispatcher,
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_UPDATE),
+            'sonata.admin.event.persistence.post_update'
         );
     }
 
     public function prePersist(AdminInterface $admin, $object)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.pre_persist',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_PERSIST)
+        EventDispatcherHelper::dispatch(
+            $this->eventDispatcher,
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_PERSIST),
+            'sonata.admin.event.persistence.pre_persist'
         );
     }
 
     public function postPersist(AdminInterface $admin, $object)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.post_persist',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_PERSIST)
+        EventDispatcherHelper::dispatch(
+            $this->eventDispatcher,
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_PERSIST),
+            'sonata.admin.event.persistence.post_persist'
         );
     }
 
     public function preRemove(AdminInterface $admin, $object)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.pre_remove',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_REMOVE)
+        EventDispatcherHelper::dispatch(
+            $this->eventDispatcher,
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_REMOVE),
+            'sonata.admin.event.persistence.pre_remove'
         );
     }
 
     public function postRemove(AdminInterface $admin, $object)
     {
-        $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.post_remove',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_REMOVE)
+        EventDispatcherHelper::dispatch(
+            $this->eventDispatcher,
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_REMOVE),
+            'sonata.admin.event.persistence.post_remove'
         );
     }
 }

--- a/src/Event/ConfigureEvent.php
+++ b/src/Event/ConfigureEvent.php
@@ -15,7 +15,6 @@ namespace Sonata\AdminBundle\Event;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Mapper\BaseMapper;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * This event is sent by hook:
@@ -32,7 +31,7 @@ use Symfony\Component\EventDispatcher\Event;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class ConfigureEvent extends Event
+class ConfigureEvent extends AbstractEvent
 {
     public const TYPE_SHOW = 'show';
     public const TYPE_DATAGRID = 'datagrid';

--- a/src/Event/ConfigureMenuEvent.php
+++ b/src/Event/ConfigureMenuEvent.php
@@ -15,7 +15,6 @@ namespace Sonata\AdminBundle\Event;
 
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Menu builder event. Used for extending the menus.
@@ -24,7 +23,7 @@ use Symfony\Component\EventDispatcher\Event;
  *
  * @author Martin Hasoň <martin.hason@gmail.com>
  */
-class ConfigureMenuEvent extends Event
+class ConfigureMenuEvent extends AbstractEvent
 {
     public const SIDEBAR = 'sonata.admin.event.configure.menu.sidebar';
 

--- a/src/Event/ConfigureQueryEvent.php
+++ b/src/Event/ConfigureQueryEvent.php
@@ -15,7 +15,6 @@ namespace Sonata\AdminBundle\Event;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * This event is sent by hook:
@@ -29,7 +28,7 @@ use Symfony\Component\EventDispatcher\Event;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class ConfigureQueryEvent extends Event
+class ConfigureQueryEvent extends AbstractEvent
 {
     /**
      * @var AdminInterface

--- a/src/Event/EventDispatcherHelper.php
+++ b/src/Event/EventDispatcherHelper.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Event;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
+
+/**
+ * @internal
+ */
+final class EventDispatcherHelper
+{
+    public static function dispatch(EventDispatcherInterface $eventDispatcher, $event, string $eventName)
+    {
+        if (class_exists(LegacyEventDispatcherProxy::class)) {
+            // Symfony 4.3+
+            LegacyEventDispatcherProxy::decorate($eventDispatcher)->dispatch($event, $eventName);
+        } else {
+            $eventDispatcher->dispatch($eventName, $event);
+        }
+    }
+}

--- a/src/Event/PersistenceEvent.php
+++ b/src/Event/PersistenceEvent.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Event;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * This event is sent by hook:
@@ -30,7 +29,7 @@ use Symfony\Component\EventDispatcher\Event;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class PersistenceEvent extends Event
+class PersistenceEvent extends AbstractEvent
 {
     public const TYPE_PRE_UPDATE = 'pre_update';
     public const TYPE_POST_UPDATE = 'post_update';

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -18,6 +18,7 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Event\ConfigureMenuEvent;
+use Sonata\AdminBundle\Event\EventDispatcherHelper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -93,7 +94,7 @@ class MenuBuilder
         }
 
         $event = new ConfigureMenuEvent($this->factory, $menu);
-        $this->eventDispatcher->dispatch(ConfigureMenuEvent::SIDEBAR, $event);
+        EventDispatcherHelper::dispatch($this->eventDispatcher, $event, ConfigureMenuEvent::SIDEBAR);
 
         return $event->getMenu();
     }

--- a/tests/Event/AdminEventExtensionTest.php
+++ b/tests/Event/AdminEventExtensionTest.php
@@ -21,10 +21,12 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Event\AdminEventExtension;
 use Sonata\AdminBundle\Event\ConfigureEvent;
+use Sonata\AdminBundle\Event\ConfigureQueryEvent;
 use Sonata\AdminBundle\Event\PersistenceEvent;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 class AdminEventExtensionTest extends TestCase
 {
@@ -32,6 +34,11 @@ class AdminEventExtensionTest extends TestCase
     {
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $stub = $eventDispatcher->expects($this->once())->method('dispatch');
+
+        if (class_exists(LegacyEventDispatcherProxy::class)) {
+            $args = array_reverse($args);
+        }
+
         $stub->with(...$args);
 
         return new AdminEventExtension($eventDispatcher);
@@ -127,6 +134,7 @@ class AdminEventExtensionTest extends TestCase
     {
         $this->getExtension([
             $this->equalTo('sonata.admin.event.configure.query'),
+            $this->isInstanceOf(ConfigureQueryEvent::class),
         ])->configureQuery($this->createMock(AdminInterface::class), $this->createMock(ProxyQueryInterface::class));
     }
 

--- a/tests/Menu/MenuBuilderTest.php
+++ b/tests/Menu/MenuBuilderTest.php
@@ -22,6 +22,7 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Event\ConfigureMenuEvent;
 use Sonata\AdminBundle\Menu\MenuBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 class MenuBuilderTest extends TestCase
 {
@@ -132,13 +133,20 @@ class MenuBuilderTest extends TestCase
 
         $this->preparePool($adminGroups);
 
+        $args = [
+            $this->equalTo('sonata.admin.event.configure.menu.sidebar'),
+            $this->isInstanceOf(ConfigureMenuEvent::class),
+        ];
+
+        if (class_exists(LegacyEventDispatcherProxy::class)) {
+            $args = array_reverse($args);
+        }
+
         $this->eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
-            ->with(
-                $this->equalTo('sonata.admin.event.configure.menu.sidebar'),
-                $this->isInstanceOf(ConfigureMenuEvent::class)
-            );
+            ->with(...$args)
+        ;
 
         $this->builder->createSidebarMenu();
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this deprecation removal is pretty much fully backwards compatible.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Symfony 4.3 event dispatcher deprecations due to changed signature
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
