### PR TITLE
Remove deprecations in CRUDController

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "knplabs/knp-menu-bundle": "^3.0",
         "sonata-project/block-bundle": "^4.0",
         "sonata-project/doctrine-extensions": "^1.4",
-        "sonata-project/exporter": "^1.11.0 || ^2.0",
+        "sonata-project/exporter": "^2.1",
         "sonata-project/form-extensions": "^1.1.2",
         "sonata-project/twig-extensions": "^1.1.1",
         "symfony/asset": "^4.3",

--- a/src/Bridge/Exporter/AdminExporter.php
+++ b/src/Bridge/Exporter/AdminExporter.php
@@ -45,8 +45,7 @@ final class AdminExporter
     {
         $adminExportFormats = $admin->getExportFormats();
 
-        // NEXT_MAJOR : compare with null
-        if ($adminExportFormats !== ['json', 'xml', 'csv', 'xls']) {
+        if (null !== $adminExportFormats) {
             return $adminExportFormats;
         }
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -881,29 +881,10 @@ class CRUDController extends Controller
 
         $format = $request->get('format');
 
-        // NEXT_MAJOR: remove the check
-        if (!$this->has('sonata.admin.admin_exporter')) {
-            @trigger_error(
-                'Not registering the exporter bundle is deprecated since version 3.14.'
-                .' You must register it to be able to use the export action in 4.0.',
-                E_USER_DEPRECATED
-            );
-            $allowedExportFormats = (array) $this->admin->getExportFormats();
-
-            $class = (string) $this->admin->getClass();
-            $filename = sprintf(
-                'export_%s_%s.%s',
-                strtolower((string) substr($class, strripos($class, '\\') + 1)),
-                date('Y_m_d_H_i_s', strtotime('now')),
-                $format
-            );
-            $exporter = $this->get('sonata.admin.exporter');
-        } else {
-            $adminExporter = $this->get('sonata.admin.admin_exporter');
-            $allowedExportFormats = $adminExporter->getAvailableFormats($this->admin);
-            $filename = $adminExporter->getExportFilename($this->admin, $format);
-            $exporter = $this->get('sonata.exporter.exporter');
-        }
+        $adminExporter = $this->get('sonata.admin.admin_exporter');
+        $allowedExportFormats = $adminExporter->getAvailableFormats($this->admin);
+        $filename = $adminExporter->getExportFilename($this->admin, $format);
+        $exporter = $this->get('sonata.exporter.exporter');
 
         if (!\in_array($format, $allowedExportFormats, true)) {
             throw new \RuntimeException(

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -96,10 +96,8 @@ class CRUDController extends Controller
      *
      * @return Response
      */
-    public function listAction()
+    public function listAction(Request $request)
     {
-        $request = $this->getRequest();
-
         $this->admin->checkAccess('list');
 
         $preResponse = $this->preList($request);
@@ -168,9 +166,8 @@ class CRUDController extends Controller
      *
      * @return Response|RedirectResponse
      */
-    public function deleteAction()
+    public function deleteAction(Request $request)
     {
-        $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
@@ -246,12 +243,11 @@ class CRUDController extends Controller
      *
      * @return Response|RedirectResponse
      */
-    public function editAction()
+    public function editAction(Request $request)
     {
         // the key used to lookup the template
         $templateKey = 'edit';
 
-        $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $existingObject = $this->admin->getObject($id);
 
@@ -364,9 +360,8 @@ class CRUDController extends Controller
      *
      * @return Response|RedirectResponse
      */
-    public function batchAction()
+    public function batchAction(Request $request)
     {
-        $request = $this->getRequest();
         $restMethod = $this->getRestMethod();
 
         if (Request::METHOD_POST !== $restMethod) {
@@ -486,9 +481,8 @@ class CRUDController extends Controller
      *
      * @return Response
      */
-    public function createAction()
+    public function createAction(Request $request)
     {
-        $request = $this->getRequest();
         // the key used to lookup the template
         $templateKey = 'edit';
 
@@ -605,9 +599,8 @@ class CRUDController extends Controller
      *
      * @return Response
      */
-    public function showAction()
+    public function showAction(Request $request)
     {
-        $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
@@ -652,9 +645,8 @@ class CRUDController extends Controller
      *
      * @return Response
      */
-    public function historyAction()
+    public function historyAction(Request $request)
     {
-        $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
@@ -699,9 +691,8 @@ class CRUDController extends Controller
      *
      * @return Response
      */
-    public function historyViewRevisionAction($revision = null)
+    public function historyViewRevisionAction(Request $request, $revision = null)
     {
-        $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
@@ -752,19 +743,18 @@ class CRUDController extends Controller
     /**
      * Compare history revisions of object.
      *
-     * @param int|string|null $base_revision
-     * @param int|string|null $compare_revision
+     * @param int|string|null $baseRevision
+     * @param int|string|null $compareRevision
      *
      * @throws AccessDeniedException If access is not granted
      * @throws NotFoundHttpException If the object or revision does not exist or the audit reader is not available
      *
      * @return Response
      */
-    public function historyCompareRevisionsAction($base_revision = null, $compare_revision = null)
+    public function historyCompareRevisionsAction(Request $request, $baseRevision = null, $compareRevision = null)
     {
         $this->admin->checkAccess('historyCompareRevisions');
 
-        $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
@@ -786,39 +776,39 @@ class CRUDController extends Controller
         $reader = $manager->getReader($this->admin->getClass());
 
         // retrieve the base revision
-        $base_object = $reader->find($this->admin->getClass(), $id, $base_revision);
-        if (!$base_object) {
+        $baseObject = $reader->find($this->admin->getClass(), $id, $baseRevision);
+        if (!$baseObject) {
             throw $this->createNotFoundException(
                 sprintf(
                     'unable to find the targeted object `%s` from the revision `%s` with classname : `%s`',
                     $id,
-                    $base_revision,
+                    $baseRevision,
                     $this->admin->getClass()
                 )
             );
         }
 
         // retrieve the compare revision
-        $compare_object = $reader->find($this->admin->getClass(), $id, $compare_revision);
-        if (!$compare_object) {
+        $compareObject = $reader->find($this->admin->getClass(), $id, $compareRevision);
+        if (!$compareObject) {
             throw $this->createNotFoundException(
                 sprintf(
                     'unable to find the targeted object `%s` from the revision `%s` with classname : `%s`',
                     $id,
-                    $compare_revision,
+                    $compareRevision,
                     $this->admin->getClass()
                 )
             );
         }
 
-        $this->admin->setSubject($base_object);
+        $this->admin->setSubject($baseObject);
 
         $template = $this->templateRegistry->getTemplate('show_compare');
 
         return $this->renderWithExtraParams($template, [
             'action' => 'show',
-            'object' => $base_object,
-            'object_compare' => $compare_object,
+            'object' => $baseObject,
+            'object_compare' => $compareObject,
             'elements' => $this->admin->getShow(),
         ], null);
     }
@@ -868,13 +858,12 @@ class CRUDController extends Controller
      *
      * @return Response|RedirectResponse
      */
-    public function aclAction()
+    public function aclAction(Request $request)
     {
         if (!$this->admin->isAclEnabled()) {
             throw $this->createNotFoundException('ACL are not enabled for this admin');
         }
 
-        $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
@@ -1423,7 +1412,7 @@ class CRUDController extends Controller
 
         if ($parentAdmin->getObject($parentId) !== $propertyAccessor->getValue($object, $propertyPath)) {
             throw new \RuntimeException(sprintf(
-                'There is no association between %s and %s',
+                'There is no association between "%s" and "%s"',
                 $parentAdmin->toString($parentAdmin->getObject($parentId)),
                 $this->admin->toString($object)
             ));

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -163,14 +163,12 @@ class CRUDController extends Controller
     /**
      * Delete action.
      *
-     * @param int|string|null $id
-     *
      * @throws NotFoundHttpException If the object does not exist
      * @throws AccessDeniedException If access is not granted
      *
      * @return Response|RedirectResponse
      */
-    public function deleteAction($id) // NEXT_MAJOR: Remove the unused $id parameter
+    public function deleteAction()
     {
         $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
@@ -242,26 +240,14 @@ class CRUDController extends Controller
     /**
      * Edit action.
      *
-     * @param int|string|null $deprecatedId
-     *
      * @throws NotFoundHttpException If the object does not exist
      * @throws \RuntimeException     If no editable field is defined
      * @throws AccessDeniedException If access is not granted
      *
      * @return Response|RedirectResponse
      */
-    public function editAction($deprecatedId = null) // NEXT_MAJOR: Remove the unused $id parameter
+    public function editAction()
     {
-        if (isset(\func_get_args()[0])) {
-            @trigger_error(
-                sprintf(
-                    'Support for the "id" route param as argument 1 at `%s()` is deprecated since sonata-project/admin-bundle 3.62 and will be removed in 4.0, use `AdminInterface::getIdParameter()` instead.',
-                    __METHOD__
-                ),
-                E_USER_DEPRECATED
-            );
-        }
-
         // the key used to lookup the template
         $templateKey = 'edit';
 
@@ -614,25 +600,13 @@ class CRUDController extends Controller
     /**
      * Show action.
      *
-     * @param int|string|null $deprecatedId
-     *
      * @throws NotFoundHttpException If the object does not exist
      * @throws AccessDeniedException If access is not granted
      *
      * @return Response
      */
-    public function showAction($deprecatedId = null) // NEXT_MAJOR: Remove the unused $id parameter
+    public function showAction()
     {
-        if (isset(\func_get_args()[0])) {
-            @trigger_error(
-                sprintf(
-                    'Support for the "id" route param as argument 1 at `%s()` is deprecated since sonata-project/admin-bundle 3.62 and will be removed in 4.0, use `AdminInterface::getIdParameter()` instead.',
-                    __METHOD__
-                ),
-                E_USER_DEPRECATED
-            );
-        }
-
         $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
@@ -655,13 +629,9 @@ class CRUDController extends Controller
         $fields = $this->admin->getShow();
         \assert($fields instanceof FieldDescriptionCollection);
 
-        // NEXT_MAJOR: replace deprecation with exception
         if (!\is_array($fields->getElements()) || 0 === $fields->count()) {
-            @trigger_error(
-                'Calling this method without implementing "configureShowFields"'
-                .' is not supported since sonata-project/admin-bundle 3.40.0'
-                .' and will no longer be possible in 4.0',
-                E_USER_DEPRECATED
+            throw new \RuntimeException(
+                'No fields defined. Did you forget to implement the "configureShowFields" method?'
             );
         }
 
@@ -677,25 +647,13 @@ class CRUDController extends Controller
     /**
      * Show history revisions for object.
      *
-     * @param int|string|null $deprecatedId
-     *
      * @throws AccessDeniedException If access is not granted
      * @throws NotFoundHttpException If the object does not exist or the audit reader is not available
      *
      * @return Response
      */
-    public function historyAction($deprecatedId = null) // NEXT_MAJOR: Remove the unused $id parameter
+    public function historyAction()
     {
-        if (isset(\func_get_args()[0])) {
-            @trigger_error(
-                sprintf(
-                    'Support for the "id" route param as argument 1 at `%s()` is deprecated since sonata-project/admin-bundle 3.62 and will be removed in 4.0, use `AdminInterface::getIdParameter()` instead.',
-                    __METHOD__
-                ),
-                E_USER_DEPRECATED
-            );
-        }
-
         $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
@@ -734,15 +692,14 @@ class CRUDController extends Controller
     /**
      * View history revision of object.
      *
-     * @param int|string|null $id
-     * @param string|null     $revision
+     * @param string|null $revision
      *
      * @throws AccessDeniedException If access is not granted
      * @throws NotFoundHttpException If the object or revision does not exist or the audit reader is not available
      *
      * @return Response
      */
-    public function historyViewRevisionAction($id = null, $revision = null) // NEXT_MAJOR: Remove the unused $id parameter
+    public function historyViewRevisionAction($revision = null)
     {
         $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
@@ -795,7 +752,6 @@ class CRUDController extends Controller
     /**
      * Compare history revisions of object.
      *
-     * @param int|string|null $id
      * @param int|string|null $base_revision
      * @param int|string|null $compare_revision
      *
@@ -804,7 +760,7 @@ class CRUDController extends Controller
      *
      * @return Response
      */
-    public function historyCompareRevisionsAction($id = null, $base_revision = null, $compare_revision = null) // NEXT_MAJOR: Remove the unused $id parameter
+    public function historyCompareRevisionsAction($base_revision = null, $compare_revision = null)
     {
         $this->admin->checkAccess('historyCompareRevisions');
 
@@ -907,25 +863,13 @@ class CRUDController extends Controller
     /**
      * Returns the Response object associated to the acl action.
      *
-     * @param int|string|null $deprecatedId
-     *
      * @throws AccessDeniedException If access is not granted
      * @throws NotFoundHttpException If the object does not exist or the ACL is not enabled
      *
      * @return Response|RedirectResponse
      */
-    public function aclAction($deprecatedId = null) // NEXT_MAJOR: Remove the unused $id parameter
+    public function aclAction()
     {
-        if (isset(\func_get_args()[0])) {
-            @trigger_error(
-                sprintf(
-                    'Support for the "id" route param as argument 1 at `%s()` is deprecated since sonata-project/admin-bundle 3.62 and will be removed in 4.0, use `AdminInterface::getIdParameter()` instead.',
-                    __METHOD__
-                ),
-                E_USER_DEPRECATED
-            );
-        }
-
         if (!$this->admin->isAclEnabled()) {
             throw $this->createNotFoundException('ACL are not enabled for this admin');
         }
@@ -1472,23 +1416,17 @@ class CRUDController extends Controller
             return;
         }
 
-        // NEXT_MAJOR: remove this check
-        if (!$this->admin->getParentAssociationMapping()) {
-            return;
-        }
-
         $parentId = $request->get($parentAdmin->getIdParameter());
 
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $propertyPath = new PropertyPath($this->admin->getParentAssociationMapping());
 
         if ($parentAdmin->getObject($parentId) !== $propertyAccessor->getValue($object, $propertyPath)) {
-            // NEXT_MAJOR: make this exception
-            @trigger_error(
-                "Accessing a child that isn't connected to a given parent is"
-                ." deprecated since sonata-project/admin-bundle 3.34 and won't be allowed in 4.0.",
-                E_USER_DEPRECATED
-            );
+            throw new \RuntimeException(sprintf(
+                'There is no association between %s and %s',
+                $parentAdmin->toString($parentAdmin->getObject($parentId)),
+                $this->admin->toString($object)
+            ));
         }
     }
 
@@ -1502,12 +1440,10 @@ class CRUDController extends Controller
         $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
     }
 
-    private function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): ?JsonResponse
+    private function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): JsonResponse
     {
         if (!\in_array('application/json', $request->getAcceptableContentTypes(), true)) {
-            @trigger_error('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json`', E_USER_DEPRECATED);
-
-            return null;
+            return $this->renderJson([], Response::HTTP_NOT_ACCEPTABLE);
         }
 
         $errors = [];
@@ -1527,7 +1463,7 @@ class CRUDController extends Controller
     private function handleXmlHttpRequestSuccessResponse(Request $request, $object): JsonResponse
     {
         if (!\in_array('application/json', $request->getAcceptableContentTypes(), true)) {
-            @trigger_error('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json`', E_USER_DEPRECATED);
+            return $this->renderJson([], Response::HTTP_NOT_ACCEPTABLE);
         }
 
         return $this->renderJson([

--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -58,10 +58,6 @@
         </service>
         <service id="Sonata\AdminBundle\Model\AuditManager" alias="sonata.admin.audit.manager"/>
         <service id="Sonata\AdminBundle\Model\AuditManagerInterface" alias="sonata.admin.audit.manager"/>
-        <!-- NEXT_MAJOR : remove this service -->
-        <service id="sonata.admin.exporter" class="Sonata\AdminBundle\Export\Exporter" public="true">
-            <deprecated>The service "%service_id%" is deprecated in favor of the "sonata.exporter.exporter" service since version 3.14 and will be removed in 4.0.</deprecated>
-        </service>
         <service id="sonata.admin.search.handler" class="Sonata\AdminBundle\Search\SearchHandler" public="true">
             <argument type="service" id="sonata.admin.pool"/>
             <argument>%sonata.admin.configuration.global_search.case_sensitive%</argument>

--- a/tests/Bridge/Exporter/AdminExporterTest.php
+++ b/tests/Bridge/Exporter/AdminExporterTest.php
@@ -24,7 +24,7 @@ class AdminExporterTest extends TestCase
     public function provideExportFormats()
     {
         return [
-            'no override' => [['xls'], ['json', 'xml', 'csv', 'xls'], ['xls']],
+            'no override' => [['xls'], null, ['xls']],
             'override in admin' => [['csv'], ['csv'], ['xls']],
         ];
     }
@@ -32,7 +32,7 @@ class AdminExporterTest extends TestCase
     /**
      * @dataProvider provideExportFormats
      */
-    public function testAdminHasPriorityOverGlobalSettings(array $expectedFormats, array $adminFormats, array $globalFormats): void
+    public function testAdminHasPriorityOverGlobalSettings(array $expectedFormats, ?array $adminFormats, array $globalFormats): void
     {
         $writers = [];
         foreach ($globalFormats as $exportFormat) {

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -25,7 +25,6 @@ use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Exception\LockException;
 use Sonata\AdminBundle\Exception\ModelManagerException;
-use Sonata\AdminBundle\Export\Exporter as SonataExporter;
 use Sonata\AdminBundle\Model\AuditManager;
 use Sonata\AdminBundle\Model\AuditReaderInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
@@ -196,16 +195,7 @@ class CRUDControllerTest extends TestCase
             ->method('render')
             ->will($templatingRenderReturnCallback);
 
-        // NEXT_MAJOR : require sonata/exporter ^1.7 and remove conditional
-        if (class_exists(Exporter::class)) {
-            $exporter = new Exporter([new JsonWriter('/tmp/sonataadmin/export.json')]);
-        } else {
-            $exporter = $this->createMock(SonataExporter::class);
-
-            $exporter
-                ->method('getResponse')
-                ->willReturn(new StreamedResponse());
-        }
+        $exporter = new Exporter([new JsonWriter('/tmp/sonataadmin/export.json')]);
 
         $this->auditManager = $this->getMockBuilder(AuditManager::class)
             ->disableOriginalConstructor()

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -543,7 +543,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('list'))
             ->will($this->throwException(new AccessDeniedException()));
 
-        $this->controller->listAction();
+        $this->controller->listAction($this->request);
     }
 
     public function testPreList(): void
@@ -561,7 +561,7 @@ class CRUDControllerTest extends TestCase
         $controller = new PreCRUDController();
         $controller->setContainer($this->container);
 
-        $response = $controller->listAction();
+        $response = $controller->listAction($this->request);
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('preList called', $response->getContent());
     }
@@ -597,7 +597,7 @@ class CRUDControllerTest extends TestCase
             ->willReturn($form);
 
         $this->parameters = [];
-        $this->assertInstanceOf(Response::class, $this->controller->listAction());
+        $this->assertInstanceOf(Response::class, $this->controller->listAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -701,7 +701,7 @@ class CRUDControllerTest extends TestCase
             ->method('getObject')
             ->willReturn(false);
 
-        $this->controller->showAction();
+        $this->controller->showAction($this->request);
     }
 
     public function testShowActionAccessDenied(): void
@@ -717,7 +717,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('show'))
             ->will($this->throwException(new AccessDeniedException()));
 
-        $this->controller->showAction();
+        $this->controller->showAction($this->request);
     }
 
     public function testShowActionExceptionWithoutFieldsDefined(): void
@@ -749,7 +749,7 @@ class CRUDControllerTest extends TestCase
             ->method('count')
             ->willReturn(0);
 
-        $this->controller->showAction();
+        $this->controller->showAction($this->request);
     }
 
     public function testPreShow(): void
@@ -769,7 +769,7 @@ class CRUDControllerTest extends TestCase
         $controller = new PreCRUDController();
         $controller->setContainer($this->container);
 
-        $response = $controller->showAction();
+        $response = $controller->showAction($this->request);
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('preShow called: 123456', $response->getContent());
     }
@@ -797,7 +797,7 @@ class CRUDControllerTest extends TestCase
             ->method('getElements')
             ->willReturn(['field' => 'fielddata']);
 
-        $this->assertInstanceOf(Response::class, $this->controller->showAction());
+        $this->assertInstanceOf(Response::class, $this->controller->showAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -893,7 +893,7 @@ class CRUDControllerTest extends TestCase
             ->method('getObject')
             ->willReturn(false);
 
-        $this->controller->deleteAction();
+        $this->controller->deleteAction($this->request);
     }
 
     public function testDeleteActionAccessDenied(): void
@@ -909,7 +909,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('delete'))
             ->will($this->throwException(new AccessDeniedException()));
 
-        $this->controller->deleteAction();
+        $this->controller->deleteAction($this->request);
     }
 
     public function testPreDelete(): void
@@ -929,7 +929,7 @@ class CRUDControllerTest extends TestCase
         $controller = new PreCRUDController();
         $controller->setContainer($this->container);
 
-        $response = $controller->deleteAction(null);
+        $response = $controller->deleteAction($this->request);
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('preDelete called: 123456', $response->getContent());
     }
@@ -947,7 +947,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('delete'))
             ->willReturn(true);
 
-        $this->assertInstanceOf(Response::class, $this->controller->deleteAction());
+        $this->assertInstanceOf(Response::class, $this->controller->deleteAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -976,7 +976,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('delete'))
             ->willReturn(true);
 
-        $this->assertInstanceOf(Response::class, $this->controller->deleteAction());
+        $this->assertInstanceOf(Response::class, $this->controller->deleteAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -1008,7 +1008,7 @@ class CRUDControllerTest extends TestCase
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
-        $response = $this->controller->deleteAction();
+        $response = $this->controller->deleteAction($this->request);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(json_encode(['result' => 'ok']), $response->getContent());
@@ -1034,7 +1034,7 @@ class CRUDControllerTest extends TestCase
 
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $response = $this->controller->deleteAction();
+        $response = $this->controller->deleteAction($this->request);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(json_encode(['result' => 'ok']), $response->getContent());
@@ -1065,7 +1065,7 @@ class CRUDControllerTest extends TestCase
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $response = $this->controller->deleteAction();
+        $response = $this->controller->deleteAction($this->request);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(json_encode(['result' => 'error']), $response->getContent());
@@ -1100,7 +1100,7 @@ class CRUDControllerTest extends TestCase
         $this->request->setMethod(Request::METHOD_DELETE);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
-        $this->controller->deleteAction();
+        $this->controller->deleteAction($this->request);
     }
 
     /**
@@ -1130,7 +1130,7 @@ class CRUDControllerTest extends TestCase
 
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
-        $response = $this->controller->deleteAction();
+        $response = $this->controller->deleteAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(['flash_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -1165,7 +1165,7 @@ class CRUDControllerTest extends TestCase
 
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
-        $response = $this->controller->deleteAction();
+        $response = $this->controller->deleteAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(['flash_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -1200,7 +1200,7 @@ class CRUDControllerTest extends TestCase
         $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('_method', Request::METHOD_DELETE);
 
-        $response = $this->controller->deleteAction();
+        $response = $this->controller->deleteAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(['flash_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -1223,7 +1223,7 @@ class CRUDControllerTest extends TestCase
         //without POST request parameter "_method" should not be used as real REST method
         $this->request->query->set('_method', Request::METHOD_DELETE);
 
-        $this->assertInstanceOf(Response::class, $this->controller->deleteAction());
+        $this->assertInstanceOf(Response::class, $this->controller->deleteAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -1265,7 +1265,7 @@ class CRUDControllerTest extends TestCase
         $this->request->setMethod(Request::METHOD_DELETE);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
 
-        $response = $this->controller->deleteAction();
+        $response = $this->controller->deleteAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(['flash_delete_error'], $this->session->getFlashBag()->get('sonata_flash_error'));
@@ -1290,7 +1290,7 @@ class CRUDControllerTest extends TestCase
         $this->request->request->set('_sonata_csrf_token', 'CSRF-INVALID');
 
         try {
-            $this->controller->deleteAction();
+            $this->controller->deleteAction($this->request);
         } catch (HttpException $e) {
             $this->assertSame('The csrf token is not valid, CSRF attack?', $e->getMessage());
             $this->assertSame(400, $e->getStatusCode());
@@ -1305,7 +1305,7 @@ class CRUDControllerTest extends TestCase
             ->method('getObject')
             ->willReturn(false);
 
-        $this->controller->editAction();
+        $this->controller->editAction($this->request);
     }
 
     public function testEditActionRuntimeException(): void
@@ -1331,7 +1331,7 @@ class CRUDControllerTest extends TestCase
             ->method('all')
             ->willReturn([]);
 
-        $this->controller->editAction();
+        $this->controller->editAction($this->request);
     }
 
     public function testEditActionAccessDenied(): void
@@ -1347,7 +1347,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('edit'))
             ->will($this->throwException(new AccessDeniedException()));
 
-        $this->controller->editAction();
+        $this->controller->editAction($this->request);
     }
 
     public function testPreEdit(): void
@@ -1367,7 +1367,7 @@ class CRUDControllerTest extends TestCase
         $controller = new PreCRUDController();
         $controller->setContainer($this->container);
 
-        $response = $controller->editAction();
+        $response = $controller->editAction($this->request);
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('preEdit called: 123456', $response->getContent());
     }
@@ -1401,7 +1401,7 @@ class CRUDControllerTest extends TestCase
             ->method('all')
             ->willReturn(['field' => 'fielddata']);
 
-        $this->assertInstanceOf(Response::class, $this->controller->editAction());
+        $this->assertInstanceOf(Response::class, $this->controller->editAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -1474,7 +1474,7 @@ class CRUDControllerTest extends TestCase
 
         $this->request->setMethod(Request::METHOD_POST);
 
-        $response = $this->controller->editAction();
+        $response = $this->controller->editAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(['flash_edit_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -1530,7 +1530,7 @@ class CRUDControllerTest extends TestCase
             ->method('createView')
             ->willReturn($formView);
 
-        $this->assertInstanceOf(Response::class, $this->controller->editAction());
+        $this->assertInstanceOf(Response::class, $this->controller->editAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -1596,7 +1596,7 @@ class CRUDControllerTest extends TestCase
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
         $this->request->headers->set('Accept', 'application/json');
 
-        $response = $this->controller->editAction();
+        $response = $this->controller->editAction($this->request);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(json_encode(['result' => 'ok', 'objectId' => 'foo_normalized', 'objectName' => 'foo']), $response->getContent());
@@ -1648,7 +1648,7 @@ class CRUDControllerTest extends TestCase
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
         $this->request->headers->set('Accept', 'application/json');
 
-        $this->assertInstanceOf(JsonResponse::class, $response = $this->controller->editAction());
+        $this->assertInstanceOf(JsonResponse::class, $response = $this->controller->editAction($this->request));
         $this->assertJsonStringEqualsJsonString('{"result":"error","errors":["Form error message"]}', $response->getContent());
     }
 
@@ -1691,7 +1691,7 @@ class CRUDControllerTest extends TestCase
             ->method('createView')
             ->willReturn($formView);
 
-        $this->assertInstanceOf(Response::class, $response = $this->controller->editAction());
+        $this->assertInstanceOf(Response::class, $response = $this->controller->editAction($this->request));
         $this->assertSame(Response::HTTP_NOT_ACCEPTABLE, $response->getStatusCode());
     }
 
@@ -1752,7 +1752,7 @@ class CRUDControllerTest extends TestCase
             ->willReturn($formView);
 
         $this->assertLoggerLogsModelManagerException($this->admin, 'update');
-        $this->assertInstanceOf(Response::class, $this->controller->editAction());
+        $this->assertInstanceOf(Response::class, $this->controller->editAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -1810,7 +1810,7 @@ class CRUDControllerTest extends TestCase
         $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('btn_preview', 'Preview');
 
-        $this->assertInstanceOf(Response::class, $this->controller->editAction());
+        $this->assertInstanceOf(Response::class, $this->controller->editAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -1886,7 +1886,7 @@ class CRUDControllerTest extends TestCase
             '%link_end%' => '</a>',
         ], 'SonataAdminBundle');
 
-        $this->assertInstanceOf(Response::class, $this->controller->editAction());
+        $this->assertInstanceOf(Response::class, $this->controller->editAction($this->request));
     }
 
     public function testCreateActionAccessDenied(): void
@@ -1898,7 +1898,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('create'))
             ->will($this->throwException(new AccessDeniedException()));
 
-        $this->controller->createAction();
+        $this->controller->createAction($this->request);
     }
 
     public function testCreateActionRuntimeException(): void
@@ -1928,7 +1928,7 @@ class CRUDControllerTest extends TestCase
             ->method('all')
             ->willReturn([]);
 
-        $this->controller->createAction();
+        $this->controller->createAction($this->request);
     }
 
     public function testPreCreate(): void
@@ -1952,7 +1952,7 @@ class CRUDControllerTest extends TestCase
         $controller = new PreCRUDController();
         $controller->setContainer($this->container);
 
-        $response = $controller->createAction();
+        $response = $controller->createAction($this->request);
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('preCreate called: 123456', $response->getContent());
     }
@@ -1990,7 +1990,7 @@ class CRUDControllerTest extends TestCase
             ->method('createView')
             ->willReturn($formView);
 
-        $this->assertInstanceOf(Response::class, $this->controller->createAction());
+        $this->assertInstanceOf(Response::class, $this->controller->createAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -2082,7 +2082,7 @@ class CRUDControllerTest extends TestCase
 
         $this->request->setMethod(Request::METHOD_POST);
 
-        $response = $this->controller->createAction();
+        $response = $this->controller->createAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame(['flash_create_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -2140,7 +2140,7 @@ class CRUDControllerTest extends TestCase
 
         $this->request->setMethod(Request::METHOD_POST);
 
-        $this->controller->createAction();
+        $this->controller->createAction($this->request);
     }
 
     /**
@@ -2196,7 +2196,7 @@ class CRUDControllerTest extends TestCase
             ->method('createView')
             ->willReturn($formView);
 
-        $this->assertInstanceOf(Response::class, $this->controller->createAction());
+        $this->assertInstanceOf(Response::class, $this->controller->createAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -2269,7 +2269,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertLoggerLogsModelManagerException($this->admin, 'create');
 
-        $this->assertInstanceOf(Response::class, $this->controller->createAction());
+        $this->assertInstanceOf(Response::class, $this->controller->createAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -2348,7 +2348,7 @@ class CRUDControllerTest extends TestCase
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
         $this->request->headers->set('Accept', 'application/json');
 
-        $response = $this->controller->createAction();
+        $response = $this->controller->createAction($this->request);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(json_encode(['result' => 'ok', 'objectId' => 'foo_normalized', 'objectName' => 'foo']), $response->getContent());
@@ -2404,7 +2404,7 @@ class CRUDControllerTest extends TestCase
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
         $this->request->headers->set('Accept', 'application/json');
 
-        $this->assertInstanceOf(JsonResponse::class, $response = $this->controller->createAction());
+        $this->assertInstanceOf(JsonResponse::class, $response = $this->controller->createAction($this->request));
         $this->assertJsonStringEqualsJsonString('{"result":"error","errors":["Form error message"]}', $response->getContent());
     }
 
@@ -2451,7 +2451,7 @@ class CRUDControllerTest extends TestCase
             ->method('createView')
             ->willReturn($formView);
 
-        $this->assertInstanceOf(Response::class, $response = $this->controller->createAction());
+        $this->assertInstanceOf(Response::class, $response = $this->controller->createAction($this->request));
         $this->assertSame(Response::HTTP_NOT_ACCEPTABLE, $response->getStatusCode());
     }
 
@@ -2503,7 +2503,7 @@ class CRUDControllerTest extends TestCase
         $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('btn_preview', 'Preview');
 
-        $this->assertInstanceOf(Response::class, $this->controller->createAction());
+        $this->assertInstanceOf(Response::class, $this->controller->createAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -2596,7 +2596,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('history'))
             ->will($this->throwException(new AccessDeniedException()));
 
-        $this->controller->historyAction();
+        $this->controller->historyAction($this->request);
     }
 
     public function testHistoryActionNotFoundException(): void
@@ -2607,7 +2607,7 @@ class CRUDControllerTest extends TestCase
             ->method('getObject')
             ->willReturn(false);
 
-        $this->controller->historyAction();
+        $this->controller->historyAction($this->request);
     }
 
     public function testHistoryActionNoReader(): void
@@ -2637,7 +2637,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'))
             ->willReturn(false);
 
-        $this->controller->historyAction();
+        $this->controller->historyAction($this->request);
     }
 
     public function testHistoryAction(): void
@@ -2676,7 +2676,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'), $this->equalTo(123))
             ->willReturn([]);
 
-        $this->assertInstanceOf(Response::class, $this->controller->historyAction());
+        $this->assertInstanceOf(Response::class, $this->controller->historyAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -2695,7 +2695,7 @@ class CRUDControllerTest extends TestCase
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('ACL are not enabled for this admin');
 
-        $this->controller->aclAction();
+        $this->controller->aclAction($this->request);
     }
 
     public function testAclActionNotFoundException(): void
@@ -2710,7 +2710,7 @@ class CRUDControllerTest extends TestCase
             ->method('getObject')
             ->willReturn(false);
 
-        $this->controller->aclAction();
+        $this->controller->aclAction($this->request);
     }
 
     public function testAclActionAccessDenied(): void
@@ -2732,7 +2732,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('acl'), $this->equalTo($object))
             ->will($this->throwException(new AccessDeniedException()));
 
-        $this->controller->aclAction();
+        $this->controller->aclAction($this->request);
     }
 
     public function testAclAction(): void
@@ -2799,7 +2799,7 @@ class CRUDControllerTest extends TestCase
             ->method('getSecurityHandler')
             ->willReturn($aclSecurityHandler);
 
-        $this->assertInstanceOf(Response::class, $this->controller->aclAction());
+        $this->assertInstanceOf(Response::class, $this->controller->aclAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -2888,7 +2888,7 @@ class CRUDControllerTest extends TestCase
 
         $this->request->setMethod(Request::METHOD_POST);
 
-        $this->assertInstanceOf(Response::class, $this->controller->aclAction());
+        $this->assertInstanceOf(Response::class, $this->controller->aclAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -2979,7 +2979,7 @@ class CRUDControllerTest extends TestCase
 
         $this->request->setMethod(Request::METHOD_POST);
 
-        $response = $this->controller->aclAction();
+        $response = $this->controller->aclAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
 
@@ -3000,7 +3000,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('historyViewRevision'))
             ->will($this->throwException(new AccessDeniedException()));
 
-        $this->controller->historyViewRevisionAction(null);
+        $this->controller->historyViewRevisionAction($this->request, null);
     }
 
     public function testHistoryViewRevisionActionNotFoundException(): void
@@ -3014,7 +3014,7 @@ class CRUDControllerTest extends TestCase
             ->method('getObject')
             ->willReturn(false);
 
-        $this->controller->historyViewRevisionAction(null);
+        $this->controller->historyViewRevisionAction($this->request, null);
     }
 
     public function testHistoryViewRevisionActionNoReader(): void
@@ -3044,7 +3044,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'))
             ->willReturn(false);
 
-        $this->controller->historyViewRevisionAction(null);
+        $this->controller->historyViewRevisionAction($this->request, null);
     }
 
     public function testHistoryViewRevisionActionNotFoundRevision(): void
@@ -3088,7 +3088,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'), $this->equalTo(123), $this->equalTo(456))
             ->willReturn(null);
 
-        $this->controller->historyViewRevisionAction(456);
+        $this->controller->historyViewRevisionAction($this->request, 456);
     }
 
     public function testHistoryViewRevisionAction(): void
@@ -3140,7 +3140,7 @@ class CRUDControllerTest extends TestCase
             ->method('getShow')
             ->willReturn($fieldDescriptionCollection);
 
-        $this->assertInstanceOf(Response::class, $this->controller->historyViewRevisionAction(456));
+        $this->assertInstanceOf(Response::class, $this->controller->historyViewRevisionAction($this->request, 456));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -3163,7 +3163,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('historyCompareRevisions'))
             ->will($this->throwException(new AccessDeniedException()));
 
-        $this->controller->historyCompareRevisionsAction(null, null);
+        $this->controller->historyCompareRevisionsAction($this->request, null, null);
     }
 
     public function testHistoryCompareRevisionsActionNotFoundException(): void
@@ -3182,7 +3182,7 @@ class CRUDControllerTest extends TestCase
             ->method('getObject')
             ->willReturn(false);
 
-        $this->controller->historyCompareRevisionsAction(null, null);
+        $this->controller->historyCompareRevisionsAction($this->request, null, null);
     }
 
     public function testHistoryCompareRevisionsActionNoReader(): void
@@ -3212,7 +3212,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'))
             ->willReturn(false);
 
-        $this->controller->historyCompareRevisionsAction(null, null);
+        $this->controller->historyCompareRevisionsAction($this->request, null, null);
     }
 
     public function testHistoryCompareRevisionsActionNotFoundBaseRevision(): void
@@ -3257,7 +3257,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'), $this->equalTo(123), $this->equalTo(456))
             ->willReturn(null);
 
-        $this->controller->historyCompareRevisionsAction(456, 789);
+        $this->controller->historyCompareRevisionsAction($this->request, 456, 789);
     }
 
     public function testHistoryCompareRevisionsActionNotFoundCompareRevision(): void
@@ -3310,7 +3310,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('Foo'), $this->equalTo(123), $this->equalTo(789))
             ->willReturn(null);
 
-        $this->controller->historyCompareRevisionsAction(456, 789);
+        $this->controller->historyCompareRevisionsAction($this->request, 456, 789);
     }
 
     public function testHistoryCompareRevisionsActionAction(): void
@@ -3370,7 +3370,7 @@ class CRUDControllerTest extends TestCase
             ->method('getShow')
             ->willReturn($fieldDescriptionCollection);
 
-        $this->assertInstanceOf(Response::class, $this->controller->historyCompareRevisionsAction(456, 789));
+        $this->assertInstanceOf(Response::class, $this->controller->historyCompareRevisionsAction($this->request, 456, 789));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -3390,7 +3390,7 @@ class CRUDControllerTest extends TestCase
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Invalid request method given "GET", POST expected');
 
-        $this->controller->batchAction();
+        $this->controller->batchAction($this->request);
     }
 
     public function testBatchActionActionNotDefined(): void
@@ -3408,7 +3408,7 @@ class CRUDControllerTest extends TestCase
         $this->request->request->set('data', json_encode(['action' => 'foo', 'idx' => ['123', '456'], 'all_elements' => false]));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $this->controller->batchAction();
+        $this->controller->batchAction($this->request);
     }
 
     public function testBatchActionActionInvalidCsrfToken(): void
@@ -3418,7 +3418,7 @@ class CRUDControllerTest extends TestCase
         $this->request->request->set('_sonata_csrf_token', 'CSRF-INVALID');
 
         try {
-            $this->controller->batchAction();
+            $this->controller->batchAction($this->request);
         } catch (HttpException $e) {
             $this->assertSame('The csrf token is not valid, CSRF attack?', $e->getMessage());
             $this->assertSame(400, $e->getStatusCode());
@@ -3452,7 +3452,7 @@ class CRUDControllerTest extends TestCase
         $this->request->request->set('data', json_encode(['action' => 'foo', 'idx' => ['123', '456'], 'all_elements' => false]));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $this->controller->batchAction();
+        $this->controller->batchAction($this->request);
     }
 
     public function testBatchActionWithoutConfirmation(): void
@@ -3500,7 +3500,7 @@ class CRUDControllerTest extends TestCase
         $this->request->request->set('data', json_encode(['action' => 'delete', 'idx' => ['123', '456'], 'all_elements' => false]));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $result = $this->controller->batchAction();
+        $result = $this->controller->batchAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -3553,7 +3553,7 @@ class CRUDControllerTest extends TestCase
         $this->request->request->set('idx', ['123', '456']);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $result = $this->controller->batchAction();
+        $result = $this->controller->batchAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
@@ -3592,7 +3592,7 @@ class CRUDControllerTest extends TestCase
             ->method('getForm')
             ->willReturn($form);
 
-        $this->assertInstanceOf(Response::class, $this->controller->batchAction());
+        $this->assertInstanceOf(Response::class, $this->controller->batchAction($this->request));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -3633,7 +3633,7 @@ class CRUDControllerTest extends TestCase
         $this->request->request->set('idx', ['789']);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $result = $controller->batchAction();
+        $result = $controller->batchAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_empty'], $this->session->getFlashBag()->get('sonata_flash_info'));
@@ -3670,7 +3670,7 @@ class CRUDControllerTest extends TestCase
             ->method('getForm')
             ->willReturn($form);
 
-        $this->controller->batchAction();
+        $this->controller->batchAction($this->request);
 
         $this->assertSame('custom_template.html.twig', $this->template);
     }
@@ -3699,7 +3699,7 @@ class CRUDControllerTest extends TestCase
         $this->request->request->set('idx', ['999']);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $result = $controller->batchAction();
+        $result = $controller->batchAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_empty'], $this->session->getFlashBag()->get('sonata_flash_info'));
@@ -3727,7 +3727,7 @@ class CRUDControllerTest extends TestCase
         $this->request->request->set('idx', []);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $result = $this->controller->batchAction();
+        $result = $this->controller->batchAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_empty'], $this->session->getFlashBag()->get('sonata_flash_info'));
@@ -3772,7 +3772,7 @@ class CRUDControllerTest extends TestCase
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
         $this->expectTranslate('flash_batch_no_elements_processed', [], 'SonataAdminBundle');
-        $result = $controller->batchAction();
+        $result = $controller->batchAction($this->request);
 
         $this->assertInstanceOf(Response::class, $result);
         $this->assertRegExp('/Redirecting to list/', $result->getContent());
@@ -3824,7 +3824,7 @@ class CRUDControllerTest extends TestCase
         $this->request->request->set('foo', 'bar');
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        $result = $this->controller->batchAction();
+        $result = $this->controller->batchAction($this->request);
 
         $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Remove deprecations found in CRUDController

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is not BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Bump exporter to 2.1
### Removed
- `$id` parameter in actions of `CRUDController`
- `sonata.admin.exporter` service
```
I was wondering if it's better to leave the action with empty parameters or add `Request $request`, I'd add the request.