### PR TITLE
Drop support of php 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "doctrine/common": "^2.7",
         "doctrine/inflector": "^1.1",
         "knplabs/knp-menu-bundle": "^2.2.2",


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

## Changelog
```markdown
### Removed
- Drop support of php 7.1
```