### PR TITLE
[Collection] initialize counter to -1 for starting items from 0

### DIFF
--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -368,7 +368,7 @@ var Admin = {
         var highestCounterRegexp = new RegExp('_([0-9]+)[^0-9]*$');
         jQuery(subject).find('[data-prototype]').each(function() {
             var collection = jQuery(this);
-            var counter = 0;
+            var counter = -1;
             collection.children().each(function() {
                 var matches = highestCounterRegexp.exec(jQuery('[id^="sonata-ba-field-container"]', this).attr('id'));
                 if (matches && matches[1] && matches[1] > counter) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

the first element of each collection starts with index `1` and not with `0`
ex:
```
my_form.my_collection[1]...
```

Form component works well and generates the child Form at position `1`:
![image](https://user-images.githubusercontent.com/4582866/76868638-80337e80-6867-11ea-9df8-e9a7bec1a925.png)

but on the validation process, validator validates a hydrated main object which has `object.myCollecton` array field that starts with index `0`, so a generated error is attached for the wrong path: 
```
data.my_collection[0]...
```
 
![image](https://user-images.githubusercontent.com/4582866/76869033-ffc14d80-6867-11ea-8f12-8e8da8c4ce1f.png)

What do you think about starting with index `0` for the first collection item?  

## Changelog

```markdown
### Changed
- [Collection][JS] update index of the first element in collection from 1 to 0 
```