### PR TITLE
Default sort on "associated_property"

### DIFF
--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -88,6 +88,11 @@ Here is an example::
             // Here we specify which property is used to render the label of each entity in the list
             ->add('productCategories', null, [
                 'associated_property' => 'name'
+                // By default, sorting will be done on the associated property.
+                // To sort on another property, add the following:
+                'sort_field_mapping' => [
+                    'fieldName' => 'weight',
+                ],
             ])
 
             // you may also use dotted-notation to access
@@ -132,6 +137,7 @@ Options
 - ``associated_property`` (o): property path to retrieve the "string"
   representation of the collection element, or a closure with the element
   as argument and return a string.
+- ``sort_field_mapping`` (o): property of the collection element to sort on.
 - ``identifier`` (o): if set to true a link appears on the value to edit the element
 
 Available types and associated options

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -74,6 +74,23 @@ class ListMapper extends BaseMapper
      */
     public function add($name, $type = null, array $fieldDescriptionOptions = [])
     {
+        // Default sort on "associated_property"
+        if (isset($fieldDescriptionOptions['associated_property'])) {
+            if (!isset($fieldDescriptionOptions['sortable'])) {
+                $fieldDescriptionOptions['sortable'] = true;
+            }
+            if (!isset($fieldDescriptionOptions['sort_parent_association_mappings'])) {
+                $fieldDescriptionOptions['sort_parent_association_mappings'] = [[
+                    'fieldName' => $name,
+                ]];
+            }
+            if (!isset($fieldDescriptionOptions['sort_field_mapping'])) {
+                $fieldDescriptionOptions['sort_field_mapping'] = [
+                    'fieldName' => $fieldDescriptionOptions['associated_property'],
+                ];
+            }
+        }
+
         // Change deprecated inline action "view" to "show"
         if ('_action' === $name && 'actions' === $type) {
             if (isset($fieldDescriptionOptions['actions']['view'])) {

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -298,6 +298,47 @@ class ListMapperTest extends TestCase
         }
     }
 
+    public function testAutoSortOnAssociatedProperty(): void
+    {
+        $this->listMapper->add('fooName');
+        $this->listMapper->add(
+            'fooNameAutoSort',
+            null,
+            [
+                'associated_property' => 'fooAssociatedProperty',
+            ]
+        );
+        $this->listMapper->add(
+            'fooNameManualSort',
+            null,
+            [
+                'associated_property' => 'fooAssociatedProperty',
+                'sortable' => false,
+                'sort_parent_association_mappings' => 'fooSortParentAssociationMapping',
+                'sort_field_mapping' => 'fooSortFieldMapping',
+            ]
+        );
+
+        $field = $this->listMapper->get('fooName');
+        $fieldAutoSort = $this->listMapper->get('fooNameAutoSort');
+        $fieldManualSort = $this->listMapper->get('fooNameManualSort');
+
+        $this->assertNull($field->getOption('associated_property'));
+        $this->assertNull($field->getOption('sortable'));
+        $this->assertNull($field->getOption('sort_parent_association_mappings'));
+        $this->assertNull($field->getOption('sort_field_mapping'));
+
+        $this->assertSame('fooAssociatedProperty', $fieldAutoSort->getOption('associated_property'));
+        $this->assertTrue($fieldAutoSort->getOption('sortable'));
+        $this->assertSame([['fieldName' => $fieldAutoSort->getName()]], $fieldAutoSort->getOption('sort_parent_association_mappings'));
+        $this->assertSame(['fieldName' => $fieldAutoSort->getOption('associated_property')], $fieldAutoSort->getOption('sort_field_mapping'));
+
+        $this->assertSame('fooAssociatedProperty', $fieldManualSort->getOption('associated_property'));
+        $this->assertFalse($fieldManualSort->getOption('sortable'));
+        $this->assertSame('fooSortParentAssociationMapping', $fieldManualSort->getOption('sort_parent_association_mappings'));
+        $this->assertSame('fooSortFieldMapping', $fieldManualSort->getOption('sort_field_mapping'));
+    }
+
     public function testKeys(): void
     {
         $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
By default, even if an `associated_property` is set when adding a collection(?) field to `ListMapper`, sorting by column header is disabled in list view.
As we set the associated property to display it in the list, it would be nice if Sonata could guess we want to order on it.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Automatically set `sortable`, `sort_parent_association_mappings`, and `sort_field_mapping` when `associated_property` is set in `ListMapper::add` to enable sorting on `associated_property` by default.
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
