### PR TITLE
[WIP] Deprecate "truncate.preserve" option

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,33 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated the `truncate.preserve` option in views
+
+You should use the `truncate.cut` option instead, which has `false` as its default value
+and the opposite behavior:
+
+Before:
+```php
+$showMapper
+    ->add('field', null, [
+        'truncate' => [
+            'preserve' => true,
+        ],
+    ])
+;
+```
+
+After:
+```php
+$showMapper
+    ->add('field', null, [
+        'truncate' => [
+            'cut' => false,
+        ],
+    ])
+;
+```
+
 ## Deprecated not setting "sonata.admin.manager" tag in model manager services
 
 If you are using [autoconfiguration](https://symfony.com/doc/4.4/service_container.html#the-autoconfigure-option),

--- a/docs/reference/field_types.rst
+++ b/docs/reference/field_types.rst
@@ -198,7 +198,7 @@ Parameter                   Description
 **strip**                   Strip HTML and PHP tags from a string
 **truncate**                Truncate a string to ``length`` characters beginning from start. Implies strip. Beware of HTML entities. Make sure to configure your HTML editor to disable entities if you want to use truncate. For instance, use `config.entities <http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-entities>`_ for ckeditor
 **truncate.length**         The length to truncate the string to (default ``30``)
-**truncate.preserve**       Preserve whole words (default ``false``)
+**truncate.cut**            Determines if whole words must be cut (default ``true``)
 **truncate.separator**      Separator to be appended to the trimmed string (default ``...``)
 ========================    ==================================================================
 
@@ -236,7 +236,7 @@ Parameter                   Description
             // `Creating a Template for the Field...`
             ->add('content', 'html', [
                 'truncate' => [
-                    'preserve' => true
+                    'cut' => false
                 ]
             ])
 
@@ -253,7 +253,7 @@ Parameter                   Description
             ->add('content', 'html', [
                 'truncate' => [
                     'length' => 20,
-                    'preserve' => true,
+                    'cut' => false,
                     'separator' => '***'
                 ]
             ])

--- a/src/Resources/views/CRUD/list_html.html.twig
+++ b/src/Resources/views/CRUD/list_html.html.twig
@@ -7,9 +7,12 @@
         {%- if field_description.options.truncate is defined -%}
             {% set truncate = field_description.options.truncate %}
             {% set length = truncate.length|default(30) %}
-            {% set preserve = truncate.preserve|default(false) %}
+            {% if truncate.preserve is defined %}
+                {% deprecated 'The "truncate.preserve" option is deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0. Use "truncate.cut" instead.' %}
+            {% endif %}
+            {% set cut = truncate.cut is defined ? truncate.cut : (truncate.preserve is defined ? truncate.preserve != true : true) %}
             {% set separator = truncate.separator|default('...') %}
-            {{ value|striptags|truncate(length, preserve, separator)|raw }}
+            {{ value|striptags|truncate(length, cut == false, separator)|raw }}
         {%- else -%}
             {%- if field_description.options.strip is defined -%}
                 {% set value = value|striptags %}

--- a/src/Resources/views/CRUD/show_html.html.twig
+++ b/src/Resources/views/CRUD/show_html.html.twig
@@ -7,9 +7,12 @@
         {%- if field_description.options.truncate is defined -%}
             {% set truncate = field_description.options.truncate %}
             {% set length = truncate.length|default(30) %}
-            {% set preserve = truncate.preserve|default(false) %}
+            {% if truncate.preserve is defined %}
+                {% deprecated 'The "truncate.preserve" option is deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0. Use "truncate.cut" instead.' %}
+            {% endif %}
+            {% set cut = truncate.cut is defined ? truncate.cut : (truncate.preserve is defined ? truncate.preserve != true : true) %}
             {% set separator = truncate.separator|default('...') %}
-            {{ value|striptags|truncate(length, preserve, separator)|raw }}
+            {{ value|striptags|truncate(length, cut == false, separator)|raw }}
         {%- else -%}
             {%- if field_description.options.strip is defined -%}
                 {% set value = value|striptags %}

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -1291,7 +1291,7 @@ EOT
                 </td>',
                 'html',
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
-                ['truncate' => ['preserve' => true]],
+                ['truncate' => ['cut' => false]],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345">
@@ -1310,7 +1310,7 @@ EOT
                 [
                     'truncate' => [
                         'length' => 20,
-                        'preserve' => true,
+                        'cut' => false,
                         'separator' => '[...]',
                     ],
                 ],
@@ -1962,7 +1962,7 @@ EOT
                 '<th>Data</th> <td> Creating a Template for the Field... </td>',
                 'html',
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
-                ['truncate' => ['preserve' => true]],
+                ['truncate' => ['cut' => false]],
             ],
             [
                 '<th>Data</th> <td> Creating a Template for the Fi etc. </td>',
@@ -1977,7 +1977,7 @@ EOT
                 [
                     'truncate' => [
                         'length' => 20,
-                        'preserve' => true,
+                        'cut' => false,
                         'separator' => '[...]',
                     ],
                 ],
@@ -2079,6 +2079,76 @@ EOT
                         'less' => 'Less',
                     ],
                     'safe' => false,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     *
+     * @dataProvider getDeprecatedTruncateOptions
+     *
+     * @expectedDeprecation The "truncate.preserve" option is deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0. Use "truncate.cut" instead. ("@SonataAdmin/CRUD/show_html.html.twig" at line %d).
+     */
+    public function testDeprecatedTruncatePreserve(string $expected, string $type, $value, array $options): void
+    {
+        $this->admin
+            ->method('getTemplate')
+            ->willReturn('@SonataAdmin/CRUD/base_show_field.html.twig');
+
+        $this->fieldDescription
+            ->method('getValue')
+            ->willReturn($value);
+
+        $this->fieldDescription
+            ->method('getType')
+            ->willReturn($type);
+
+        $this->fieldDescription
+            ->method('getOptions')
+            ->willReturn($options);
+
+        $this->fieldDescription
+            ->method('getTemplate')
+            ->willReturn('@SonataAdmin/CRUD/show_html.html.twig');
+
+        $this->assertSame(
+            $this->removeExtraWhitespace($expected),
+            $this->removeExtraWhitespace(
+                $this->twigExtension->renderViewElement(
+                    $this->environment,
+                    $this->fieldDescription,
+                    $this->object
+                )
+            )
+        );
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
+    public function getDeprecatedTruncateOptions(): iterable
+    {
+        yield from [
+            [
+                '<th>Data</th> <td> Creating a Template for the Field... </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                ['truncate' => ['preserve' => true]],
+            ],
+            [
+                '<th>Data</th> <td> Creating a Template for[...] </td>',
+                'html',
+                '<p><strong>Creating a Template for the Field</strong> and form</p>',
+                [
+                    'truncate' => [
+                        'length' => 20,
+                        'preserve' => true,
+                        'separator' => '[...]',
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Deprecate "truncate.preserve" option in views.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Triggered by #5973.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added "truncate.cut" option in `list_html.html.twig` and `show_html.html.twig` views.

### Deprecated
- Deprecated "truncate.preserve" option in `list_html.html.twig` and `show_html.html.twig` views.
```