### PR TITLE
Simplify code, make it more strict

### DIFF
--- a/docs/cookbook/recipe_sonata_admin_without_user_bundle.rst
+++ b/docs/cookbook/recipe_sonata_admin_without_user_bundle.rst
@@ -203,11 +203,7 @@ more about it `here <https://symfony.com/doc/current/security/guard_authenticati
 
         public function supports(Request $request): bool
         {
-            if ($request->getPathInfo() != '/admin/login' || $request->getMethod() != 'POST') {
-                return false;
-            }
-
-            return true;
+            return $request->attributes->get('_route') === 'admin_login' && $request->isMethod('POST');
         }
 
         public function getCredentials(Request $request): array


### PR DESCRIPTION
Before:

```php
public function supports(Request $request): bool
{
    if ($request->getPathInfo() != '/admin/login' || $request->getMethod() != 'POST') {
        return false;
    }
    return true;
}
```

After:

```php
public function supports(Request $request): bool
{
    return $request->attributes->get('_route') === 'admin_login' && $request->isMethod('POST');
}
```

And this is in line with the Symfony's style: see https://symfony.com/doc/current/security/guard_authentication.html#avoid-authenticating-the-browser-on-every-request
