### PR TITLE
Modernize controller references

### DIFF
--- a/docs/reference/dashboard.rst
+++ b/docs/reference/dashboard.rst
@@ -7,7 +7,7 @@ as defined by your ``Admin`` services. This is useful to help you start using
 advantage of the Dashboard.
 
 The Dashboard is, by default, available at ``/admin/dashboard``, which is handled by
-the ``SonataAdminBundle:Core:dashboard`` controller action. The default view file for
+the ``Sonata\AdminBundle\Action\DashboardAction`` controller action. The default view file for
 this action is ``@SonataAdmin/Core/dashboard.html.twig``, but you can change
 this in your admin configuration:
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -93,7 +93,7 @@ class AdminTest extends TestCase
     public function testConstructor(): void
     {
         $class = 'Application\Sonata\NewsBundle\Entity\Post';
-        $baseControllerName = 'SonataNewsBundle:PostAdmin';
+        $baseControllerName = 'Sonata\NewsBundle\Controller\PostAdminController';
 
         $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
         $this->assertInstanceOf(AbstractAdmin::class, $admin);
@@ -104,7 +104,7 @@ class AdminTest extends TestCase
     public function testGetClass(): void
     {
         $class = Post::class;
-        $baseControllerName = 'SonataNewsBundle:PostAdmin';
+        $baseControllerName = 'Sonata\NewsBundle\Controller\PostAdminController';
 
         $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
 
@@ -131,7 +131,7 @@ class AdminTest extends TestCase
         $this->expectExceptionMessage('Feature not implemented: an embedded admin cannot have subclass');
 
         $class = 'Application\Sonata\NewsBundle\Entity\Post';
-        $baseControllerName = 'SonataNewsBundle:PostAdmin';
+        $baseControllerName = 'Sonata\NewsBundle\Controller\PostAdminController';
 
         $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
         $admin->setParentFieldDescription(new FieldDescription());
@@ -145,7 +145,7 @@ class AdminTest extends TestCase
         $admin = new PostAdmin(
             'sonata.post.admin.post',
             'Application\Sonata\NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $this->expectException(
             \InvalidArgumentException::class
@@ -161,7 +161,7 @@ class AdminTest extends TestCase
         $admin = new PostAdmin(
             'sonata.post.admin.post',
             'Application\Sonata\NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $securityHandler = $this->prophesize(SecurityHandlerInterface::class);
         $securityHandler->isGranted($admin, 'CUSTOM_ROLE', $admin)->willReturn(true);
@@ -186,7 +186,7 @@ class AdminTest extends TestCase
         $admin = new PostAdmin(
             'sonata.post.admin.post',
             'Application\Sonata\NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
 
         $this->assertFalse($admin->hasAccess('made-up'));
@@ -197,7 +197,7 @@ class AdminTest extends TestCase
         $admin = new PostAdmin(
             'sonata.post.admin.post',
             'Application\Sonata\NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $securityHandler = $this->prophesize(SecurityHandlerInterface::class);
         $securityHandler->isGranted($admin, 'CUSTOM_ROLE', $admin)->willReturn(true);
@@ -217,7 +217,7 @@ class AdminTest extends TestCase
         $admin = new PostAdmin(
             'sonata.post.admin.post',
             'Application\Sonata\NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $securityHandler = $this->prophesize(SecurityHandlerInterface::class);
         $securityHandler->isGranted($admin, 'CUSTOM_ROLE', $admin)->willReturn(true);
@@ -237,7 +237,7 @@ class AdminTest extends TestCase
         $admin = new PostAdmin(
             'sonata.post.admin.post',
             'Application\Sonata\NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $securityHandler = $this->prophesize(SecurityHandlerInterface::class);
         $securityHandler->isGranted($admin, 'EDIT_ROLE', $admin)->willReturn(true);
@@ -261,11 +261,11 @@ class AdminTest extends TestCase
      */
     public function testChildren(): void
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $this->assertFalse($postAdmin->hasChildren());
         $this->assertFalse($postAdmin->hasChild('comment'));
 
-        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
+        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentAdminController');
         $postAdmin->addChild($commentAdmin, 'post');
 
         $this->assertTrue($postAdmin->hasChildren());
@@ -287,14 +287,14 @@ class AdminTest extends TestCase
      */
     public function testConfigure(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $this->assertNotNull($admin->getUniqid());
 
         $admin->initialize();
         $this->assertNotNull($admin->getUniqid());
         $this->assertSame('Post', $admin->getClassnameLabel());
 
-        $admin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
+        $admin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentAdminController');
         $admin->setClassnameLabel('postcomment');
 
         $admin->initialize();
@@ -303,7 +303,7 @@ class AdminTest extends TestCase
 
     public function testConfigureWithValidParentAssociationMapping(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->setParentAssociationMapping('Category');
 
         $admin->initialize();
@@ -381,7 +381,7 @@ class AdminTest extends TestCase
      */
     public function testGetBaseRoutePattern(string $objFqn, string $expected): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', $objFqn, 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', $objFqn, 'Sonata\NewsBundle\Controller\PostAdminController');
         $this->assertSame($expected, $admin->getBaseRoutePattern());
     }
 
@@ -390,8 +390,8 @@ class AdminTest extends TestCase
      */
     public function testGetBaseRoutePatternWithChildAdmin(string $objFqn, string $expected): void
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', $objFqn, 'SonataNewsBundle:PostAdmin');
-        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
+        $postAdmin = new PostAdmin('sonata.post.admin.post', $objFqn, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentAdminController');
         $commentAdmin->setParent($postAdmin);
 
         $this->assertSame($expected.'/{id}/comment', $commentAdmin->getBaseRoutePattern());
@@ -402,16 +402,16 @@ class AdminTest extends TestCase
      */
     public function testGetBaseRoutePatternWithTwoNestedChildAdmin(string $objFqn, string $expected): void
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', $objFqn, 'SonataNewsBundle:PostAdmin');
+        $postAdmin = new PostAdmin('sonata.post.admin.post', $objFqn, 'Sonata\NewsBundle\Controller\PostAdminController');
         $commentAdmin = new CommentAdmin(
             'sonata.post.admin.comment',
             'Application\Sonata\NewsBundle\Entity\Comment',
-            'SonataNewsBundle:CommentAdmin'
+            'Sonata\NewsBundle\Controller\CommentAdminController'
         );
         $commentVoteAdmin = new CommentVoteAdmin(
             'sonata.post.admin.comment_vote',
             'Application\Sonata\NewsBundle\Entity\CommentVote',
-            'SonataNewsBundle:CommentVoteAdmin'
+            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
         );
         $commentAdmin->setParent($postAdmin);
         $commentVoteAdmin->setParent($commentAdmin);
@@ -421,15 +421,15 @@ class AdminTest extends TestCase
 
     public function testGetBaseRoutePatternWithSpecifedPattern(): void
     {
-        $postAdmin = new PostWithCustomRouteAdmin('sonata.post.admin.post_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostWithCustomRouteAdmin');
+        $postAdmin = new PostWithCustomRouteAdmin('sonata.post.admin.post_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostWithCustomRouteAdminController');
 
         $this->assertSame('/post-custom', $postAdmin->getBaseRoutePattern());
     }
 
     public function testGetBaseRoutePatternWithChildAdminAndWithSpecifedPattern(): void
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-        $commentAdmin = new CommentWithCustomRouteAdmin('sonata.post.admin.comment_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentWithCustomRouteAdmin');
+        $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
+        $commentAdmin = new CommentWithCustomRouteAdmin('sonata.post.admin.comment_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentWithCustomRouteAdminController');
         $commentAdmin->setParent($postAdmin);
 
         $this->assertSame('/sonata/news/post/{id}/comment-custom', $commentAdmin->getBaseRoutePattern());
@@ -439,7 +439,7 @@ class AdminTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $admin = new PostAdmin('sonata.post.admin.post', 'News\Thing\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'News\Thing\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->getBaseRoutePattern();
     }
 
@@ -514,7 +514,7 @@ class AdminTest extends TestCase
      */
     public function testGetBaseRouteName(string $objFqn, string $expected): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', $objFqn, 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', $objFqn, 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame($expected, $admin->getBaseRouteName());
     }
@@ -535,7 +535,7 @@ class AdminTest extends TestCase
         $pool = new Pool($container, 'Sonata Admin', '/path/to/pic.png');
 
         $pathInfo = new PathInfoBuilder($this->createMock(AuditManagerInterface::class));
-        $postAdmin = new PostAdmin('sonata.post.admin.post', $objFqn, 'SonataNewsBundle:PostAdmin');
+        $postAdmin = new PostAdmin('sonata.post.admin.post', $objFqn, 'Sonata\NewsBundle\Controller\PostAdminController');
         $container->set('sonata.post.admin.post', $postAdmin);
         $postAdmin->setConfigurationPool($pool);
         $postAdmin->setRouteBuilder($pathInfo);
@@ -545,7 +545,7 @@ class AdminTest extends TestCase
         $commentAdmin = new CommentAdmin(
             'sonata.post.admin.comment',
             'Application\Sonata\NewsBundle\Entity\Comment',
-            'SonataNewsBundle:CommentAdmin'
+            'Sonata\NewsBundle\Controller\CommentAdminController'
         );
         $container->set('sonata.post.admin.comment', $commentAdmin);
         $commentAdmin->setConfigurationPool($pool);
@@ -558,7 +558,7 @@ class AdminTest extends TestCase
         $commentVoteAdmin = new CommentVoteAdmin(
             'sonata.post.admin.comment_vote',
             'Application\Sonata\NewsBundle\Entity\CommentVote',
-            'SonataNewsBundle:CommentVoteAdmin'
+            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
         );
 
         $container->set('sonata.post.admin.comment_vote', $commentVoteAdmin);
@@ -614,21 +614,21 @@ class AdminTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $admin = new PostAdmin('sonata.post.admin.post', 'News\Thing\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'News\Thing\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->getBaseRouteName();
     }
 
     public function testGetBaseRouteNameWithSpecifiedName(): void
     {
-        $postAdmin = new PostWithCustomRouteAdmin('sonata.post.admin.post_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $postAdmin = new PostWithCustomRouteAdmin('sonata.post.admin.post_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame('post_custom', $postAdmin->getBaseRouteName());
     }
 
     public function testGetBaseRouteNameWithChildAdminAndWithSpecifiedName(): void
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
-        $commentAdmin = new CommentWithCustomRouteAdmin('sonata.post.admin.comment_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentWithCustomRouteAdmin');
+        $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
+        $commentAdmin = new CommentWithCustomRouteAdmin('sonata.post.admin.comment_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentWithCustomRouteAdminController');
         $commentAdmin->setParent($postAdmin);
 
         $this->assertSame('admin_sonata_news_post_comment_custom', $commentAdmin->getBaseRouteName());
@@ -639,17 +639,17 @@ class AdminTest extends TestCase
         $postAdmin = new PostAdmin(
             'sonata.post.admin.post',
             'Application\Sonata\NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $commentAdmin = new CommentWithCustomRouteAdmin(
             'sonata.post.admin.comment_with_custom_route',
             'Application\Sonata\NewsBundle\Entity\Comment',
-            'SonataNewsBundle:CommentWithCustomRouteAdmin'
+            'Sonata\NewsBundle\Controller\CommentWithCustomRouteAdminController'
         );
         $commentVoteAdmin = new CommentVoteAdmin(
             'sonata.post.admin.comment_vote',
             'Application\Sonata\NewsBundle\Entity\CommentVote',
-            'SonataNewsBundle:CommentVoteAdmin'
+            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
         );
         $commentAdmin->setParent($postAdmin);
         $commentVoteAdmin->setParent($commentAdmin);
@@ -663,7 +663,7 @@ class AdminTest extends TestCase
      */
     public function testSetUniqid(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $uniqid = uniqid();
         $admin->setUniqid($uniqid);
@@ -673,7 +673,7 @@ class AdminTest extends TestCase
 
     public function testToString(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $s = new \stdClass();
 
@@ -691,11 +691,11 @@ class AdminTest extends TestCase
 
     public function testIsAclEnabled(): void
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $postAdmin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertFalse($postAdmin->isAclEnabled());
 
-        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
+        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentAdminController');
         $commentAdmin->setSecurityHandler($this->createMock(AclSecurityHandlerInterface::class));
         $this->assertTrue($commentAdmin->isAclEnabled());
     }
@@ -720,7 +720,7 @@ class AdminTest extends TestCase
         $admin = new PostAdmin(
             'sonata.post.admin.post',
             Post::class,
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $this->assertFalse($admin->hasSubClass('test'));
         $this->assertFalse($admin->hasActiveSubClass());
@@ -785,7 +785,7 @@ class AdminTest extends TestCase
     public function testNonExistantSubclass(): void
     {
         // NEXT_MAJOR: Remove the "@group" and "@expectedDeprecation" annotations
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->setModelManager($this->getMockForAbstractClass(ModelManagerInterface::class));
 
         $admin->setRequest(new Request(['subclass' => 'inject']));
@@ -804,7 +804,7 @@ class AdminTest extends TestCase
      */
     public function testOnlyOneSubclassNeededToBeActive(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->setSubClasses(['extended1' => 'NewsBundle\Entity\PostExtended1']);
         $request = new Request(['subclass' => 'extended1']);
         $admin->setRequest($request);
@@ -820,14 +820,14 @@ class AdminTest extends TestCase
         $admin = new PostAdmin(
             'sonata.post.admin.post',
             Post::class,
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $admin->addSubClass('whatever');
     }
 
     public function testGetPerPageOptions(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $perPageOptions = $admin->getPerPageOptions();
 
@@ -841,7 +841,7 @@ class AdminTest extends TestCase
 
     public function testGetLabelTranslatorStrategy(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getLabelTranslatorStrategy());
 
@@ -852,7 +852,7 @@ class AdminTest extends TestCase
 
     public function testGetRouteBuilder(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getRouteBuilder());
 
@@ -863,7 +863,7 @@ class AdminTest extends TestCase
 
     public function testGetMenuFactory(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getMenuFactory());
 
@@ -874,7 +874,7 @@ class AdminTest extends TestCase
 
     public function testGetExtensions(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame([], $admin->getExtensions());
 
@@ -888,7 +888,7 @@ class AdminTest extends TestCase
 
     public function testGetFilterTheme(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame([], $admin->getFilterTheme());
 
@@ -898,7 +898,7 @@ class AdminTest extends TestCase
 
     public function testGetFormTheme(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame([], $admin->getFormTheme());
 
@@ -909,7 +909,7 @@ class AdminTest extends TestCase
 
     public function testGetValidator(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getValidator());
 
@@ -921,7 +921,7 @@ class AdminTest extends TestCase
 
     public function testGetSecurityHandler(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getSecurityHandler());
 
@@ -932,7 +932,7 @@ class AdminTest extends TestCase
 
     public function testGetSecurityInformation(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame([], $admin->getSecurityInformation());
 
@@ -947,7 +947,7 @@ class AdminTest extends TestCase
 
     public function testGetManagerType(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getManagerType());
 
@@ -957,7 +957,7 @@ class AdminTest extends TestCase
 
     public function testGetModelManager(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getModelManager());
 
@@ -974,7 +974,7 @@ class AdminTest extends TestCase
      */
     public function testGetBaseCodeRoute(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame('', $admin->getBaseCodeRoute());
 
@@ -988,12 +988,12 @@ class AdminTest extends TestCase
     //     $postAdmin = new PostAdmin(
     //         'sonata.post.admin.post',
     //         'NewsBundle\Entity\Post',
-    //         'SonataNewsBundle:PostAdmin'
+    //         'Sonata\NewsBundle\Controller\PostAdminController'
     //     );
     //     $commentAdmin = new CommentAdmin(
     //         'sonata.post.admin.comment',
     //         'Application\Sonata\NewsBundle\Entity\Comment',
-    //         'SonataNewsBundle:CommentAdmin'
+    //         'Sonata\NewsBundle\Controller\CommentAdminController'
     //     );
     //
     //     $this->assertSame($postAdmin->getCode(), $postAdmin->getBaseCodeRoute());
@@ -1008,7 +1008,7 @@ class AdminTest extends TestCase
 
     public function testGetRouteGenerator(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getRouteGenerator());
 
@@ -1020,7 +1020,7 @@ class AdminTest extends TestCase
 
     public function testGetConfigurationPool(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getConfigurationPool());
 
@@ -1034,7 +1034,7 @@ class AdminTest extends TestCase
 
     public function testGetShowBuilder(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getShowBuilder());
 
@@ -1046,7 +1046,7 @@ class AdminTest extends TestCase
 
     public function testGetListBuilder(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getListBuilder());
 
@@ -1058,7 +1058,7 @@ class AdminTest extends TestCase
 
     public function testGetDatagridBuilder(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getDatagridBuilder());
 
@@ -1070,7 +1070,7 @@ class AdminTest extends TestCase
 
     public function testGetFormContractor(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getFormContractor());
 
@@ -1082,7 +1082,7 @@ class AdminTest extends TestCase
 
     public function testGetRequest(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertFalse($admin->hasRequest());
 
@@ -1098,13 +1098,13 @@ class AdminTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The Request object has not been set');
 
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->getRequest();
     }
 
     public function testGetTranslationDomain(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame('messages', $admin->getTranslationDomain());
 
@@ -1117,7 +1117,7 @@ class AdminTest extends TestCase
      */
     public function testGetTranslator(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getTranslator());
 
@@ -1129,7 +1129,7 @@ class AdminTest extends TestCase
 
     public function testGetShowGroups(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertFalse($admin->getShowGroups());
 
@@ -1141,7 +1141,7 @@ class AdminTest extends TestCase
 
     public function testGetFormGroups(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertFalse($admin->getFormGroups());
 
@@ -1153,7 +1153,7 @@ class AdminTest extends TestCase
 
     public function testGetMaxPageLinks(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame(25, $admin->getMaxPageLinks());
 
@@ -1163,7 +1163,7 @@ class AdminTest extends TestCase
 
     public function testGetMaxPerPage(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame(32, $admin->getMaxPerPage());
 
@@ -1173,7 +1173,7 @@ class AdminTest extends TestCase
 
     public function testGetLabel(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertNull($admin->getLabel());
 
@@ -1183,17 +1183,17 @@ class AdminTest extends TestCase
 
     public function testGetBaseController(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
-        $this->assertSame('SonataNewsBundle:PostAdmin', $admin->getBaseControllerName());
+        $this->assertSame('Sonata\NewsBundle\Controller\PostAdminController', $admin->getBaseControllerName());
 
-        $admin->setBaseControllerName('SonataNewsBundle:FooAdmin');
-        $this->assertSame('SonataNewsBundle:FooAdmin', $admin->getBaseControllerName());
+        $admin->setBaseControllerName('Sonata\NewsBundle\Controller\FooAdminController');
+        $this->assertSame('Sonata\NewsBundle\Controller\FooAdminController', $admin->getBaseControllerName());
     }
 
     public function testGetTemplates(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $templates = [
             'list' => '@FooAdmin/CRUD/list.html.twig',
@@ -1211,7 +1211,7 @@ class AdminTest extends TestCase
 
     public function testGetTemplate1(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
         $templateRegistry->getTemplate('edit')->shouldBeCalled()->willReturn('@FooAdmin/CRUD/edit.html.twig');
@@ -1228,7 +1228,7 @@ class AdminTest extends TestCase
         $postAdmin = new PostAdmin(
             'sonata.post.admin.post',
             'NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
 
         $this->assertSame('id', $postAdmin->getIdParameter());
@@ -1237,7 +1237,7 @@ class AdminTest extends TestCase
         $commentAdmin = new CommentAdmin(
             'sonata.post.admin.comment',
             'Application\Sonata\NewsBundle\Entity\Comment',
-            'SonataNewsBundle:CommentAdmin'
+            'Sonata\NewsBundle\Controller\CommentAdminController'
         );
         $commentAdmin->setParent($postAdmin);
 
@@ -1247,7 +1247,7 @@ class AdminTest extends TestCase
         $commentVoteAdmin = new CommentVoteAdmin(
             'sonata.post.admin.comment_vote',
             'Application\Sonata\NewsBundle\Entity\CommentVote',
-            'SonataNewsBundle:CommentVoteAdmin'
+            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
         );
         $commentVoteAdmin->setParent($commentAdmin);
 
@@ -1257,14 +1257,14 @@ class AdminTest extends TestCase
 
     public function testGetExportFormats(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame(['json', 'xml', 'csv', 'xls'], $admin->getExportFormats());
     }
 
     public function testGetUrlsafeIdentifier(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $entity = new \stdClass();
 
@@ -1280,7 +1280,7 @@ class AdminTest extends TestCase
 
     public function testDeterminedPerPageValue(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertFalse($admin->determinedPerPageValue('foo'));
         $this->assertFalse($admin->determinedPerPageValue(123));
@@ -1293,7 +1293,7 @@ class AdminTest extends TestCase
 
     public function testIsGranted(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $entity = new \stdClass();
 
@@ -1327,14 +1327,14 @@ class AdminTest extends TestCase
 
     public function testSupportsPreviewMode(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertFalse($admin->supportsPreviewMode());
     }
 
     public function testGetPermissionsShow(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame(['LIST'], $admin->getPermissionsShow(AbstractAdmin::CONTEXT_DASHBOARD));
         $this->assertSame(['LIST'], $admin->getPermissionsShow(AbstractAdmin::CONTEXT_MENU));
@@ -1343,7 +1343,7 @@ class AdminTest extends TestCase
 
     public function testShowIn(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $securityHandler = $this->createMock(AclSecurityHandlerInterface::class);
         $securityHandler
@@ -1361,7 +1361,7 @@ class AdminTest extends TestCase
 
     public function testGetObjectIdentifier(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'Acme\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame('sonata.post.admin.post', $admin->getObjectIdentifier());
     }
@@ -1371,7 +1371,7 @@ class AdminTest extends TestCase
      */
     public function testTrans(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->setTranslationDomain('fooMessageDomain');
 
         $translator = $this->createMock(TranslatorInterface::class);
@@ -1390,7 +1390,7 @@ class AdminTest extends TestCase
      */
     public function testTransWithMessageDomain(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $translator = $this->createMock(TranslatorInterface::class);
         $admin->setTranslator($translator);
@@ -1408,7 +1408,7 @@ class AdminTest extends TestCase
      */
     public function testTransChoice(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->setTranslationDomain('fooMessageDomain');
 
         $translator = $this->createMock(TranslatorInterface::class);
@@ -1427,7 +1427,7 @@ class AdminTest extends TestCase
      */
     public function testTransChoiceWithMessageDomain(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $translator = $this->createMock(TranslatorInterface::class);
         $admin->setTranslator($translator);
@@ -1457,11 +1457,11 @@ class AdminTest extends TestCase
 
     public function testGetRootCode(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame('sonata.post.admin.post', $admin->getRootCode());
 
-        $parentAdmin = new PostAdmin('sonata.post.admin.post.parent', 'NewsBundle\Entity\PostParent', 'SonataNewsBundle:PostParentAdmin');
+        $parentAdmin = new PostAdmin('sonata.post.admin.post.parent', 'NewsBundle\Entity\PostParent', 'Sonata\NewsBundle\Controller\PostParentAdminController');
         $parentFieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $parentFieldDescription->expects($this->once())
             ->method('getAdmin')
@@ -1475,11 +1475,11 @@ class AdminTest extends TestCase
 
     public function testGetRoot(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertSame($admin, $admin->getRoot());
 
-        $parentAdmin = new PostAdmin('sonata.post.admin.post.parent', 'NewsBundle\Entity\PostParent', 'SonataNewsBundle:PostParentAdmin');
+        $parentAdmin = new PostAdmin('sonata.post.admin.post.parent', 'NewsBundle\Entity\PostParent', 'Sonata\NewsBundle\Controller\PostParentAdminController');
         $parentFieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $parentFieldDescription->expects($this->once())
             ->method('getAdmin')
@@ -1493,7 +1493,7 @@ class AdminTest extends TestCase
 
     public function testGetExportFields(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelManager->expects($this->once())
@@ -1507,7 +1507,7 @@ class AdminTest extends TestCase
 
     public function testGetPersistentParametersWithNoExtension(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $this->assertEmpty($admin->getPersistentParameters());
     }
@@ -1516,7 +1516,7 @@ class AdminTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $extension = $this->createMock(AdminExtensionInterface::class);
         $extension->expects($this->once())->method('getPersistentParameters')->willReturn(null);
@@ -1532,7 +1532,7 @@ class AdminTest extends TestCase
             'context' => 'foobar',
         ];
 
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $extension = $this->createMock(AdminExtensionInterface::class);
         $extension->expects($this->once())->method('getPersistentParameters')->willReturn($expected);
@@ -1590,7 +1590,7 @@ class AdminTest extends TestCase
 
     public function testFormAddPostSubmitEventForPreValidation(): void
     {
-        $modelAdmin = new ModelAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'SonataFooBundle:ModelAdmin');
+        $modelAdmin = new ModelAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'Sonata\FooBundle\Controller\ModelAdminController');
         $object = new \stdClass();
 
         $labelTranslatorStrategy = $this->createMock(LabelTranslatorStrategyInterface::class);
@@ -1661,7 +1661,7 @@ class AdminTest extends TestCase
             ],
         ];
 
-        $admin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->setFormGroups($formGroups);
 
         $admin->removeFieldFromFormGroup('foo');
@@ -1681,9 +1681,9 @@ class AdminTest extends TestCase
     {
         $authorId = uniqid();
 
-        $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
-        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
+        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentAdminController');
         $commentAdmin->setParentAssociationMapping('post.author');
         $commentAdmin->setParent($postAdmin);
 
@@ -1720,7 +1720,7 @@ class AdminTest extends TestCase
 
     public function testGetFilterFieldDescription(): void
     {
-        $modelAdmin = new ModelAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'SonataFooBundle:ModelAdmin');
+        $modelAdmin = new ModelAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'Sonata\FooBundle\Controller\ModelAdminController');
 
         $fooFieldDescription = new FieldDescription();
         $barFieldDescription = new FieldDescription();
@@ -1797,7 +1797,7 @@ class AdminTest extends TestCase
             ->expects($this->never())
             ->method('find');
 
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->setModelManager($modelManager);
 
         $this->assertNull($admin->getSubject());
@@ -1821,7 +1821,7 @@ class AdminTest extends TestCase
             ->method('createItem')
             ->willReturn($item);
 
-        $modelAdmin = new ModelAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'SonataFooBundle:ModelAdmin');
+        $modelAdmin = new ModelAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'Sonata\FooBundle\Controller\ModelAdminController');
         $modelAdmin->setMenuFactory($menuFactory);
         $modelAdmin->setTranslationDomain('foo_bar_baz');
 
@@ -1854,7 +1854,7 @@ class AdminTest extends TestCase
             ->with('NewsBundle\Entity\Post', $id)
             ->willReturn(null); // entity not found
 
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->setModelManager($modelManager);
 
         $admin->setRequest(new Request(['id' => $id]));
@@ -1875,7 +1875,7 @@ class AdminTest extends TestCase
             ->with('NewsBundle\Entity\Post', $id)
             ->willReturn($entity);
 
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->setModelManager($modelManager);
 
         $admin->setRequest(new Request(['id' => $id]));
@@ -1897,10 +1897,10 @@ class AdminTest extends TestCase
 
         $request = new Request(['id' => $adminId]);
 
-        $postAdmin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $postAdmin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $postAdmin->setRequest($request);
 
-        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'NewsBundle\Entity\Comment', 'SonataNewsBundle:CommentAdmin');
+        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentAdminController');
         $commentAdmin->setRequest($request);
         $commentAdmin->setModelManager($modelManager);
 
@@ -1923,7 +1923,7 @@ class AdminTest extends TestCase
             ],
         ];
 
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
         $templateRegistry->getTemplate('button_create')->willReturn('Foo.html.twig');
@@ -1954,7 +1954,7 @@ class AdminTest extends TestCase
      */
     public function testGetActionButtonsListCreateDisabled(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $securityHandler = $this->createMock(SecurityHandlerInterface::class);
         $securityHandler
@@ -2001,7 +2001,7 @@ class AdminTest extends TestCase
                 return $context.'.'.$type.'_'.$label;
             });
 
-        $admin = new PostAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'SonataFooBundle:ModelAdmin');
+        $admin = new PostAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'Sonata\FooBundle\Controller\ModelAdminController');
         $admin->setRouteBuilder($pathInfo);
         $admin->setTranslationDomain('SonataAdminBundle');
         $admin->setLabelTranslatorStrategy($labelTranslatorStrategy);
@@ -2030,7 +2030,7 @@ class AdminTest extends TestCase
      */
     public function testShowMosaicButton(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $listModes = $admin->getListModes();
 
         $admin->showMosaicButton(true);
@@ -2043,7 +2043,7 @@ class AdminTest extends TestCase
      */
     public function testShowMosaicButtonHideMosaic(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $listModes = $admin->getListModes();
         $expected['list'] = $listModes['list'];
 
@@ -2065,7 +2065,7 @@ class AdminTest extends TestCase
             new RoutesCache($this->cacheTempFolder, true)
         );
 
-        $admin = new PostAdmin('sonata.post.admin.post', $objFqn, 'SonataNewsBundle:PostAdmin');
+        $admin = new PostAdmin('sonata.post.admin.post', $objFqn, 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->setRouteBuilder($pathInfo);
         $admin->setRouteGenerator($routeGenerator);
         $admin->initialize();
@@ -2090,7 +2090,7 @@ class AdminTest extends TestCase
 
     public function testDefaultFilters(): void
     {
-        $admin = new FilteredAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'SonataFooBundle:ModelAdmin');
+        $admin = new FilteredAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'Sonata\FooBundle\Controller\ModelAdminController');
 
         $subjectId = uniqid();
 
@@ -2167,7 +2167,7 @@ class AdminTest extends TestCase
             ->willReturn($container);
 
         $admin = $this->getMockForAbstractClass(AbstractAdmin::class, [
-            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin',
+            'admin.my_code', 'My\Class', 'MyBundle\ClassAdminController',
         ], '', true, true, true, ['getConfigurationPool']);
         $admin->expects($this->once())
             ->method('getConfigurationPool')
@@ -2182,7 +2182,7 @@ class AdminTest extends TestCase
     public function testBreadcrumbsBuilderSetter(): void
     {
         $admin = $this->getMockForAbstractClass(AbstractAdmin::class, [
-            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin',
+            'admin.my_code', 'My\Class', 'MyBundle\ClassAdminController',
         ]);
         $this->assertSame($admin, $admin->setBreadcrumbsBuilder($builder = $this->createMock(
             BreadcrumbsBuilderInterface::class
@@ -2196,7 +2196,7 @@ class AdminTest extends TestCase
     public function testGetBreadcrumbs(): void
     {
         $admin = $this->getMockForAbstractClass(AbstractAdmin::class, [
-            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin',
+            'admin.my_code', 'My\Class', 'MyBundle\ClassAdminController',
         ]);
         $builder = $this->prophesize(BreadcrumbsBuilderInterface::class);
         $action = 'myaction';
@@ -2210,7 +2210,7 @@ class AdminTest extends TestCase
     public function testBuildBreadcrumbs(): void
     {
         $admin = $this->getMockForAbstractClass(AbstractAdmin::class, [
-            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin',
+            'admin.my_code', 'My\Class', 'MyBundle\ClassAdminController',
         ]);
         $builder = $this->prophesize(BreadcrumbsBuilderInterface::class);
         $action = 'myaction';
@@ -2233,7 +2233,7 @@ class AdminTest extends TestCase
     public function testCreateQueryLegacyCallWorks(): void
     {
         $admin = $this->getMockForAbstractClass(AbstractAdmin::class, [
-            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin',
+            'admin.my_code', 'My\Class', 'MyBundle\ClassAdminController',
         ]);
         $query = $this->createMock(ProxyQueryInterface::class);
         $modelManager = $this->createMock(ModelManagerInterface::class);
@@ -2299,12 +2299,12 @@ class AdminTest extends TestCase
         $postAdmin = new PostAdmin(
             'sonata.post.admin.post',
             'Application\Sonata\NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $commentAdmin = new CommentAdmin(
             'sonata.post.admin.comment',
             'Application\Sonata\NewsBundle\Entity\Comment',
-            'SonataNewsBundle:CommentAdmin'
+            'Sonata\NewsBundle\Controller\CommentAdminController'
         );
         $postAdmin->addChild($commentAdmin, 'post');
         $commentAdmin->addChild($postAdmin, 'comment');
@@ -2320,17 +2320,17 @@ class AdminTest extends TestCase
         $postAdmin = new PostAdmin(
             'sonata.post.admin.post',
             'Application\Sonata\NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $commentAdmin = new CommentAdmin(
             'sonata.post.admin.comment',
             'Application\Sonata\NewsBundle\Entity\Comment',
-            'SonataNewsBundle:CommentAdmin'
+            'Sonata\NewsBundle\Controller\CommentAdminController'
         );
         $commentVoteAdmin = new CommentVoteAdmin(
             'sonata.post.admin.comment_vote',
             'Application\Sonata\NewsBundle\Entity\CommentVote',
-            'SonataNewsBundle:CommentVoteAdmin'
+            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
         );
         $postAdmin->addChild($commentAdmin, 'post');
         $commentAdmin->addChild($commentVoteAdmin, 'comment');
@@ -2347,7 +2347,7 @@ class AdminTest extends TestCase
         $postAdmin = new PostAdmin(
             'sonata.post.admin.post',
             'Application\Sonata\NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $postAdmin->addChild($postAdmin);
     }
@@ -2357,17 +2357,17 @@ class AdminTest extends TestCase
         $postAdmin = new PostAdmin(
             'sonata.post.admin.post',
             'Application\Sonata\NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $commentAdmin = new CommentAdmin(
             'sonata.post.admin.comment',
             'Application\Sonata\NewsBundle\Entity\Comment',
-            'SonataNewsBundle:CommentAdmin'
+            'Sonata\NewsBundle\Controller\CommentAdminController'
         );
         $commentVoteAdmin = new CommentVoteAdmin(
             'sonata.post.admin.comment_vote',
             'Application\Sonata\NewsBundle\Entity\CommentVote',
-            'SonataNewsBundle:CommentVoteAdmin'
+            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
         );
 
         $this->assertSame($postAdmin, $postAdmin->getRootAncestor());
@@ -2392,17 +2392,17 @@ class AdminTest extends TestCase
         $postAdmin = new PostAdmin(
             'sonata.post.admin.post',
             'Application\Sonata\NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $commentAdmin = new CommentAdmin(
             'sonata.post.admin.comment',
             'Application\Sonata\NewsBundle\Entity\Comment',
-            'SonataNewsBundle:CommentAdmin'
+            'Sonata\NewsBundle\Controller\CommentAdminController'
         );
         $commentVoteAdmin = new CommentVoteAdmin(
             'sonata.post.admin.comment_vote',
             'Application\Sonata\NewsBundle\Entity\CommentVote',
-            'SonataNewsBundle:CommentVoteAdmin'
+            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
         );
 
         $this->assertSame(0, $postAdmin->getChildDepth());
@@ -2427,17 +2427,17 @@ class AdminTest extends TestCase
         $postAdmin = new PostAdmin(
             'sonata.post.admin.post',
             'Application\Sonata\NewsBundle\Entity\Post',
-            'SonataNewsBundle:PostAdmin'
+            'Sonata\NewsBundle\Controller\PostAdminController'
         );
         $commentAdmin = new CommentAdmin(
             'sonata.post.admin.comment',
             'Application\Sonata\NewsBundle\Entity\Comment',
-            'SonataNewsBundle:CommentAdmin'
+            'Sonata\NewsBundle\Controller\CommentAdminController'
         );
         $commentVoteAdmin = new CommentVoteAdmin(
             'sonata.post.admin.comment_vote',
             'Application\Sonata\NewsBundle\Entity\CommentVote',
-            'SonataNewsBundle:CommentVoteAdmin'
+            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
         );
 
         $postAdmin->addChild($commentAdmin, 'post');
@@ -2475,7 +2475,7 @@ class AdminTest extends TestCase
             ->setConstructorArgs([
                 'admin.tag',
                 Tag::class,
-                'MyBundle:MyController',
+                'MyBundle\MyController',
             ])
             ->setMethods(['getFormBuilder'])
             ->getMock();

--- a/tests/Admin/BreadcrumbsBuilderTest.php
+++ b/tests/Admin/BreadcrumbsBuilderTest.php
@@ -62,9 +62,9 @@ class BreadcrumbsBuilderTest extends TestCase
                 return $menu;
             });
 
-        $postAdmin = new PostAdmin('sonata.post.admin.post', DummySubject::class, 'SonataNewsBundle:PostAdmin');
-        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'SonataNewsBundle:CommentAdmin');
-        $subCommentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'SonataNewsBundle:CommentAdmin');
+        $postAdmin = new PostAdmin('sonata.post.admin.post', DummySubject::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
+        $subCommentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
 
         $postAdmin->addChild($commentAdmin);
         $postAdmin->setRequest(new Request(['id' => $postAdminSubjectId]));
@@ -222,8 +222,8 @@ class BreadcrumbsBuilderTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $postAdmin = new PostAdmin('sonata.post.admin.post', DummySubject::class, 'SonataNewsBundle:PostAdmin');
-        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'SonataNewsBundle:CommentAdmin');
+        $postAdmin = new PostAdmin('sonata.post.admin.post', DummySubject::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
 
         $postAdmin->addChild($commentAdmin);
         $postAdmin->setRequest(new Request(['id' => $postAdminSubjectId]));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Modernize controller references.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.