### PR TITLE
Add configureQuery and make createQuery final

### DIFF
--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -214,6 +214,10 @@ to more field types, see `SonataDoctrineORMAdminBundle Documentation`_.
 Customizing the query used to generate the list
 -----------------------------------------------
 
+.. versionadded:: 3.63
+
+    The ``configureQuery`` method was introduced in 3.63.
+
 You can customize the list query thanks to the ``configureQuery`` method::
 
     protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -214,11 +214,11 @@ to more field types, see `SonataDoctrineORMAdminBundle Documentation`_.
 Customizing the query used to generate the list
 -----------------------------------------------
 
-You can customize the list query thanks to the ``createQuery`` method::
+You can customize the list query thanks to the ``configureQuery`` method::
 
-    public function createQuery($context = 'list')
+    protected function configureQuery($query)
     {
-        $query = parent::createQuery($context);
+        $query = parent::configureQuery($query);
         $query->andWhere(
             $query->expr()->eq($query->getRootAliases()[0] . '.my_field', ':my_param')
         );

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -216,7 +216,7 @@ Customizing the query used to generate the list
 
 You can customize the list query thanks to the ``configureQuery`` method::
 
-    protected function configureQuery($query)
+    protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface
     {
         $query = parent::configureQuery($query);
         $query->andWhere(

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1382,6 +1382,9 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return $this->list;
     }
 
+    /**
+     * @final since sonata-project/admin-bundle 3.x
+     */
     public function createQuery($context = 'list')
     {
         if (\func_num_args() > 0) {
@@ -1390,8 +1393,10 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
                 E_USER_DEPRECATED
             );
         }
+
         $query = $this->getModelManager()->createQuery($this->getClass());
 
+        $query = $this->configureQuery($query);
         foreach ($this->extensions as $extension) {
             $extension->configureQuery($this, $query, $context);
         }
@@ -2849,6 +2854,11 @@ EOT;
     public function canAccessObject($action, $object)
     {
         return $object && $this->id($object) && $this->hasAccess($action, $object);
+    }
+
+    protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface
+    {
+        return $query;
     }
 
     /**

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -32,6 +32,7 @@ use Sonata\AdminBundle\Builder\RouteBuilderInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Filter\Persister\FilterPersisterInterface;
 use Sonata\AdminBundle\Model\AuditManagerInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
@@ -2234,14 +2235,15 @@ class AdminTest extends TestCase
         $admin = $this->getMockForAbstractClass(AbstractAdmin::class, [
             'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin',
         ]);
+        $query = $this->createMock(ProxyQueryInterface::class);
         $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelManager->expects($this->once())
             ->method('createQuery')
             ->with('My\Class')
-            ->willReturn('a query');
+            ->willReturn($query);
 
         $admin->setModelManager($modelManager);
-        $this->assertSame('a query', $admin->createQuery('list'));
+        $this->assertSame($query, $admin->createQuery('list'));
     }
 
     public function testGetDataSourceIterator(): void

--- a/tests/Admin/BaseAdminModelManagerTest.php
+++ b/tests/Admin/BaseAdminModelManagerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 
@@ -59,12 +60,13 @@ class BaseAdminModelManagerTest extends TestCase
 
     public function testCreateQuery(): void
     {
+        $query = $this->createMock(ProxyQueryInterface::class);
         $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
-        $modelManager->expects($this->once())->method('createQuery')->willReturnCallback(static function (string $class): void {
-            if ('class' !== $class) {
-                throw new \RuntimeException('Invalid class argument');
-            }
-        });
+        $modelManager
+            ->expects($this->once())
+            ->method('createQuery')
+            ->with('class')
+            ->willReturn($query);
 
         $admin = new BaseAdminModelManager_Admin('code', 'class', 'controller');
         $admin->setModelManager($modelManager);


### PR DESCRIPTION
## Subject

I recently found myself in this situation.

Admin A override createQuery.
Admin B extends A
Admin C extends A
Admin D extends A but override createQuery.

I needed to write in my createQuery method
```php
$query = $this->getModelManager()->createQuery($this->getClass());

foreach ($this->extensions as $extension) {
    $extension->configureQuery($this, $query, $context);
}
```
to get a fresh new query.

But what if Sonata add something in the createQuery method ?

With the new `configureQuery` method.
I just need to override configureQuery method, and still will get all the new code in createQuery method.

## Changelog

```markdown
### Added
- Added `configureQuery` method for an easier way to override Admin list queries.
### Deprecated
- Inheritance of the `createQuery` method.
```
