### PR TITLE
Fix some Twig deprecations

### DIFF
--- a/src/Resources/views/Core/dashboard.html.twig
+++ b/src/Resources/views/Core/dashboard.html.twig
@@ -16,36 +16,36 @@ file that was distributed with this source code.
 {% block content %}
 
     {% set has_left = false %}
-    {% for block in blocks.left if not has_left %}
-        {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
+    {% for block in blocks.left %}
+        {% if not has_left and (block.roles|length == 0 or is_granted_affirmative(block.roles)) %}
             {% set has_left = true %}
         {% endif %}
     {% endfor %}
 
     {% set has_center = false %}
-    {% for block in blocks.center if not has_center %}
-        {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
+    {% for block in blocks.center %}
+        {% if not has_center and (block.roles|length == 0 or is_granted_affirmative(block.roles)) %}
             {% set has_center = true %}
         {% endif %}
     {% endfor %}
 
     {% set has_right = false %}
-    {% for block in blocks.right if not has_right %}
-        {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
+    {% for block in blocks.right %}
+        {% if not has_right and (block.roles|length == 0 or is_granted_affirmative(block.roles)) %}
             {% set has_right = true %}
         {% endif %}
     {% endfor %}
 
     {% set has_top = false %}
-    {% for block in blocks.top if not has_top %}
-        {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
+    {% for block in blocks.top %}
+        {% if not has_top and (block.roles|length == 0 or is_granted_affirmative(block.roles)) %}
             {% set has_top = true %}
         {% endif %}
     {% endfor %}
 
     {% set has_bottom = false %}
-    {% for block in blocks.bottom if not has_bottom %}
-        {% if block.roles|length == 0 or is_granted_affirmative(block.roles) %}
+    {% for block in blocks.bottom %}
+        {% if not has_bottom and (block.roles|length == 0 or is_granted_affirmative(block.roles)) %}
             {% set has_bottom = true %}
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix some Twig deprecations.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes only apply to `master`.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Removed deprecated `{% for .. if .. %}` Twig clauses.
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
