### PR TITLE
Remove deprecated code and NEXT_MAJOR related to templates

### DIFF
--- a/src/Action/GetShortObjectDescriptionAction.php
+++ b/src/Action/GetShortObjectDescriptionAction.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Action;
 
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -79,7 +80,17 @@ final class GetShortObjectDescriptionAction
                 'label' => $admin->toString($object),
             ]]);
         } elseif ('html' === $request->get('_format')) {
-            return new Response($this->twig->render($admin->getTemplate('short_object_description'), [
+            $templateRegistryId = $admin->getCode().'.template_registry';
+            $templateRegistry = $this->pool->getContainer()->get($templateRegistryId);
+
+            if (!$templateRegistry instanceof TemplateRegistryInterface) {
+                throw new \RuntimeException(sprintf(
+                    'Unable to find the template registry related to the current admin (%s)',
+                    $admin->getCode()
+                ));
+            }
+
+            return new Response($this->twig->render($templateRegistry->getTemplate('short_object_description'), [
                 'admin' => $admin,
                 'description' => $admin->toString($object),
                 'object' => $object,

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -397,13 +397,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     protected $filterTheme = [];
 
     /**
-     * @var array<string, string>
-     *
-     * @deprecated since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead
-     */
-    protected $templates = [];
-
-    /**
      * @var AdminExtensionInterface[]
      */
     protected $extensions = [];
@@ -1153,9 +1146,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      */
     public function setTemplates(array $templates): void
     {
-        // NEXT_MAJOR: Remove this line
-        $this->templates = $templates;
-
         $this->getTemplateRegistry()->setTemplates($templates);
     }
 
@@ -1164,32 +1154,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      */
     public function setTemplate($name, $template): void
     {
-        // NEXT_MAJOR: Remove this line
-        $this->templates[$name] = $template;
-
         $this->getTemplateRegistry()->setTemplate($name, $template);
-    }
-
-    /**
-     * @deprecated since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead
-     *
-     * @return array<string, string>
-     */
-    public function getTemplates(): array
-    {
-        return $this->getTemplateRegistry()->getTemplates();
-    }
-
-    /**
-     * @deprecated since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead
-     *
-     * @param string $name
-     *
-     * @return string|null
-     */
-    public function getTemplate($name)
-    {
-        return $this->getTemplateRegistry()->getTemplate($name);
     }
 
     public function getNewInstance()
@@ -2503,9 +2468,7 @@ EOT;
             $actions['create'] = [
                 'label' => 'link_add',
                 'translation_domain' => 'SonataAdminBundle',
-                // NEXT_MAJOR: Remove this line and use commented line below it instead
-                'template' => $this->getTemplate('action_create'),
-                // 'template' => $this->getTemplateRegistry()->getTemplate('action_create'),
+                'template' => $this->getTemplateRegistry()->getTemplate('action_create'),
                 'url' => $this->generateUrl('create'),
                 'icon' => 'plus-circle',
             ];
@@ -2718,9 +2681,7 @@ EOT;
             );
 
             $fieldDescription->setAdmin($this);
-            // NEXT_MAJOR: Remove this line and use commented line below it instead
-            $fieldDescription->setTemplate($this->getTemplate('batch'));
-            // $fieldDescription->setTemplate($this->getTemplateRegistry()->getTemplate('batch'));
+            $fieldDescription->setTemplate($this->getTemplateRegistry()->getTemplate('batch'));
 
             $mapper->add($fieldDescription, 'batch');
         }
@@ -2744,9 +2705,7 @@ EOT;
             );
 
             $fieldDescription->setAdmin($this);
-            // NEXT_MAJOR: Remove this line and use commented line below it instead
-            $fieldDescription->setTemplate($this->getTemplate('select'));
-            // $fieldDescription->setTemplate($this->getTemplateRegistry()->getTemplate('select'));
+            $fieldDescription->setTemplate($this->getTemplateRegistry()->getTemplate('select'));
 
             $mapper->add($fieldDescription, 'select');
         }

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -114,13 +114,6 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function setTemplate($name, $template);
 
     /**
-     * Get all templates.
-     *
-     * @return array
-     */
-    public function getTemplates();
-
-    /**
      * @return \Sonata\AdminBundle\Model\ModelManagerInterface
      */
     public function getModelManager();
@@ -469,17 +462,6 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @return bool
      */
     public function isChild();
-
-    /**
-     * Returns template.
-     *
-     * @deprecated since sonata-project/admin-bundle 3.35. To be removed in 4.0. Use TemplateRegistry services instead
-     *
-     * @param string $name
-     *
-     * @return string|null
-     */
-    public function getTemplate($name);
 
     /**
      * Set the translation domain.

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Admin;
 
 use InvalidArgumentException;
-use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -47,13 +46,6 @@ class Pool
     protected $adminClasses = [];
 
     /**
-     * @deprecated since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
-     *
-     * @var array
-     */
-    protected $templates = [];
-
-    /**
      * @var array
      */
     protected $assets = [];
@@ -77,11 +69,6 @@ class Pool
      * @var PropertyAccessorInterface
      */
     protected $propertyAccessor;
-
-    /**
-     * @var MutableTemplateRegistryInterface
-     */
-    private $templateRegistry;
 
     /**
      * @param string $title
@@ -378,44 +365,6 @@ class Pool
     public function getAdminClasses()
     {
         return $this->adminClasses;
-    }
-
-    final public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void
-    {
-        $this->templateRegistry = $templateRegistry;
-    }
-
-    /**
-     * @deprecated since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
-     */
-    public function setTemplates(array $templates): void
-    {
-        // NEXT MAJOR: Remove this line
-        $this->templates = $templates;
-
-        $this->templateRegistry->setTemplates($templates);
-    }
-
-    /**
-     * @deprecated since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
-     *
-     * @return array
-     */
-    public function getTemplates()
-    {
-        return $this->templateRegistry->getTemplates();
-    }
-
-    /**
-     * @deprecated since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
-     *
-     * @param string $name
-     *
-     * @return string|null
-     */
-    public function getTemplate($name)
-    {
-        return $this->templateRegistry->getTemplate($name);
     }
 
     /**

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -127,9 +127,7 @@ class CRUDController extends Controller
         // set the theme for the current Admin Form
         $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-        // NEXT_MAJOR: Remove this line and use commented line below it instead
-        $template = $this->admin->getTemplate('list');
-        // $template = $this->templateRegistry->getTemplate('list');
+        $template = $this->templateRegistry->getTemplate('list');
 
         return $this->renderWithExtraParams($template, [
             'action' => 'list',
@@ -242,9 +240,7 @@ class CRUDController extends Controller
             return $this->redirectTo($object);
         }
 
-        // NEXT_MAJOR: Remove this line and use commented line below it instead
-        $template = $this->admin->getTemplate('delete');
-        // $template = $this->templateRegistry->getTemplate('delete');
+        $template = $this->templateRegistry->getTemplate('delete');
 
         return $this->renderWithExtraParams($template, [
             'object' => $object,
@@ -364,9 +360,7 @@ class CRUDController extends Controller
         // set the theme for the current Admin Form
         $this->setFormTheme($formView, $this->admin->getFormTheme());
 
-        // NEXT_MAJOR: Remove this line and use commented line below it instead
-        $template = $this->admin->getTemplate($templateKey);
-        // $template = $this->templateRegistry->getTemplate($templateKey);
+        $template = $this->templateRegistry->getTemplate($templateKey);
 
         return $this->renderWithExtraParams($template, [
             'action' => 'edit',
@@ -456,13 +450,9 @@ class CRUDController extends Controller
             $formView = $datagrid->getForm()->createView();
             $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-            // NEXT_MAJOR: Remove these lines and use commented lines below them instead
             $template = !empty($batchActions[$action]['template']) ?
                 $batchActions[$action]['template'] :
-                $this->admin->getTemplate('batch_confirmation');
-            // $template = !empty($batchActions[$action]['template']) ?
-            //     $batchActions[$action]['template'] :
-            //     $this->templateRegistry->getTemplate('batch_confirmation');
+                $this->templateRegistry->getTemplate('batch_confirmation');
 
             return $this->renderWithExtraParams($template, [
                 'action' => 'list',
@@ -611,9 +601,7 @@ class CRUDController extends Controller
         // set the theme for the current Admin Form
         $this->setFormTheme($formView, $this->admin->getFormTheme());
 
-        // NEXT_MAJOR: Remove this line and use commented line below it instead
-        $template = $this->admin->getTemplate($templateKey);
-        // $template = $this->templateRegistry->getTemplate($templateKey);
+        $template = $this->templateRegistry->getTemplate($templateKey);
 
         return $this->renderWithExtraParams($template, [
             'action' => 'create',
@@ -668,9 +656,7 @@ class CRUDController extends Controller
             );
         }
 
-        // NEXT_MAJOR: Remove this line and use commented line below it instead
-        $template = $this->admin->getTemplate('show');
-        //$template = $this->templateRegistry->getTemplate('show');
+        $template = $this->templateRegistry->getTemplate('show');
 
         return $this->renderWithExtraParams($template, [
             'action' => 'show',
@@ -717,9 +703,7 @@ class CRUDController extends Controller
 
         $revisions = $reader->findRevisions($this->admin->getClass(), $id);
 
-        // NEXT_MAJOR: Remove this line and use commented line below it instead
-        $template = $this->admin->getTemplate('history');
-        // $template = $this->templateRegistry->getTemplate('history');
+        $template = $this->templateRegistry->getTemplate('history');
 
         return $this->renderWithExtraParams($template, [
             'action' => 'history',
@@ -782,9 +766,7 @@ class CRUDController extends Controller
 
         $this->admin->setSubject($object);
 
-        // NEXT_MAJOR: Remove this line and use commented line below it instead
-        $template = $this->admin->getTemplate('show');
-        // $template = $this->templateRegistry->getTemplate('show');
+        $template = $this->templateRegistry->getTemplate('show');
 
         return $this->renderWithExtraParams($template, [
             'action' => 'show',
@@ -860,9 +842,7 @@ class CRUDController extends Controller
 
         $this->admin->setSubject($base_object);
 
-        // NEXT_MAJOR: Remove this line and use commented line below it instead
-        $template = $this->admin->getTemplate('show_compare');
-        // $template = $this->templateRegistry->getTemplate('show_compare');
+        $template = $this->templateRegistry->getTemplate('show_compare');
 
         return $this->renderWithExtraParams($template, [
             'action' => 'show',
@@ -996,9 +976,7 @@ class CRUDController extends Controller
             }
         }
 
-        // NEXT_MAJOR: Remove this line and use commented line below it instead
-        $template = $this->admin->getTemplate('acl');
-        // $template = $this->templateRegistry->getTemplate('acl');
+        $template = $this->templateRegistry->getTemplate('acl');
 
         return $this->renderWithExtraParams($template, [
             'action' => 'acl',
@@ -1150,14 +1128,10 @@ class CRUDController extends Controller
     protected function getBaseTemplate()
     {
         if ($this->isXmlHttpRequest()) {
-            // NEXT_MAJOR: Remove this line and use commented line below it instead
-            return $this->admin->getTemplate('ajax');
-            // return $this->templateRegistry->getTemplate('ajax');
+            return $this->templateRegistry->getTemplate('ajax');
         }
 
-        // NEXT_MAJOR: Remove this line and use commented line below it instead
-        return $this->admin->getTemplate('layout');
-        // return $this->templateRegistry->getTemplate('layout');
+        return $this->templateRegistry->getTemplate('layout');
     }
 
     /**

--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -7,9 +7,6 @@
             <argument/>
             <argument type="collection"/>
             <argument type="service" id="property_accessor"/>
-            <call method="setTemplateRegistry">
-                <argument type="service" id="sonata.admin.global_template_registry"/>
-            </call>
         </service>
         <service id="Sonata\AdminBundle\Admin\Pool" alias="sonata.admin.pool"/>
         <service id="sonata.admin.route_loader" class="Sonata\AdminBundle\Route\AdminPoolLoader" public="true">

--- a/src/Templating/TemplateRegistry.php
+++ b/src/Templating/TemplateRegistry.php
@@ -52,27 +52,16 @@ final class TemplateRegistry implements MutableTemplateRegistryInterface
         return isset($this->templates[$name]);
     }
 
-    /**
-     * @param string $name
-     */
-    public function getTemplate($name): ?string
+    public function getTemplate($name): string
     {
         if (isset($this->templates[$name])) {
             return $this->templates[$name];
         }
 
-        @trigger_error(sprintf(
-            'Passing a nonexistent template name as argument 1 to %s() is deprecated since sonata-project/admin-bundle 3.52 and will throw an exception in 4.0.',
-            __METHOD__
-        ), E_USER_DEPRECATED);
-
-        // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare string as return type
-        // throw new \InvalidArgumentException(sprintf(
-        //    'Template named "%s" doesn\'t exist.',
-        //    $name
-        // ));
-
-        return null;
+        throw new \InvalidArgumentException(sprintf(
+            'Template named "%s" doesn\'t exist.',
+            $name
+        ));
     }
 
     public function setTemplate($name, $template): void

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -29,7 +29,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundE
 use Symfony\Component\Translation\TranslatorInterface;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
-use Twig\Template;
 use Twig\TemplateWrapper;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -168,9 +167,7 @@ final class SonataAdminExtension extends AbstractExtension
     ) {
         $template = $this->getTemplate(
             $fieldDescription,
-            // NEXT_MAJOR: Remove this line and use commented line below instead
-            $fieldDescription->getAdmin()->getTemplate('base_list_field'),
-            //$this->getTemplateRegistry($fieldDescription->getAdmin()->getCode())->getTemplate('base_list_field'),
+            $this->getTemplateRegistry($fieldDescription->getAdmin()->getCode())->getTemplate('base_list_field'),
             $environment
         );
 

--- a/src/Twig/Extension/TemplateRegistryExtension.php
+++ b/src/Twig/Extension/TemplateRegistryExtension.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Twig\Extension;
 
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
@@ -44,9 +43,6 @@ final class TemplateRegistryExtension extends AbstractExtension
         return [
             new TwigFunction('get_admin_template', [$this, 'getAdminTemplate']),
             new TwigFunction('get_global_template', [$this, 'getGlobalTemplate']),
-
-            // NEXT MAJOR: Remove this line
-            new TwigFunction('get_admin_pool_template', [$this, 'getPoolTemplate'], ['deprecated' => true]),
         ];
     }
 
@@ -59,19 +55,7 @@ final class TemplateRegistryExtension extends AbstractExtension
      */
     public function getAdminTemplate($name, $adminCode): ?string
     {
-        // NEXT_MAJOR: Remove this line and use commented line below it instead
-        return $this->getAdmin($adminCode)->getTemplate($name);
-        // return $this->getTemplateRegistry($adminCode)->getTemplate($name);
-    }
-
-    /**
-     * @deprecated since sonata-project/admin-bundle 3.34, to be removed in 4.0. Use getGlobalTemplate instead.
-     *
-     * @param string $name
-     */
-    public function getPoolTemplate($name): ?string
-    {
-        return $this->getGlobalTemplate($name);
+        return $this->getTemplateRegistry($adminCode)->getTemplate($name);
     }
 
     /**
@@ -95,21 +79,5 @@ final class TemplateRegistryExtension extends AbstractExtension
         }
 
         throw new ServiceNotFoundException($serviceId);
-    }
-
-    /**
-     * @deprecated since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead
-     *
-     * @throws ServiceNotFoundException
-     * @throws ServiceCircularReferenceException
-     */
-    private function getAdmin(string $adminCode): AdminInterface
-    {
-        $admin = $this->container->get($adminCode);
-        if ($admin instanceof AdminInterface) {
-            return $admin;
-        }
-
-        throw new ServiceNotFoundException($adminCode);
     }
 }

--- a/tests/Action/DashboardActionTest.php
+++ b/tests/Action/DashboardActionTest.php
@@ -37,7 +37,6 @@ class DashboardActionTest extends TestCase
         $templateRegistry->getTemplate('layout')->willReturn('layout.html');
 
         $pool = new Pool($container, 'title', 'logo.png');
-        $pool->setTemplateRegistry($templateRegistry->reveal());
 
         $twig = $this->createMock(Environment::class);
 

--- a/tests/Action/GetShortObjectDescriptionActionTest.php
+++ b/tests/Action/GetShortObjectDescriptionActionTest.php
@@ -18,6 +18,8 @@ use Prophecy\Argument;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistry;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -49,7 +51,7 @@ final class GetShortObjectDescriptionActionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->twig = new Environment(new ArrayLoader(['template' => 'renderedTemplate']));
+        $this->twig = new Environment(new ArrayLoader(['short_object_description' => 'renderedTemplate']));
         $this->pool = $this->prophesize(Pool::class);
         $this->admin = $this->prophesize(AbstractAdmin::class);
         $this->pool->getInstance(Argument::any())->willReturn($this->admin->reveal());
@@ -110,6 +112,13 @@ final class GetShortObjectDescriptionActionTest extends TestCase
 
     public function testGetShortObjectDescriptionActionObject(): void
     {
+        $templateRegistry = new TemplateRegistry([
+            'short_object_description' => 'short_object_description',
+        ]);
+        $container = new Container();
+        $container->set('sonata.post.admin.template_registry', $templateRegistry);
+        $this->pool->getContainer()->willReturn($container);
+
         $request = new Request([
             'code' => 'sonata.post.admin',
             'objectId' => 42,
@@ -120,8 +129,8 @@ final class GetShortObjectDescriptionActionTest extends TestCase
 
         $this->admin->setUniqid('asdasd123')->shouldBeCalled();
         $this->admin->getObject(42)->willReturn($object);
-        $this->admin->getTemplate('short_object_description')->willReturn('template');
         $this->admin->toString($object)->willReturn('bar');
+        $this->admin->getCode()->willReturn('sonata.post.admin');
 
         $response = ($this->action)($request);
 
@@ -161,7 +170,6 @@ final class GetShortObjectDescriptionActionTest extends TestCase
         $this->admin->setUniqid('asdasd123')->shouldBeCalled();
         $this->admin->id($object)->willReturn(42);
         $this->admin->getObject(42)->willReturn($object);
-        $this->admin->getTemplate('short_object_description')->willReturn('template');
         $this->admin->toString($object)->willReturn('bar');
 
         $response = ($this->action)($request);

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -102,8 +102,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->hasAccess('edit', $object)->willReturn(true);
         $this->admin->getListFieldDescription('enabled')->willReturn($fieldDescription->reveal());
         $this->admin->update($object)->shouldBeCalled();
-        // NEXT_MAJOR: Remove this line
-        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
         $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
         $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
         $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
@@ -152,8 +150,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->getClass()->willReturn(\get_class($object));
         $this->admin->update($object)->shouldBeCalled();
         $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
-        // NEXT_MAJOR: Remove this line
-        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
         $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
         $this->admin->getModelManager()->willReturn($modelManager->reveal());
         $this->twig->addExtension(new SonataAdminExtension(
@@ -236,8 +232,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->hasAccess('edit', $object)->willReturn(true);
         $this->admin->getListFieldDescription('status')->willReturn($fieldDescription->reveal());
         $this->admin->update($object)->shouldBeCalled();
-        // NEXT_MAJOR: Remove this line
-        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
         $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
         $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
         $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1170,38 +1170,6 @@ class AdminTest extends TestCase
         $this->assertSame('SonataNewsBundle:FooAdmin', $admin->getBaseControllerName());
     }
 
-    public function testGetTemplates(): void
-    {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-
-        $templates = [
-            'list' => '@FooAdmin/CRUD/list.html.twig',
-            'show' => '@FooAdmin/CRUD/show.html.twig',
-            'edit' => '@FooAdmin/CRUD/edit.html.twig',
-        ];
-
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->getTemplates()->shouldBeCalled()->willReturn($templates);
-
-        $admin->setTemplateRegistry($templateRegistry->reveal());
-
-        $this->assertSame($templates, $admin->getTemplates());
-    }
-
-    public function testGetTemplate1(): void
-    {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->getTemplate('edit')->shouldBeCalled()->willReturn('@FooAdmin/CRUD/edit.html.twig');
-        $templateRegistry->getTemplate('show')->shouldBeCalled()->willReturn('@FooAdmin/CRUD/show.html.twig');
-
-        $admin->setTemplateRegistry($templateRegistry->reveal());
-
-        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $admin->getTemplate('edit'));
-        $this->assertSame('@FooAdmin/CRUD/show.html.twig', $admin->getTemplate('show'));
-    }
-
     public function testGetIdParameter(): void
     {
         $postAdmin = new PostAdmin(

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
-use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class PoolTest extends TestCase
@@ -515,45 +514,6 @@ class PoolTest extends TestCase
     public function testGetContainer(): void
     {
         $this->assertInstanceOf(ContainerInterface::class, $this->pool->getContainer());
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testTemplate(): void
-    {
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->getTemplate('ajax')
-            ->shouldBeCalledTimes(1)
-            ->willReturn('Foo.html.twig');
-
-        $this->pool->setTemplateRegistry($templateRegistry->reveal());
-
-        $this->assertSame('Foo.html.twig', $this->pool->getTemplate('ajax'));
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testSetGetTemplates(): void
-    {
-        $templates = [
-            'ajax' => 'Foo.html.twig',
-            'layout' => 'Bar.html.twig',
-        ];
-
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->setTemplates($templates)
-            ->shouldBeCalledTimes(1);
-        $templateRegistry->getTemplates()
-            ->shouldBeCalledTimes(1)
-            ->willReturn($templates);
-
-        $this->pool->setTemplateRegistry($templateRegistry->reveal());
-
-        $this->pool->setTemplates($templates);
-
-        $this->assertSame($templates, $this->pool->getTemplates());
     }
 
     public function testGetTitleLogo(): void

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -345,24 +345,6 @@ class CRUDControllerTest extends TestCase
         $this->templateRegistry->getTemplate('batch')->willReturn('@SonataAdmin/CRUD/list__batch.html.twig');
         $this->templateRegistry->getTemplate('batch_confirmation')->willReturn('@SonataAdmin/CRUD/batch_confirmation.html.twig');
 
-        // NEXT_MAJOR: Remove this call
-        $this->admin->method('getTemplate')->willReturnMap([
-            ['ajax', '@SonataAdmin/ajax_layout.html.twig'],
-            ['layout', '@SonataAdmin/standard_layout.html.twig'],
-            ['show', '@SonataAdmin/CRUD/show.html.twig'],
-            ['show_compare', '@SonataAdmin/CRUD/show_compare.html.twig'],
-            ['edit', '@SonataAdmin/CRUD/edit.html.twig'],
-            ['dashboard', '@SonataAdmin/Core/dashboard.html.twig'],
-            ['search', '@SonataAdmin/Core/search.html.twig'],
-            ['list', '@SonataAdmin/CRUD/list.html.twig'],
-            ['preview', '@SonataAdmin/CRUD/preview.html.twig'],
-            ['history', '@SonataAdmin/CRUD/history.html.twig'],
-            ['acl', '@SonataAdmin/CRUD/acl.html.twig'],
-            ['delete', '@SonataAdmin/CRUD/delete.html.twig'],
-            ['batch', '@SonataAdmin/CRUD/list__batch.html.twig'],
-            ['batch_confirmation', '@SonataAdmin/CRUD/batch_confirmation.html.twig'],
-        ]);
-
         $this->admin
             ->method('getIdParameter')
             ->willReturn('id');

--- a/tests/Templating/TemplateRegistryTest.php
+++ b/tests/Templating/TemplateRegistryTest.php
@@ -42,17 +42,9 @@ class TemplateRegistryTest extends TestCase
         $this->assertSame($templates, $this->templateRegistry->getTemplates());
     }
 
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation Passing a nonexistent template name as argument 1 to Sonata\AdminBundle\Templating\TemplateRegistry::getTemplate() is deprecated since sonata-project/admin-bundle 3.52 and will throw an exception in 4.0.
-     */
-    public function testGetTemplate1(): void
+    public function testSetTemplate(): void
     {
         $this->assertFalse($this->templateRegistry->hasTemplate('edit'));
-        $this->assertNull($this->templateRegistry->getTemplate('edit'));
-        // NEXT_MAJOR: Remove previous assertion, the "@group" and "@expectedDeprecation" annotations and uncomment the following line
-        // $this->assertFalse($this->templateRegistry->hasTemplate('edit'));
 
         $this->templateRegistry->setTemplate('edit', '@FooAdmin/CRUD/edit.html.twig');
         $this->templateRegistry->setTemplate('show', '@FooAdmin/CRUD/show.html.twig');
@@ -63,17 +55,9 @@ class TemplateRegistryTest extends TestCase
         $this->assertSame('@FooAdmin/CRUD/show.html.twig', $this->templateRegistry->getTemplate('show'));
     }
 
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation Passing a nonexistent template name as argument 1 to Sonata\AdminBundle\Templating\TemplateRegistry::getTemplate() is deprecated since sonata-project/admin-bundle 3.52 and will throw an exception in 4.0.
-     */
-    public function testGetTemplate2(): void
+    public function testSetTemplates(): void
     {
         $this->assertFalse($this->templateRegistry->hasTemplate('edit'));
-        $this->assertNull($this->templateRegistry->getTemplate('edit'));
-        // NEXT_MAJOR: Remove previous assertion, the "@group" and "@expectedDeprecation" annotations and uncomment the following line
-        // $this->assertFalse($this->templateRegistry->hasTemplate('edit'));
 
         $templates = [
             'list' => '@FooAdmin/CRUD/list.html.twig',
@@ -87,5 +71,15 @@ class TemplateRegistryTest extends TestCase
         $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $this->templateRegistry->getTemplate('edit'));
         $this->assertTrue($this->templateRegistry->hasTemplate('show'));
         $this->assertSame('@FooAdmin/CRUD/show.html.twig', $this->templateRegistry->getTemplate('show'));
+    }
+
+    public function testThrowExceptionIfTheTemplateDoesNotExist(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Template named "edit" doesn\'t exist.');
+
+        $this->assertFalse($this->templateRegistry->hasTemplate('edit'));
+
+        $this->templateRegistry->getTemplate('edit');
     }
 }

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -260,95 +260,6 @@ class SonataAdminExtensionTest extends TestCase
             ->willReturn('Data');
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).
-     * @dataProvider getRenderListElementTests
-     */
-    public function testRenderListElement(string $expected, string $type, $value, array $options): void
-    {
-        $this->admin
-            ->method('getPersistentParameters')
-            ->willReturn(['context' => 'foo']);
-
-        $this->admin
-            ->method('hasAccess')
-            ->willReturn(true);
-
-        // NEXT_MAJOR: Remove this line
-        $this->admin
-            ->method('getTemplate')
-            ->with('base_list_field')
-            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
-
-        $this->templateRegistry->getTemplate('base_list_field')->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
-
-        $this->fieldDescription
-            ->method('getValue')
-            ->willReturn($value);
-
-        $this->fieldDescription
-            ->method('getType')
-            ->willReturn($type);
-
-        $this->fieldDescription
-            ->method('getOptions')
-            ->willReturn($options);
-
-        $this->fieldDescription
-            ->method('getOption')
-            ->willReturnCallback(static function ($name, $default = null) use ($options) {
-                return $options[$name] ?? $default;
-            });
-
-        $this->fieldDescription
-            ->method('getTemplate')
-            ->willReturnCallback(static function () use ($type) {
-                switch ($type) {
-                    case 'string':
-                        return '@SonataAdmin/CRUD/list_string.html.twig';
-                    case 'boolean':
-                        return '@SonataAdmin/CRUD/list_boolean.html.twig';
-                    case 'datetime':
-                        return '@SonataAdmin/CRUD/list_datetime.html.twig';
-                    case 'date':
-                        return '@SonataAdmin/CRUD/list_date.html.twig';
-                    case 'time':
-                        return '@SonataAdmin/CRUD/list_time.html.twig';
-                    case 'currency':
-                        return '@SonataAdmin/CRUD/list_currency.html.twig';
-                    case 'percent':
-                        return '@SonataAdmin/CRUD/list_percent.html.twig';
-                    case 'email':
-                        return '@SonataAdmin/CRUD/list_email.html.twig';
-                    case 'choice':
-                        return '@SonataAdmin/CRUD/list_choice.html.twig';
-                    case 'array':
-                        return '@SonataAdmin/CRUD/list_array.html.twig';
-                    case 'trans':
-                        return '@SonataAdmin/CRUD/list_trans.html.twig';
-                    case 'url':
-                        return '@SonataAdmin/CRUD/list_url.html.twig';
-                    case 'html':
-                        return '@SonataAdmin/CRUD/list_html.html.twig';
-                    case 'nonexistent':
-                        // template doesn't exist
-                        return '@SonataAdmin/CRUD/list_nonexistent_template.html.twig';
-                    default:
-                        return false;
-                }
-            });
-
-        $this->assertSame(
-            $this->removeExtraWhitespace($expected),
-            $this->removeExtraWhitespace($this->twigExtension->renderListElement(
-                $this->environment,
-                $this->object,
-                $this->fieldDescription
-            ))
-        );
-    }
-
     public function getRenderListElementTests()
     {
         return [
@@ -1323,10 +1234,6 @@ EOT
      */
     public function testRenderViewElement(string $expected, string $type, $value, array $options): void
     {
-        $this->admin
-            ->method('getTemplate')
-            ->willReturn('@SonataAdmin/CRUD/base_show_field.html.twig');
-
         $this->fieldDescription
             ->method('getValue')
             ->willReturnCallback(static function () use ($value) {
@@ -2035,50 +1942,6 @@ EOT
                 $this->twigExtension,
                 $object,
                 $fieldDescription
-            )
-        );
-    }
-
-    /**
-     * @group legacy
-     * @expectedDeprecation The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).
-     */
-    public function testRenderWithDebug(): void
-    {
-        $this->fieldDescription
-            ->method('getTemplate')
-            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
-
-        $this->fieldDescription
-            ->method('getFieldName')
-            ->willReturn('fd_name');
-
-        $this->fieldDescription
-            ->method('getValue')
-            ->willReturn('foo');
-
-        $parameters = [
-            'admin' => $this->admin,
-            'value' => 'foo',
-            'field_description' => $this->fieldDescription,
-            'object' => $this->object,
-        ];
-
-        $this->environment->enableDebug();
-
-        $this->assertSame(
-            $this->removeExtraWhitespace(<<<'EOT'
-<!-- START
-    fieldName: fd_name
-    template: @SonataAdmin/CRUD/base_list_field.html.twig
-    compiled template: @SonataAdmin/CRUD/base_list_field.html.twig
--->
-    <td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> foo </td>
-<!-- END - fieldName: fd_name -->
-EOT
-            ),
-            $this->removeExtraWhitespace(
-                $this->twigExtension->renderListElement($this->environment, $this->object, $this->fieldDescription, $parameters)
             )
         );
     }

--- a/tests/Twig/Extension/TemplateRegistryExtensionTest.php
+++ b/tests/Twig/Extension/TemplateRegistryExtensionTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\AdminBundle\Twig\Extension\TemplateRegistryExtension;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -41,23 +40,10 @@ class TemplateRegistryExtensionTest extends TestCase
      */
     private $container;
 
-    /**
-     * NEXT_MAJOR: Remove this attribute.
-     *
-     * @var AdminInterface
-     */
-    private $admin;
-
     protected function setUp(): void
     {
         $this->templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
         $this->container = $this->prophesize(ContainerInterface::class);
-
-        // NEXT_MAJOR: Remove this line
-        $this->admin = $this->prophesize(AdminInterface::class);
-
-        // NEXT_MAJOR: Remove this line
-        $this->admin->getTemplate('edit')->willReturn('@SonataAdmin/CRUD/edit.html.twig');
 
         $this->templateRegistry->getTemplate('edit')->willReturn('@SonataAdmin/CRUD/edit.html.twig');
 
@@ -72,9 +58,6 @@ class TemplateRegistryExtensionTest extends TestCase
         $expected = [
             new TwigFunction('get_admin_template', [$this->extension, 'getAdminTemplate']),
             new TwigFunction('get_global_template', [$this->extension, 'getGlobalTemplate']),
-
-            // NEXT MAJOR: Remove this line
-            new TwigFunction('get_admin_pool_template', [$this->extension, 'getGlobalTemplate'], ['deprecated' => true]),
         ];
 
         $this->assertSame($expected, $this->extension->getFunctions());
@@ -82,9 +65,6 @@ class TemplateRegistryExtensionTest extends TestCase
 
     public function testGetAdminTemplate(): void
     {
-        // NEXT_MAJOR: Remove this line
-        $this->container->get('admin.post')->willReturn($this->admin->reveal());
-
         $this->container->get('admin.post.template_registry')->willReturn($this->templateRegistry->reveal());
 
         $this->assertSame(
@@ -95,15 +75,11 @@ class TemplateRegistryExtensionTest extends TestCase
 
     public function testGetAdminTemplateFailure(): void
     {
-        // NEXT_MAJOR: Remove this line
-        $this->container->get('admin.post')->willReturn(null);
         $this->container->get('admin.post.template_registry')->willReturn(null);
 
         $this->expectException(ServiceNotFoundException::class);
 
-        // NEXT_MAJOR: Remove this line and use the commented line below instead
-        $this->expectExceptionMessage('You have requested a non-existent service "admin.post"');
-        // $this->expectExceptionMessage('You have requested a non-existent service "admin.post.template_registry"');
+        $this->expectExceptionMessage('You have requested a non-existent service "admin.post.template_registry"');
 
         $this->assertSame(
             '@SonataAdmin/CRUD/edit.html.twig',


### PR DESCRIPTION
This removes the deprecations of using templates in the Admin classes instead of the TemplateRegistry.

Refs: https://github.com/sonata-project/SonataAdminBundle/issues/5763