### PR TITLE
Fix bug with getLoginUrl()

### DIFF
--- a/docs/cookbook/recipe_sonata_admin_without_user_bundle.rst
+++ b/docs/cookbook/recipe_sonata_admin_without_user_bundle.rst
@@ -241,9 +241,9 @@ more about it `here <https://symfony.com/doc/current/security/guard_authenticati
             return new RedirectResponse($this->router->generate('admin_login'));
         }
 
-        protected function getLoginUrl(): RedirectResponse
+        protected function getLoginUrl(): string
         {
-            return new RedirectResponse($this->router->generate('admin_login'));
+            return $this->router->generate('admin_login');
         }
 
         public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey): RedirectResponse


### PR DESCRIPTION
PHPStan complains about `getLoginUrl`

```
------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   src/Security/AdminLoginAuthenticator.php
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  89     Return type (Symfony\Component\HttpFoundation\RedirectResponse) of method App\Security\AdminLoginAuthenticator::getLoginUrl() should be compatible with return type (string) of method Symfony\Component\Security\Guard\Authenticator\AbstractFormLoginAuthenticator::getLoginUrl()
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

This method should return a string, this is what abstract method requires

https://github.com/symfony/symfony/blob/c650fe6dfc15c9faf7756514ef5bdc490cb926f4/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php#L27-L32

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog


```markdown

### Fixed

- Make the guard's method `getLoginUrl()` compatible with its abstract class