### PR TITLE
refactor CRUDControllerTest to use real container instance

### DIFF
--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Controller;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilder;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Controller\CRUDController;
@@ -40,6 +42,7 @@ use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Exporter\Writer\JsonWriter;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -154,12 +157,16 @@ class CRUDControllerTest extends TestCase
     private $formBuilder;
 
     /**
+     * @var LoggerInterface|MockObject
+     */
+    private $logger;
+
+    /**
      * {@inheritdoc}
      */
     protected function setUp(): void
     {
-        $this->container = $this->createMock(ContainerInterface::class);
-
+        $this->container = new Container();
         $this->request = new Request();
         $this->pool = new Pool($this->container, 'title', 'logo.png');
         $this->pool->setAdminServiceIds(['foo.admin']);
@@ -178,9 +185,7 @@ class CRUDControllerTest extends TestCase
 
         $this->templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
 
-        $templating = $this->getMockBuilder(DelegatingEngine::class)
-            ->setConstructorArgs([$this->container, []])
-            ->getMock();
+        $templating = $this->createMock(DelegatingEngine::class);
 
         $templatingRenderReturnCallback = $this->returnCallback(function (
             $view,
@@ -253,82 +258,27 @@ class CRUDControllerTest extends TestCase
 
         $this->kernel = $this->createMock(KernelInterface::class);
 
-        $this->container
-            ->method('get')
-            ->willReturnCallback(function (string $id) use (
-                $templating,
-                $twig,
-                $exporter,
-                $requestStack
-            ) {
-                switch ($id) {
-                    case 'sonata.admin.pool':
-                        return $this->pool;
-                    case 'request_stack':
-                        return $requestStack;
-                    case 'foo.admin':
-                        return $this->admin;
-                    case 'foo.admin.template_registry':
-                        return $this->templateRegistry->reveal();
-                    case 'templating':
-                        return $templating;
-                    case 'twig':
-                        return $twig;
-                    case 'session':
-                        return $this->session;
-                    case 'sonata.admin.exporter':
-                        return $exporter;
-                    case 'sonata.admin.audit.manager':
-                        return $this->auditManager;
-                    case 'sonata.admin.object.manipulator.acl.admin':
-                        return $this->adminObjectAclManipulator;
-                    case 'security.csrf.token_manager':
-                        return $this->csrfProvider;
-                    case 'logger':
-                        return $this->logger;
-                    case 'kernel':
-                        return $this->kernel;
-                    case 'translator':
-                        return $this->translator;
-                }
-            });
+        $this->container->set('sonata.admin.pool', $this->pool);
+        $this->container->set('request_stack', $requestStack);
+        $this->container->set('foo.admin', $this->admin);
+        $this->container->set('foo.admin.template_registry', $this->templateRegistry->reveal());
+        $this->container->set('templating', $templating);
+        $this->container->set('twig', $twig);
+        $this->container->set('session', $this->session);
+        $this->container->set('sonata.admin.exporter', $exporter);
+        $this->container->set('sonata.admin.audit.manager', $this->auditManager);
+        $this->container->set('sonata.admin.object.manipulator.acl.admin', $this->adminObjectAclManipulator);
+        $this->container->set('security.csrf.token_manager', $this->csrfProvider);
+        $this->container->set('logger', $this->logger);
+        $this->container->set('kernel', $this->kernel);
+        $this->container->set('translator', $this->translator);
+        $this->container->set('sonata.admin.breadcrumbs_builder', new BreadcrumbsBuilder([]));
 
-        $this->container
-            ->method('has')
-            ->willReturnCallback(function (string $id): bool {
-                if ('security.csrf.token_manager' === $id && null !== $this->getCsrfProvider()) {
-                    return true;
-                }
-
-                if ('logger' === $id) {
-                    return true;
-                }
-
-                if ('session' === $id) {
-                    return true;
-                }
-
-                if ('templating' === $id) {
-                    return true;
-                }
-
-                if ('translator' === $id) {
-                    return true;
-                }
-
-                return false;
-            });
-
-        $this->container
-            ->method('getParameter')
-            ->willReturnCallback(static function (string $name): ?array {
-                switch ($name) {
-                    case 'security.role_hierarchy.roles':
-                       return ['ROLE_SUPER_ADMIN' => ['ROLE_USER', 'ROLE_SONATA_ADMIN', 'ROLE_ADMIN']];
-                    default:
-                       return null;
-                }
-            });
+        $this->container->setParameter(
+            'security.role_hierarchy.roles',
+            ['ROLE_SUPER_ADMIN' => ['ROLE_USER', 'ROLE_SONATA_ADMIN', 'ROLE_ADMIN']]
+        );
+        $this->container->setParameter('sonata.admin.security.acl_user_manager', null);
 
         $this->templateRegistry->getTemplate('ajax')->willReturn('@SonataAdmin/ajax_layout.html.twig');
         $this->templateRegistry->getTemplate('layout')->willReturn('@SonataAdmin/standard_layout.html.twig');
@@ -538,7 +488,7 @@ class CRUDControllerTest extends TestCase
     public function testConfigureWithException2(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Found service "nonexistent.admin" is not a valid admin service');
+        $this->expectExceptionMessage('You have requested a non-existent service "nonexistent.admin".');
 
         $this->pool->setAdminServiceIds(['nonexistent.admin']);
         $this->request->attributes->set('_sonata_admin', 'nonexistent.admin');
@@ -1123,7 +1073,7 @@ class CRUDControllerTest extends TestCase
 
     public function testDeleteActionNoCsrfToken(): void
     {
-        $this->csrfProvider = null;
+        $this->container->set('security.csrf.token_manager', null);
 
         $object = new \stdClass();
 
@@ -1367,7 +1317,7 @@ class CRUDControllerTest extends TestCase
      */
     public function testDeleteActionSuccessNoCsrfTokenProvider(string $expectedToStringValue, string $toStringValue): void
     {
-        $this->csrfProvider = null;
+        $this->container->set('security.csrf.token_manager', null);
 
         $object = new \stdClass();
 

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -157,7 +157,7 @@ class CRUDControllerTest extends TestCase
     private $formBuilder;
 
     /**
-     * @var LoggerInterface|MockObject
+     * @var LoggerInterface&MockObject
      */
     private $logger;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Whille checking this deprecation

```
1x: The "Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait" trait is considered internal. It may change without further notice. You should not use it from "Sonata\AdminBundle\Controller\CRUDController".
```

i had a look at the test for the controller.

It was using a ContainerInterface mock that actually does not behave like a real container instance at all. The mock was not adhering to the interface's contract. 

For example a PSR containe (and also the implementation from Symfony) should throw an exception by default if a service or parameter does not exist.

=> **The container mock simply returned null.**

So I don't think it makes sense to mock the container and over-complicate the test. Simply using a real container seems a lot better here.


I am targeting this branch, because its BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->


<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
