### PR TITLE
Fix Regular expression in test

### DIFF
--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -168,7 +168,7 @@ class ListMapperTest extends TestCase
         $this->assertFalse($this->listMapper->has('fooName'));
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('{^Value for "identifier" option must be boolean, [^]+ given.$}');
+        $this->expectExceptionMessageMatches('/^Value for "identifier" option must be boolean, .+ given.$/');
 
         $this->listMapper->add('fooName', null, ['identifier' => $value]);
     }


### PR DESCRIPTION
It fails in https://github.com/sonata-project/SonataAdminBundle/pull/5917 because of this. It doesn't fail now because this test is skipped in `3.x`