### PR TITLE
Deprecate methods in AdminExtractor

### DIFF
--- a/src/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
+++ b/src/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
@@ -26,6 +26,8 @@ use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
+ * NEXT_MAJOR: Remove implementing TranslatorInterface and SecurityHandlerInterface.
+ *
  * @final since sonata-project/admin-bundle 3.52
  */
 class AdminExtractor implements ExtractorInterface, TranslatorInterface, SecurityHandlerInterface, LabelTranslatorStrategyInterface
@@ -106,7 +108,7 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
         $this->catalogue = new MessageCatalogue();
 
         foreach ($this->adminPool->getAdminGroups() as $name => $group) {
-            $this->trans($name, [], $group['label_catalogue']);
+            $this->addMessage($name, $group['label_catalogue']);
         }
 
         foreach ($this->adminPool->getAdminServiceIds() as $id) {
@@ -114,7 +116,7 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
 
             $label = $admin->getLabel();
             if (!empty($label)) {
-                $this->trans($label, [], $admin->getTranslationDomain());
+                $this->addMessage($label, $admin->getTranslationDomain());
             }
 
             $this->translator = $admin->getTranslator();
@@ -188,6 +190,11 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
         return $catalogue;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     */
     public function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
         $this->addMessage($id, $domain);
@@ -195,6 +202,11 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
         return $id;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     */
     public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
     {
         $this->addMessage($id, $domain);
@@ -202,33 +214,68 @@ class AdminExtractor implements ExtractorInterface, TranslatorInterface, Securit
         return $id;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     */
     public function setLocale($locale)
     {
         $this->translator->setLocale($locale);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     */
     public function getLocale()
     {
         return $this->translator->getLocale();
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     */
     public function isGranted(AdminInterface $admin, $attributes, $object = null)
     {
         return true;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     */
     public function buildSecurityInformation(AdminInterface $admin)
     {
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     */
     public function createObjectSecurity(AdminInterface $admin, $object)
     {
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     */
     public function deleteObjectSecurity(AdminInterface $admin, $object)
     {
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     */
     public function getBaseRole(AdminInterface $admin)
     {
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

[`AdminExtractor` implements `TranslatorInterface`](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php#L31) from  [the Translator component and it's deprecated](https://github.com/symfony/symfony/blob/4.3/src/Symfony/Component/Translation/TranslatorInterface.php). [The new `TranslatorInterface` from contracts](https://github.com/symfony/symfony/blob/4.3/src/Symfony/Contracts/Translation/TranslatorInterface.php) only has the `trans` method.

I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `AdminExtractor::trans` method
- `AdminExtractor::transChoice` method
- `AdminExtractor::getLocale` method
- `AdminExtractor::setLocale` method
- `AdminExtractor::isGranted` method
- `AdminExtractor::buildSecurityInformation` method
- `AdminExtractor::createObjectSecurity` method
- `AdminExtractor::deleteObjectSecurity` method
- `AdminExtractor::getBaseRole` method
```
And also I have no idea why `AdminExtractor` is implementing `SecurityHandlerInterface`, looks like it was [from the beginning](https://github.com/sonata-project/SonataAdminBundle/commit/1295dc79a714e515ca762ec0703a79cdbcb47981), so maybe we could also deprecate those method to remove them in `master`.

**EDIT**:  I've ended up deprecating also those methods as I haven't seen that they are necessary.