### PR TITLE
Create custom intl twig functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
         "symfony/twig-bundle": "^4.3",
         "symfony/validator": "^4.3",
         "twig/extensions": "^1.5",
-        "twig/extra-bundle": "^3.0",
         "twig/intl-extra": "^3.0",
         "twig/twig": "^2.12"
     },

--- a/src/DependencyInjection/AbstractSonataAdminExtension.php
+++ b/src/DependencyInjection/AbstractSonataAdminExtension.php
@@ -78,7 +78,9 @@ abstract class AbstractSonataAdminExtension extends Extension
             ],
         ];
 
-        $useIntlTemplates = $container->getParameter('sonata.admin.configuration.use_intl_templates');
+        $useIntlTemplates = $container->hasParameter('sonata.admin.configuration.use_intl_templates')
+            ? $container->getParameter('sonata.admin.configuration.use_intl_templates')
+            : false;
 
         if ($useIntlTemplates) {
             $defaultConfig['templates']['types']['list'] = array_merge($defaultConfig['templates']['types']['list'], [

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -91,6 +91,8 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $useIntlTemplates = $container->getParameter('sonata.admin.configuration.use_intl_templates');
 
         if ($useIntlTemplates) {
+            $loader->load('intl.xml');
+
             if ('@SonataAdmin/CRUD/history_revision_timestamp.html.twig' === $config['templates']['history_revision_timestamp']) {
                 $config['templates']['history_revision_timestamp'] = '@SonataAdmin/CRUD/Intl/history_revision_timestamp.html.twig';
             }

--- a/src/Resources/config/intl.xml
+++ b/src/Resources/config/intl.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Twig\Extra\Intl\IntlExtension"/>
+        <service id="Sonata\AdminBundle\Twig\Extension\IntlExtension">
+            <argument type="service" id="Twig\Extra\Intl\IntlExtension"/>
+            <tag name="twig.extension"/>
+        </service>
+    </services>
+</container>

--- a/src/Resources/views/CRUD/Intl/display_currency.html.twig
+++ b/src/Resources/views/CRUD/Intl/display_currency.html.twig
@@ -17,6 +17,6 @@ file that was distributed with this source code.
         {% set attributes = field_description.options.attributes|default({}) %}
         {% set locale = field_description.options.locale|default(null) %}
 
-        {{ value|format_currency(currency, attributes, locale) }}
+        {{ value|sonata_format_currency(currency, attributes, locale) }}
     {%- endif -%}
 {% endapply -%}

--- a/src/Resources/views/CRUD/Intl/display_date.html.twig
+++ b/src/Resources/views/CRUD/Intl/display_date.html.twig
@@ -20,7 +20,7 @@ file that was distributed with this source code.
         {% set dateType = field_description.options.dateType|default(null) %}
 
         <time datetime="{{ value|date('Y-m-d', 'UTC') }}" title="{{ value|date('Y-m-d', 'UTC') }}">
-            {{ value|format_date(dateType, pattern, timezone, calendar, locale) }}
+            {{ value|sonata_format_date(dateType, pattern, timezone, calendar, locale) }}
         </time>
     {%- endif -%}
 {% endapply -%}

--- a/src/Resources/views/CRUD/Intl/display_datetime.html.twig
+++ b/src/Resources/views/CRUD/Intl/display_datetime.html.twig
@@ -21,7 +21,7 @@ file that was distributed with this source code.
         {% set timeType = field_description.options.timeType|default(null) %}
 
         <time datetime="{{ value|date('c', 'UTC') }}" title="{{ value|date('c', 'UTC') }}">
-            {{ value|format_datetime(dateType, timeType, pattern, timezone, calendar, locale) }}
+            {{ value|sonata_format_datetime(dateType, timeType, pattern, timezone, calendar, locale) }}
         </time>
     {%- endif -%}
 {% endapply -%}

--- a/src/Resources/views/CRUD/Intl/display_decimal.html.twig
+++ b/src/Resources/views/CRUD/Intl/display_decimal.html.twig
@@ -17,6 +17,6 @@ file that was distributed with this source code.
         {% set locale = field_description.options.locale|default(null) %}
         {% set type = field_description.options.type|default('default') %}
 
-        {{ value | format_number(attributes, 'decimal', type, locale) }}
+        {{ value | sonata_format_number(attributes, 'decimal', type, locale) }}
     {%- endif -%}
 {% endapply -%}

--- a/src/Resources/views/CRUD/Intl/display_percent.html.twig
+++ b/src/Resources/views/CRUD/Intl/display_percent.html.twig
@@ -17,6 +17,6 @@ file that was distributed with this source code.
         {% set locale = field_description.options.locale|default(null) %}
         {% set type = field_description.options.type|default('default') %}
 
-        {{ value | format_number(attributes, 'percent', type, locale) }}
+        {{ value | sonata_format_number(attributes, 'percent', type, locale) }}
     {%- endif -%}
 {% endapply -%}

--- a/src/Twig/Extension/IntlExtension.php
+++ b/src/Twig/Extension/IntlExtension.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig\Extension;
+
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\Extra\Intl\IntlExtension as TwigIntlExtension;
+use Twig\TwigFilter;
+
+/**
+ * @internal
+ */
+final class IntlExtension extends AbstractExtension
+{
+    /**
+     * @var TwigIntlExtension
+     */
+    private $extension;
+
+    public function __construct(TwigIntlExtension $extension)
+    {
+        $this->extension = $extension;
+    }
+
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('sonata_format_currency', [$this, 'formatCurrency']),
+            new TwigFilter('sonata_format_number', [$this, 'formatNumber']),
+            new TwigFilter('sonata_format_datetime', [$this, 'formatDateTime'], ['needs_environment' => true]),
+            new TwigFilter('sonata_format_date', [$this, 'formatDate'], ['needs_environment' => true]),
+        ];
+    }
+
+    public function formatCurrency($amount, string $currency, array $attrs = [], string $locale = null): string
+    {
+        return $this->extension->formatCurrency($amount, $currency, $attrs, $locale);
+    }
+
+    public function formatNumber($number, array $attrs = [], string $style = 'decimal', string $type = 'default', string $locale = null): string
+    {
+        return $this->extension->formatNumber($number, $attrs, $style, $type, $locale);
+    }
+
+    public function formatDateTime(Environment $env, $date, ?string $dateFormat = 'medium', ?string $timeFormat = 'medium', string $pattern = '', $timezone = null, string $calendar = 'gregorian', string $locale = null): string
+    {
+        return $this->extension->formatDateTime($env, $date, $dateFormat, $timeFormat, $pattern, $timezone, $calendar, $locale);
+    }
+
+    public function formatDate(Environment $env, $date, ?string $dateFormat = 'medium', string $pattern = '', $timezone = null, string $calendar = 'gregorian', string $locale = null): string
+    {
+        return $this->extension->formatDateTime($env, $date, $dateFormat, 'none', $pattern, $timezone, $calendar, $locale);
+    }
+}

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -37,6 +37,7 @@ use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy;
 use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
 use Sonata\AdminBundle\Translator\UnderscoreLabelTranslatorStrategy;
+use Sonata\AdminBundle\Twig\Extension\IntlExtension;
 use Sonata\AdminBundle\Twig\GlobalVariables;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -320,6 +321,8 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
 
         $templates = $container->getParameter('sonata.admin.configuration.templates');
         $this->assertSame('@SonataAdmin/CRUD/Intl/history_revision_timestamp.html.twig', $templates['history_revision_timestamp']);
+
+        $this->assertTrue($container->hasDefinition(IntlExtension::class));
     }
 
     protected function getContainerExtensions(): array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There are conflicts using the last version of this bundle and `SonataIntlBundle` because both register twig functions with the same name and different signature. 

The only way I could come up with is removing `twig/extra-bundle`, so the `IntlExtension` from `twig/intl-extra` is not automatically registered anymore and I created our `IntlExtension` which decorates the Twig one and exposes only the methods we're using changing their names to `sonata_*`. 

The problem I see now is people using these functions in their projects and we should remove the in the next major version since this is a patch to make it work with `sonata/intl-bundle`. Don't know if there is a way to make twig functions as internal or something like that.

I am targeting this branch, because this is BC.

Closes https://github.com/sonata-project/SonataIntlBundle/issues/299

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- `twig/extra-bundle` dependency
### Fixed
- Compatibility with `sonata/intl-bundle`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

To test:

```shell
composer config repositories.franmomu vcs https://github.com/franmomu/SonataAdminBundle
composer require sonata-project/admin-bundle "dev-allow_intl_extension as 3.62.1"
```