### PR TITLE
Fix sortOrder default value

### DIFF
--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -163,7 +163,9 @@ class Datagrid implements DatagridInterface
 
             if ($this->values['_sort_by']->isSortable()) {
                 $this->query->setSortBy($this->values['_sort_by']->getSortParentAssociationMapping(), $this->values['_sort_by']->getSortFieldMapping());
-                $this->query->setSortOrder(isset($this->values['_sort_order']) ? $this->values['_sort_order'] : null);
+
+                $this->values['_sort_order'] = $this->values['_sort_order'] ?? 'ASC';
+                $this->query->setSortOrder($this->values['_sort_order']);
             }
         }
 

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -445,7 +445,7 @@ class DatagridTest extends TestCase
 
         $this->datagrid->buildPager();
 
-        $this->assertSame(['_sort_by' => $sortBy, 'foo' => null], $this->datagrid->getValues());
+        $this->assertSame(['_sort_by' => $sortBy, 'foo' => null, '_sort_order' => 'ASC'], $this->datagrid->getValues());
         $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('fooFormName'));
         $this->assertSame(['bar' => 'baz'], $this->formBuilder->get('fooFormName')->getOptions());
         $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_by'));
@@ -499,6 +499,7 @@ class DatagridTest extends TestCase
             '_page' => $page,
             '_per_page' => $perPage,
             'foo' => null,
+            '_sort_order' => 'ASC',
         ], $this->datagrid->getValues());
         $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('fooFormName'));
         $this->assertSame(['bar' => 'baz'], $this->formBuilder->get('fooFormName')->getOptions());


### PR DESCRIPTION
## Subject

`$this->query->setSortOrder(null)` is not valid.

```
/**
     * @param string $sortOrder
     *
     * @return ProxyQueryInterface
     */
    public function setSortOrder($sortOrder);
```
So I use the default value `'ASC'`.

## Changelog
```markdown
### Fixed
- `_sort_by` without `_sort_order` does not use invalid value anymore
```