### PR TITLE
Add missing `UnicodeStringTest`

### DIFF
--- a/tests/Twig/Extension/UnicodeStringTest.php
+++ b/tests/Twig/Extension/UnicodeStringTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Twig\Extension\UnicodeString;
+use Symfony\Component\String\Exception\InvalidArgumentException;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+final class UnicodeStringTest extends TestCase
+{
+    public function testCreateFromStringWithInvalidUtf8Input(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        static::createFromString("\xE9");
+    }
+
+    public function testAscii(): void
+    {
+        $s = static::createFromString('Dieser Wert sollte größer oder gleich');
+        $this->assertSame('Dieser Wert sollte grosser oder gleich', (string) $s->ascii());
+        $this->assertSame('Dieser Wert sollte groesser oder gleich', (string) $s->ascii(['de-ASCII']));
+    }
+
+    /**
+     * @dataProvider provideTruncate
+     */
+    public function testTruncate(string $expected, string $origin, int $length, string $ellipsis, bool $preserve = false): void
+    {
+        $instance = static::createFromString($origin)->truncate($length, $ellipsis, $preserve);
+
+        $this->assertSame((string) static::createFromString($expected), (string) $instance);
+    }
+
+    public static function provideTruncate(): iterable
+    {
+        yield from [
+            ['', '', 3, ''],
+            ['', 'foo', 0, '...'],
+            ['foo', 'foo', 0, '...', true],
+            ['fo', 'foobar', 2, ''],
+            ['foobar', 'foobar', 10, ''],
+            ['foobar', 'foobar', 10, '...', true],
+            ['foo', 'foo', 3, '...'],
+            ['fo', 'foobar', 2, '...'],
+            ['...', 'foobar', 3, '...'],
+            ['fo...', 'foobar', 5, '...'],
+            ['foobar...', 'foobar foo', 6, '...', true],
+            ['foobar...', 'foobar foo', 7, '...', true],
+            ['foobar foo...', 'foobar foo a', 10, '...', true],
+        ];
+    }
+
+    /**
+     * @dataProvider wordwrapProvider
+     */
+    public function testWordwrap(string $expected, string $actual, int $length, string $break, bool $cut = false): void
+    {
+        $instance = static::createFromString($actual);
+        $actual = $instance->wordwrap($length, $break, $cut);
+
+        $this->assertSame((string) $expected, (string) $actual);
+    }
+
+    public function wordwrapProvider(): iterable
+    {
+        yield from [
+            [
+                'Lo-re-m-Ip-su-m',
+                'Lorem Ipsum',
+                2,
+                '-',
+                true,
+            ],
+            [
+                'Lorem-Ipsum',
+                'Lorem Ipsum',
+                2,
+                '-',
+            ],
+            [
+                'Lor-em-Ips-um',
+                'Lorem Ipsum',
+                3,
+                '-',
+                true,
+            ],
+            [
+                'L-o-r-e-m-I-p-s-u-m',
+                'Lorem Ipsum',
+                1,
+                '-',
+                true,
+            ],
+        ];
+    }
+
+    private static function createFromString(string $string): UnicodeString
+    {
+        return new UnicodeString($string);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Add missing `UnicodeStringTest` (#5983).

Seems that I forgot to stage this file while working at that PR.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to #5983.