### PR TITLE
Show message_form_group_empty only if...

### DIFF
--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -81,6 +81,8 @@ abstract class BaseGroupedMapper extends BaseMapper
             'translation_domain' => null,
             'name' => $name,
             'box_class' => 'box box-primary',
+            'empty_message' => 'message_form_group_empty',
+            'empty_message_translation_domain' => 'SonataAdminBundle',
         ];
 
         // NEXT_MAJOR: remove this code

--- a/src/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -20,7 +20,9 @@
                         {% for field_name in form_group.fields|filter(field_name => form[field_name] is defined) %}
                             {{ form_row(form[field_name]) }}
                         {% else %}
-                            <em>{{ 'message_form_group_empty'|trans({}, 'SonataAdminBundle') }}</em>
+                            {% if form_group.description is not defined %}
+                                <em>{{ 'message_form_group_empty'|trans({}, 'SonataAdminBundle') }}</em>
+                            {% endif %}
                         {% endfor %}
                     </div>
                 </div>

--- a/src/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -20,8 +20,8 @@
                         {% for field_name in form_group.fields|filter(field_name => form[field_name] is defined) %}
                             {{ form_row(form[field_name]) }}
                         {% else %}
-                            {% if form_group.description is not defined %}
-                                <em>{{ 'message_form_group_empty'|trans({}, 'SonataAdminBundle') }}</em>
+                            {% if form_group.empty_message is not defined or form_group.empty_message != false %}
+                                <em>{{ (form_group.empty_message ?? 'message_form_group_empty')|trans({}, 'SonataAdminBundle') }}</em>
                             {% endif %}
                         {% endfor %}
                     </div>

--- a/src/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -20,8 +20,8 @@
                         {% for field_name in form_group.fields|filter(field_name => form[field_name] is defined) %}
                             {{ form_row(form[field_name]) }}
                         {% else %}
-                            {% if form_group.empty_message is not defined or form_group.empty_message != false %}
-                                <em>{{ (form_group.empty_message ?? 'message_form_group_empty')|trans({}, 'SonataAdminBundle') }}</em>
+                            {% if form_group.empty_message != false %}
+                                <em>{{ form_group.empty_message|trans({}, form_group.empty_message_translation_domain) }}</em>
                             {% endif %}
                         {% endfor %}
                     </div>

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -107,6 +107,8 @@ class FormMapperTest extends TestCase
             'translation_domain' => null,
             'name' => 'default',
             'box_class' => 'box box-primary',
+            'empty_message' => 'message_form_group_empty',
+            'empty_message_translation_domain' => 'SonataAdminBundle',
             'auto_created' => true,
             'groups' => ['foobar'],
             'tab' => true,
@@ -120,6 +122,8 @@ class FormMapperTest extends TestCase
             'translation_domain' => null,
             'name' => 'foobar',
             'box_class' => 'box box-primary',
+            'empty_message' => 'message_form_group_empty',
+            'empty_message_translation_domain' => 'SonataAdminBundle',
             'fields' => [],
         ]], $this->admin->getFormGroups());
     }
@@ -139,6 +143,8 @@ class FormMapperTest extends TestCase
             'translation_domain' => 'Foobar',
             'name' => 'foobar',
             'box_class' => 'box box-primary',
+            'empty_message' => 'message_form_group_empty',
+            'empty_message_translation_domain' => 'SonataAdminBundle',
             'fields' => [],
             'role' => self::DEFAULT_GRANTED_ROLE,
         ]], $this->admin->getFormGroups());
@@ -151,6 +157,8 @@ class FormMapperTest extends TestCase
             'translation_domain' => 'Foobar',
             'name' => 'default',
             'box_class' => 'box box-primary',
+            'empty_message' => 'message_form_group_empty',
+            'empty_message_translation_domain' => 'SonataAdminBundle',
             'auto_created' => true,
             'groups' => ['foobar'],
             'tab' => true,
@@ -184,6 +192,8 @@ class FormMapperTest extends TestCase
             'translation_domain' => 'Foobar',
             'name' => 'default',
             'box_class' => 'box box-primary',
+            'empty_message' => 'message_form_group_empty',
+            'empty_message_translation_domain' => 'SonataAdminBundle',
             'auto_created' => true,
             'groups' => ['foobar'],
             'tab' => true,
@@ -197,6 +207,8 @@ class FormMapperTest extends TestCase
             'translation_domain' => 'Foobar',
             'name' => 'foobar',
             'box_class' => 'box box-primary',
+            'empty_message' => 'message_form_group_empty',
+            'empty_message_translation_domain' => 'SonataAdminBundle',
             'fields' => [
                 'foo' => 'foo',
             ],

--- a/tests/Show/ShowMapperTest.php
+++ b/tests/Show/ShowMapperTest.php
@@ -448,6 +448,8 @@ class ShowMapperTest extends TestCase
                 'translation_domain' => null,
                 'name' => 'Group1',
                 'box_class' => 'box box-primary',
+                'empty_message' => 'message_form_group_empty',
+                'empty_message_translation_domain' => 'SonataAdminBundle',
                 'fields' => ['fooName1' => 'fooName1', 'fooName2' => 'fooName2', 'fooName3' => 'fooName3', 'fooName4' => 'fooName4'],
             ], ], $this->admin->getShowGroups());
 
@@ -463,6 +465,8 @@ class ShowMapperTest extends TestCase
                 'translation_domain' => null,
                 'name' => 'Group1',
                 'box_class' => 'box box-primary',
+                'empty_message' => 'message_form_group_empty',
+                'empty_message_translation_domain' => 'SonataAdminBundle',
                 'fields' => ['fooName3' => 'fooName3', 'fooName2' => 'fooName2', 'fooName1' => 'fooName1', 'fooName4' => 'fooName4'],
             ], ], true), print_r($this->admin->getShowGroups(), true));
     }


### PR DESCRIPTION
Show message_form_group_empty only if there is nothing to show in the box.

<!-- Describe your Pull Request content here -->


I am targeting this branch, because everything backwards compatible.

## Changelog

```markdown
### Changed
- Show message_form_group_empty only if there is nothing to show in the box.
```