### PR TITLE
Call getNewInstance before creating a form every time a subject is not already provided

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1323,6 +1323,20 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      */
     public function defineFormBuilder(FormBuilderInterface $formBuilder)
     {
+        if (!$this->hasSubject()) {
+            @trigger_error(sprintf(
+                'Calling %s() when there is no subject is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0. '.
+                'Use %s::setSubject() to set the subject.',
+                __METHOD__,
+                __CLASS__
+            ), E_USER_DEPRECATED);
+            // NEXT_MAJOR : remove the previous `trigger_error()` call and uncomment the following exception
+            // throw new \LogicException(sprintf(
+            //    'Admin "%s" has no subject.',
+            //    static::class
+            // ));
+        }
+
         $mapper = new FormMapper($this->getFormContractor(), $formBuilder, $this);
 
         $this->configureFormFields($mapper);

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -190,13 +190,6 @@ class AdminHelper
 
             $associationAdmin = $fieldDescription->getAssociationAdmin();
             $associationAdmin->setSubject($newInstance);
-            $fields = array_keys($associationAdmin->getFormFieldDescriptions());
-
-            // for now, not sure how to do that
-            $value = [];
-            foreach ($fields as $name) {
-                $value[$name] = '';
-            }
         }
 
         $finalForm = $admin->getFormBuilder()->getForm();

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -110,7 +110,7 @@ class AdminHelper
     {
         // child rows marked as toDelete
         $toDelete = [];
-        // retrieve the subject
+
         $formBuilder = $admin->getFormBuilder();
 
         // get the field element
@@ -141,11 +141,10 @@ class AdminHelper
         //if childFormBuilder was not found resulted in fatal error getName() method call on non object
         if (!$childFormBuilder) {
             $propertyAccessor = $this->pool->getPropertyAccessor();
-            $entity = $admin->getSubject();
 
-            $path = $this->getElementAccessPath($elementId, $entity);
+            $path = $this->getElementAccessPath($elementId, $subject);
 
-            $collection = $propertyAccessor->getValue($entity, $path);
+            $collection = $propertyAccessor->getValue($subject, $path);
 
             if ($collection instanceof DoctrinePersistentCollection || $collection instanceof PersistentCollection) {
                 //since doctrine 2.4
@@ -157,7 +156,7 @@ class AdminHelper
             }
 
             $collection->add(new $entityClassName());
-            $propertyAccessor->setValue($entity, $path, $collection);
+            $propertyAccessor->setValue($subject, $path, $collection);
 
             $fieldDescription = null;
         } else {
@@ -180,14 +179,6 @@ class AdminHelper
             $objectCount = null === $value ? 0 : \count($value);
             $postCount = \count($data[$childFormBuilder->getName()]);
 
-            $fields = array_keys($fieldDescription->getAssociationAdmin()->getFormFieldDescriptions());
-
-            // for now, not sure how to do that
-            $value = [];
-            foreach ($fields as $name) {
-                $value[$name] = '';
-            }
-
             // add new elements to the subject
             while ($objectCount < $postCount) {
                 // append a new instance into the object
@@ -195,7 +186,17 @@ class AdminHelper
                 ++$objectCount;
             }
 
-            $this->addNewInstance($form->getData(), $fieldDescription);
+            $newInstance = $this->addNewInstance($form->getData(), $fieldDescription);
+
+            $associationAdmin = $fieldDescription->getAssociationAdmin();
+            $associationAdmin->setSubject($newInstance);
+            $fields = array_keys($associationAdmin->getFormFieldDescriptions());
+
+            // for now, not sure how to do that
+            $value = [];
+            foreach ($fields as $name) {
+                $value[$name] = '';
+            }
         }
 
         $finalForm = $admin->getFormBuilder()->getForm();
@@ -224,6 +225,8 @@ class AdminHelper
      * @param object $object
      *
      * @throws \RuntimeException
+     *
+     * @return object
      */
     public function addNewInstance($object, FieldDescriptionInterface $fieldDescription)
     {
@@ -266,6 +269,8 @@ class AdminHelper
         }
 
         $object->$method($instance);
+
+        return $instance;
     }
 
     /**

--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -57,7 +57,7 @@ class AdminType extends AbstractType
 
             try {
                 $parentSubject = $admin->getParentFieldDescription()->getAdmin()->getSubject();
-                if (null !== $parentSubject && false !== $parentSubject) {
+                if (null !== $parentSubject && false !== $parentSubject && isset($options['property_path'])) {
                     // this check is to work around duplication issue in property path
                     // https://github.com/sonata-project/SonataAdminBundle/issues/4425
                     if ($this->getFieldDescription($options)->getFieldName() === $options['property_path']) {
@@ -78,9 +78,14 @@ class AdminType extends AbstractType
 
                     $subject = $p->getValue($parentSubject, $parentPath.$path);
                     $builder->setData($subject);
+                } else {
+                    $subject = $admin->getNewInstance();
+                    $builder->setData($subject);
                 }
             } catch (NoSuchIndexException $e) {
-                // no object here
+                // no object here, we create a new one
+                $subject = $admin->getNewInstance();
+                $builder->setData($subject);
             }
         }
 

--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -56,8 +56,8 @@ class AdminType extends AbstractType
             $p = new PropertyAccessor(false, true);
 
             try {
-                $parentSubject = $admin->getParentFieldDescription()->getAdmin()->getSubject();
-                if (null !== $parentSubject && false !== $parentSubject && isset($options['property_path'])) {
+                $parentAdmin = $admin->getParentFieldDescription()->getAdmin();
+                if ($parentAdmin->hasSubject() && isset($options['property_path'])) {
                     // this check is to work around duplication issue in property path
                     // https://github.com/sonata-project/SonataAdminBundle/issues/4425
                     if ($this->getFieldDescription($options)->getFieldName() === $options['property_path']) {
@@ -76,7 +76,7 @@ class AdminType extends AbstractType
                         )
                     );
 
-                    $subject = $p->getValue($parentSubject, $parentPath.$path);
+                    $subject = $p->getValue($parentAdmin->getSubject(), $parentPath.$path);
                     $builder->setData($subject);
                 } else {
                     $subject = $admin->getNewInstance();

--- a/tests/Admin/AdminHelperTest.php
+++ b/tests/Admin/AdminHelperTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Admin;
 
-use Doctrine\Common\Collections\Collection;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Tests\Fixtures\Entity\Bar;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -194,14 +194,19 @@ class AdminHelperTest extends TestCase
         $container = new Container();
 
         $propertyAccessorBuilder = new PropertyAccessorBuilder();
-        $propertyAccesor = $propertyAccessorBuilder->getPropertyAccessor();
-        $pool = new Pool($container, 'title', 'logo.png', [], $propertyAccesor);
+        $propertyAccessor = $propertyAccessorBuilder->getPropertyAccessor();
+        $pool = new Pool($container, 'title', 'logo.png', [], $propertyAccessor);
         $helper = new AdminHelper($pool);
 
         $admin = $this->createMock(AdminInterface::class);
         $admin
             ->method('getClass')
             ->willReturn(Foo::class);
+
+        $associationAdmin = $this->createMock(AdminInterface::class);
+        $associationAdmin
+            ->method('getClass')
+            ->willReturn(Bar::class);
 
         $associationMapping = [
             'fieldName' => 'bar',
@@ -211,7 +216,7 @@ class AdminHelperTest extends TestCase
         ];
 
         $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
-        $fieldDescription->method('getAssociationAdmin')->willReturn($admin);
+        $fieldDescription->method('getAssociationAdmin')->willReturn($associationAdmin);
         $fieldDescription->method('getAssociationMapping')->willReturn($associationMapping);
         $fieldDescription->method('getParentAssociationMappings')->willReturn([]);
 
@@ -219,7 +224,7 @@ class AdminHelperTest extends TestCase
             ->method('getFormFieldDescription')
             ->willReturn($fieldDescription);
 
-        $admin
+        $associationAdmin
             ->method('getFormFieldDescriptions')
             ->willReturn([
                 'bar' => $fieldDescription,
@@ -246,9 +251,20 @@ class AdminHelperTest extends TestCase
             ->will($this->onConsecutiveCalls($request, $request, $request, null, $request, $request, $request, $request, null, $request));
 
         $foo = $this->createMock(Foo::class);
+        $admin
+            ->method('hasSubject')
+            ->willReturn(true);
+        $admin
+            ->method('getSubject')
+            ->willReturn($foo);
 
-        $collection = $this->createMock(Collection::class);
-        $foo->setBar($collection);
+        $bar = new \stdClass();
+        $associationAdmin
+            ->expects($this->atLeastOnce())
+            ->method('getNewInstance')
+            ->willReturn($bar);
+
+        $foo->expects($this->atLeastOnce())->method('addBar')->with($bar);
 
         $dataMapper = $this->createMock(DataMapperInterface::class);
         $formFactory = $this->createMock(FormFactoryInterface::class);
@@ -266,8 +282,8 @@ class AdminHelperTest extends TestCase
         $formBuilder->setDataMapper($dataMapper);
         $formBuilder->add($childFormBuilder);
 
+        $associationAdmin->expects($this->atLeastOnce())->method('setSubject')->with($bar);
         $admin->method('getFormBuilder')->willReturn($formBuilder);
-        $admin->method('getSubject')->willReturn($foo);
 
         $finalForm = $helper->appendFormFieldElement($admin, $foo, 'test_bar')[1];
 
@@ -292,9 +308,7 @@ class AdminHelperTest extends TestCase
         $object = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getSubObject'])
             ->getMock();
-        $simpleObject = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['getSubObject'])
-            ->getMock();
+
         $subObject = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getAnd'])
             ->getMock();
@@ -307,7 +321,7 @@ class AdminHelperTest extends TestCase
         $dataMapper = $this->createMock(DataMapperInterface::class);
         $formFactory = $this->createMock(FormFactoryInterface::class);
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $formBuilder = new FormBuilder('test', \get_class($simpleObject), $eventDispatcher, $formFactory);
+        $formBuilder = new FormBuilder('test', \get_class($object), $eventDispatcher, $formFactory);
         $childFormBuilder = new FormBuilder('subObject', \get_class($subObject), $eventDispatcher, $formFactory);
 
         $object->expects($this->atLeastOnce())->method('getSubObject')->willReturn([$subObject]);
@@ -319,12 +333,13 @@ class AdminHelperTest extends TestCase
         $formBuilder->setDataMapper($dataMapper);
         $formBuilder->add($childFormBuilder);
 
+        $admin->method('hasSubject')->willReturn(true);
+        $admin->method('getSubject')->willReturn($object);
         $admin->expects($this->once())->method('getFormBuilder')->willReturn($formBuilder);
-        $admin->expects($this->once())->method('getSubject')->willReturn($object);
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('unknown collection class');
 
-        $this->helper->appendFormFieldElement($admin, $simpleObject, 'uniquePartOfId_sub_object_0_and_more_0_final_data');
+        $this->helper->appendFormFieldElement($admin, $object, 'uniquePartOfId_sub_object_0_and_more_0_final_data');
     }
 }

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1611,7 +1611,7 @@ class AdminTest extends TestCase
 
     public function testFormAddPostSubmitEventForPreValidation(): void
     {
-        $modelAdmin = new ModelAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'Sonata\FooBundle\Controller\ModelAdminController');
+        $modelAdmin = new ModelAdmin('sonata.post.admin.model', \stdClass::class, 'Sonata\FooBundle\Controller\ModelAdminController');
         $object = new \stdClass();
 
         $labelTranslatorStrategy = $this->createMock(LabelTranslatorStrategyInterface::class);
@@ -1667,6 +1667,7 @@ class AdminTest extends TestCase
                 ->willReturn($formBuild);
 
         $modelAdmin->setFormContractor($formContractor);
+        $modelAdmin->setSubject($object);
         $modelAdmin->defineFormBuilder($formBuild);
         $modelAdmin->getForm();
     }

--- a/tests/Fixtures/Entity/Bar.php
+++ b/tests/Fixtures/Entity/Bar.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Entity;
+
+class Bar
+{
+}

--- a/tests/Form/Type/AdminTypeTest.php
+++ b/tests/Form/Type/AdminTypeTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Prophecy\Argument;
 use Prophecy\Argument\Token\AnyValueToken;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
@@ -53,6 +54,7 @@ class AdminTypeTest extends TypeTestCase
         $parentAdmin = $this->prophesize(AdminInterface::class);
         $parentAdmin->hasSubject()->shouldBeCalled()->willReturn(false);
         $parentField = $this->prophesize(FieldDescriptionInterface::class);
+        $parentField->setAssociationAdmin(Argument::type(AdminInterface::class))->shouldBeCalled();
         $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
 
         $modelManager = $this->prophesize(ModelManagerInterface::class);
@@ -60,7 +62,7 @@ class AdminTypeTest extends TypeTestCase
         $foo = new Foo();
 
         $admin = $this->prophesize(AbstractAdmin::class);
-        $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(false);
+        $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(true);
         $admin->getParentFieldDescription()->shouldBeCalled()->willReturn($parentField->reveal());
         $admin->hasAccess('delete')->shouldBeCalled()->willReturn(false);
         $admin->defineFormBuilder(new AnyValueToken())->shouldBeCalled();
@@ -101,12 +103,13 @@ class AdminTypeTest extends TypeTestCase
         $parentAdmin->getSubject()->shouldBeCalled()->willReturn($parentSubject);
         $parentAdmin->hasSubject()->shouldBeCalled()->willReturn(true);
         $parentField = $this->prophesize(FieldDescriptionInterface::class);
+        $parentField->setAssociationAdmin(Argument::type(AdminInterface::class))->shouldBeCalled();
         $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
 
         $modelManager = $this->prophesize(ModelManagerInterface::class);
 
         $admin = $this->prophesize(AbstractAdmin::class);
-        $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(false);
+        $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(true);
         $admin->getParentFieldDescription()->shouldBeCalled()->willReturn($parentField->reveal());
         $admin->setSubject(1)->shouldBeCalled();
         $admin->defineFormBuilder(new AnyValueToken())->shouldBeCalled();
@@ -143,12 +146,13 @@ class AdminTypeTest extends TypeTestCase
         $parentAdmin->getSubject()->shouldBeCalled()->willReturn($parentSubject);
         $parentAdmin->hasSubject()->shouldBeCalled()->willReturn(true);
         $parentField = $this->prophesize(FieldDescriptionInterface::class);
+        $parentField->setAssociationAdmin(Argument::type(AdminInterface::class))->shouldBeCalled();
         $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
 
         $modelManager = $this->prophesize(ModelManagerInterface::class);
 
         $admin = $this->prophesize(AbstractAdmin::class);
-        $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(false);
+        $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(true);
         $admin->getParentFieldDescription()->shouldBeCalled()->willReturn($parentField->reveal());
         $admin->defineFormBuilder(new AnyValueToken())->shouldBeCalled();
         $admin->getModelManager()->shouldBeCalled()->willReturn($modelManager);
@@ -183,6 +187,7 @@ class AdminTypeTest extends TypeTestCase
         $parentAdmin->getSubject()->shouldBeCalled()->willReturn($parentSubject);
         $parentAdmin->hasSubject()->shouldBeCalled()->willReturn(true);
         $parentField = $this->prophesize(FieldDescriptionInterface::class);
+        $parentField->setAssociationAdmin(Argument::type(AdminInterface::class))->shouldBeCalled();
         $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
 
         $modelManager = $this->prophesize(ModelManagerInterface::class);
@@ -190,7 +195,7 @@ class AdminTypeTest extends TypeTestCase
         $foo = new Foo();
 
         $admin = $this->prophesize(AbstractAdmin::class);
-        $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(false);
+        $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(true);
         $admin->getParentFieldDescription()->shouldBeCalled()->willReturn($parentField->reveal());
         $admin->defineFormBuilder(new AnyValueToken())->shouldBeCalled();
         $admin->getModelManager()->shouldBeCalled()->willReturn($modelManager);

--- a/tests/Form/Type/AdminTypeTest.php
+++ b/tests/Form/Type/AdminTypeTest.php
@@ -51,7 +51,7 @@ class AdminTypeTest extends TypeTestCase
     public function testSubmitValidData(): void
     {
         $parentAdmin = $this->prophesize(AdminInterface::class);
-        $parentAdmin->getSubject()->shouldBeCalled()->willReturn(null);
+        $parentAdmin->hasSubject()->shouldBeCalled()->willReturn(false);
         $parentField = $this->prophesize(FieldDescriptionInterface::class);
         $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
 
@@ -99,6 +99,7 @@ class AdminTypeTest extends TypeTestCase
 
         $parentAdmin = $this->prophesize(AdminInterface::class);
         $parentAdmin->getSubject()->shouldBeCalled()->willReturn($parentSubject);
+        $parentAdmin->hasSubject()->shouldBeCalled()->willReturn(true);
         $parentField = $this->prophesize(FieldDescriptionInterface::class);
         $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
 
@@ -140,6 +141,7 @@ class AdminTypeTest extends TypeTestCase
 
         $parentAdmin = $this->prophesize(AdminInterface::class);
         $parentAdmin->getSubject()->shouldBeCalled()->willReturn($parentSubject);
+        $parentAdmin->hasSubject()->shouldBeCalled()->willReturn(true);
         $parentField = $this->prophesize(FieldDescriptionInterface::class);
         $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
 
@@ -179,6 +181,7 @@ class AdminTypeTest extends TypeTestCase
 
         $parentAdmin = $this->prophesize(AdminInterface::class);
         $parentAdmin->getSubject()->shouldBeCalled()->willReturn($parentSubject);
+        $parentAdmin->hasSubject()->shouldBeCalled()->willReturn(true);
         $parentField = $this->prophesize(FieldDescriptionInterface::class);
         $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I want to try to stop building form with null subject.

I am targeting this branch, because I tried to be BC.

Closes #5933

## Changelog
```markdown
### Changed
- `$this->getSubject()` always return a value in `configureFormField`
```