### PR TITLE
Fix wording of EqualOperatorType

### DIFF
--- a/src/Form/Type/Operator/EqualOperatorType.php
+++ b/src/Form/Type/Operator/EqualOperatorType.php
@@ -19,16 +19,25 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class EqualOperatorType extends AbstractType
 {
+    /**
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use EqualOperatorType::TYPE_EQUAL instead
+     */
     public const TYPE_YES = 1;
+    /**
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0: Use EqualOperatorType::TYPE_NOT_EQUAL instead
+     */
     public const TYPE_NO = 2;
+
+    public const TYPE_EQUAL = 1;
+    public const TYPE_NOT_EQUAL = 2;
 
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'choice_translation_domain' => 'SonataAdminBundle',
             'choices' => [
-                'label_type_yes' => self::TYPE_YES,
-                'label_type_no' => self::TYPE_NO,
+                'label_type_equals' => self::TYPE_EQUAL,
+                'label_type_not_equals' => self::TYPE_NOT_EQUAL,
             ],
         ]);
     }


### PR DESCRIPTION
## Subject

When making https://github.com/sonata-project/SonataAdminBundle/pull/5804 I think I made a mistake with the EqualOperatorType.

The EqualOperatorType was using yes/no label instead of is equal/is not equal labels.

I am targeting this branch, because BC-break free.

## Changelog

```markdown
### Fixed
Wording of EqualOperatorType
```