### PR TITLE
Fix explicitly set use_intl_templates

### DIFF
--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -212,7 +212,9 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $configs = $container->getExtensionConfig($this->getAlias());
         $config = $this->processConfiguration(new Configuration(), $configs);
 
-        $useIntlTemplates = $config['use_intl_templates'] || isset($bundles['SonataIntlBundle']);
+        $defaultUseIntlTemplates = $config['use_intl_templates'] || isset($bundles['SonataIntlBundle']);
+        $useIntlTemplates = $this->getExplicitlyConfigured('use_intl_templates', $configs, $defaultUseIntlTemplates);
+
         $container->setParameter('sonata.admin.configuration.use_intl_templates', $useIntlTemplates);
 
         if (!isset($bundles['JMSDiExtraBundle'])) {
@@ -321,5 +323,19 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
 
         $modelChoice = $container->getDefinition('sonata.admin.form.type.model_choice');
         $modelChoice->replaceArgument(0, new Reference('form.property_accessor'));
+    }
+
+    /**
+     * @return mixed
+     */
+    private function getExplicitlyConfigured(string $property, array $configs, $defaultValue)
+    {
+        foreach ($configs as $config) {
+            if (isset($config[$property])) {
+                return $config[$property];
+            }
+        }
+
+        return $defaultValue;
     }
 }

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -335,7 +335,35 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $this->load();
 
         $templates = $this->container->getParameter('sonata.admin.configuration.templates');
-        $this->assertSame('@SonataAdmin/CRUD/Intl/history_revision_timestamp.html.twig', $templates['history_revision_timestamp']);
+        $this->assertSame(
+            '@SonataAdmin/CRUD/Intl/history_revision_timestamp.html.twig',
+            $templates['history_revision_timestamp']
+        );
+    }
+
+    public function testLoadIntlTemplateIfTheSonataIntlBundleIsEnabled(): void
+    {
+        $this->container->setParameter('kernel.bundles', ['SonataIntlBundle' => true]);
+        $this->load();
+
+        $templates = $this->container->getParameter('sonata.admin.configuration.templates');
+        $this->assertSame(
+            '@SonataAdmin/CRUD/Intl/history_revision_timestamp.html.twig',
+            $templates['history_revision_timestamp']
+        );
+    }
+
+    public function testDoNotLoadIntlTemplatesWithIntlBundleEnabledAndParameterSetToFalse(): void
+    {
+        $this->container->setParameter('kernel.bundles', ['SonataIntlBundle' => true]);
+        $this->container->prependExtensionConfig('sonata_admin', ['use_intl_templates' => false]);
+        $this->load();
+
+        $templates = $this->container->getParameter('sonata.admin.configuration.templates');
+        $this->assertSame(
+            '@SonataAdmin/CRUD/history_revision_timestamp.html.twig',
+            $templates['history_revision_timestamp']
+        );
     }
 
     protected function getContainerExtensions(): array

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Admin\BreadcrumbsBuilder;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Bridge\Exporter\AdminExporter;
+use Sonata\AdminBundle\DependencyInjection\Configuration;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
 use Sonata\AdminBundle\Event\AdminEventExtension;
 use Sonata\AdminBundle\Filter\FilterFactory;
@@ -38,35 +39,27 @@ use Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy;
 use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
 use Sonata\AdminBundle\Translator\UnderscoreLabelTranslatorStrategy;
 use Sonata\AdminBundle\Twig\GlobalVariables;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\Definition\Processor;
 
 class SonataAdminExtensionTest extends AbstractExtensionTestCase
 {
     /**
-     * @var string[]
+     * @var array
      */
-    private $defaultStylesheets = [];
-
-    /**
-     * @var string[]
-     */
-    private $defaultJavascripts = [];
+    private $defaultConfiguration = [];
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->container->setParameter('kernel.bundles', []);
-        $this->load();
-        $this->defaultStylesheets = $this->container
-            ->getDefinition('sonata.admin.pool')->getArgument(3)['stylesheets']
-        ;
-        $this->defaultJavascripts = $this->container
-            ->getDefinition('sonata.admin.pool')->getArgument(3)['javascripts']
-        ;
+
+        $this->defaultConfiguration = (new Processor())->processConfiguration(new Configuration(), []);
     }
 
     public function testHasCoreServicesAlias(): void
     {
+        $this->load();
+
         $this->assertContainerBuilderHasService(Pool::class);
         $this->assertContainerBuilderHasService(AdminPoolLoader::class);
         $this->assertContainerBuilderHasService(AdminHelper::class);
@@ -117,6 +110,8 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
             'JMSDiExtraBundle' => true,
         ]);
 
+        $this->load();
+
         $this->container->compile();
     }
 
@@ -166,15 +161,20 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
     public function testExtraStylesheetsGetAdded(): void
     {
         $this->container->setParameter('kernel.bundles', []);
+
         $extraStylesheets = ['foo/bar.css', 'bar/quux.css'];
         $this->load([
             'assets' => [
                 'extra_stylesheets' => $extraStylesheets,
             ],
         ]);
+
         $stylesheets = $this->container->getDefinition('sonata.admin.pool')->getArgument(3)['stylesheets'];
 
-        $this->assertSame(array_merge($this->defaultStylesheets, $extraStylesheets), $stylesheets);
+        $this->assertSame(
+            array_merge($this->defaultConfiguration['assets']['stylesheets'], $extraStylesheets),
+            $stylesheets
+        );
     }
 
     public function testRemoveStylesheetsGetRemoved(): void
@@ -191,7 +191,12 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
         ]);
         $stylesheets = $this->container->getDefinition('sonata.admin.pool')->getArgument(3)['stylesheets'];
 
-        $this->assertSame(array_values(array_diff($this->defaultStylesheets, $removeStylesheets)), $stylesheets);
+        $this->assertSame(
+            array_values(
+                array_diff($this->defaultConfiguration['assets']['stylesheets'], $removeStylesheets)
+            ),
+            $stylesheets
+        );
     }
 
     public function testExtraJavascriptsGetAdded(): void
@@ -205,7 +210,10 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
         ]);
         $javascripts = $this->container->getDefinition('sonata.admin.pool')->getArgument(3)['javascripts'];
 
-        $this->assertSame(array_merge($this->defaultJavascripts, $extraJavascripts), $javascripts);
+        $this->assertSame(
+            array_merge($this->defaultConfiguration['assets']['javascripts'], $extraJavascripts),
+            $javascripts
+        );
     }
 
     public function testRemoveJavascriptsGetRemoved(): void
@@ -222,7 +230,12 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
         ]);
         $javascripts = $this->container->getDefinition('sonata.admin.pool')->getArgument(3)['javascripts'];
 
-        $this->assertSame(array_values(array_diff($this->defaultJavascripts, $removeJavascripts)), $javascripts);
+        $this->assertSame(
+            array_values(
+                array_diff($this->defaultConfiguration['assets']['javascripts'], $removeJavascripts)
+            ),
+            $javascripts
+        );
     }
 
     public function testAssetsCanBeAddedAndRemoved(): void
@@ -251,20 +264,28 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
         ;
 
         $this->assertSame(
-            array_merge(array_diff($this->defaultStylesheets, $removeStylesheets), $extraStylesheets),
+            array_merge(
+                array_diff($this->defaultConfiguration['assets']['stylesheets'], $removeStylesheets),
+                $extraStylesheets
+            ),
             $stylesheets
         );
 
         $javascripts = $this->container->getDefinition('sonata.admin.pool')->getArgument(3)['javascripts'];
 
         $this->assertSame(
-            array_merge(array_diff($this->defaultJavascripts, $removeJavascripts), $extraJavascripts),
+            array_merge(
+                array_diff($this->defaultConfiguration['assets']['javascripts'], $removeJavascripts),
+                $extraJavascripts
+            ),
             $javascripts
         );
     }
 
     public function testDefaultTemplates(): void
     {
+        $this->load();
+
         $this->assertSame([
             'user_block' => '@SonataAdmin/Core/user_block.html.twig',
             'add_block' => '@SonataAdmin/Core/add_block.html.twig',
@@ -310,15 +331,10 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
 
     public function testLoadIntlTemplate(): void
     {
-        $container = new ContainerBuilder();
-        $container->setParameter('kernel.bundles', []);
-        $container->prependExtensionConfig('sonata_admin', ['use_intl_templates' => true]);
-        $extension = new SonataAdminExtension();
-        $extension->prepend($container);
-        $configs = $container->getExtensionConfig('sonata_admin');
-        $extension->load($configs, $container);
+        $this->container->prependExtensionConfig('sonata_admin', ['use_intl_templates' => true]);
+        $this->load();
 
-        $templates = $container->getParameter('sonata.admin.configuration.templates');
+        $templates = $this->container->getParameter('sonata.admin.configuration.templates');
         $this->assertSame('@SonataAdmin/CRUD/Intl/history_revision_timestamp.html.twig', $templates['history_revision_timestamp']);
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataAdminBundle/issues/5977

Basically, when `use_intl_templates` was explicitly set to `false` but with `SonataIntlBundle` enabled, it kept loading the intl templates.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5977

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Setting explicitly `use_intl_templates` to `false` does not load the intl templates
```

To test:
```shell
composer config repositories.franmomu vcs https://github.com/franmomu/SonataAdminBundle
composer require sonata-project/admin-bundle "dev-fix_override_use_intl_templates as 3.62.1"
```
PS: I'll try later to add the missing services to https://github.com/sonata-project/SonataAdminBundle/pull/5975 