### PR TITLE
Make setParent consistent with addChild

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -248,6 +248,11 @@ parameters:
             count: 1
             path: src/Datagrid/Pager.php
 
+        -
+            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AdminInterface\\<object\\>\\:\\:setParent\\(\\) invoked with 2 parameters, 1 required\\.$#"
+            count: 1
+            path: src/Admin/AbstractAdmin.php
+
 # Symfony related errors
         -
             message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\:\\:arrayNode\\(\\)\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6,8 +6,9 @@
             <code>$this-&gt;parentAssociationMapping</code>
         </InvalidReturnStatement>
         <!--will be fixed in v4. Currently BC break. Remove string from union type of $this->parentAssociationMapping-->
-        <InvalidArrayOffset occurrences="1">
+        <InvalidArrayOffset occurrences="2">
             <code>$this-&gt;parentAssociationMapping[$code]</code>
+            <code>$this-&gt;parentAssociationMapping[$parent-&gt;getCode()]</code>
         </InvalidArrayOffset>
         <!--will be removed in v4. Currently BC break-->
         <InvalidPropertyAssignmentValue occurrences="1">

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -456,7 +456,7 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
     /**
      * @return void
      */
-    public function setParent(self $admin);
+    public function setParent(self $admin/*, string $parentAssociationMapping*/);
 
     /**
      * Returns true if the Admin class has an Parent Admin defined.

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -305,6 +305,23 @@ class AdminTest extends TestCase
     }
 
     /**
+     * @covers \Sonata\AdminBundle\Admin\AbstractAdmin::getParent
+     * @covers \Sonata\AdminBundle\Admin\AbstractAdmin::setParent
+     */
+    public function testParent(): void
+    {
+        $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
+        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentAdminController');
+        $this->assertFalse($commentAdmin->isChild());
+        $this->assertFalse($commentAdmin->hasParentFieldDescription());
+
+        $commentAdmin->setParent($postAdmin, 'post');
+
+        $this->assertSame($postAdmin, $commentAdmin->getParent());
+        $this->assertSame('post', $commentAdmin->getParentAssociationMapping());
+    }
+
+    /**
      * @covers \Sonata\AdminBundle\Admin\AbstractAdmin::configure
      */
     public function testConfigure(): void
@@ -414,7 +431,7 @@ class AdminTest extends TestCase
     {
         $postAdmin = new PostAdmin('sonata.post.admin.post', $objFqn, 'Sonata\NewsBundle\Controller\PostAdminController');
         $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentAdminController');
-        $commentAdmin->setParent($postAdmin);
+        $commentAdmin->setParent($postAdmin, 'post');
 
         $this->assertSame(sprintf('%s/{id}/comment', $expected), $commentAdmin->getBaseRoutePattern());
     }
@@ -435,8 +452,8 @@ class AdminTest extends TestCase
             'Application\Sonata\NewsBundle\Entity\CommentVote',
             'Sonata\NewsBundle\Controller\CommentVoteAdminController'
         );
-        $commentAdmin->setParent($postAdmin);
-        $commentVoteAdmin->setParent($commentAdmin);
+        $commentAdmin->setParent($postAdmin, 'post');
+        $commentVoteAdmin->setParent($commentAdmin, 'comment');
 
         $this->assertSame(sprintf('%s/{id}/comment/{childId}/commentvote', $expected), $commentVoteAdmin->getBaseRoutePattern());
     }
@@ -452,7 +469,7 @@ class AdminTest extends TestCase
     {
         $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $commentAdmin = new CommentWithCustomRouteAdmin('sonata.post.admin.comment_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentWithCustomRouteAdminController');
-        $commentAdmin->setParent($postAdmin);
+        $commentAdmin->setParent($postAdmin, 'post');
 
         $this->assertSame('/sonata/news/post/{id}/comment-custom', $commentAdmin->getBaseRoutePattern());
     }
@@ -651,7 +668,7 @@ class AdminTest extends TestCase
     {
         $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $commentAdmin = new CommentWithCustomRouteAdmin('sonata.post.admin.comment_with_custom_route', 'Application\Sonata\NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentWithCustomRouteAdminController');
-        $commentAdmin->setParent($postAdmin);
+        $commentAdmin->setParent($postAdmin, 'post');
 
         $this->assertSame('admin_sonata_news_post_comment_custom', $commentAdmin->getBaseRouteName());
     }
@@ -673,8 +690,8 @@ class AdminTest extends TestCase
             'Application\Sonata\NewsBundle\Entity\CommentVote',
             'Sonata\NewsBundle\Controller\CommentVoteAdminController'
         );
-        $commentAdmin->setParent($postAdmin);
-        $commentVoteAdmin->setParent($commentAdmin);
+        $commentAdmin->setParent($postAdmin, 'post');
+        $commentVoteAdmin->setParent($commentAdmin, 'comment');
 
         $this->assertSame('admin_sonata_news_post_comment_custom_commentvote', $commentVoteAdmin->getBaseRouteName());
     }
@@ -1268,7 +1285,7 @@ class AdminTest extends TestCase
             'Application\Sonata\NewsBundle\Entity\Comment',
             'Sonata\NewsBundle\Controller\CommentAdminController'
         );
-        $commentAdmin->setParent($postAdmin);
+        $commentAdmin->setParent($postAdmin, 'post');
 
         $this->assertTrue($commentAdmin->isChild());
         $this->assertSame('childId', $commentAdmin->getIdParameter());
@@ -1278,7 +1295,7 @@ class AdminTest extends TestCase
             'Application\Sonata\NewsBundle\Entity\CommentVote',
             'Sonata\NewsBundle\Controller\CommentVoteAdminController'
         );
-        $commentVoteAdmin->setParent($commentAdmin);
+        $commentVoteAdmin->setParent($commentAdmin, 'comment');
 
         $this->assertTrue($commentVoteAdmin->isChild());
         $this->assertSame('childChildId', $commentVoteAdmin->getIdParameter());
@@ -1606,7 +1623,7 @@ class AdminTest extends TestCase
 
         $tagAdmin = new TagAdmin('admin.tag', Tag::class, 'MyBundle\MyController');
         $tagAdmin->setModelManager($modelManager);
-        $tagAdmin->setParent($postAdmin);
+        $tagAdmin->setParent($postAdmin, 'post');
 
         $request = $this->createStub(Request::class);
         $tagAdmin->setRequest($request);
@@ -1634,7 +1651,7 @@ class AdminTest extends TestCase
 
         $postCategoryAdmin = new PostCategoryAdmin('admin.post_category', PostCategoryAdmin::class, 'MyBundle\MyController');
         $postCategoryAdmin->setModelManager($modelManager);
-        $postCategoryAdmin->setParent($postAdmin);
+        $postCategoryAdmin->setParent($postAdmin, 'post');
 
         $request = $this->createStub(Request::class);
         $postCategoryAdmin->setRequest($request);
@@ -1832,8 +1849,7 @@ class AdminTest extends TestCase
         $postAdmin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $commentAdmin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentAdminController');
-        $commentAdmin->setParentAssociationMapping('post.author');
-        $commentAdmin->setParent($postAdmin);
+        $commentAdmin->setParent($postAdmin, 'post.author');
 
         $request = $this->createMock(Request::class);
         $query = $this->createMock(ParameterBag::class);

--- a/tests/Fixtures/Admin/CommentAdmin.php
+++ b/tests/Fixtures/Admin/CommentAdmin.php
@@ -27,9 +27,4 @@ class CommentAdmin extends AbstractAdmin
     {
         $collection->remove('edit');
     }
-
-    public function setParentAssociationMapping($associationMapping): void
-    {
-        $this->parentAssociationMapping = $associationMapping;
-    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Looks like the the only place where `addParentAssociationMapping` is used is where `addChild` is called. 

Inside that function [every time `setParent` is called on `$child`, is also called that function (if the second parameter is passed, that will be mandatory in the next major version)](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Admin/AbstractAdmin.php#L2119-L2132).

And it's also the only place I've seen where `setParent` is called, so for consistency, I added a second parameter to `setParent`, so in the next major version we can get rid of the exception thrown in [`getParentAssociationMapping`](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Admin/AbstractAdmin.php#L947) because the attribute `parentAssociationMapping` will always have the parent code.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `AbstractAdmin::addParentAssociationMapping` method.
- Calling `AdminInterface::setParent` without second argument.
```


## To do
    
- [x] Update the tests to remove deprecation notices.