### PR TITLE
Make filter alias optional

### DIFF
--- a/src/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
@@ -38,7 +38,9 @@ class AddFilterTypeCompilerPass implements CompilerPassInterface
 
             // NEXT_MAJOR: Remove this loop, only FQCN will be supported
             foreach ($attributes as $eachTag) {
-                $types[$eachTag['alias']] = $id;
+                if (isset($eachTag['alias'])) {
+                    $types[$eachTag['alias']] = $id;
+                }
             }
         }
 

--- a/tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
@@ -26,11 +26,14 @@ class AddFilterTypeCompilerPassTest extends TestCase
 
     private $barFilter;
 
+    private $bazFilter;
+
     public function setUp(): void
     {
         $this->filterFactory = $this->createMock(Definition::class);
         $this->fooFilter = $this->createMock(Definition::class);
         $this->barFilter = $this->createMock(Definition::class);
+        $this->bazFilter = $this->createMock(Definition::class);
     }
 
     public function testProcess(): void
@@ -44,6 +47,7 @@ class AddFilterTypeCompilerPassTest extends TestCase
                 ['sonata.admin.builder.filter.factory', $this->filterFactory],
                 ['acme.demo.foo_filter', $this->fooFilter],
                 ['acme.demo.bar_filter', $this->barFilter],
+                ['acme.demo.baz_filter', $this->bazFilter],
             ]);
 
         $containerBuilderMock->expects($this->once())
@@ -60,6 +64,10 @@ class AddFilterTypeCompilerPassTest extends TestCase
                         'alias' => 'bar_filter_alias',
                     ],
                 ],
+                'acme.demo.baz_filter' => [
+                    'tag1' => [
+                    ],
+                ],
             ]);
 
         $this->fooFilter->method('getClass')
@@ -68,6 +76,9 @@ class AddFilterTypeCompilerPassTest extends TestCase
         $this->barFilter->method('getClass')
             ->willReturn('Acme\Filter\BarFilter');
 
+        $this->bazFilter->method('getClass')
+            ->willReturn('Acme\Filter\BazFilter');
+
         $this->filterFactory->expects($this->once())
             ->method('replaceArgument')
             ->with(1, $this->equalTo([
@@ -75,6 +86,7 @@ class AddFilterTypeCompilerPassTest extends TestCase
                 'Acme\Filter\FooFilter' => 'acme.demo.foo_filter',
                 'bar_filter_alias' => 'acme.demo.bar_filter',
                 'Acme\Filter\BarFilter' => 'acme.demo.bar_filter',
+                'Acme\Filter\BazFilter' => 'acme.demo.baz_filter',
             ]));
 
         $extensionsPass = new AddFilterTypeCompilerPass();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Form aliases are not supported by symfony and we will remove them for filter elements too. ATM aliases are required. This PR makes them really optional.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Make filter alias optional
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
