### PR TITLE
fix symfony deprecations for event dispatching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "symfony/dependency-injection": "^4.3",
         "symfony/doctrine-bridge": "^4.3",
         "symfony/event-dispatcher": "^4.3",
+        "symfony/event-dispatcher-contracts": "^1.1",
         "symfony/expression-language": "^4.3",
         "symfony/form": "^4.0",
         "symfony/framework-bundle": "^4.3",

--- a/src/Event/AdminEventExtension.php
+++ b/src/Event/AdminEventExtension.php
@@ -21,6 +21,7 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 /**
  * @final since sonata-project/admin-bundle 3.52
@@ -33,94 +34,94 @@ class AdminEventExtension extends AbstractAdminExtension
 
     public function __construct(EventDispatcherInterface $eventDispatcher)
     {
-        $this->eventDispatcher = $eventDispatcher;
+        $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
     }
 
     public function configureFormFields(FormMapper $form)
     {
         $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.form',
-            new ConfigureEvent($form->getAdmin(), $form, ConfigureEvent::TYPE_FORM)
+            new ConfigureEvent($form->getAdmin(), $form, ConfigureEvent::TYPE_FORM),
+            'sonata.admin.event.configure.form'
         );
     }
 
     public function configureListFields(ListMapper $list)
     {
         $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.list',
-            new ConfigureEvent($list->getAdmin(), $list, ConfigureEvent::TYPE_LIST)
+            new ConfigureEvent($list->getAdmin(), $list, ConfigureEvent::TYPE_LIST),
+            'sonata.admin.event.configure.list'
         );
     }
 
     public function configureDatagridFilters(DatagridMapper $filter)
     {
         $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.datagrid',
-            new ConfigureEvent($filter->getAdmin(), $filter, ConfigureEvent::TYPE_DATAGRID)
+            new ConfigureEvent($filter->getAdmin(), $filter, ConfigureEvent::TYPE_DATAGRID),
+            'sonata.admin.event.configure.datagrid'
         );
     }
 
     public function configureShowFields(ShowMapper $show)
     {
         $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.show',
-            new ConfigureEvent($show->getAdmin(), $show, ConfigureEvent::TYPE_SHOW)
+            new ConfigureEvent($show->getAdmin(), $show, ConfigureEvent::TYPE_SHOW),
+            'sonata.admin.event.configure.show'
         );
     }
 
     public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list')
     {
         $this->eventDispatcher->dispatch(
-            'sonata.admin.event.configure.query',
-            new ConfigureQueryEvent($admin, $query, $context)
+            new ConfigureQueryEvent($admin, $query, $context),
+            'sonata.admin.event.configure.query'
         );
     }
 
     public function preUpdate(AdminInterface $admin, $object)
     {
         $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.pre_update',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_UPDATE)
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_UPDATE),
+            'sonata.admin.event.persistence.pre_update'
         );
     }
 
     public function postUpdate(AdminInterface $admin, $object)
     {
         $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.post_update',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_UPDATE)
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_UPDATE),
+            'sonata.admin.event.persistence.post_update'
         );
     }
 
     public function prePersist(AdminInterface $admin, $object)
     {
         $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.pre_persist',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_PERSIST)
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_PERSIST),
+            'sonata.admin.event.persistence.pre_persist'
         );
     }
 
     public function postPersist(AdminInterface $admin, $object)
     {
         $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.post_persist',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_PERSIST)
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_PERSIST),
+            'sonata.admin.event.persistence.post_persist'
         );
     }
 
     public function preRemove(AdminInterface $admin, $object)
     {
         $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.pre_remove',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_REMOVE)
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_PRE_REMOVE),
+            'sonata.admin.event.persistence.pre_remove'
         );
     }
 
     public function postRemove(AdminInterface $admin, $object)
     {
         $this->eventDispatcher->dispatch(
-            'sonata.admin.event.persistence.post_remove',
-            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_REMOVE)
+            new PersistenceEvent($admin, $object, PersistenceEvent::TYPE_POST_REMOVE),
+            'sonata.admin.event.persistence.post_remove'
         );
     }
 }

--- a/src/Event/ConfigureEvent.php
+++ b/src/Event/ConfigureEvent.php
@@ -15,7 +15,7 @@ namespace Sonata\AdminBundle\Event;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Mapper\BaseMapper;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * This event is sent by hook:

--- a/src/Event/ConfigureMenuEvent.php
+++ b/src/Event/ConfigureMenuEvent.php
@@ -15,7 +15,7 @@ namespace Sonata\AdminBundle\Event;
 
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Menu builder event. Used for extending the menus.

--- a/src/Event/ConfigureQueryEvent.php
+++ b/src/Event/ConfigureQueryEvent.php
@@ -15,7 +15,7 @@ namespace Sonata\AdminBundle\Event;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * This event is sent by hook:

--- a/src/Event/PersistenceEvent.php
+++ b/src/Event/PersistenceEvent.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Event;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * This event is sent by hook:

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -19,6 +19,7 @@ use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Event\ConfigureMenuEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 /**
  * Sonata menu builder.
@@ -59,7 +60,7 @@ class MenuBuilder
         $this->pool = $pool;
         $this->factory = $factory;
         $this->provider = $provider;
-        $this->eventDispatcher = $eventDispatcher;
+        $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
     }
 
     /**
@@ -93,7 +94,7 @@ class MenuBuilder
         }
 
         $event = new ConfigureMenuEvent($this->factory, $menu);
-        $this->eventDispatcher->dispatch(ConfigureMenuEvent::SIDEBAR, $event);
+        $this->eventDispatcher->dispatch($event, ConfigureMenuEvent::SIDEBAR);
 
         return $event->getMenu();
     }

--- a/tests/Event/AdminEventExtensionTest.php
+++ b/tests/Event/AdminEventExtensionTest.php
@@ -21,6 +21,7 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Event\AdminEventExtension;
 use Sonata\AdminBundle\Event\ConfigureEvent;
+use Sonata\AdminBundle\Event\ConfigureQueryEvent;
 use Sonata\AdminBundle\Event\PersistenceEvent;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
@@ -79,8 +80,8 @@ class AdminEventExtensionTest extends TestCase
     {
         $this
             ->getExtension([
-                $this->equalTo('sonata.admin.event.configure.form'),
                 $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_FORM)),
+                $this->equalTo('sonata.admin.event.configure.form'),
             ])
             ->configureFormFields($this->getMapper(FormMapper::class));
     }
@@ -89,8 +90,8 @@ class AdminEventExtensionTest extends TestCase
     {
         $this
             ->getExtension([
-                $this->equalTo('sonata.admin.event.configure.list'),
                 $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_LIST)),
+                $this->equalTo('sonata.admin.event.configure.list'),
             ])
             ->configureListFields($this->getMapper(ListMapper::class));
     }
@@ -99,8 +100,8 @@ class AdminEventExtensionTest extends TestCase
     {
         $this
             ->getExtension([
-                $this->equalTo('sonata.admin.event.configure.datagrid'),
                 $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_DATAGRID)),
+                $this->equalTo('sonata.admin.event.configure.datagrid'),
             ])
             ->configureDatagridFilters($this->getMapper(DatagridMapper::class));
     }
@@ -109,8 +110,8 @@ class AdminEventExtensionTest extends TestCase
     {
         $this
             ->getExtension([
-                $this->equalTo('sonata.admin.event.configure.show'),
                 $this->callback($this->getConfigureEventClosure(ConfigureEvent::TYPE_SHOW)),
+                $this->equalTo('sonata.admin.event.configure.show'),
             ])
             ->configureShowFields($this->getMapper(ShowMapper::class));
     }
@@ -118,14 +119,15 @@ class AdminEventExtensionTest extends TestCase
     public function testPreUpdate(): void
     {
         $this->getExtension([
-            $this->equalTo('sonata.admin.event.persistence.pre_update'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_UPDATE)),
+            $this->equalTo('sonata.admin.event.persistence.pre_update'),
         ])->preUpdate($this->createMock(AdminInterface::class), new \stdClass());
     }
 
     public function testConfigureQuery(): void
     {
         $this->getExtension([
+            $this->isInstanceOf(ConfigureQueryEvent::class),
             $this->equalTo('sonata.admin.event.configure.query'),
         ])->configureQuery($this->createMock(AdminInterface::class), $this->createMock(ProxyQueryInterface::class));
     }
@@ -133,40 +135,40 @@ class AdminEventExtensionTest extends TestCase
     public function testPostUpdate(): void
     {
         $this->getExtension([
-            $this->equalTo('sonata.admin.event.persistence.post_update'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_UPDATE)),
+            $this->equalTo('sonata.admin.event.persistence.post_update'),
         ])->postUpdate($this->createMock(AdminInterface::class), new \stdClass());
     }
 
     public function testPrePersist(): void
     {
         $this->getExtension([
-            $this->equalTo('sonata.admin.event.persistence.pre_persist'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_PERSIST)),
+            $this->equalTo('sonata.admin.event.persistence.pre_persist'),
         ])->prePersist($this->createMock(AdminInterface::class), new \stdClass());
     }
 
     public function testPostPersist(): void
     {
         $this->getExtension([
-            $this->equalTo('sonata.admin.event.persistence.post_persist'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_PERSIST)),
+            $this->equalTo('sonata.admin.event.persistence.post_persist'),
         ])->postPersist($this->createMock(AdminInterface::class), new \stdClass());
     }
 
     public function testPreRemove(): void
     {
         $this->getExtension([
-            $this->equalTo('sonata.admin.event.persistence.pre_remove'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_PRE_REMOVE)),
+            $this->equalTo('sonata.admin.event.persistence.pre_remove'),
         ])->preRemove($this->createMock(AdminInterface::class), new \stdClass());
     }
 
     public function testPostRemove(): void
     {
         $this->getExtension([
-            $this->equalTo('sonata.admin.event.persistence.post_remove'),
             $this->callback($this->getConfigurePersistenceClosure(PersistenceEvent::TYPE_POST_REMOVE)),
+            $this->equalTo('sonata.admin.event.persistence.post_remove'),
         ])->postRemove($this->createMock(AdminInterface::class), new \stdClass());
     }
 }

--- a/tests/Menu/MenuBuilderTest.php
+++ b/tests/Menu/MenuBuilderTest.php
@@ -136,8 +136,8 @@ class MenuBuilderTest extends TestCase
             ->expects($this->once())
             ->method('dispatch')
             ->with(
-                $this->equalTo('sonata.admin.event.configure.menu.sidebar'),
-                $this->isInstanceOf(ConfigureMenuEvent::class)
+                $this->isInstanceOf(ConfigureMenuEvent::class),
+                $this->equalTo('sonata.admin.event.configure.menu.sidebar')
             );
 
         $this->builder->createSidebarMenu();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

This is a follow-up for https://github.com/sonata-project/SonataAdminBundle/pull/5842.

Now that we dropped support for Symfony < 4.3 it simplifies the patch :blush: 

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because its BC.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- deprecations for event dispatching

```

