### PR TITLE
Fix entries per page dropdown URLs when used in custom actions

### DIFF
--- a/src/Resources/views/Pager/base_results.html.twig
+++ b/src/Resources/views/Pager/base_results.html.twig
@@ -23,7 +23,7 @@ file that was distributed with this source code.
     <label class="control-label" for="{{ admin.uniqid }}_per_page">{% trans from 'SonataAdminBundle' %}label_per_page{% endtrans %}</label>
     <select class="per-page small form-control" id="{{ admin.uniqid }}_per_page" style="width: auto">
         {% for per_page in admin.getperpageoptions %}
-            <option {% if per_page == admin.datagrid.pager.maxperpage %}selected="selected"{% endif %} value="{{ admin.generateUrl('list', {'filter': admin.datagrid.values|merge({'_page': 1, '_per_page': per_page})}) }}">
+            <option {% if per_page == admin.datagrid.pager.maxperpage %}selected="selected"{% endif %} value="{{ admin.generateUrl(action, {'filter': admin.datagrid.values|merge({'_page': 1, '_per_page': per_page})}) }}">
                 {{- per_page -}}
             </option>
         {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When creating custom actions that work like the 'list' action, the "number of entries per page" dropdown would always send the user back to the 'list' action.

This pull request replaces all occurrences of `'list'` in `base_results.html.twig` by `action`.

I am targeting this branch, because this is a patch/feature that is backwards compatible.

See https://github.com/sonata-project/SonataAdminBundle/pull/5880 which fixes basically the same problem right next to this one.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

```markdown
### Changed
- Fixed "entries per page" dropdown links in custom actions

```
