### PR TITLE
Datagrid filters apply default filters from configureDefaultFilterValues

### DIFF
--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -553,6 +553,32 @@ class DatagridTest extends TestCase
         $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_per_page'));
     }
 
+    public function testBuildPagerDefaultFilters()
+    {
+        $filter = $this->createMock(FilterInterface::class);
+        $filter->expects($this->once())
+            ->method('getName')
+            ->willReturn('propertyName');
+        $filter
+            ->method('getRenderSettings')
+            ->willReturn(['foo2', ['bar2' => 'baz2']]);
+        $filter
+            ->expects($this->once())
+            ->method('apply')
+            ->willReturnCallback(function (ProxyQueryInterface $query, array $value): void {
+                $this->assertArrayHasKey('type', $value);
+                $this->assertSame('type', $value['type']);
+                $this->assertArrayHasKey('value', $value);
+                $this->assertSame('value', $value['value']);
+            });
+
+        $this->datagrid->addFilter($filter);
+
+        $this->datagrid->setValue('propertyName', 'type', 'value');
+
+        $this->datagrid->buildPager();
+    }
+
     public function getBuildPagerWithPage2Tests(): array
     {
         // tests for php 5.3, because isset functionality was changed since php 5.4


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's not break BC.

When I set default filter values by `configureDefaultFilterValues` it not applies for `Datagrid`. 
```php
protected function configureDefaultFilterValues(array &$filterValues)
{
    $filterValues['orgStatus'] = [
        'type'  => ContainsOperatorType::TYPE_EQUAL,
        'value' => CreditOrgStatus::STR_NORM,
    ];
}
```

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add `Datagrid::resolveFilterValue` for get actual filter value
- Tests for default values
```
