### PR TITLE
Replace transchoice with trans in templates

### DIFF
--- a/src/Resources/views/Block/block_stats.html.twig
+++ b/src/Resources/views/Block/block_stats.html.twig
@@ -20,9 +20,7 @@ file that was distributed with this source code.
             <h3>{{ pager.count() }}</h3>
             <p>
                 {% if translation_domain %}
-                    {{ settings.text|transchoice(pager.count(), {}, translation_domain) }}
-                    {# NEXT_MAJOR: bump "symfony/translation" to ^4.2 and replace the previous line with the following #}
-                    {# {{ settings.text|trans({'%count%': pager.count()}, translation_domain) }} #}
+                    {{ settings.text|trans({'%count%': pager.count()}, translation_domain) }}
                 {% else %}
                     {{ settings.text }}
                 {% endif %}

--- a/src/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/src/Resources/views/CRUD/batch_confirmation.html.twig
@@ -35,9 +35,7 @@ file that was distributed with this source code.
                 {% if data.all_elements %}
                     {{ 'message_batch_all_confirmation'|trans({}, 'SonataAdminBundle') }}
                 {% else %}
-                    {% transchoice data.idx|length with {'%count%': data.idx|length} from 'SonataAdminBundle' %}message_batch_confirmation{% endtranschoice %}
-                    {# NEXT_MAJOR: bump "symfony/translation" to ^4.2 and replace the previous line with the following #}
-                    {# {% trans with {'%count%': data.idx|length} from 'SonataAdminBundle' %}message_batch_confirmation{% endtrans %} #}
+                    {% trans with {'%count%': data.idx|length} from 'SonataAdminBundle' %}message_batch_confirmation{% endtrans %}
                 {% endif %}
             </div>
             <div class="box-footer clearfix">

--- a/src/Resources/views/Pager/base_results.html.twig
+++ b/src/Resources/views/Pager/base_results.html.twig
@@ -15,9 +15,7 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block num_results %}
-    {% transchoice admin.datagrid.pager.nbresults with {'%count%': admin.datagrid.pager.nbresults} from 'SonataAdminBundle' %}list_results_count{% endtranschoice %}
-    {# NEXT_MAJOR: bump "symfony/translation" to ^4.2 and replace the previous line with the following #}
-    {# {% trans with {'%count%': admin.datagrid.pager.nbresults} from 'SonataAdminBundle' %}list_results_count{% endtrans %} #}
+    {% trans with {'%count%': admin.datagrid.pager.nbresults} from 'SonataAdminBundle' %}list_results_count{% endtrans %}
     &nbsp;-&nbsp;
 {% endblock %}
 

--- a/src/Resources/views/Pager/simple_pager_results.html.twig
+++ b/src/Resources/views/Pager/simple_pager_results.html.twig
@@ -15,9 +15,7 @@ file that was distributed with this source code.
     {% if admin.datagrid.pager.lastPage != admin.datagrid.pager.page %}
         {{ 'list_results_count_prefix'|trans({}, 'SonataAdminBundle') }}
     {% endif %}
-    {% transchoice admin.datagrid.pager.nbresults with {'%count%': admin.datagrid.pager.nbresults} from 'SonataAdminBundle' %}list_results_count{% endtranschoice %}
-    {# NEXT_MAJOR: bump "symfony/translation" to ^4.2 and replace the previous line with the following #}
-    {# {% trans with {'%count%': admin.datagrid.pager.nbresults} from 'SonataAdminBundle' %}list_results_count{% endtrans %} #}
+    {% trans with {'%count%': admin.datagrid.pager.nbresults} from 'SonataAdminBundle' %}list_results_count{% endtrans %}
     &nbsp;-&nbsp;
 {% endblock %}
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Since the minimum requirement is [`symfony/translation: ^4.3`](https://github.com/sonata-project/SonataAdminBundle/pull/5843) we can replace `transchoice` with `trans`.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Replaced the use of `transchoice` by `trans`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
