### PR TITLE
Handle case without _sort_by value

### DIFF
--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -66,7 +66,9 @@ file that was distributed with this source code.
                                             {% if field_description.options.sortable is defined and field_description.options.sortable %}
                                                 {% set sortable             = true %}
                                                 {% set sort_parameters      = admin.modelmanager.sortparameters(field_description, admin.datagrid) %}
-                                                {% set current              = admin.datagrid.values._sort_by == field_description or admin.datagrid.values._sort_by.name == sort_parameters.filter._sort_by %}
+                                                {% set current              = admin.datagrid.values._sort_by is defined
+                                                    and (admin.datagrid.values._sort_by == field_description
+                                                        or admin.datagrid.values._sort_by.name == sort_parameters.filter._sort_by) %}
                                                 {% set sort_active_class    = current ? 'sonata-ba-list-field-order-active' : '' %}
                                                 {% set sort_by              = current ? admin.datagrid.values._sort_order : field_description.options._sort_order %}
                                             {% endif %}


### PR DESCRIPTION
## Subject

Following https://github.com/sonata-project/SonataAdminBundle/issues/5929, I want to introduce the ability of using `sortable => true` without a default column to sort the list.
This means that `$value['_sort_by']` can be 'not set'. 

## Changelog

```markdown
### Added
- Allow `_sort_by` filter to not be initially defined. 
```