### PR TITLE
Move type checks to argument declarations

### DIFF
--- a/src/Security/Handler/AclSecurityHandler.php
+++ b/src/Security/Handler/AclSecurityHandler.php
@@ -69,26 +69,15 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
     protected $maskBuilderClass;
 
     /**
-     * @param TokenStorageInterface         $tokenStorage
-     * @param AuthorizationCheckerInterface $authorizationChecker
-     * @param string                        $maskBuilderClass
+     * @param string $maskBuilderClass
      */
     public function __construct(
-        $tokenStorage,
-        $authorizationChecker,
+        TokenStorageInterface $tokenStorage,
+        AuthorizationCheckerInterface $authorizationChecker,
         MutableAclProviderInterface $aclProvider,
         $maskBuilderClass,
         array $superAdminRoles
     ) {
-        // NEXT_MAJOR: Move TokenStorageInterface check to method signature
-        if (!$tokenStorage instanceof TokenStorageInterface) {
-            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
-        }
-        // NEXT_MAJOR: Move AuthorizationCheckerInterface check to method signature
-        if (!$authorizationChecker instanceof AuthorizationCheckerInterface) {
-            throw new \InvalidArgumentException('Argument 2 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
-        }
-
         $this->tokenStorage = $tokenStorage;
         $this->authorizationChecker = $authorizationChecker;
         $this->aclProvider = $aclProvider;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Move type checks to argument declarations.

I don't know why these checks weren't placed as type declarations originally.
Now, `\TypeError` is thrown instead of `\InvalidArgumentException` when arguments 1 or 2 passed to `AclSecurityHandler::__construct()` haven't the required type.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

<!--
## Changelog
-->
<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
<!--
```markdown
### Changed
- 
-->
