### PR TITLE
Update logic for detecting relations 

### DIFF
--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -234,7 +234,7 @@ class AdminHelper
         foreach ($parentMappings as $parentMapping) {
             $method = sprintf('get%s', Inflector::classify($parentMapping['fieldName']));
 
-            if (!\is_callable([$object, $method])) {
+            if (!(\is_callable([$object, $method]) && method_exists($object, $method))) {
                 /*
                  * NEXT_MAJOR: Use BadMethodCallException instead
                  */
@@ -248,13 +248,13 @@ class AdminHelper
 
         $method = sprintf('add%s', Inflector::classify($mapping['fieldName']));
 
-        if (!\is_callable([$object, $method])) {
+        if (!(\is_callable([$object, $method]) && method_exists($object, $method))) {
             $method = rtrim($method, 's');
 
-            if (!\is_callable([$object, $method])) {
+            if (!(\is_callable([$object, $method]) && method_exists($object, $method))) {
                 $method = sprintf('add%s', Inflector::classify(Inflector::singularize($mapping['fieldName'])));
 
-                if (!\is_callable([$object, $method])) {
+                if (!(\is_callable([$object, $method]) && method_exists($object, $method))) {
                     /*
                      * NEXT_MAJOR: Use BadMethodCallException instead
                      */


### PR DESCRIPTION
…st before resorting to callable check.
## Subject
Fix relation function detection regression that occurred when switching to is_callable.

I am targeting this branch, because this is a BC break and affects the current published release.


Closes #6008

## Changelog


```markdown
### Fixed
 - AdminHelper::addNewInstance to detect methods based on method_exists instead of callable to maintain previous BC behavior.

```


