### PR TITLE
Use "sonata.admin.manager" tag for services implementing `ModelManagerInterface`'

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,27 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated not setting "sonata.admin.manager" tag in model manager services
+
+If you are using [autoconfiguration](https://symfony.com/doc/4.4/service_container.html#the-autoconfigure-option),
+all the services implementing `Sonata\AdminBundle\Model\ModelManagerInterface` will
+be automatically tagged. Otherwise, you must tag them explicitly.
+
+Before:
+```xml
+<service id="sonata.admin.manager.custom" class="App\Model\ModelManager">
+    <!-- ... -->
+</service>
+```
+
+After:
+```xml
+<service id="sonata.admin.manager.custom" class="App\Model\ModelManager">
+    <!-- ... -->
+    <tag name="sonata.admin.manager"/>
+</service>
+```
+
 ## Deprecated `sonata_help` option in form types
 
 You should use Symfony's [`help`](https://symfony.com/doc/4.4/reference/forms/types/form.html#help) option instead.

--- a/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 
 /**
  * This class injects available model managers to services which depend on them.
@@ -26,22 +27,46 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 final class ModelManagerCompilerPass implements CompilerPassInterface
 {
+    public const MANAGER_TAG = 'sonata.admin.manager';
+
     public function process(ContainerBuilder $container): void
     {
         $availableManagers = [];
 
+        // NEXT_MAJOR: Replace the `foreach()` clause with the following one.
+        // foreach ($container->findTaggedServiceIds(self::MANAGER_TAG) as $id => $tags) {
         foreach ($container->getServiceIds() as $id) {
-            if (0 !== strpos($id, 'sonata.admin.manager.') || !is_subclass_of($container->getDefinition($id)->getClass(), ModelManagerInterface::class)) {
+            $definition = $container->findDefinition($id);
+
+            // NEXT_MAJOR: Remove this check.
+            if (!$definition->hasTag(self::MANAGER_TAG) && 0 !== strpos($id, 'sonata.admin.manager.')) {
                 continue;
             }
 
-            $availableManagers[$id] = $container->getDefinition($id);
+            if (!is_subclass_of($definition->getClass(), ModelManagerInterface::class)) {
+                throw new LogicException(sprintf('Service "%s" must implement `%s`.', $id, ModelManagerInterface::class));
+            }
+
+            // NEXT_MAJOR: Remove this check.
+            if (!$definition->hasTag(self::MANAGER_TAG)) {
+                @trigger_error(sprintf(
+                    'Not setting the "%s" tag on the "%s" service is deprecated since sonata-project/admin-bundle 3.x.',
+                    self::MANAGER_TAG,
+                    $id
+                ), E_USER_DEPRECATED);
+
+                $definition->addTag(self::MANAGER_TAG);
+            }
+
+            $availableManagers[$id] = $definition;
         }
 
-        $bundles = $container->getParameter('kernel.bundles');
-        if (isset($bundles['MakerBundle'])) {
-            $adminMakerDefinition = $container->getDefinition('sonata.admin.maker');
-            $adminMakerDefinition->replaceArgument(1, $availableManagers);
+        if (!empty($availableManagers)) {
+            $bundles = $container->getParameter('kernel.bundles');
+            if (isset($bundles['MakerBundle'])) {
+                $adminMakerDefinition = $container->getDefinition('sonata.admin.maker');
+                $adminMakerDefinition->replaceArgument(1, $availableManagers);
+            }
         }
     }
 }

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\DependencyInjection;
 
 use JMS\DiExtraBundle\DependencyInjection\Configuration as JMSDiExtraBundleDependencyInjectionConfiguration;
+use Sonata\AdminBundle\DependencyInjection\Compiler\ModelManagerCompilerPass;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -179,7 +181,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
             $container->removeDefinition('sonata.admin.translator.extractor.jms_translator_bundle');
         }
 
-        //remove non-Mopa compatibility layer
+        // remove non-Mopa compatibility layer
         if (isset($bundles['MopaBootstrapBundle'])) {
             $container->removeDefinition('sonata.admin.form.extension.field.mopa');
         }
@@ -193,6 +195,10 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $container->setParameter('sonata.admin.configuration.translate_group_label', $config['translate_group_label']);
 
         $this->replacePropertyAccessor($container);
+
+        $container
+            ->registerForAutoconfiguration(ModelManagerInterface::class)
+            ->addTag(ModelManagerCompilerPass::MANAGER_TAG);
     }
 
     /**

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -76,7 +76,7 @@ final class AppKernel extends Kernel
             'secret' => 'MySecret',
             'fragments' => ['enabled' => true],
             'form' => ['enabled' => true],
-            'session' => ['handler_id' => null, 'storage_id' => 'session.storage.mock_file', 'name' => 'MOCKSESSID'],
+            'session' => ['handler_id' => 'session.handler.native_file', 'storage_id' => 'session.storage.mock_file', 'name' => 'MOCKSESSID'],
             'assets' => null,
             'test' => true,
         ]);

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -1,10 +1,16 @@
 services:
+    # Under real conditions, this service is registered by "doctrine/doctrine-bundle"
+    database_connection:
+        class: Sonata\AdminBundle\Tests\Fixtures\DoctrineBundle\Connection
+
     Sonata\AdminBundle\Tests\App\Model\FooRepository: ~
 
     sonata.admin.manager.test:
         class: Sonata\AdminBundle\Tests\App\Model\ModelManager
         arguments:
             - '@Sonata\AdminBundle\Tests\App\Model\FooRepository'
+        tags:
+            - {name: sonata.admin.manager}
 
     sonata.admin.builder.test_form:
         class: Sonata\AdminBundle\Tests\App\Builder\FormContractor

--- a/tests/DependencyInjection/Compiler/ModelManagerCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ModelManagerCompilerPassTest.php
@@ -16,48 +16,160 @@ namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ModelManagerCompilerPass;
-use Sonata\AdminBundle\Maker\AdminMaker;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Tests\App\Model\ModelManager;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 
 /**
  * @author Gaurav Singh Faujdar <faujdar@gmail.com>
  */
-class ModelManagerCompilerPassTest extends TestCase
+final class ModelManagerCompilerPassTest extends TestCase
 {
-    /**
-     * @var AdminMaker
-     */
-    private $adminMaker;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-        $this->adminMaker = $this->prophesize(Definition::class);
-        $this->adminMaker->replaceArgument(Argument::type('integer'), Argument::any())->shouldBeCalledTimes(1);
-    }
-
     public function testProcess(): void
     {
+        $adminMaker = $this->prophesize(Definition::class);
+        $adminMaker->replaceArgument(Argument::type('integer'), Argument::any())->shouldNotBeCalled();
         $containerBuilderMock = $this->prophesize(ContainerBuilder::class);
 
         $containerBuilderMock->getServiceIds()
+            ->willReturn([]);
+
+        $containerBuilderMock->findTaggedServiceIds(Argument::exact(ModelManagerCompilerPass::MANAGER_TAG))
             ->willReturn([]);
 
         $containerBuilderMock->getParameter(Argument::exact('kernel.bundles'))
             ->willReturn(['MakerBundle' => 'MakerBundle']);
 
         $containerBuilderMock->getDefinition(Argument::exact('sonata.admin.maker'))
-            ->willReturn($this->adminMaker->reveal());
-
-        $containerBuilderMock->hasDefinition(Argument::containingString('sonata.admin.manager'))
-            ->willReturn(null);
-        $containerBuilderMock->getDefinition(Argument::containingString('sonata.admin.manager'))
-            ->willReturn(null);
+            ->willReturn($adminMaker->reveal());
         $containerBuilderMock->getParameter(Argument::containingString('kernel.project_dir'))
             ->willReturn(null);
 
         $compilerPass = new ModelManagerCompilerPass();
+        $compilerPass->process($containerBuilderMock->reveal());
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     *
+     * @expectedDeprecation Not setting the "sonata.admin.manager" tag on the "sonata.admin.manager.test" service is deprecated since sonata-project/admin-bundle 3.x.
+     */
+    public function testProcessWithUntaggedManagerDefinition(): void
+    {
+        $adminMaker = $this->prophesize(Definition::class);
+        $adminMaker->replaceArgument(Argument::type('integer'), Argument::any())->shouldBeCalledTimes(1);
+        $containerBuilderMock = $this->prophesize(ContainerBuilder::class);
+
+        $containerBuilderMock->getServiceIds()
+            ->willReturn(['sonata.admin.manager.test']);
+
+        $definitionMock = $this->prophesize(Definition::class);
+
+        $definitionMock->getClass()
+            ->willReturn(ModelManager::class);
+
+        $definitionMock->hasTag(Argument::exact(ModelManagerCompilerPass::MANAGER_TAG))
+            ->willReturn(false);
+
+        $definitionMock->addTag(Argument::exact(ModelManagerCompilerPass::MANAGER_TAG))
+            ->willReturn(null);
+
+        $containerBuilderMock->findTaggedServiceIds(Argument::exact(ModelManagerCompilerPass::MANAGER_TAG))
+            ->willReturn(['sonata.admin.manager.test' => ['other.tag']]);
+
+        $containerBuilderMock->getParameter(Argument::exact('kernel.bundles'))
+            ->willReturn(['MakerBundle' => 'MakerBundle']);
+
+        $containerBuilderMock->findDefinition(Argument::exact('sonata.admin.manager.test'))
+            ->willReturn($definitionMock->reveal());
+
+        $containerBuilderMock->getDefinition(Argument::exact('sonata.admin.maker'))
+            ->willReturn($adminMaker->reveal());
+
+        $containerBuilderMock->getParameter(Argument::containingString('kernel.project_dir'))
+            ->willReturn(null);
+
+        $compilerPass = new ModelManagerCompilerPass();
+        $compilerPass->process($containerBuilderMock->reveal());
+    }
+
+    public function testProcessWithTaggedManagerDefinition(): void
+    {
+        $adminMaker = $this->prophesize(Definition::class);
+        $adminMaker->replaceArgument(Argument::type('integer'), Argument::any())->shouldBeCalledTimes(1);
+        $containerBuilderMock = $this->prophesize(ContainerBuilder::class);
+
+        $containerBuilderMock->getServiceIds()
+            ->willReturn(['sonata.admin.manager.test']);
+
+        $definitionMock = $this->prophesize(Definition::class);
+
+        $definitionMock->getClass()
+            ->willReturn(ModelManager::class);
+
+        $definitionMock->hasTag(Argument::exact(ModelManagerCompilerPass::MANAGER_TAG))
+            ->willReturn(true);
+
+        $containerBuilderMock->findTaggedServiceIds(Argument::exact(ModelManagerCompilerPass::MANAGER_TAG))
+            ->willReturn(['sonata.admin.manager.test' => [ModelManagerCompilerPass::MANAGER_TAG, 'other.tag']]);
+
+        $containerBuilderMock->getParameter(Argument::exact('kernel.bundles'))
+            ->willReturn(['MakerBundle' => 'MakerBundle']);
+
+        $containerBuilderMock->findDefinition(Argument::exact('sonata.admin.manager.test'))
+            ->willReturn($definitionMock->reveal());
+
+        $containerBuilderMock->getDefinition(Argument::exact('sonata.admin.maker'))
+            ->willReturn($adminMaker->reveal());
+
+        $containerBuilderMock->getParameter(Argument::containingString('kernel.project_dir'))
+            ->willReturn(null);
+
+        $compilerPass = new ModelManagerCompilerPass();
+        $compilerPass->process($containerBuilderMock->reveal());
+    }
+
+    public function testProcessWithInvalidTaggedManagerDefinition(): void
+    {
+        $adminMaker = $this->prophesize(Definition::class);
+        $adminMaker->replaceArgument(Argument::type('integer'), Argument::any())->shouldNotBeCalled();
+        $containerBuilderMock = $this->prophesize(ContainerBuilder::class);
+
+        $containerBuilderMock->getServiceIds()
+            ->willReturn(['sonata.admin.manager.test']);
+
+        $definitionMock = $this->prophesize(Definition::class);
+
+        $definitionMock->getClass()
+            ->willReturn(\stdClass::class);
+
+        $definitionMock->hasTag(Argument::exact(ModelManagerCompilerPass::MANAGER_TAG))
+            ->willReturn(true);
+
+        $containerBuilderMock->findTaggedServiceIds(Argument::exact(ModelManagerCompilerPass::MANAGER_TAG))
+            ->willReturn(['sonata.admin.manager.test' => [ModelManagerCompilerPass::MANAGER_TAG, 'other.tag']]);
+
+        $containerBuilderMock->getParameter(Argument::exact('kernel.bundles'))
+            ->willReturn(['MakerBundle' => 'MakerBundle']);
+
+        $containerBuilderMock->findDefinition(Argument::exact('sonata.admin.manager.test'))
+            ->willReturn($definitionMock->reveal());
+
+        $containerBuilderMock->getDefinition(Argument::exact('sonata.admin.maker'))
+            ->willReturn($adminMaker->reveal());
+
+        $containerBuilderMock->getParameter(Argument::containingString('kernel.project_dir'))
+            ->willReturn(null);
+
+        $compilerPass = new ModelManagerCompilerPass();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(sprintf('Service "sonata.admin.manager.test" must implement `%s`.', ModelManagerInterface::class));
+
         $compilerPass->process($containerBuilderMock->reveal());
     }
 }

--- a/tests/Fixtures/DoctrineBundle/Connection.php
+++ b/tests/Fixtures/DoctrineBundle/Connection.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Fixtures\DoctrineBundle;
+
+/**
+ * Class for the fake "database_connection" service defined at `services.yml`.
+ *
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+final class Connection
+{
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Use tags for "sonata.admin.manager.*" services

I am targeting this branch, because this change respects BC.

Closes sonata-project/SonataDoctrineORMAdminBundle#924.

## Changelog
```markdown
### Added
- "sonata.admin.manager" tag to services implementing `ModelManagerInterface`.
```
