### PR TITLE
Use Symfony\Component\Filesystem\Filesystem to remove test files

### DIFF
--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -60,6 +60,7 @@ use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Sonata\Doctrine\Adapter\AdapterInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -80,8 +81,8 @@ class AdminTest extends TestCase
     public function setUp(): void
     {
         $this->cacheTempFolder = sys_get_temp_dir().'/sonata_test_route';
-
-        exec('rm -rf '.$this->cacheTempFolder);
+        $filesystem = new Filesystem();
+        $filesystem->remove($this->cacheTempFolder);
     }
 
     /**

--- a/tests/Route/DefaultRouteGeneratorTest.php
+++ b/tests/Route/DefaultRouteGeneratorTest.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Route\DefaultRouteGenerator;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Route\RoutesCache;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
@@ -31,7 +32,8 @@ class DefaultRouteGeneratorTest extends TestCase
     {
         $this->cacheTempFolder = sys_get_temp_dir().'/sonata_test_route';
 
-        exec('rm -rf '.$this->cacheTempFolder);
+        $filesystem = new Filesystem();
+        $filesystem->remove($this->cacheTempFolder);
     }
 
     public function testGenerate(): void


### PR DESCRIPTION
This makes these tests work on Windows

## Subject

When running the tests on Windows there were lots of warnings regarding the non-existent `rm` command. Using `Symfony\Component\Filesystem\Filesystem::remove()` to remove test files fixes this problem.

I am targeting this branch, because it's only a test change and compatible with Linux.

## Changelog

```markdown
### Fixed

Running tests on Windows
```