### PR TITLE
Iterate services with `getDefinitions()` instead of `getServiceIds()`

### DIFF
--- a/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
@@ -35,9 +35,7 @@ final class ModelManagerCompilerPass implements CompilerPassInterface
 
         // NEXT_MAJOR: Replace the `foreach()` clause with the following one.
         // foreach ($container->findTaggedServiceIds(self::MANAGER_TAG) as $id => $tags) {
-        foreach ($container->getServiceIds() as $id) {
-            $definition = $container->findDefinition($id);
-
+        foreach ($container->getDefinitions() as $id => $definition) {
             // NEXT_MAJOR: Remove this check.
             if (!$definition->hasTag(self::MANAGER_TAG) && 0 !== strpos($id, 'sonata.admin.manager.')) {
                 continue;

--- a/tests/DependencyInjection/Compiler/ModelManagerCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ModelManagerCompilerPassTest.php
@@ -31,9 +31,14 @@ final class ModelManagerCompilerPassTest extends TestCase
     {
         $adminMaker = $this->prophesize(Definition::class);
         $adminMaker->replaceArgument(Argument::type('integer'), Argument::any())->shouldNotBeCalled();
+        $adminMaker->hasTag(Argument::exact(ModelManagerCompilerPass::MANAGER_TAG))
+            ->willReturn(false);
         $containerBuilderMock = $this->prophesize(ContainerBuilder::class);
 
         $containerBuilderMock->getServiceIds()
+            ->willReturn([]);
+
+        $containerBuilderMock->getDefinitions()
             ->willReturn([]);
 
         $containerBuilderMock->findTaggedServiceIds(Argument::exact(ModelManagerCompilerPass::MANAGER_TAG))
@@ -62,12 +67,20 @@ final class ModelManagerCompilerPassTest extends TestCase
     {
         $adminMaker = $this->prophesize(Definition::class);
         $adminMaker->replaceArgument(Argument::type('integer'), Argument::any())->shouldBeCalledTimes(1);
+        $adminMaker->hasTag(Argument::exact(ModelManagerCompilerPass::MANAGER_TAG))
+            ->willReturn(false);
         $containerBuilderMock = $this->prophesize(ContainerBuilder::class);
 
         $containerBuilderMock->getServiceIds()
             ->willReturn(['sonata.admin.manager.test']);
 
         $definitionMock = $this->prophesize(Definition::class);
+
+        $containerBuilderMock->getDefinitions()
+            ->willReturn([
+                'sonata.admin.maker' => $adminMaker->reveal(),
+                'sonata.admin.manager.test' => $definitionMock->reveal(),
+            ]);
 
         $definitionMock->getClass()
             ->willReturn(ModelManager::class);
@@ -101,12 +114,20 @@ final class ModelManagerCompilerPassTest extends TestCase
     {
         $adminMaker = $this->prophesize(Definition::class);
         $adminMaker->replaceArgument(Argument::type('integer'), Argument::any())->shouldBeCalledTimes(1);
+        $adminMaker->hasTag(Argument::exact(ModelManagerCompilerPass::MANAGER_TAG))
+            ->willReturn(false);
         $containerBuilderMock = $this->prophesize(ContainerBuilder::class);
 
         $containerBuilderMock->getServiceIds()
             ->willReturn(['sonata.admin.manager.test']);
 
         $definitionMock = $this->prophesize(Definition::class);
+
+        $containerBuilderMock->getDefinitions()
+            ->willReturn([
+                'sonata.admin.maker' => $adminMaker->reveal(),
+                'sonata.admin.manager.test' => $definitionMock->reveal(),
+            ]);
 
         $definitionMock->getClass()
             ->willReturn(ModelManager::class);
@@ -137,12 +158,20 @@ final class ModelManagerCompilerPassTest extends TestCase
     {
         $adminMaker = $this->prophesize(Definition::class);
         $adminMaker->replaceArgument(Argument::type('integer'), Argument::any())->shouldNotBeCalled();
+        $adminMaker->hasTag(Argument::exact(ModelManagerCompilerPass::MANAGER_TAG))
+            ->willReturn(false);
         $containerBuilderMock = $this->prophesize(ContainerBuilder::class);
 
         $containerBuilderMock->getServiceIds()
             ->willReturn(['sonata.admin.manager.test']);
 
         $definitionMock = $this->prophesize(Definition::class);
+
+        $containerBuilderMock->getDefinitions()
+            ->willReturn([
+                'sonata.admin.maker' => $adminMaker->reveal(),
+                'sonata.admin.manager.test' => $definitionMock->reveal(),
+            ]);
 
         $definitionMock->getClass()
             ->willReturn(\stdClass::class);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Iterate services with `getDefinitions()` instead of `getServiceIds()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5903.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Calling `ContainerBuilder::getDefinition()` with ids which have no associated definition.
```