### PR TITLE
Drop deprecated symfony/templating

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,6 @@
         "symfony/security-bundle": "^4.3",
         "symfony/security-core": "^4.3",
         "symfony/security-csrf": "^4.3",
-        "symfony/templating": "^4.3",
         "symfony/translation": "^4.3",
         "symfony/twig-bridge": "^4.3",
         "symfony/twig-bundle": "^4.3",

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -77,7 +77,7 @@ final class AppKernel extends Kernel
             'fragments' => ['enabled' => true],
             'form' => ['enabled' => true],
             'session' => ['handler_id' => null, 'storage_id' => 'session.storage.mock_file', 'name' => 'MOCKSESSID'],
-            'templating' => ['engine' => ['twig']],
+            'assets' => null,
             'test' => true,
         ]);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

[symfony/templating](https://symfony.com/blog/new-in-symfony-4-3-deprecated-the-templating-component-integration) was deprecated in 4.3
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- `symfony/templating` dependency
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
