### PR TITLE
Handle parent association mappings

### DIFF
--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -66,7 +66,17 @@ class AdminType extends AbstractType
                         $path = $this->getFieldDescription($options)->getFieldName().$options['property_path'];
                     }
 
-                    $subject = $p->getValue($parentSubject, $path);
+                    $parentPath = implode(
+                        '',
+                        array_map(
+                            static function (array $associationMapping): string {
+                                return $associationMapping['fieldName'].'.';
+                            },
+                            $this->getFieldDescription($options)->getParentAssociationMappings()
+                        )
+                    );
+
+                    $subject = $p->getValue($parentSubject, $parentPath.$path);
                     $builder->setData($subject);
                 }
             } catch (NoSuchIndexException $e) {

--- a/tests/Form/Type/AdminTypeTest.php
+++ b/tests/Form/Type/AdminTypeTest.php
@@ -87,8 +87,11 @@ class AdminTypeTest extends TypeTestCase
 
     public function testDotFields(): void
     {
+        $foo = new \stdClass();
+        $foo->bar = 1;
+
         $parentSubject = new \stdClass();
-        $parentSubject->foo = 1;
+        $parentSubject->foo = $foo;
 
         $parentAdmin = $this->prophesize(AdminInterface::class);
         $parentAdmin->getSubject()->shouldBeCalled()->willReturn($parentSubject);
@@ -107,7 +110,8 @@ class AdminTypeTest extends TypeTestCase
 
         $field = $this->prophesize(FieldDescriptionInterface::class);
         $field->getAssociationAdmin()->shouldBeCalled()->willReturn($admin->reveal());
-        $field->getFieldName()->shouldBeCalled()->willReturn('foo');
+        $field->getFieldName()->shouldBeCalled()->willReturn('bar');
+        $field->getParentAssociationMappings()->shouldBeCalled()->willReturn([['fieldName' => 'foo']]);
 
         $this->builder->add('foo.bar');
 
@@ -116,7 +120,7 @@ class AdminTypeTest extends TypeTestCase
             $type->buildForm($this->builder, [
                 'sonata_field_description' => $field->reveal(),
                 'delete' => false, // not needed
-                'property_path' => 'foo', // actual test case
+                'property_path' => 'bar', // actual test case
             ]);
         } catch (NoSuchPropertyException $exception) {
             $this->fail($exception->getMessage());


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC (and bugfix).

When using
```
$formMapper->add(
    'subscription.appendixes',
    CollectionType::class,
    ['by_reference' => false],
    ['edit'   => 'inline', 'inline' => 'table']
)
```

The Admin type is building the following path `appendixes[0]` instead of `subscription.appendixes[0]`. This is because he's not using the parent association mappings.

Closes #5738 (which was closed too soon).

## Changelog
```markdown
### Fixed
- Admin Type is correctly using parentAssociationsMappings when using form with OneToOneToMany fields.
```