### PR TITLE
Fix pager URLs when used in cutom actions

### DIFF
--- a/src/Resources/views/Pager/base_links.html.twig
+++ b/src/Resources/views/Pager/base_links.html.twig
@@ -12,28 +12,28 @@ file that was distributed with this source code.
 <div class="text-center">
     <ul class="pagination">
         {% if admin.datagrid.pager.page > 2 %}
-            <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, 1)) }}" title="{{ 'link_first_pager'|trans({}, 'SonataAdminBundle') }}">&laquo;</a></li>
+            <li><a href="{{ admin.generateUrl(action, admin.modelmanager.paginationparameters(admin.datagrid, 1)) }}" title="{{ 'link_first_pager'|trans({}, 'SonataAdminBundle') }}">&laquo;</a></li>
         {% endif %}
 
         {% if admin.datagrid.pager.page != admin.datagrid.pager.previouspage %}
-            <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.previouspage)) }}" title="{{ 'link_previous_pager'|trans({}, 'SonataAdminBundle') }}">&lsaquo;</a></li>
+            <li><a href="{{ admin.generateUrl(action, admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.previouspage)) }}" title="{{ 'link_previous_pager'|trans({}, 'SonataAdminBundle') }}">&lsaquo;</a></li>
         {% endif %}
 
         {# Set the number of pages to display in the pager #}
         {% for page in admin.datagrid.pager.getLinks(admin_pool.getOption('pager_links')) %}
             {% if page == admin.datagrid.pager.page %}
-                <li class="active"><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, page)) }}">{{ page }}</a></li>
+                <li class="active"><a href="{{ admin.generateUrl(action, admin.modelmanager.paginationparameters(admin.datagrid, page)) }}">{{ page }}</a></li>
             {% else %}
-                <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, page)) }}">{{ page }}</a></li>
+                <li><a href="{{ admin.generateUrl(action, admin.modelmanager.paginationparameters(admin.datagrid, page)) }}">{{ page }}</a></li>
             {% endif %}
         {% endfor %}
 
         {% if admin.datagrid.pager.page != admin.datagrid.pager.nextpage %}
-            <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.nextpage)) }}" title="{{ 'link_next_pager'|trans({}, 'SonataAdminBundle') }}">&rsaquo;</a></li>
+            <li><a href="{{ admin.generateUrl(action, admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.nextpage)) }}" title="{{ 'link_next_pager'|trans({}, 'SonataAdminBundle') }}">&rsaquo;</a></li>
         {% endif %}
 
         {% if admin.datagrid.pager.page != admin.datagrid.pager.lastpage and admin.datagrid.pager.lastpage != admin.datagrid.pager.nextpage %}
-            <li><a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.lastpage)) }}" title="{{ 'link_last_pager'|trans({}, 'SonataAdminBundle') }}">&raquo;</a></li>
+            <li><a href="{{ admin.generateUrl(action, admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.lastpage)) }}" title="{{ 'link_last_pager'|trans({}, 'SonataAdminBundle') }}">&raquo;</a></li>
         {% endif %}
     </ul>
 </div>


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When creating custom actions that work like the 'list' action, the pager would always send the user back to the 'list' action.

This pull request replaces all occurrences of `'list'` in `base_links.html.twig` by `action`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch/feature that is backwards compatible.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- Fixed pager links in custom actions

```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
