### PR TITLE
Add support for symfony/contracts 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "symfony/dependency-injection": "^4.3",
         "symfony/doctrine-bridge": "^4.3",
         "symfony/event-dispatcher": "^4.3",
-        "symfony/event-dispatcher-contracts": "^1.1",
+        "symfony/event-dispatcher-contracts": "^1.1 || ^2.0",
         "symfony/expression-language": "^4.3",
         "symfony/form": "^4.0",
         "symfony/framework-bundle": "^4.3",


### PR DESCRIPTION
## Subject
I am targeting this branch, because BC.

I don't see BC-break in symfony/contracts 2.0

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for symfony/contracts 2.0
```