### PR TITLE
Address PHPUnit's warnings

### DIFF
--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -32,6 +32,7 @@ use Sonata\AdminBundle\Builder\RouteBuilderInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
+use Sonata\AdminBundle\Filter\Persister\FilterPersisterInterface;
 use Sonata\AdminBundle\Model\AuditManagerInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Route\DefaultRouteGenerator;
@@ -1440,14 +1441,17 @@ class AdminTest extends TestCase
 
     public function testSetFilterPersister(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new class('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle\Controller\PostAdminController') extends PostAdmin {
+            public function persistFilters(): bool
+            {
+                return $this->persistFilters;
+            }
+        };
 
-        $filterPersister = $this->createMock('Sonata\AdminBundle\Filter\Persister\FilterPersisterInterface');
+        $filterPersister = $this->createMock(FilterPersisterInterface::class);
 
-        $this->assertAttributeSame(null, 'filterPersister', $admin);
         $admin->setFilterPersister($filterPersister);
-        $this->assertAttributeSame($filterPersister, 'filterPersister', $admin);
-        $this->assertAttributeSame(true, 'persistFilters', $admin);
+        $this->assertTrue($admin->persistFilters());
     }
 
     public function testGetRootCode(): void
@@ -1578,7 +1582,7 @@ class AdminTest extends TestCase
 
         $tagAdmin->getForm();
 
-        $this->assertInternalType('array', $tag->getPosts());
+        $this->assertIsArray($tag->getPosts());
         $this->assertCount(2, $tag->getPosts());
         $this->assertContains($post, $tag->getPosts());
     }

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -439,7 +439,6 @@ class CRUDControllerTest extends TestCase
         $this->protectedTestedMethods['configure']->invoke($this->controller);
 
         $this->assertSame(123456, $uniqueId);
-        $this->assertAttributeSame($this->admin, 'admin', $this->controller);
     }
 
     public function testConfigureChild(): void
@@ -467,7 +466,6 @@ class CRUDControllerTest extends TestCase
         $this->protectedTestedMethods['configure']->invoke($this->controller);
 
         $this->assertSame(123456, $uniqueId);
-        $this->assertAttributeInstanceOf(\get_class($adminParent), 'admin', $this->controller);
     }
 
     public function testConfigureWithException(): void

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -168,7 +168,7 @@ class ListMapperTest extends TestCase
         $this->assertFalse($this->listMapper->has('fooName'));
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('{^Value for "identifier" option must be boolean, [^]+ given.$}');
+        $this->expectExceptionMessageMatches('{^Value for "identifier" option must be boolean, [^]+ given.$}');
 
         $this->listMapper->add('fooName', null, ['identifier' => $value]);
     }

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -140,7 +140,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
 
         $this->assertArrayHasKey('sonata_group_two', $dashboardGroupsSettings);
         $this->assertArrayHasKey('provider', $dashboardGroupsSettings['sonata_group_two']);
-        $this->assertContains('my_menu', $dashboardGroupsSettings['sonata_group_two']['provider']);
+        $this->assertStringContainsString('my_menu', $dashboardGroupsSettings['sonata_group_two']['provider']);
 
         $this->assertArrayHasKey('sonata_group_five', $dashboardGroupsSettings);
         $this->assertTrue($dashboardGroupsSettings['sonata_group_five']['keep_open']);
@@ -183,7 +183,10 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $this->assertFalse($adminGroups['sonata_group_one']['on_top']);
         $this->assertTrue($adminGroups['sonata_group_three']['on_top']);
         $this->assertFalse($adminGroups['sonata_group_one']['keep_open']);
-        $this->assertContains('sonata_post_admin', $adminGroups['sonata_group_one']['items'][0]['admin']);
+        $this->assertStringContainsString(
+            'sonata_post_admin',
+            $adminGroups['sonata_group_one']['items'][0]['admin']
+        );
         $this->assertContains('sonata_news_admin', $adminGroups['sonata_group_one']['items']);
         $this->assertContains('sonata_news_admin', $adminGroups['sonata_group_one']['item_adds']);
         $this->assertNotContains('sonata_article_admin', $adminGroups['sonata_group_one']['items']);
@@ -191,7 +194,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
 
         $this->assertArrayHasKey('sonata_group_two', $adminGroups);
         $this->assertArrayHasKey('provider', $adminGroups['sonata_group_two']);
-        $this->assertContains('my_menu', $adminGroups['sonata_group_two']['provider']);
+        $this->assertStringContainsString('my_menu', $adminGroups['sonata_group_two']['provider']);
 
         $this->assertArrayHasKey('sonata_group_five', $adminGroups);
         $this->assertTrue($adminGroups['sonata_group_five']['keep_open']);

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -152,7 +152,10 @@ class FilterTest extends TestCase
         try {
             $filter->getFieldMapping();
         } catch (\RuntimeException $e) {
-            $this->assertContains('The option `field_mapping` must be set for field: `foo`', $e->getMessage());
+            $this->assertStringContainsString(
+                'The option `field_mapping` must be set for field: `foo`',
+                $e->getMessage()
+            );
 
             return;
         }
@@ -207,7 +210,10 @@ class FilterTest extends TestCase
         try {
             $filter->getAssociationMapping();
         } catch (\RuntimeException $e) {
-            $this->assertContains('The option `association_mapping` must be set for field: `foo`', $e->getMessage());
+            $this->assertStringContainsString(
+                'The option `association_mapping` must be set for field: `foo`',
+                $e->getMessage()
+            );
 
             return;
         }

--- a/tests/Form/Type/ChoiceFieldMaskTypeTest.php
+++ b/tests/Form/Type/ChoiceFieldMaskTypeTest.php
@@ -59,7 +59,7 @@ class ChoiceFieldMaskTypeTest extends TypeTestCase
     public function testSetAllowedTypes($map): void
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->expectExceptionMessageRegExp('/The option "map" with value .* is expected to be of type "array", but is of type ".*"/');
+        $this->expectExceptionMessageMatches('/The option "map" with value .* is expected to be of type "array", but is of type ".*"/');
 
         $this->resolveOptions(['map' => $map]);
     }

--- a/tests/Form/Widget/FilterChoiceWidgetTest.php
+++ b/tests/Form/Widget/FilterChoiceWidgetTest.php
@@ -34,7 +34,7 @@ class FilterChoiceWidgetTest extends BaseWidgetTest
 
         $html = $this->renderWidget($choice->createView());
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<option value="" selected="selected">[trans]Choose an option[/trans]</option>',
             $this->cleanHtmlWhitespace($html)
         );
@@ -50,7 +50,7 @@ class FilterChoiceWidgetTest extends BaseWidgetTest
 
         $html = $this->renderWidget($choice->createView());
 
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             'required="required"',
             $this->cleanHtmlWhitespace($html)
         );
@@ -66,7 +66,7 @@ class FilterChoiceWidgetTest extends BaseWidgetTest
 
         $html = $this->renderWidget($choice->createView());
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'required="required"',
             $this->cleanHtmlWhitespace($html)
         );

--- a/tests/Form/Widget/FormChoiceWidgetTest.php
+++ b/tests/Form/Widget/FormChoiceWidgetTest.php
@@ -43,7 +43,7 @@ class FormChoiceWidgetTest extends BaseWidgetTest
 
         $html = $this->renderWidget($choice->createView());
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li><div class="checkbox"><label><input type="checkbox" id="choice_0" name="choice[]" value="0" /><span class="control-label__text">[trans]some[/trans]</span></label></div></li>',
             $this->cleanHtmlWhitespace($html)
         );
@@ -59,7 +59,7 @@ class FormChoiceWidgetTest extends BaseWidgetTest
 
         $html = $this->renderWidget($choice->createView());
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<option value="" selected="selected">[trans]Choose an option[/trans]</option>',
             $this->cleanHtmlWhitespace($html)
         );
@@ -75,7 +75,7 @@ class FormChoiceWidgetTest extends BaseWidgetTest
 
         $html = $this->renderWidget($choice->createView());
 
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             'required="required"',
             $this->cleanHtmlWhitespace($html)
         );
@@ -91,7 +91,7 @@ class FormChoiceWidgetTest extends BaseWidgetTest
 
         $html = $this->renderWidget($choice->createView());
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'required="required"',
             $this->cleanHtmlWhitespace($html)
         );

--- a/tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
+++ b/tests/Form/Widget/FormSonataFilterChoiceWidgetTest.php
@@ -40,17 +40,17 @@ class FormSonataFilterChoiceWidgetTest extends BaseWidgetTest
         $html = $this->cleanHtmlWhitespace($this->renderWidget($choice->createView()));
         $html = $this->cleanHtmlAttributeWhitespace($html);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<option value="1">[trans]label_type_contains[/trans]</option>',
             $html
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<option value="2">[trans]label_type_not_contains[/trans]</option>',
             $html
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<option value="3">[trans]label_type_equals[/trans]</option></select>',
             $html
         );

--- a/tests/Form/Widget/FormSonataNativeCollectionWidgetTest.php
+++ b/tests/Form/Widget/FormSonataNativeCollectionWidgetTest.php
@@ -48,7 +48,7 @@ class FormSonataNativeCollectionWidgetTest extends BaseWidgetTest
 
         $html = $this->renderWidget($choice->createView());
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'sonata-collection-delete',
             $this->cleanHtmlWhitespace($html)
         );

--- a/tests/Menu/Integration/TabMenuTest.php
+++ b/tests/Menu/Integration/TabMenuTest.php
@@ -47,7 +47,7 @@ class TabMenuTest extends BaseMenuTest
         $factory = new MenuFactory();
         $menu = new MenuItem('test-menu', $factory);
         $menu->addChild('some-label', ['uri' => '/whatever']);
-        $this->assertContains('my-translation', $this->renderMenu($menu));
+        $this->assertStringContainsString('my-translation', $this->renderMenu($menu));
     }
 
     public function testLabelTranslationWithParameters(): void
@@ -69,7 +69,7 @@ class TabMenuTest extends BaseMenuTest
         $menu->addChild('some-label', ['uri' => '/whatever'])
             ->setExtra('translation_params', $params);
 
-        $this->assertContains('my-translation', $this->renderMenu($menu));
+        $this->assertStringContainsString('my-translation', $this->renderMenu($menu));
     }
 
     public function testLabelTranslationDomainOverride(): void
@@ -91,8 +91,8 @@ class TabMenuTest extends BaseMenuTest
         $menu->addChild('some-other-label', ['uri' => '/whatever']);
 
         $html = $this->renderMenu($menu);
-        $this->assertContains('my-translation', $html);
-        $this->assertContains('my-other-translation', $html);
+        $this->assertStringContainsString('my-translation', $html);
+        $this->assertStringContainsString('my-other-translation', $html);
     }
 
     protected function getTemplate()


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is BC.
`assertAttributeSame` has no replacement so I removed it, because I don't think testing an object's internal is a great practice anyway. I managed to keep it in one occurence.
