### PR TITLE
[WIP] Allow Twig 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
         "sonata-project/block-bundle": "^4.0",
         "sonata-project/doctrine-extensions": "^1.4",
         "sonata-project/exporter": "^2.1",
-        "sonata-project/form-extensions": "^1.1.2",
-        "sonata-project/twig-extensions": "^1.1.1",
+        "sonata-project/form-extensions": "^1.2",
+        "sonata-project/twig-extensions": "^1.2",
         "symfony/asset": "^4.3",
         "symfony/config": "^4.3",
         "symfony/console": "^4.3",
@@ -55,10 +55,9 @@
         "symfony/twig-bridge": "^4.3",
         "symfony/twig-bundle": "^4.3",
         "symfony/validator": "^4.3",
-        "twig/extensions": "^1.5",
         "twig/extra-bundle": "^3.0",
         "twig/string-extra": "^3.0",
-        "twig/twig": "^2.12.1"
+        "twig/twig": "^2.12.1 || ^3.0"
     },
     "conflict": {
         "doctrine/doctrine-bundle": ">=3",

--- a/src/Resources/views/CRUD/base_edit.html.twig
+++ b/src/Resources/views/CRUD/base_edit.html.twig
@@ -13,17 +13,17 @@ file that was distributed with this source code.
 
 {% block title %}
     {% if objectId is not null %}
-        {{ 'title_edit'|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
+        {{ 'title_edit'|trans({'%name%': admin.toString(object)|sonata_truncate(15) }, 'SonataAdminBundle') }}
     {% else %}
-        {{ 'title_create'|trans({}, 'SonataAdminBundle')|truncate(15) }}
+        {{ 'title_create'|trans({}, 'SonataAdminBundle')|sonata_truncate(15) }}
     {% endif %}
 {% endblock %}
 
 {% block navbar_title %}
     {% if objectId is not null %}
-        {{ 'title_edit'|trans({'%name%': admin.toString(object)|truncate(100) }, 'SonataAdminBundle') }}
+        {{ 'title_edit'|trans({'%name%': admin.toString(object)|sonata_truncate(100) }, 'SonataAdminBundle') }}
     {% else %}
-        {{ 'title_create'|trans({}, 'SonataAdminBundle')|truncate(100) }}
+        {{ 'title_create'|trans({}, 'SonataAdminBundle')|sonata_truncate(100) }}
     {% endif %}
 {% endblock %}
 

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -23,11 +23,11 @@ file that was distributed with this source code.
 {%- endblock -%}
 
 {% block title %}
-    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject)|truncate(15) }, 'SonataAdminBundle') : '' }}
+    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject)|sonata_truncate(15) }, 'SonataAdminBundle') : '' }}
 {% endblock %}
 
 {% block navbar_title %}
-    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject)|truncate(100) }, 'SonataAdminBundle') : '' }}
+    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject)|sonata_truncate(100) }, 'SonataAdminBundle') : '' }}
 {% endblock %}
 
 {% block list_table %}

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -12,11 +12,11 @@ file that was distributed with this source code.
 {% extends base_template %}
 
 {% block title %}
-    {{ 'title_show'|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
+    {{ 'title_show'|trans({'%name%': admin.toString(object)|sonata_truncate(15) }, 'SonataAdminBundle') }}
 {% endblock %}
 
 {% block navbar_title %}
-    {{ 'title_show'|trans({'%name%': admin.toString(object)|truncate(100) }, 'SonataAdminBundle') }}
+    {{ 'title_show'|trans({'%name%': admin.toString(object)|sonata_truncate(100) }, 'SonataAdminBundle') }}
 {% endblock %}
 
 {%- block actions -%}

--- a/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
+++ b/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
@@ -59,7 +59,7 @@ This template can be customized to match your needs. You should only extends the
                             {% endif %}
 
                             {% block sonata_mosaic_description %}
-                                {{ meta.title|truncate(40) }}
+                                {{ meta.title|sonata_truncate(40) }}
                             {% endblock %}
                         </div>
                     </div>

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -169,15 +169,15 @@ file that was distributed with this source code.
                                                                         {% if menu.extra('safe_label', true) %}
                                                                             {{- label|raw -}}
                                                                         {% else %}
-                                                                            {{- label|truncate(100) -}}
+                                                                            {{- label|sonata_truncate(100) -}}
                                                                         {% endif %}
                                                                     </a>
                                                                 {% else %}
-                                                                    <span>{{ label|truncate(100) }}</span>
+                                                                    <span>{{ label|sonata_truncate(100) }}</span>
                                                                 {% endif %}
                                                             </li>
                                                         {% else %}
-                                                            <li class="active"><span>{{ label|truncate(100) }}</span></li>
+                                                            <li class="active"><span>{{ label|sonata_truncate(100) }}</span></li>
                                                         {% endif %}
                                                     {% endfor %}
                                                 {% endif %}

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -1,7 +1,4 @@
 services:
-    Twig\Extensions\TextExtension:
-        tags:
-            - {name: twig.extension}
     # Under real conditions, this service is registered by "doctrine/doctrine-bundle"
     database_connection:
         class: Sonata\AdminBundle\Tests\Fixtures\DoctrineBundle\Connection


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Allow Twig 3.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes can not be done at the stable branch.

Related to #5788, symfony/symfony#35649.
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for "twig/twig:^3.0".
```
## To do

- [x] Use stable versions of "sonata-project/form-extensions" and "sonata-project/twig-extensions" when released;
- [x] Ensure results from `StringExtension` is the same as `TextExtension`;
- [x] ~~Wait for the removal of "sonata-project/intl-bundle"~~.

When symfony/symfony#35649 is available in a stable release, we need to remove some of the stuff added in this PR and bump "symfony/string" to the version which ships them.
Regarding the Twig `truncate` filter, I had to make some slight modifications at test assertions since the new behavior differs a little bit from the previous one. Plus, I renamed "preserve" option to "cut", in order to be consistent with the term used at the String component (which also has the opposite behavior than "preserve").
In this way, I think we should deprecate the "preserve" option at the stable branch.