### PR TITLE
`LockInterface` extends from `ModelManagerInterface`

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -71,3 +71,6 @@ The `sonata_admin` twig extension is now final. You may no longer extend it.
 
 ## SimplePager
 Method `SimplePager::getResults` is always returning an array
+
+## LockInterface
+`LockInterface` extends from `ModelManagerInterface`.

--- a/src/Model/LockInterface.php
+++ b/src/Model/LockInterface.php
@@ -18,7 +18,7 @@ use Sonata\AdminBundle\Exception\LockException;
 /**
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
  */
-interface LockInterface
+interface LockInterface extends ModelManagerInterface
 {
     /**
      * @param object $object

--- a/tests/Admin/Extension/LockExtensionTest.php
+++ b/tests/Admin/Extension/LockExtensionTest.php
@@ -215,7 +215,7 @@ class LockExtensionTest extends TestCase
     private function configureAdmin(
         ?string $uniqid = null,
         ?Request $request = null,
-        $modelManager = null
+        ModelManagerInterface $modelManager = null
     ): void {
         $this->admin->getUniqid()->willReturn($uniqid);
         $this->admin->getRequest()->willReturn($request);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Since this interface is intended to be implemented by a model manager, `LockInterface` extends from `ModelManagerInterface`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change breaks BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added extension from `ModelManagerInterface` to `LockInterface`
```