### PR TITLE
Handle ParentAssociationMapping when looking for new instance

### DIFF
--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -231,6 +231,19 @@ class AdminHelper
     {
         $instance = $fieldDescription->getAssociationAdmin()->getNewInstance();
         $mapping = $fieldDescription->getAssociationMapping();
+        $parentMappings = $fieldDescription->getParentAssociationMappings();
+
+        foreach ($parentMappings as $parentMapping) {
+            $method = sprintf('get%s', Inflector::classify($parentMapping['fieldName']));
+
+            if (!method_exists($object, $method)) {
+                throw new \RuntimeException(
+                    sprintf('Please add a method %s in the %s class!', $method, ClassUtils::getClass($object))
+                );
+            }
+
+            $object = $object->$method();
+        }
 
         $method = sprintf('add%s', Inflector::classify($mapping['fieldName']));
 

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -97,8 +97,6 @@ class AdminHelper
     /**
      * Note:
      *   This code is ugly, but there is no better way of doing it.
-     *   For now the append form element action used to add a new row works
-     *   only for direct FieldDescription (not nested one).
      *
      * @param object $subject
      * @param string $elementId

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -234,9 +234,12 @@ class AdminHelper
         foreach ($parentMappings as $parentMapping) {
             $method = sprintf('get%s', Inflector::classify($parentMapping['fieldName']));
 
-            if (!method_exists($object, $method)) {
+            if (!\is_callable([$object, $method])) {
+                /*
+                 * NEXT_MAJOR: Use BadMethodCallException instead
+                 */
                 throw new \RuntimeException(
-                    sprintf('Please add a method %s in the %s class!', $method, ClassUtils::getClass($object))
+                    sprintf('Method %s::%s() does not exist.', ClassUtils::getClass($object), $method)
                 );
             }
 
@@ -245,15 +248,18 @@ class AdminHelper
 
         $method = sprintf('add%s', Inflector::classify($mapping['fieldName']));
 
-        if (!method_exists($object, $method)) {
+        if (!\is_callable([$object, $method])) {
             $method = rtrim($method, 's');
 
-            if (!method_exists($object, $method)) {
+            if (!\is_callable([$object, $method])) {
                 $method = sprintf('add%s', Inflector::classify(Inflector::singularize($mapping['fieldName'])));
 
-                if (!method_exists($object, $method)) {
+                if (!\is_callable([$object, $method])) {
+                    /*
+                     * NEXT_MAJOR: Use BadMethodCallException instead
+                     */
                     throw new \RuntimeException(
-                        sprintf('Please add a method %s in the %s class!', $method, ClassUtils::getClass($object))
+                        sprintf('Method %s::%s() does not exist.', ClassUtils::getClass($object), $method)
                     );
                 }
             }

--- a/tests/Admin/AdminHelperTest.php
+++ b/tests/Admin/AdminHelperTest.php
@@ -80,6 +80,7 @@ class AdminHelperTest extends TestCase
         $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getAssociationAdmin')->willReturn($admin);
         $fieldDescription->expects($this->once())->method('getAssociationMapping')->willReturn(['fieldName' => 'fooBar']);
+        $fieldDescription->expects($this->once())->method('getParentAssociationMappings')->willReturn([]);
 
         $object = $this->getMockBuilder('stdClass')
             ->setMethods(['addFooBar'])
@@ -87,6 +88,29 @@ class AdminHelperTest extends TestCase
         $object->expects($this->once())->method('addFooBar');
 
         $this->helper->addNewInstance($object, $fieldDescription);
+    }
+
+    public function testAddNewInstanceWithParentAssociation(): void
+    {
+        $admin = $this->createMock(AdminInterface::class);
+        $admin->expects($this->once())->method('getNewInstance')->willReturn(new \stdClass());
+
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
+        $fieldDescription->expects($this->once())->method('getAssociationAdmin')->willReturn($admin);
+        $fieldDescription->expects($this->once())->method('getAssociationMapping')->willReturn(['fieldName' => 'fooBar']);
+        $fieldDescription->expects($this->once())->method('getParentAssociationMappings')->willReturn([['fieldName' => 'parent']]);
+
+        $object2 = $this->getMockBuilder('stdClass')
+            ->setMethods(['addFooBar'])
+            ->getMock();
+        $object2->expects($this->once())->method('addFooBar');
+
+        $object1 = $this->getMockBuilder('stdClass')
+            ->setMethods(['getParent'])
+            ->getMock();
+        $object1->expects($this->once())->method('getParent')->willReturn($object2);
+
+        $this->helper->addNewInstance($object1, $fieldDescription);
     }
 
     public function testAddNewInstancePlural(): void
@@ -97,6 +121,7 @@ class AdminHelperTest extends TestCase
         $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getAssociationAdmin')->willReturn($admin);
         $fieldDescription->expects($this->once())->method('getAssociationMapping')->willReturn(['fieldName' => 'fooBars']);
+        $fieldDescription->expects($this->once())->method('getParentAssociationMappings')->willReturn([]);
 
         $object = $this->getMockBuilder('stdClass')
             ->setMethods(['addFooBar'])
@@ -114,6 +139,7 @@ class AdminHelperTest extends TestCase
         $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getAssociationAdmin')->willReturn($admin);
         $fieldDescription->expects($this->once())->method('getAssociationMapping')->willReturn(['fieldName' => 'entries']);
+        $fieldDescription->expects($this->once())->method('getParentAssociationMappings')->willReturn([]);
 
         $object = $this->getMockBuilder('stdClass')
             ->setMethods(['addEntry'])
@@ -187,6 +213,7 @@ class AdminHelperTest extends TestCase
         $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->method('getAssociationAdmin')->willReturn($admin);
         $fieldDescription->method('getAssociationMapping')->willReturn($associationMapping);
+        $fieldDescription->method('getParentAssociationMappings')->willReturn([]);
 
         $admin
             ->method('getFormFieldDescription')

--- a/tests/Admin/AdminHelperTest.php
+++ b/tests/Admin/AdminHelperTest.php
@@ -51,9 +51,9 @@ class AdminHelperTest extends TestCase
         $formFactory = $this->createMock(FormFactoryInterface::class);
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
-        $formBuilder = new FormBuilder('test', 'stdClass', $eventDispatcher, $formFactory);
+        $formBuilder = new FormBuilder('test', \stdClass::class, $eventDispatcher, $formFactory);
 
-        $childFormBuilder = new FormBuilder('elementId', 'stdClass', $eventDispatcher, $formFactory);
+        $childFormBuilder = new FormBuilder('elementId', \stdClass::class, $eventDispatcher, $formFactory);
         $formBuilder->add($childFormBuilder);
 
         $this->assertNull($this->helper->getChildFormBuilder($formBuilder, 'foo'));
@@ -82,7 +82,7 @@ class AdminHelperTest extends TestCase
         $fieldDescription->expects($this->once())->method('getAssociationMapping')->willReturn(['fieldName' => 'fooBar']);
         $fieldDescription->expects($this->once())->method('getParentAssociationMappings')->willReturn([]);
 
-        $object = $this->getMockBuilder('stdClass')
+        $object = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['addFooBar'])
             ->getMock();
         $object->expects($this->once())->method('addFooBar');
@@ -100,12 +100,12 @@ class AdminHelperTest extends TestCase
         $fieldDescription->expects($this->once())->method('getAssociationMapping')->willReturn(['fieldName' => 'fooBar']);
         $fieldDescription->expects($this->once())->method('getParentAssociationMappings')->willReturn([['fieldName' => 'parent']]);
 
-        $object2 = $this->getMockBuilder('stdClass')
+        $object2 = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['addFooBar'])
             ->getMock();
         $object2->expects($this->once())->method('addFooBar');
 
-        $object1 = $this->getMockBuilder('stdClass')
+        $object1 = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getParent'])
             ->getMock();
         $object1->expects($this->once())->method('getParent')->willReturn($object2);
@@ -123,7 +123,7 @@ class AdminHelperTest extends TestCase
         $fieldDescription->expects($this->once())->method('getAssociationMapping')->willReturn(['fieldName' => 'fooBars']);
         $fieldDescription->expects($this->once())->method('getParentAssociationMappings')->willReturn([]);
 
-        $object = $this->getMockBuilder('stdClass')
+        $object = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['addFooBar'])
             ->getMock();
         $object->expects($this->once())->method('addFooBar');
@@ -141,7 +141,7 @@ class AdminHelperTest extends TestCase
         $fieldDescription->expects($this->once())->method('getAssociationMapping')->willReturn(['fieldName' => 'entries']);
         $fieldDescription->expects($this->once())->method('getParentAssociationMappings')->willReturn([]);
 
-        $object = $this->getMockBuilder('stdClass')
+        $object = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['addEntry'])
             ->getMock();
         $object->expects($this->once())->method('addEntry');
@@ -151,13 +151,13 @@ class AdminHelperTest extends TestCase
 
     public function testGetElementAccessPath(): void
     {
-        $object = $this->getMockBuilder('stdClass')
+        $object = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getPathToObject'])
             ->getMock();
-        $subObject = $this->getMockBuilder('stdClass')
+        $subObject = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getAnother'])
             ->getMock();
-        $sub2Object = $this->getMockBuilder('stdClass')
+        $sub2Object = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getMoreThings'])
             ->getMock();
 
@@ -173,10 +173,10 @@ class AdminHelperTest extends TestCase
     public function testItThrowsExceptionWhenDoesNotFindTheFullPath(): void
     {
         $path = 'uniquePartOfId_path_to_object_0_more_calls';
-        $object = $this->getMockBuilder('stdClass')
+        $object = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getPathToObject'])
             ->getMock();
-        $subObject = $this->getMockBuilder('stdClass')
+        $subObject = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getMore'])
             ->getMock();
 
@@ -289,19 +289,19 @@ class AdminHelperTest extends TestCase
     public function testAppendFormFieldElementNested(): void
     {
         $admin = $this->createMock(AdminInterface::class);
-        $object = $this->getMockBuilder('stdClass')
+        $object = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getSubObject'])
             ->getMock();
-        $simpleObject = $this->getMockBuilder('stdClass')
+        $simpleObject = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getSubObject'])
             ->getMock();
-        $subObject = $this->getMockBuilder('stdClass')
+        $subObject = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getAnd'])
             ->getMock();
-        $sub2Object = $this->getMockBuilder('stdClass')
+        $sub2Object = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getMore'])
             ->getMock();
-        $sub3Object = $this->getMockBuilder('stdClass')
+        $sub3Object = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getFinalData'])
             ->getMock();
         $dataMapper = $this->createMock(DataMapperInterface::class);


### PR DESCRIPTION
## Subject

When using `->add('foo.bar', CollectionType::class)` in PostAdmin, the adminHelper try to call the function `addBar` on Post entity instead of Foo entity.

After the PR, it will do `$post->getFoo()->addBar()`;

I am targeting this branch, because BC.

Closes #5738

## Changelog
```markdown
### Fixed
Class Helper addNewInstance take care about parentAssociation mapping.
```
