### PR TITLE
Add some missing return values

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2080,6 +2080,8 @@ EOT;
                 return $children;
             }
         }
+
+        return null;
     }
 
     public function trans($id, array $parameters = [], $domain = null, $locale = null)
@@ -2822,6 +2824,8 @@ EOT;
                 return $this->generateObjectUrl($action, $object);
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -64,7 +64,7 @@ interface ModelManagerInterface
     /**
      * @param string $class
      *
-     * @return object an object matching the criteria or null if none match
+     * @return object|null an object matching the criteria or null if none match
      */
     public function findOneBy($class, array $criteria = []);
 
@@ -216,6 +216,8 @@ interface ModelManagerInterface
 
     /**
      * @param string $class
+     *
+     * @return object
      */
     public function modelReverseTransform($class, array $array = []);
 

--- a/tests/App/Admin/FieldDescription.php
+++ b/tests/App/Admin/FieldDescription.php
@@ -23,6 +23,7 @@ final class FieldDescription extends BaseFieldDescription
 
     public function getTargetEntity()
     {
+        return null;
     }
 
     public function setFieldMapping($fieldMapping)
@@ -35,6 +36,7 @@ final class FieldDescription extends BaseFieldDescription
 
     public function isIdentifier()
     {
+        return false;
     }
 
     public function getValue($object)

--- a/tests/App/Datagrid/Datagrid.php
+++ b/tests/App/Datagrid/Datagrid.php
@@ -37,6 +37,7 @@ final class Datagrid implements DatagridInterface
 
     public function getQuery()
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
     public function getResults()
@@ -54,6 +55,7 @@ final class Datagrid implements DatagridInterface
 
     public function getFilters()
     {
+        return [];
     }
 
     public function reorderFilters(array $keys)
@@ -67,6 +69,7 @@ final class Datagrid implements DatagridInterface
 
     public function getColumns()
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
     public function setValue($name, $operator, $value)
@@ -80,10 +83,12 @@ final class Datagrid implements DatagridInterface
 
     public function getFilter($name)
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
     public function hasFilter($name)
     {
+        return false;
     }
 
     public function removeFilter($name)
@@ -92,9 +97,11 @@ final class Datagrid implements DatagridInterface
 
     public function hasActiveFilters()
     {
+        return false;
     }
 
     public function hasDisplayableFilters()
     {
+        return false;
     }
 }

--- a/tests/App/Datagrid/Pager.php
+++ b/tests/App/Datagrid/Pager.php
@@ -31,6 +31,7 @@ final class Pager implements PagerInterface
 
     public function getMaxPerPage()
     {
+        return 1;
     }
 
     public function setMaxPerPage($max)
@@ -56,5 +57,6 @@ final class Pager implements PagerInterface
 
     public function getMaxPageLinks()
     {
+        return 1;
     }
 }

--- a/tests/App/Datagrid/ProxyQuery.php
+++ b/tests/App/Datagrid/ProxyQuery.php
@@ -31,6 +31,7 @@ final class ProxyQuery implements ProxyQueryInterface
 
     public function getSortBy()
     {
+        return 'e.id';
     }
 
     public function setSortOrder($sortOrder)
@@ -39,10 +40,12 @@ final class ProxyQuery implements ProxyQueryInterface
 
     public function getSortOrder()
     {
+        return 'ASC';
     }
 
     public function getSingleScalarResult()
     {
+        return 0;
     }
 
     public function setFirstResult($firstResult)
@@ -51,6 +54,7 @@ final class ProxyQuery implements ProxyQueryInterface
 
     public function getFirstResult()
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
     public function setMaxResults($maxResults)
@@ -59,10 +63,12 @@ final class ProxyQuery implements ProxyQueryInterface
 
     public function getMaxResults()
     {
+        return 1;
     }
 
     public function getUniqueParameterId()
     {
+        return 1;
     }
 
     public function entityJoin(array $associationMappings)

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -59,10 +59,12 @@ final class ModelManager implements ModelManagerInterface
 
     public function findBy($class, array $criteria = [])
     {
+        return [];
     }
 
     public function findOneBy($class, array $criteria = [])
     {
+        return null;
     }
 
     public function find($class, $id)
@@ -76,6 +78,7 @@ final class ModelManager implements ModelManagerInterface
 
     public function getParentFieldDescription($parentAssociationMapping, $class)
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
     public function createQuery($class, $alias = 'o')
@@ -89,14 +92,17 @@ final class ModelManager implements ModelManagerInterface
 
     public function getIdentifierValues($model)
     {
+        return [];
     }
 
     public function getIdentifierFieldNames($class)
     {
+        return [];
     }
 
     public function getNormalizedIdentifier($model)
     {
+        return null;
     }
 
     public function getUrlsafeIdentifier($model)
@@ -106,10 +112,12 @@ final class ModelManager implements ModelManagerInterface
 
     public function getModelInstance($class)
     {
+        return new Foo('test_id', 'foo_name');
     }
 
     public function getModelCollectionInstance($class)
     {
+        return [];
     }
 
     public function collectionRemoveElement(&$collection, &$element)
@@ -130,6 +138,7 @@ final class ModelManager implements ModelManagerInterface
 
     public function getSortParameters(FieldDescriptionInterface $fieldDescription, DatagridInterface $datagrid)
     {
+        return [];
     }
 
     public function getDefaultSortValues($class)
@@ -139,10 +148,12 @@ final class ModelManager implements ModelManagerInterface
 
     public function modelReverseTransform($class, array $array = [])
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
     public function modelTransform($class, $instance)
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
     public function executeQuery($query)
@@ -155,6 +166,7 @@ final class ModelManager implements ModelManagerInterface
 
     public function getExportFields($class)
     {
+        return [];
     }
 
     public function getPaginationParameters(DatagridInterface $datagrid, $page)

--- a/tests/Fixtures/Admin/TagAdmin.php
+++ b/tests/Fixtures/Admin/TagAdmin.php
@@ -22,5 +22,7 @@ class TagAdmin extends AbstractAdmin
         if ($this->getParent() instanceof PostAdmin) {
             return 'posts';
         }
+
+        return null;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Add some missing return values in methods which are not intended to return `void`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

```markdown
### Fixed
- Fixed returning `void` in some methods which are intended to return a value or `null`.
```
