### PR TITLE
Remove some CoreBundle dependency

### DIFF
--- a/src/Export/Exporter.php
+++ b/src/Export/Exporter.php
@@ -13,7 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Export;
 
-use Sonata\CoreBundle\Exporter\Exporter as BaseExporter;
+use Sonata\Exporter\Handler;
+use Sonata\Exporter\Source\SourceIteratorInterface;
+use Sonata\Exporter\Writer\CsvWriter;
+use Sonata\Exporter\Writer\JsonWriter;
+use Sonata\Exporter\Writer\XlsWriter;
+use Sonata\Exporter\Writer\XmlWriter;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 @trigger_error(
     'The '.__NAMESPACE__.'\Exporter class is deprecated since version 3.14 and will be removed in 4.0.'.
@@ -26,6 +32,51 @@ use Sonata\CoreBundle\Exporter\Exporter as BaseExporter;
  *
  * @deprecated since sonata-project/admin-bundle 3.14, to be removed in 4.0.
  */
-class Exporter extends BaseExporter
+class Exporter
 {
+    /**
+     * @param string $format
+     * @param string $filename
+     *
+     * @throws \RuntimeException
+     *
+     * @return StreamedResponse
+     */
+    public function getResponse($format, $filename, SourceIteratorInterface $source)
+    {
+        switch ($format) {
+            case 'xls':
+                $writer = new XlsWriter('php://output');
+                $contentType = 'application/vnd.ms-excel';
+
+                break;
+            case 'xml':
+                $writer = new XmlWriter('php://output');
+                $contentType = 'text/xml';
+
+                break;
+            case 'json':
+                $writer = new JsonWriter('php://output');
+                $contentType = 'application/json';
+
+                break;
+            case 'csv':
+                $writer = new CsvWriter('php://output', ',', '"', '\\', true, true);
+                $contentType = 'text/csv';
+
+                break;
+            default:
+                throw new \RuntimeException('Invalid format');
+        }
+
+        $callback = static function () use ($source, $writer) {
+            $handler = Handler::create($source, $writer);
+            $handler->export();
+        };
+
+        return new StreamedResponse($callback, 200, [
+            'Content-Type' => $contentType,
+            'Content-Disposition' => sprintf('attachment; filename="%s"', $filename),
+        ]);
+    }
 }

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
-use Sonata\CoreBundle\Form\Type\DateRangeType as FormDateRangeType;
+use Sonata\Form\Type\DateRangeType as FormDateRangeType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
-use Sonata\CoreBundle\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
+use Sonata\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;

--- a/src/Object/MetadataInterface.php
+++ b/src/Object/MetadataInterface.php
@@ -13,10 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Object;
 
-/**
- * NEXT_MAJOR: Remove CoreBundle dependency.
- */
-interface MetadataInterface extends \Sonata\CoreBundle\Model\MetadataInterface
+interface MetadataInterface extends \Sonata\BlockBundle\Meta\MetadataInterface
 {
     public function getTitle(): string;
 

--- a/src/Resources/config/validator.xml
+++ b/src/Resources/config/validator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.admin.validator.inline" class="Sonata\CoreBundle\Validator\InlineValidator" public="true">
+        <service id="sonata.admin.validator.inline" class="Sonata\Form\Validator\InlineValidator" public="true">
             <argument type="service" id="service_container"/>
             <argument type="service" id="validator.validator_factory"/>
             <tag name="validator.constraint_validator" alias="sonata.admin.validator.inline"/>

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -16,7 +16,6 @@ namespace Sonata\AdminBundle\Tests\App;
 use Knp\Bundle\MenuBundle\KnpMenuBundle;
 use Sonata\AdminBundle\SonataAdminBundle;
 use Sonata\BlockBundle\SonataBlockBundle;
-use Sonata\CoreBundle\SonataCoreBundle;
 use Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
@@ -44,7 +43,6 @@ final class AppKernel extends Kernel
             new SecurityBundle(),
             new KnpMenuBundle(),
             new SonataBlockBundle(),
-            new SonataCoreBundle(),
             new SonataDoctrineBundle(),
             new SonataAdminBundle(),
         ];

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -635,7 +635,6 @@ class AddDependencyCallsCompilerPassTest extends TestCase
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.bundles', [
-            'SonataCoreBundle' => true,
             'KnpMenuBundle' => true,
         ]);
         $container->setParameter('kernel.cache_dir', '/tmp');

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -338,7 +338,6 @@ class ExtensionCompilerPassTest extends TestCase
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.bundles', [
-            'SonataCoreBundle' => true,
             'KnpMenuBundle' => true,
         ]);
         $container->setParameter('kernel.cache_dir', '/tmp');

--- a/tests/Form/Extension/ChoiceTypeExtensionTest.php
+++ b/tests/Form/Extension/ChoiceTypeExtensionTest.php
@@ -15,9 +15,9 @@ namespace Sonata\AdminBundle\Tests\Form\Extension;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Form\Extension\ChoiceTypeExtension;
-use Sonata\CoreBundle\Form\Extension\DependencyInjectionExtension;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension;
 use Symfony\Component\Form\Forms;
 
 class ChoiceTypeExtensionTest extends TestCase
@@ -25,30 +25,11 @@ class ChoiceTypeExtensionTest extends TestCase
     protected function setup(): void
     {
         $container = $this->getMockForAbstractClass(ContainerInterface::class);
-        $container->method('has')->willReturn(true);
-        $container->method('get')
-            ->with($this->equalTo('sonata.admin.form.choice_extension'))
-            ->willReturn(new ChoiceTypeExtension());
-
-        $typeServiceIds = [];
-        $typeExtensionServiceIds = [];
-        $guesserServiceIds = [];
-        $mappingTypes = [
-            'choice' => ChoiceType::class,
-        ];
-        $extensionTypes = [
-            'choice' => [
-                'sonata.admin.form.choice_extension',
-            ],
-        ];
 
         $dependency = new DependencyInjectionExtension(
             $container,
-            $typeServiceIds,
-            $typeExtensionServiceIds,
-            $guesserServiceIds,
-            $mappingTypes,
-            $extensionTypes
+            [ChoiceType::class => [new ChoiceTypeExtension()]],
+            []
         );
 
         $this->factory = Forms::createFormFactoryBuilder()

--- a/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
+++ b/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
-use Sonata\CoreBundle\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
+use Sonata\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

There is still one CoreBundle usage:
- FormHelper is used in SonataAdminBundle.php. I don't know what is this and how to remove it.
- ~~The CoreBundle Exporter is use in the deprecated Exporter.php. Since the class from the exporter project is final I can't use it ATM. So this will be only dropped in next major.~~
- There is a XliffTest extending the CoreBundle XliffValidatorTestCase. Does this TestCase was moved somewhere else or should I add this file to the AdminBundle ?
- The assets https://github.com/sonata-project/SonataAdminBundle/pull/5834, this is BC-break

Closes #5906 

Changelog is not needed isn't it ?