### PR TITLE
Remove some deprecations

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -529,12 +529,9 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         $this->datagridValues['_per_page'] = $this->maxPerPage;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getExportFormats()
+    public function getExportFormats(): array
     {
-        return null;
+        return [];
     }
 
     /**
@@ -741,10 +738,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      * value (ie the parent object) or to filter the object.
      *
      * @throws \InvalidArgumentException
-     *
-     * @return string|null
      */
-    public function getParentAssociationMapping()
+    public function getParentAssociationMapping(): ?string
     {
         if (!$this->getParent()) {
             return null;
@@ -763,11 +758,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         ));
     }
 
-    /**
-     * @param string $code
-     * @param string $value
-     */
-    final public function addParentAssociationMapping($code, $value): void
+    final public function addParentAssociationMapping(string $code, string $value): void
     {
         $this->parentAssociationMapping[$code] = $value;
     }
@@ -871,7 +862,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return $this->cachedBaseRouteName;
     }
 
-    public function getClass()
+    public function getClass(): string
     {
         if ($this->hasActiveSubClass()) {
             if ($this->getParentFieldDescription()) {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -737,7 +737,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      * Returns the name of the parent related field, so the field can be use to set the default
      * value (ie the parent object) or to filter the object.
      *
-     * @throws \InvalidArgumentException
+     * @throws \DomainException
      */
     public function getParentAssociationMapping(): ?string
     {
@@ -751,7 +751,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
             return $this->parentAssociationMapping[$parent];
         }
 
-        throw new \InvalidArgumentException(sprintf(
+        throw new \DomainException(sprintf(
             'There\'s no association between "%s" and "%s".',
             $this->getCode(),
             $this->getParent()->getCode()

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2630,24 +2630,12 @@ EOT;
     }
 
     /**
-     * NEXT_MAJOR: remove this method.
-     *
-     * @deprecated Use configureTabMenu instead
-     */
-    protected function configureSideMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
-    {
-    }
-
-    /**
      * Configures the tab menu in your admin.
      *
      * @param string $action
      */
     protected function configureTabMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
     {
-        // Use configureSideMenu not to mess with previous overrides
-        // NEXT_MAJOR: remove this line
-        $this->configureSideMenu($menu, $action, $childAdmin);
     }
 
     /**

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -47,15 +47,8 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     {
     }
 
-    public function configureSideMenu(AdminInterface $admin, MenuItemInterface $menu, $action, AdminInterface $childAdmin = null): void
-    {
-    }
-
     public function configureTabMenu(AdminInterface $admin, MenuItemInterface $menu, $action, AdminInterface $childAdmin = null): void
     {
-        // Use configureSideMenu not to mess with previous overrides
-        // NEXT_MAJOR: remove this line
-        $this->configureSideMenu($admin, $menu, $action, $childAdmin);
     }
 
     public function validate(AdminInterface $admin, ErrorElement $errorElement, $object): void

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -55,7 +55,7 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     {
     }
 
-    public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list'): void
+    public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query): void
     {
     }
 

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -54,10 +54,7 @@ interface AdminExtensionInterface
      */
     public function validate(AdminInterface $admin, ErrorElement $errorElement, $object);
 
-    /**
-     * @param string $context
-     */
-    public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list');
+    public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query): void;
 
     /**
      * Get a chance to modify a newly created instance.

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -38,22 +38,6 @@ interface AdminExtensionInterface
     public function configureRoutes(AdminInterface $admin, RouteCollection $collection);
 
     /**
-     * DEPRECATED: Use configureTabMenu instead.
-     *
-     * NEXT_MAJOR: remove this method.
-     *
-     * @param string $action
-     *
-     * @deprecated
-     */
-    public function configureSideMenu(
-        AdminInterface $admin,
-        MenuItemInterface $menu,
-        $action,
-        AdminInterface $childAdmin = null
-    );
-
-    /**
      * Builds the tab menu.
      *
      * @param string $action

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -223,7 +223,7 @@ class AdminHelper
      *
      * @param object $object
      *
-     * @throws \RuntimeException
+     * @throws \BadMethodCallException
      */
     public function addNewInstance($object, FieldDescriptionInterface $fieldDescription): void
     {
@@ -235,10 +235,7 @@ class AdminHelper
             $method = sprintf('get%s', Inflector::classify($parentMapping['fieldName']));
 
             if (!(\is_callable([$object, $method]) && method_exists($object, $method))) {
-                /*
-                 * NEXT_MAJOR: Use BadMethodCallException instead
-                 */
-                throw new \RuntimeException(
+                throw new \BadMethodCallException(
                     sprintf('Method %s::%s() does not exist.', ClassUtils::getClass($object), $method)
                 );
             }
@@ -255,10 +252,7 @@ class AdminHelper
                 $method = sprintf('add%s', Inflector::classify(Inflector::singularize($mapping['fieldName'])));
 
                 if (!(\is_callable([$object, $method]) && method_exists($object, $method))) {
-                    /*
-                     * NEXT_MAJOR: Use BadMethodCallException instead
-                     */
-                    throw new \RuntimeException(
+                    throw new \BadMethodCallException(
                         sprintf('Method %s::%s() does not exist.', ClassUtils::getClass($object), $method)
                     );
                 }

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -74,10 +74,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * - subclass name if subclass parameter is defined
      * - subject class name if subject is defined
      * - class name if not.
-     *
-     * @return string
      */
-    public function getClass();
+    public function getClass(): string;
 
     public function attachAdminClass(FieldDescriptionInterface $fieldDescription);
 
@@ -384,7 +382,7 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      *
      * @return string[]
      */
-    public function getExportFormats();
+    public function getExportFormats(): array;
 
     /**
      * Retuns a list of exported fields.

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -123,12 +123,7 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function getManagerType();
 
-    /**
-     * @param string $context NEXT_MAJOR: remove this argument
-     *
-     * @return ProxyQueryInterface
-     */
-    public function createQuery($context = 'list');
+    public function createQuery(): ProxyQueryInterface;
 
     /**
      * @return FormBuilderInterface the form builder
@@ -548,13 +543,6 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * Returns list of supported sub classes.
      */
     public function getSubClasses(): array;
-
-    /**
-     * Adds a new class to a list of supported sub classes.
-     *
-     * @param $subClass
-     */
-    public function addSubClass($subClass);
 
     /**
      * Sets the list of supported sub classes.

--- a/src/Admin/ParentAdminInterface.php
+++ b/src/Admin/ParentAdminInterface.php
@@ -25,7 +25,7 @@ interface ParentAdminInterface
     /**
      * add an Admin child to the current one.
      */
-    public function addChild(AdminInterface $child);
+    public function addChild(AdminInterface $child, string $parentMappingField);
 
     /**
      * Returns true or false if an Admin child exists for the given $code.

--- a/src/Bridge/Exporter/AdminExporter.php
+++ b/src/Bridge/Exporter/AdminExporter.php
@@ -45,7 +45,7 @@ final class AdminExporter
     {
         $adminExportFormats = $admin->getExportFormats();
 
-        if (null !== $adminExportFormats) {
+        if (!empty($adminExportFormats)) {
             return $adminExportFormats;
         }
 

--- a/src/Bridge/Exporter/AdminExporter.php
+++ b/src/Bridge/Exporter/AdminExporter.php
@@ -45,7 +45,7 @@ final class AdminExporter
     {
         $adminExportFormats = $admin->getExportFormats();
 
-        if (!empty($adminExportFormats)) {
+        if ([] !== $adminExportFormats) {
             return $adminExportFormats;
         }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -527,12 +527,6 @@ CASESENSITIVE;
                     ->info('Show mosaic button on all admin screens')
                 ->end()
 
-                // NEXT_MAJOR : remove this option
-                ->booleanNode('translate_group_label')
-                    ->defaultFalse()
-                    ->info('Translate group label')
-                ->end()
-
             ->end()
         ->end();
 

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -191,8 +191,6 @@ final class SonataAdminExtension extends Extension
 
         $container->setParameter('sonata.admin.configuration.show.mosaic.button', $config['show_mosaic_button']);
 
-        $container->setParameter('sonata.admin.configuration.translate_group_label', $config['translate_group_label']);
-
         $this->replacePropertyAccessor($container);
 
         $container

--- a/src/Event/AdminEventExtension.php
+++ b/src/Event/AdminEventExtension.php
@@ -69,10 +69,10 @@ class AdminEventExtension extends AbstractAdminExtension
         );
     }
 
-    public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list'): void
+    public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query): void
     {
         $this->eventDispatcher->dispatch(
-            new ConfigureQueryEvent($admin, $query, $context),
+            new ConfigureQueryEvent($admin, $query),
             'sonata.admin.event.configure.query'
         );
     }

--- a/src/Event/ConfigureQueryEvent.php
+++ b/src/Event/ConfigureQueryEvent.php
@@ -41,19 +41,10 @@ class ConfigureQueryEvent extends Event
      */
     protected $proxyQuery;
 
-    /**
-     * @var string
-     */
-    protected $context;
-
-    /**
-     * @param string $context
-     */
-    public function __construct(AdminInterface $admin, ProxyQueryInterface $proxyQuery, $context)
+    public function __construct(AdminInterface $admin, ProxyQueryInterface $proxyQuery)
     {
         $this->admin = $admin;
         $this->proxyQuery = $proxyQuery;
-        $this->context = $context;
     }
 
     /**
@@ -62,14 +53,6 @@ class ConfigureQueryEvent extends Event
     public function getAdmin()
     {
         return $this->admin;
-    }
-
-    /**
-     * @return string
-     */
-    public function getContext()
-    {
-        return $this->context;
     }
 
     /**

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -299,7 +299,7 @@ class FormMapper extends BaseGroupedMapper
         $this->admin->setFormTabs($tabs);
     }
 
-    protected function getName()
+    protected function getName(): string
     {
         return 'form';
     }

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -254,10 +254,7 @@ abstract class BaseGroupedMapper extends BaseMapper
 
     abstract protected function setTabs(array $tabs);
 
-    /**
-     * @return string
-     */
-    abstract protected function getName();
+    abstract protected function getName(): string;
 
     /**
      * Add the field name to the current group.

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Mapper;
 
-use Sonata\AdminBundle\Admin\AbstractAdmin;
-
 /**
  * This class is used to simulate the Form API.
  *
@@ -76,21 +74,13 @@ abstract class BaseGroupedMapper extends BaseMapper
             'collapsed' => false,
             'class' => false,
             'description' => false,
-            'label' => $name, // NEXT_MAJOR: Remove this line and uncomment the next one
-//            'label' => $this->admin->getLabelTranslatorStrategy()->getLabel($name, $this->getName(), 'group'),
+            'label' => $this->admin->getLabelTranslatorStrategy()->getLabel($name, $this->getName(), 'group'),
             'translation_domain' => null,
             'name' => $name,
             'box_class' => 'box box-primary',
             'empty_message' => 'message_form_group_empty',
             'empty_message_translation_domain' => 'SonataAdminBundle',
         ];
-
-        // NEXT_MAJOR: remove this code
-        if ($this->admin instanceof AbstractAdmin && $pool = $this->admin->getConfigurationPool()) {
-            if ($pool->getContainer()->getParameter('sonata.admin.configuration.translate_group_label')) {
-                $defaultOptions['label'] = $this->admin->getLabelTranslatorStrategy()->getLabel($name, $this->getName(), 'group');
-            }
-        }
 
         $code = $name;
 
@@ -265,16 +255,9 @@ abstract class BaseGroupedMapper extends BaseMapper
     abstract protected function setTabs(array $tabs);
 
     /**
-     * NEXT_MAJOR: make this method abstract.
-     *
      * @return string
      */
-    protected function getName()
-    {
-        @trigger_error(__METHOD__.' should be implemented and will be abstract in 4.0.', E_USER_DEPRECATED);
-
-        return 'default';
-    }
+    abstract protected function getName();
 
     /**
      * Add the field name to the current group.

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -183,7 +183,7 @@ class ShowMapper extends BaseGroupedMapper
         $this->admin->setShowTabs($tabs);
     }
 
-    protected function getName()
+    protected function getName(): string
     {
         return 'show';
     }

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -286,7 +286,7 @@ class AdminTest extends TestCase
 
     public function testGetParentAssociationMappingThrowsExceptionWithWrongNoAssociation(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\DomainException::class);
 
         $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
         $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1132,7 +1132,7 @@ class AdminTest extends TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
-        $this->assertNull($admin->getExportFormats());
+        $this->assertEmpty($admin->getExportFormats());
     }
 
     public function testGetUrlsafeIdentifier(): void
@@ -2054,8 +2054,9 @@ class AdminTest extends TestCase
 
         $admin = $this->getMockBuilder(AbstractAdmin::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getDatagrid', 'getTranslationLabel', 'trans'])
+            ->setMethods(['getDatagrid', 'getTranslationLabel', 'trans', 'getClass'])
             ->getMockForAbstractClass();
+        $admin->method('getClass')->willReturn(AbstractAdmin::class);
         $admin->method('getDatagrid')->willReturn($datagrid);
         $admin->setModelManager($modelManager);
 

--- a/tests/Bridge/Exporter/AdminExporterTest.php
+++ b/tests/Bridge/Exporter/AdminExporterTest.php
@@ -24,7 +24,7 @@ class AdminExporterTest extends TestCase
     public function provideExportFormats()
     {
         return [
-            'no override' => [['xls'], null, ['xls']],
+            'no override' => [['xls'], [], ['xls']],
             'override in admin' => [['csv'], ['csv'], ['xls']],
         ];
     }

--- a/tests/Event/ConfigureQueryEventTest.php
+++ b/tests/Event/ConfigureQueryEventTest.php
@@ -43,11 +43,6 @@ class ConfigureQueryEventTest extends TestCase
         $this->event = new ConfigureQueryEvent($this->admin, $this->proxyQuery, 'Foo');
     }
 
-    public function testGetContext(): void
-    {
-        $this->assertSame('Foo', $this->event->getContext());
-    }
-
     public function testGetAdmin(): void
     {
         $result = $this->event->getAdmin();

--- a/tests/Fixtures/Admin/AbstractDummyGroupedMapper.php
+++ b/tests/Fixtures/Admin/AbstractDummyGroupedMapper.php
@@ -17,7 +17,7 @@ use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
 
 abstract class AbstractDummyGroupedMapper extends BaseGroupedMapper
 {
-    protected function getName()
+    protected function getName(): string
     {
         return 'dummy';
     }

--- a/tests/Fixtures/Admin/CommentAdmin.php
+++ b/tests/Fixtures/Admin/CommentAdmin.php
@@ -27,9 +27,4 @@ class CommentAdmin extends AbstractAdmin
     {
         $collection->remove('edit');
     }
-
-    public function setParentAssociationMapping($associationMapping): void
-    {
-        $this->parentAssociationMapping = $associationMapping;
-    }
 }

--- a/tests/Fixtures/Admin/PostAdmin.php
+++ b/tests/Fixtures/Admin/PostAdmin.php
@@ -17,12 +17,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 
 class PostAdmin extends AbstractAdmin
 {
-    protected $metadataClass = null;
-
-    public function setParentAssociationMapping($associationMapping): void
-    {
-        $this->parentAssociationMapping = $associationMapping;
-    }
+    protected $classMetaData;
 
     public function setClassMetaData($classMetaData): void
     {

--- a/tests/Fixtures/Admin/TagAdmin.php
+++ b/tests/Fixtures/Admin/TagAdmin.php
@@ -17,7 +17,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 
 class TagAdmin extends AbstractAdmin
 {
-    public function getParentAssociationMapping()
+    public function getParentAssociationMapping(): ?string
     {
         if ($this->getParent() instanceof PostAdmin) {
             return 'posts';

--- a/tests/Fixtures/Translator/DummyLabelTranslatorStrategy.php
+++ b/tests/Fixtures/Translator/DummyLabelTranslatorStrategy.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Translator;
+
+use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
+
+final class DummyLabelTranslatorStrategy implements LabelTranslatorStrategyInterface
+{
+    public function getLabel($label, $context = '', $type = ''): string
+    {
+        return (string) $label;
+    }
+}

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -21,36 +21,36 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CleanAdmin;
-use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
+use Sonata\AdminBundle\Tests\Fixtures\Translator\DummyLabelTranslatorStrategy;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\ResolvedFormTypeInterface;
 
-class FormMapperTest extends TestCase
+final class FormMapperTest extends TestCase
 {
     private const DEFAULT_GRANTED_ROLE = 'ROLE_ADMIN_BAZ';
 
     /**
      * @var FormContractorInterface
      */
-    protected $contractor;
+    private $contractor;
 
     /**
      * @var AdminInterface
      */
-    protected $admin;
+    private $admin;
 
     /**
      * @var ModelManagerInterface
      */
-    protected $modelManager;
+    private $modelManager;
 
     /**
      * @var FormMapper
      */
-    protected $formMapper;
+    private $formMapper;
 
     protected function setUp(): void
     {
@@ -85,8 +85,7 @@ class FormMapperTest extends TestCase
 
         $this->admin->setModelManager($this->modelManager);
 
-        $labelTranslatorStrategy = $this->getMockForAbstractClass(LabelTranslatorStrategyInterface::class);
-        $this->admin->setLabelTranslatorStrategy($labelTranslatorStrategy);
+        $this->admin->setLabelTranslatorStrategy(new DummyLabelTranslatorStrategy());
 
         $this->formMapper = new FormMapper(
             $this->contractor,

--- a/tests/Mapper/BaseGroupedMapperTest.php
+++ b/tests/Mapper/BaseGroupedMapperTest.php
@@ -27,14 +27,21 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class BaseGroupedMapperTest extends TestCase
+final class BaseGroupedMapperTest extends TestCase
 {
     /**
      * @var BaseGroupedMapper
      */
     protected $baseGroupedMapper;
 
+    /**
+     * @var array
+     */
     private $tabs;
+
+    /**
+     * @var array
+     */
     private $groups;
 
     public function setUp(): void
@@ -214,27 +221,16 @@ class BaseGroupedMapperTest extends TestCase
     public function labelDataProvider(): array
     {
         return [
-            'nominal use case not translated' => [false, 'default', 'fooGroup1', null, 'fooGroup1'],
-            'nominal use case translated' => [true, 'label_default', 'fooGroup1', null, 'label_foogroup1'],
-            'custom label not translated' => [false, 'default', 'fooGroup1', 'custom_label', 'custom_label'],
-            'custom label translated' => [true, 'label_default', 'fooGroup1', 'custom_label', 'custom_label'],
+            'nominal use case translated' => ['label_default', 'fooGroup1', null, 'label_foogroup1'],
+            'custom label translated' => ['label_default', 'fooGroup1', 'custom_label', 'custom_label'],
         ];
     }
 
     /**
      * @dataProvider labelDataProvider
      */
-    public function testLabel(bool $parameter, string $translated, string $name, ?string $label, string $expectedLabel): void
+    public function testLabel(string $translated, string $name, ?string $label, string $expectedLabel): void
     {
-        $container = $this->baseGroupedMapper
-            ->getAdmin()
-            ->getConfigurationPool()
-            ->getContainer();
-
-        $container
-            ->method('getParameter')
-            ->willReturn($parameter);
-
         $options = [];
 
         if (null !== $label) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Remove some deprecations in `master` branch to be able to release a major version some day.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this breaks BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- `AdminInterface::addChild` method to allow a second parameter to indicate the parent mapping field
### Removed
- `persistFilters` and `persistFilters` properties in `AbstractAdmin`
- `$context` parameter in `AdminInterface::createQuery`
- `AdminInterface::addSubClass` method
- `AdminExtensionInterface::configureSideMenu` method
- `translate_group_label` option from configuration
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
