### PR TITLE
Fix non-existent parameter

### DIFF
--- a/src/DependencyInjection/AbstractSonataAdminExtension.php
+++ b/src/DependencyInjection/AbstractSonataAdminExtension.php
@@ -79,6 +79,7 @@ abstract class AbstractSonataAdminExtension extends Extension
         ];
 
         $useIntlTemplates = $container->getParameter('sonata.admin.configuration.use_intl_templates');
+
         if ($useIntlTemplates) {
             $defaultConfig['templates']['types']['list'] = array_merge($defaultConfig['templates']['types']['list'], [
                 'date' => '@SonataAdmin/CRUD/Intl/list_date.html.twig',

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -88,9 +88,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
             $container->removeDefinition('sonata.admin.lock.extension');
         }
 
-        $useIntlTemplates = $config['use_intl_templates'] || isset($bundles['SonataIntlBundle']);
-
-        $container->setParameter('sonata.admin.configuration.use_intl_templates', $useIntlTemplates);
+        $useIntlTemplates = $container->getParameter('sonata.admin.configuration.use_intl_templates');
 
         if ($useIntlTemplates) {
             if ('@SonataAdmin/CRUD/history_revision_timestamp.html.twig' === $config['templates']['history_revision_timestamp']) {
@@ -211,12 +209,16 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
     {
         $bundles = $container->getParameter('kernel.bundles');
 
+        $configs = $container->getExtensionConfig($this->getAlias());
+        $config = $this->processConfiguration(new Configuration(), $configs);
+
+        $useIntlTemplates = $config['use_intl_templates'] || isset($bundles['SonataIntlBundle']);
+        $container->setParameter('sonata.admin.configuration.use_intl_templates', $useIntlTemplates);
+
         if (!isset($bundles['JMSDiExtraBundle'])) {
             return;
         }
 
-        $configs = $container->getExtensionConfig($this->getAlias());
-        $config = $this->processConfiguration(new Configuration(), $configs);
         if (!$config['options']['enable_jms_di_extra_autoregistration']) {
             return;
         }

--- a/tests/DependencyInjection/AbstractSonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/AbstractSonataAdminExtensionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
+use Sonata\AdminBundle\Tests\Fixtures\DependencyInjection\DummySonataAdminExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class AbstractSonataAdminExtensionTest extends TestCase
+{
+    public function testLoadIntlTemplates(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', []);
+        $container->prependExtensionConfig('sonata_admin', ['use_intl_templates' => true]);
+        $extension = new SonataAdminExtension();
+        $dummyExtension = new DummySonataAdminExtension();
+        $container->registerExtension($dummyExtension);
+        $container->registerExtension($extension);
+        $extension->prepend($container);
+        $dummyExtension->load([], $container);
+
+        $this->assertSame('@SonataAdmin/CRUD/Intl/list_date.html.twig', $dummyExtension->configs[0]['templates']['types']['list']['date']);
+    }
+}

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -75,6 +75,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $container = $this->getContainer();
         $container->removeAlias('translator');
         $container->removeDefinition('translator');
+        $this->extension->prepend($container);
         $this->extension->load([$this->config], $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();
@@ -88,6 +89,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
     public function testProcessParsingFullValidConfig(): void
     {
         $container = $this->getContainer();
+        $this->extension->prepend($container);
         $this->extension->load([$this->config], $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();
@@ -152,6 +154,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
     public function testProcessResultingConfig(): void
     {
         $container = $this->getContainer();
+        $this->extension->prepend($container);
         $this->extension->load([$this->config], $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();
@@ -246,6 +249,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $config['options']['sort_admins'] = true;
         unset($config['dashboard']['groups']);
 
+        $this->extension->prepend($container);
         $this->extension->load([$config], $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();
@@ -272,6 +276,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $container = $this->getContainer();
         $container->setParameter('sonata.admin.parameter.groupname', 'resolved_group_name');
 
+        $this->extension->prepend($container);
         $this->extension->load([$config], $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();
@@ -288,6 +293,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
     {
         $container = $this->getContainer();
 
+        $this->extension->prepend($container);
         $this->extension->load([$this->getConfig()], $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();
@@ -347,6 +353,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
     {
         $container = $this->getContainer();
 
+        $this->extension->prepend($container);
         $this->extension->load([$this->getConfig()], $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();
@@ -386,6 +393,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
             'route_params' => ['articleId' => 3],
         ];
 
+        $this->extension->prepend($container);
         $this->extension->load([$config], $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();
@@ -423,6 +431,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
             'roles' => ['ROLE_ONE'],
         ];
 
+        $this->extension->prepend($container);
         $this->extension->load([$config], $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();
@@ -440,6 +449,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $config = $this->config;
         $config['dashboard']['groups'] = [];
 
+        $this->extension->prepend($container);
         $this->extension->load([$config], $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();
@@ -462,6 +472,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $config = $this->config;
         $config['dashboard']['groups'] = [];
 
+        $this->extension->prepend($container);
         $this->extension->load([$config], $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();
@@ -487,6 +498,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $config = $this->config;
         $config['dashboard']['groups'] = [];
 
+        $this->extension->prepend($container);
         $this->extension->load([$config], $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();
@@ -515,6 +527,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $config = $this->config;
         $config['dashboard']['groups'] = [];
 
+        $this->extension->prepend($container);
         $this->extension->load([$config], $container);
 
         $compilerPass = new AddDependencyCallsCompilerPass();

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -66,7 +66,8 @@ class ExtensionCompilerPassTest extends TestCase
      */
     public function testAdminExtensionLoad(): void
     {
-        $this->extension->load([], $container = $this->getContainer());
+        $this->extension->prepend($container = $this->getContainer());
+        $this->extension->load([], $container);
 
         $this->assertTrue($container->hasParameter($this->root.'.extension.map'));
         $this->assertIsArray($extensionMap = $container->getParameter($this->root.'.extension.map'));
@@ -84,7 +85,8 @@ class ExtensionCompilerPassTest extends TestCase
      */
     public function testFlattenEmptyExtensionConfiguration(): void
     {
-        $this->extension->load([], $container = $this->getContainer());
+        $this->extension->prepend($container = $this->getContainer());
+        $this->extension->load([], $container);
         $extensionMap = $container->getParameter($this->root.'.extension.map');
 
         $method = new \ReflectionMethod(
@@ -116,7 +118,8 @@ class ExtensionCompilerPassTest extends TestCase
     public function testFlattenExtensionConfiguration(): void
     {
         $config = $this->getConfig();
-        $this->extension->load([$config], $container = $this->getContainer());
+        $this->extension->prepend($container = $this->getContainer());
+        $this->extension->load([$config], $container);
         $extensionMap = $container->getParameter($this->root.'.extension.map');
 
         $method = new \ReflectionMethod(
@@ -197,6 +200,7 @@ class ExtensionCompilerPassTest extends TestCase
         ];
 
         $container = $this->getContainer();
+        $this->extension->prepend($container);
         $this->extension->load([$config], $container);
 
         $extensionsPass = new ExtensionCompilerPass();
@@ -220,6 +224,7 @@ class ExtensionCompilerPassTest extends TestCase
         ];
 
         $container = $this->getContainer();
+        $this->extension->prepend($container);
         $this->extension->load([$config], $container);
 
         $extensionsPass = new ExtensionCompilerPass();
@@ -235,6 +240,7 @@ class ExtensionCompilerPassTest extends TestCase
     public function testProcess(): void
     {
         $container = $this->getContainer();
+        $this->extension->prepend($container);
         $this->extension->load([$this->config], $container);
 
         $extensionsPass = new ExtensionCompilerPass();
@@ -297,6 +303,7 @@ class ExtensionCompilerPassTest extends TestCase
         ];
 
         $container = $this->getContainer();
+        $this->extension->prepend($container);
         $this->extension->load([$config], $container);
 
         $extensionsPass = new ExtensionCompilerPass();

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -38,6 +38,7 @@ use Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy;
 use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
 use Sonata\AdminBundle\Translator\UnderscoreLabelTranslatorStrategy;
 use Sonata\AdminBundle\Twig\GlobalVariables;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class SonataAdminExtensionTest extends AbstractExtensionTestCase
 {
@@ -309,10 +310,15 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
 
     public function testLoadIntlTemplate(): void
     {
-        $this->load([
-            'use_intl_templates' => true,
-        ]);
-        $templates = $this->container->getParameter('sonata.admin.configuration.templates');
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', []);
+        $container->prependExtensionConfig('sonata_admin', ['use_intl_templates' => true]);
+        $extension = new SonataAdminExtension();
+        $extension->prepend($container);
+        $configs = $container->getExtensionConfig('sonata_admin');
+        $extension->load($configs, $container);
+
+        $templates = $container->getParameter('sonata.admin.configuration.templates');
         $this->assertSame('@SonataAdmin/CRUD/Intl/history_revision_timestamp.html.twig', $templates['history_revision_timestamp']);
     }
 

--- a/tests/Fixtures/DependencyInjection/DummySonataAdminExtension.php
+++ b/tests/Fixtures/DependencyInjection/DummySonataAdminExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Fixtures\DependencyInjection;
+
+use Sonata\AdminBundle\DependencyInjection\AbstractSonataAdminExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class DummySonataAdminExtension extends AbstractSonataAdminExtension
+{
+    /**
+     * @var array
+     */
+    public $configs;
+
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $this->configs = $this->fixTemplatesConfiguration($configs, $container);
+    }
+}


### PR DESCRIPTION
## Subject

[In AbstractSonataAdminExtension I added this line](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/DependencyInjection/AbstractSonataAdminExtension.php#L81):
```php
$useIntlTemplates = $container->getParameter('sonata.admin.configuration.use_intl_templates');
```
This is class is extended in other bundles, so the problem is that depending on the order of how the bundles are registered works or not (if the AdminBundle is registered first works).

I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5961

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Accessing to a non-existing parameter when extending `AbstractSonataAdminExtension`
```

I only could come up with this solution, any other way/help is appreciated. ~I can't take a further look until this evening/night.~