### PR TITLE
Do not extend deprecated controller

### DIFF
--- a/docs/cookbook/recipe_sonata_admin_without_user_bundle.rst
+++ b/docs/cookbook/recipe_sonata_admin_without_user_bundle.rst
@@ -260,13 +260,13 @@ this will be handled by Symfony, but we still need to register that route::
 
     namespace App\Controller;
 
-    use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
     use App\Form\AdminLoginForm;
     use Symfony\Component\Routing\Annotation\Route;
     use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
     use Symfony\Component\HttpFoundation\Response;
 
-    final class AdminLoginController extends Controller
+    final class AdminLoginController extends AbstractController
     {
         /**
          * @var AuthenticationUtils


### PR DESCRIPTION
Class `Symfony\Bundle\FrameworkBundle\Controller\Controller' is deprecated:

```
@deprecated since Symfony 4.2, use "Symfony\Bundle\FrameworkBundle\Controller\AbstractController" instead.
```
