### PR TITLE
Some API update messages

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -228,11 +228,11 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     protected $children = [];
 
     /**
-     * Reference the parent collection.
+     * Reference the parent admin.
      *
      * @var AdminInterface|null
      */
-    protected $parent = null;
+    protected $parent;
 
     /**
      * The base code route refer to the prefix used to generate the route name.
@@ -250,7 +250,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      *
      * @var string|array
      */
-    protected $parentAssociationMapping = null;
+    protected $parentAssociationMapping;
 
     /**
      * Reference the parent FieldDescription related to this admin
@@ -359,12 +359,12 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     /**
      * @var SecurityHandlerInterface
      */
-    protected $securityHandler = null;
+    protected $securityHandler;
 
     /**
      * @var ValidatorInterface
      */
-    protected $validator = null;
+    protected $validator;
 
     /**
      * The configuration pool.
@@ -498,11 +498,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     private $form;
 
     /**
-     * @var DatagridInterface
-     */
-    private $filter;
-
-    /**
      * The cached base route name.
      *
      * @var string
@@ -519,12 +514,18 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     /**
      * The form group disposition.
      *
+     * NEXT_MAJOR: must have `[]` as default value and remove the possibility to
+     * hold boolean values.
+     *
      * @var array|bool
      */
     private $formGroups = false;
 
     /**
      * The form tabs disposition.
+     *
+     * NEXT_MAJOR: must have `[]` as default value and remove the possibility to
+     * hold boolean values.
      *
      * @var array|bool
      */
@@ -533,12 +534,18 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     /**
      * The view group disposition.
      *
+     * NEXT_MAJOR: must have `[]` as default value and remove the possibility to
+     * hold boolean values.
+     *
      * @var array|bool
      */
     private $showGroups = false;
 
     /**
      * The view tab disposition.
+     *
+     * NEXT_MAJOR: must have `[]` as default value and remove the possibility to
+     * hold boolean values.
      *
      * @var array|bool
      */
@@ -566,14 +573,32 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     private $filterPersister;
 
     /**
-     * @param string $code
-     * @param string $class
-     * @param string $baseControllerName
+     * @param string      $code
+     * @param string      $class
+     * @param string|null $baseControllerName
      */
-    public function __construct($code, $class, $baseControllerName)
+    public function __construct($code, $class, $baseControllerName = null)
     {
+        if (!\is_string($code)) {
+            @trigger_error(sprintf(
+                'Passing other type than string as argument 1 for method %s() is deprecated since sonata-project/admin-bundle 3.x. It will accept only string in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
         $this->code = $code;
+        if (!\is_string($class)) {
+            @trigger_error(sprintf(
+                'Passing other type than string as argument 2 for method %s() is deprecated since sonata-project/admin-bundle 3.x. It will accept only string in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
         $this->class = $class;
+        if (null !== $baseControllerName && !\is_string($baseControllerName)) {
+            @trigger_error(sprintf(
+                'Passing other type than string or null as argument 3 for method %s() is deprecated since sonata-project/admin-bundle 3.x. It will accept only string and null in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
         $this->baseControllerName = $baseControllerName;
 
         $this->predefinePerPageOptions();
@@ -582,8 +607,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     /**
      * {@inheritdoc}
-     *
-     * NEXT_MAJOR: return null to indicate no override
      */
     public function getExportFormats()
     {
@@ -1228,7 +1251,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     public function generateObjectUrl($name, $object, array $parameters = [], $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        $parameters['id'] = $this->getUrlsafeIdentifier($object);
+        $parameters['id'] = $this->getUrlSafeIdentifier($object);
 
         return $this->generateUrl($name, $parameters, $referenceType);
     }
@@ -1566,6 +1589,13 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     public function getFormGroups()
     {
+        if (!\is_array($this->formGroups) && 'sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'Returning other type than array in method %s() is deprecated since sonata-project/admin-bundle 3.x. It will return only array in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         return $this->formGroups;
     }
 
@@ -1586,17 +1616,25 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     }
 
     /**
-     * @param array $group
+     * @param string $group
      */
     public function reorderFormGroup($group, array $keys)
     {
-        $formGroups = $this->getFormGroups();
+        // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
+        $formGroups = $this->getFormGroups('sonata_deprecation_mute');
         $formGroups[$group]['fields'] = array_merge(array_flip($keys), $formGroups[$group]['fields']);
         $this->setFormGroups($formGroups);
     }
 
     public function getFormTabs()
     {
+        if (!\is_array($this->formTabs) && 'sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'Returning other type than array in method %s() is deprecated since sonata-project/admin-bundle 3.x. It will return only array in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         return $this->formTabs;
     }
 
@@ -1607,6 +1645,13 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     public function getShowTabs()
     {
+        if (!\is_array($this->showTabs) && 'sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'Returning other type than array in method %s() is deprecated since sonata-project/admin-bundle 3.x. It will return only array in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         return $this->showTabs;
     }
 
@@ -1617,6 +1662,13 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     public function getShowGroups()
     {
+        if (!\is_array($this->showGroups) && 'sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'Returning other type than array in method %s() is deprecated since sonata-project/admin-bundle 3.x. It will return only array in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         return $this->showGroups;
     }
 
@@ -1627,7 +1679,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     public function reorderShowGroup($group, array $keys)
     {
-        $showGroups = $this->getShowGroups();
+        // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
+        $showGroups = $this->getShowGroups('sonata_deprecation_mute');
         $showGroups[$group]['fields'] = array_merge(array_flip($keys), $showGroups[$group]['fields']);
         $this->setShowGroups($showGroups);
     }
@@ -2427,9 +2480,9 @@ EOT;
         return $this->cacheIsGranted[$key];
     }
 
-    public function getUrlsafeIdentifier($entity)
+    public function getUrlSafeIdentifier($entity)
     {
-        return $this->getModelManager()->getUrlsafeIdentifier($entity);
+        return $this->getModelManager()->getUrlSafeIdentifier($entity);
     }
 
     public function getNormalizedIdentifier($entity)

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -484,6 +484,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     /**
      * Return the form groups.
      *
+     * NEXT_MAJOR: must return only `array<string, mixed>`.
+     *
      * @return array<string, mixed>|false (false if the groups have not been initialized)
      */
     public function getFormGroups();
@@ -493,10 +495,16 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function setFormGroups(array $formGroups);
 
+    /**
+     * NEXT_MAJOR: must return only `array<string, mixed>`.
+     */
     public function getFormTabs();
 
     public function setFormTabs(array $formTabs);
 
+    /**
+     * NEXT_MAJOR: must return only `array<string, mixed>`.
+     */
     public function getShowTabs();
 
     public function setShowTabs(array $showTabs);
@@ -510,6 +518,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * Returns the show groups.
+     *
+     * NEXT_MAJOR: must return only `array<string, mixed>`.
      *
      * @return array<string, mixed>|false (false if the groups have not been initialized)
      */

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -109,7 +109,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     /**
      * @var AdminInterface|null the parent Admin instance
      */
-    protected $parent = null;
+    protected $parent;
 
     /**
      * @var AdminInterface the related admin instance
@@ -209,6 +209,13 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
 
     public function getTemplate()
     {
+        if (null !== $this->template && !\is_string($this->template) && 'sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'Returning other type than string or null in method %s() is deprecated since sonata-project/admin-bundle 3.x. It will return only those types in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         return $this->template;
     }
 
@@ -398,6 +405,13 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
 
     public function getLabel()
     {
+        if (null !== $this->getOption('label') && !\is_string($this->getOption('label')) && 'sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'Returning other type than string or null in method %s() is deprecated since sonata-project/admin-bundle 3.x. It will return only those types in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         return $this->getOption('label');
     }
 

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -90,7 +90,7 @@ interface FieldDescriptionInterface
     /**
      * return the template name.
      *
-     * @return string the template name
+     * @return string|null the template name
      */
     public function getTemplate();
 
@@ -239,7 +239,7 @@ interface FieldDescriptionInterface
     /**
      * return the label to use for the current field.
      *
-     * @return string
+     * @return string|null
      */
     public function getLabel();
 

--- a/src/Admin/UrlGeneratorInterface.php
+++ b/src/Admin/UrlGeneratorInterface.php
@@ -84,5 +84,5 @@ interface UrlGeneratorInterface
      *
      * @return string a string representation of the id that is safe to use in a url
      */
-    public function getUrlsafeIdentifier($entity);
+    public function getUrlSafeIdentifier($entity);
 }

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -145,7 +145,8 @@ class ListMapper extends BaseMapper
             );
         }
 
-        if (null === $fieldDescription->getLabel()) {
+        // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
+        if (null === $fieldDescription->getLabel('sonata_deprecation_mute')) {
             $fieldDescription->setOption(
                 'label',
                 $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'list', 'label')

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -71,7 +71,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * @var \Traversable|array|null
      */
-    protected $results = null;
+    protected $results;
 
     /**
      * @var int
@@ -81,7 +81,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * @var ProxyQueryInterface|null
      */
-    protected $query = null;
+    protected $query;
 
     /**
      * @var array

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -23,12 +23,12 @@ abstract class Filter implements FilterInterface
     /**
      * @var string|null
      */
-    protected $name = null;
+    protected $name;
 
     /**
      * @var mixed|null
      */
-    protected $value = null;
+    protected $value;
 
     /**
      * @var array

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -281,7 +281,9 @@ class FormMapper extends BaseGroupedMapper
 
     protected function getGroups()
     {
-        return $this->admin->getFormGroups();
+        // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
+
+        return $this->admin->getFormGroups('sonata_deprecation_mute');
     }
 
     protected function setGroups(array $groups)
@@ -291,7 +293,9 @@ class FormMapper extends BaseGroupedMapper
 
     protected function getTabs()
     {
-        return $this->admin->getFormTabs();
+        // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
+
+        return $this->admin->getFormTabs('sonata_deprecation_mute');
     }
 
     protected function setTabs(array $tabs)

--- a/src/Menu/Matcher/Voter/AdminVoter.php
+++ b/src/Menu/Matcher/Voter/AdminVoter.php
@@ -34,9 +34,9 @@ class AdminVoter implements VoterInterface
     private $requestStack;
 
     /**
-     * @var Request
+     * @var Request|null
      */
-    private $request = null;
+    private $request;
 
     public function __construct(?RequestStack $requestStack = null)
     {

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -115,7 +115,7 @@ interface ModelManagerInterface
      *
      * This returns an array to handle cases like a primary key that is
      * composed of multiple columns. If you need a string representation,
-     * use getNormalizedIdentifier resp. getUrlsafeIdentifier
+     * use getNormalizedIdentifier resp. getUrlSafeIdentifier
      *
      * @param object $model
      *
@@ -153,7 +153,7 @@ interface ModelManagerInterface
      *
      * @return string string representation of the id that is safe to use in a url
      */
-    public function getUrlsafeIdentifier($model);
+    public function getUrlSafeIdentifier($model);
 
     /**
      * Create a new instance of the model of the specified class.

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -77,7 +77,8 @@ class ShowMapper extends BaseGroupedMapper
             );
         }
 
-        if (!$fieldDescription->getLabel() && false !== $fieldDescription->getOption('label')) {
+        // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
+        if (!$fieldDescription->getLabel('sonata_deprecation_mute') && false !== $fieldDescription->getOption('label')) {
             $fieldDescription->setOption('label', $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'show', 'label'));
         }
 
@@ -165,7 +166,9 @@ class ShowMapper extends BaseGroupedMapper
 
     protected function getGroups()
     {
-        return $this->admin->getShowGroups();
+        // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
+
+        return $this->admin->getShowGroups('sonata_deprecation_mute');
     }
 
     protected function setGroups(array $groups)
@@ -175,7 +178,9 @@ class ShowMapper extends BaseGroupedMapper
 
     protected function getTabs()
     {
-        return $this->admin->getShowTabs();
+        // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
+
+        return $this->admin->getShowTabs('sonata_deprecation_mute');
     }
 
     protected function setTabs(array $tabs)

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -154,7 +154,7 @@ class SonataAdminExtension extends AbstractExtension
             ),
             new TwigFilter(
                 'sonata_urlsafeid',
-                [$this, 'getUrlsafeIdentifier']
+                [$this, 'getUrlSafeIdentifier']
             ),
             new TwigFilter(
                 'sonata_xeditable_type',
@@ -406,13 +406,13 @@ class SonataAdminExtension extends AbstractExtension
      *
      * @return string string representation of the id that is safe to use in a url
      */
-    public function getUrlsafeIdentifier($model, ?AdminInterface $admin = null)
+    public function getUrlSafeIdentifier($model, ?AdminInterface $admin = null)
     {
         if (null === $admin) {
             $admin = $this->pool->getAdminByClass(ClassUtils::getClass($model));
         }
 
-        return $admin->getUrlsafeIdentifier($model);
+        return $admin->getUrlSafeIdentifier($model);
     }
 
     /**

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1131,7 +1131,8 @@ class AdminTest extends TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
-        $this->assertFalse($admin->getShowGroups());
+        // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
+        $this->assertFalse($admin->getShowGroups('sonata_deprecation_mute'));
 
         $groups = ['foo', 'bar', 'baz'];
 
@@ -1143,7 +1144,8 @@ class AdminTest extends TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
-        $this->assertFalse($admin->getFormGroups());
+        // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
+        $this->assertFalse($admin->getFormGroups('sonata_deprecation_mute'));
 
         $groups = ['foo', 'bar', 'baz'];
 
@@ -1270,12 +1272,12 @@ class AdminTest extends TestCase
 
         $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelManager->expects($this->once())
-            ->method('getUrlsafeIdentifier')
+            ->method('getUrlSafeIdentifier')
             ->with($this->equalTo($entity))
             ->willReturn('foo');
         $admin->setModelManager($modelManager);
 
-        $this->assertSame('foo', $admin->getUrlsafeIdentifier($entity));
+        $this->assertSame('foo', $admin->getUrlSafeIdentifier($entity));
     }
 
     public function testDeterminedPerPageValue(): void
@@ -2479,6 +2481,42 @@ class AdminTest extends TestCase
         $this->assertSame($commentVoteAdmin, $postAdmin->getCurrentLeafChildAdmin());
         $this->assertSame($commentVoteAdmin, $commentAdmin->getCurrentLeafChildAdmin());
         $this->assertNull($commentVoteAdmin->getCurrentLeafChildAdmin());
+    }
+
+    public function testAdminWithoutControllerName(): void
+    {
+        $admin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', null);
+
+        $this->assertNull($admin->getBaseControllerName());
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test and its data provider.
+     *
+     * @group legacy
+     *
+     * @dataProvider getDeprecatedAbstractAdminConstructorArgs
+     *
+     * @expectedDeprecation Passing other type than string%S as argument %d for method Sonata\AdminBundle\Admin\AbstractAdmin::__construct() is deprecated since sonata-project/admin-bundle 3.x. It will accept only string%S in version 4.0.
+     */
+    public function testDeprecatedAbstractAdminConstructorArgs($code, $class, $baseControllerName): void
+    {
+        new PostAdmin($code, $class, $baseControllerName);
+    }
+
+    public function getDeprecatedAbstractAdminConstructorArgs(): iterable
+    {
+        yield from [
+            ['sonata.post.admin.post', null, null],
+            [null, null, null],
+            ['sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', false],
+            ['sonata.post.admin.post', false, false],
+            [false, false, false],
+            [true, true, true],
+            [new \stdClass(), new \stdClass(), new \stdClass()],
+            [0, 0, 0],
+            [1, 1, 1],
+        ];
     }
 
     private function createTagAdmin(Post $post): TagAdmin

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -107,7 +107,7 @@ class BaseFieldDescriptionTest extends TestCase
         $description = new FieldDescription();
         $description->setOption('code', 'getFoo');
 
-        $mock = $this->getMockBuilder('stdClass')
+        $mock = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getFoo'])
             ->getMock();
         $mock->expects($this->once())->method('getFoo')->willReturn(42);
@@ -123,7 +123,7 @@ class BaseFieldDescriptionTest extends TestCase
         $description1->setOption('code', 'getWithOneParameter');
         $description1->setOption('parameters', $oneParameter);
 
-        $mock1 = $this->getMockBuilder('stdClass')
+        $mock1 = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getWithOneParameter'])
             ->getMock();
         $returnValue1 = $arg1 + 2;
@@ -140,7 +140,7 @@ class BaseFieldDescriptionTest extends TestCase
         $description2->setOption('code', 'getWithTwoParameters');
         $description2->setOption('parameters', $twoParameters);
 
-        $mock2 = $this->getMockBuilder('stdClass')
+        $mock2 = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getWithTwoParameters'])
             ->getMock();
         $returnValue2 = $arg1 + $arg2;
@@ -152,7 +152,7 @@ class BaseFieldDescriptionTest extends TestCase
          */
         foreach (['getFake', 'isFake', 'hasFake'] as $method) {
             $description3 = new FieldDescription();
-            $mock3 = $this->getMockBuilder('stdClass')
+            $mock3 = $this->getMockBuilder(\stdClass::class)
                 ->setMethods([$method])
                 ->getMock();
 
@@ -178,7 +178,7 @@ class BaseFieldDescriptionTest extends TestCase
         $this->expectException(\Sonata\AdminBundle\Exception\NoValueException::class);
 
         $description = new FieldDescription();
-        $mock = $this->getMockBuilder('stdClass')
+        $mock = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getFoo'])
             ->getMock();
 
@@ -191,7 +191,7 @@ class BaseFieldDescriptionTest extends TestCase
     public function testGetVirtualValue(): void
     {
         $description = new FieldDescription();
-        $mock = $this->getMockBuilder('stdClass')
+        $mock = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getFoo'])
             ->getMock();
 

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -105,7 +105,7 @@ final class ModelManager implements ModelManagerInterface
         return null;
     }
 
-    public function getUrlsafeIdentifier($model)
+    public function getUrlSafeIdentifier($model)
     {
         return $model->getId();
     }

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -1148,7 +1148,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin
             ->method('getClass')
-            ->willReturn('stdClass');
+            ->willReturn(\stdClass::class);
 
         $this->assertLoggerLogsModelManagerException($this->admin, 'delete');
 
@@ -1821,7 +1821,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin
             ->method('getClass')
-            ->willReturn('stdClass');
+            ->willReturn(\stdClass::class);
 
         $form = $this->createMock(Form::class);
 
@@ -2020,7 +2020,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin
             ->method('getClass')
-            ->willReturn('stdClass');
+            ->willReturn(\stdClass::class);
 
         $this->admin->expects($this->once())
             ->method('getNewInstance')
@@ -2051,7 +2051,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin
             ->method('getClass')
-            ->willReturn('stdClass');
+            ->willReturn(\stdClass::class);
 
         $this->admin->expects($this->once())
             ->method('getNewInstance')
@@ -2076,7 +2076,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin
             ->method('getClass')
-            ->willReturn('stdClass');
+            ->willReturn(\stdClass::class);
 
         $this->admin->expects($this->once())
             ->method('getNewInstance')
@@ -2159,7 +2159,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin
             ->method('getClass')
-            ->willReturn('stdClass');
+            ->willReturn(\stdClass::class);
 
         $this->admin->expects($this->once())
             ->method('getForm')
@@ -2224,7 +2224,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin
             ->method('getClass')
-            ->willReturn('stdClass');
+            ->willReturn(\stdClass::class);
 
         $this->admin->expects($this->once())
             ->method('getForm')
@@ -2265,7 +2265,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin
             ->method('getClass')
-            ->willReturn('stdClass');
+            ->willReturn(\stdClass::class);
 
         $this->admin->expects($this->once())
             ->method('getNewInstance')
@@ -2330,7 +2330,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin
             ->method('getClass')
-            ->willReturn('stdClass');
+            ->willReturn(\stdClass::class);
 
         $object = new \stdClass();
 
@@ -2441,7 +2441,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin
             ->method('getClass')
-            ->willReturn('stdClass');
+            ->willReturn(\stdClass::class);
 
         $this->admin->expects($this->once())
             ->method('getNormalizedIdentifier')
@@ -2479,7 +2479,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin
             ->method('getClass')
-            ->willReturn('stdClass');
+            ->willReturn(\stdClass::class);
 
         $this->admin->expects($this->once())
             ->method('getForm')
@@ -2536,7 +2536,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin
             ->method('getClass')
-            ->willReturn('stdClass');
+            ->willReturn(\stdClass::class);
 
         $this->admin->expects($this->once())
             ->method('getForm')
@@ -2596,7 +2596,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin
             ->method('getClass')
-            ->willReturn('stdClass');
+            ->willReturn(\stdClass::class);
 
         $this->admin->expects($this->once())
             ->method('getForm')

--- a/tests/Fixtures/Admin/PostAdmin.php
+++ b/tests/Fixtures/Admin/PostAdmin.php
@@ -17,7 +17,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 
 class PostAdmin extends AbstractAdmin
 {
-    protected $metadataClass = null;
+    protected $metadataClass;
 
     public function setParentAssociationMapping($associationMapping): void
     {

--- a/tests/Fixtures/Bundle/DemoAdminBundle.php
+++ b/tests/Fixtures/Bundle/DemoAdminBundle.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class DemoAdminBundle extends Bundle
 {
-    protected $path = null;
+    protected $path;
 
     public function setPath($path): void
     {

--- a/tests/Form/ChoiceList/LegacyModelChoiceListTest.php
+++ b/tests/Form/ChoiceList/LegacyModelChoiceListTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 
 class LegacyModelChoiceListTest extends TestCase
 {
-    private $modelManager = null;
+    private $modelManager;
 
     public function setUp(): void
     {

--- a/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
+++ b/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
@@ -20,7 +20,7 @@ use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
 
 class ModelChoiceLoaderTest extends TestCase
 {
-    private $modelManager = null;
+    private $modelManager;
 
     public function setUp(): void
     {

--- a/tests/Form/DataTransformer/ArrayToModelTransformerTest.php
+++ b/tests/Form/DataTransformer/ArrayToModelTransformerTest.php
@@ -23,7 +23,7 @@ use Sonata\AdminBundle\Tests\Fixtures\Entity\Form\FooEntity;
  */
 class ArrayToModelTransformerTest extends TestCase
 {
-    private $modelManager = null;
+    private $modelManager;
 
     public function setUp(): void
     {

--- a/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
@@ -22,7 +22,7 @@ use Sonata\AdminBundle\Tests\Fixtures\Entity\FooArrayAccess;
 
 class ModelToIdPropertyTransformerTest extends TestCase
 {
-    private $modelManager = null;
+    private $modelManager;
 
     public function setUp(): void
     {

--- a/tests/Form/DataTransformer/ModelToIdTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelToIdTransformerTest.php
@@ -19,7 +19,7 @@ use Sonata\AdminBundle\Model\ModelManagerInterface;
 
 class ModelToIdTransformerTest extends TestCase
 {
-    private $modelManager = null;
+    private $modelManager;
 
     public function setUp(): void
     {

--- a/tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
+++ b/tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
@@ -60,7 +60,7 @@ class FormTypeFieldExtensionTest extends TestCase
         $formView->parent = $parentFormView;
 
         $options = [];
-        $config = new FormConfigBuilder('test', 'stdClass', $eventDispatcher, $options);
+        $config = new FormConfigBuilder('test', \stdClass::class, $eventDispatcher, $options);
         $form = new Form($config);
 
         $extension = new FormTypeFieldExtension([], []);
@@ -94,7 +94,7 @@ class FormTypeFieldExtensionTest extends TestCase
 
         $formView = new FormView();
         $options = [];
-        $config = new FormConfigBuilder('test', 'stdClass', $eventDispatcher, $options);
+        $config = new FormConfigBuilder('test', \stdClass::class, $eventDispatcher, $options);
         $config->setAttribute('sonata_admin', [
             'admin' => $admin,
             'name' => 'name',
@@ -137,7 +137,7 @@ class FormTypeFieldExtensionTest extends TestCase
         $formView->vars['name'] = 'format';
 
         $options = [];
-        $config = new FormConfigBuilder('test', 'stdClass', $eventDispatcher, $options);
+        $config = new FormConfigBuilder('test', \stdClass::class, $eventDispatcher, $options);
         $config->setAttribute('sonata_admin', ['admin' => false]);
 
         $form = new Form($config);
@@ -194,7 +194,7 @@ class FormTypeFieldExtensionTest extends TestCase
 
         $formView = new FormView();
         $options = [];
-        $config = new FormConfigBuilder('test', 'stdClass', $eventDispatcher, $options);
+        $config = new FormConfigBuilder('test', \stdClass::class, $eventDispatcher, $options);
         $form = new Form($config);
 
         $extension = new FormTypeFieldExtension([], []);
@@ -262,7 +262,7 @@ class FormTypeFieldExtensionTest extends TestCase
         $formView->parent->parent->parent->vars['sonata_admin_enabled'] = false;
 
         $options = [];
-        $config = new FormConfigBuilder('test', 'stdClass', $eventDispatcher, $options);
+        $config = new FormConfigBuilder('test', \stdClass::class, $eventDispatcher, $options);
         $config->setAttribute('sonata_admin', ['admin' => false]);
 
         $form = new Form($config);

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -59,9 +59,14 @@ class FormMapperTest extends TestCase
         $formFactory = $this->createMock(FormFactoryInterface::class);
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
-        $formBuilder = new FormBuilder('test', 'stdClass', $eventDispatcher, $formFactory);
+        $formBuilder = new FormBuilder('test', \stdClass::class, $eventDispatcher, $formFactory);
 
         $this->admin = new CleanAdmin('code', 'class', 'controller');
+
+        // NEXT_MAJOR: Remove the calls to `setFormGroups()` and `setFormTabs()`
+        $this->admin->setFormGroups([]);
+        $this->admin->setFormTabs([]);
+
         $securityHandler = $this->createMock(SecurityHandlerInterface::class);
         $securityHandler
             ->method('isGranted')

--- a/tests/Form/Widget/BaseWidgetTest.php
+++ b/tests/Form/Widget/BaseWidgetTest.php
@@ -31,7 +31,7 @@ abstract class BaseWidgetTest extends AbstractWidgetTestCase
      *
      * @var string
      */
-    protected $type = null;
+    protected $type;
 
     /**
      * @var array

--- a/tests/Security/Handler/NoopSecurityHandlerTest.php
+++ b/tests/Security/Handler/NoopSecurityHandlerTest.php
@@ -22,7 +22,7 @@ class NoopSecurityHandlerTest extends TestCase
     /**
      * @var NoopSecurityHandler
      */
-    private $handler = null;
+    private $handler;
 
     public function setUp(): void
     {

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -2421,7 +2421,7 @@ EOT
                 }
             });
 
-        $element = $this->getMockBuilder('stdClass')
+        $element = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['customToString'])
             ->getMock();
         $element
@@ -2497,14 +2497,14 @@ EOT
 
         // set admin to pool
         $this->pool->setAdminServiceIds(['sonata_admin_foo_service']);
-        $this->pool->setAdminClasses(['stdClass' => ['sonata_admin_foo_service']]);
+        $this->pool->setAdminClasses([\stdClass::class => ['sonata_admin_foo_service']]);
 
         $this->admin->expects($this->once())
-            ->method('getUrlsafeIdentifier')
+            ->method('getUrlSafeIdentifier')
             ->with($this->equalTo($entity))
             ->willReturn(1234567);
 
-        $this->assertSame(1234567, $this->twigExtension->getUrlsafeIdentifier($entity));
+        $this->assertSame(1234567, $this->twigExtension->getUrlSafeIdentifier($entity));
     }
 
     public function testGetUrlsafeIdentifier_GivenAdmin_Foo(): void
@@ -2516,20 +2516,20 @@ EOT
             'sonata_admin_foo_service',
             'sonata_admin_bar_service',
         ]);
-        $this->pool->setAdminClasses(['stdClass' => [
+        $this->pool->setAdminClasses([\stdClass::class => [
             'sonata_admin_foo_service',
             'sonata_admin_bar_service',
         ]]);
 
         $this->admin->expects($this->once())
-            ->method('getUrlsafeIdentifier')
+            ->method('getUrlSafeIdentifier')
             ->with($this->equalTo($entity))
             ->willReturn(1234567);
 
         $this->adminBar->expects($this->never())
-            ->method('getUrlsafeIdentifier');
+            ->method('getUrlSafeIdentifier');
 
-        $this->assertSame(1234567, $this->twigExtension->getUrlsafeIdentifier($entity, $this->admin));
+        $this->assertSame(1234567, $this->twigExtension->getUrlSafeIdentifier($entity, $this->admin));
     }
 
     public function testGetUrlsafeIdentifier_GivenAdmin_Bar(): void
@@ -2538,20 +2538,20 @@ EOT
 
         // set admin to pool
         $this->pool->setAdminServiceIds(['sonata_admin_foo_service', 'sonata_admin_bar_service']);
-        $this->pool->setAdminClasses(['stdClass' => [
+        $this->pool->setAdminClasses([\stdClass::class => [
             'sonata_admin_foo_service',
             'sonata_admin_bar_service',
         ]]);
 
         $this->admin->expects($this->never())
-            ->method('getUrlsafeIdentifier');
+            ->method('getUrlSafeIdentifier');
 
         $this->adminBar->expects($this->once())
-            ->method('getUrlsafeIdentifier')
+            ->method('getUrlSafeIdentifier')
             ->with($this->equalTo($entity))
             ->willReturn(1234567);
 
-        $this->assertSame(1234567, $this->twigExtension->getUrlsafeIdentifier($entity, $this->adminBar));
+        $this->assertSame(1234567, $this->twigExtension->getUrlSafeIdentifier($entity, $this->adminBar));
     }
 
     public function xEditableChoicesProvider()

--- a/tests/Util/AdminObjectAclDataTest.php
+++ b/tests/Util/AdminObjectAclDataTest.php
@@ -85,7 +85,7 @@ class AdminObjectAclDataTest extends TestCase
     /**
      * @group legacy
      */
-    public function testSetForm()
+    public function testSetForm(): AdminObjectAclData
     {
         $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
@@ -108,7 +108,7 @@ class AdminObjectAclDataTest extends TestCase
         $this->assertInstanceOf(Form::class, $adminObjectAclData->getAclUsersForm());
     }
 
-    public function testSetAclUsersForm()
+    public function testSetAclUsersForm(): AdminObjectAclData
     {
         $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
@@ -129,7 +129,7 @@ class AdminObjectAclDataTest extends TestCase
         $this->assertInstanceOf(Form::class, $adminObjectAclData->getAclUsersForm());
     }
 
-    public function testSetAclRolesForm()
+    public function testSetAclRolesForm(): AdminObjectAclData
     {
         $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()

--- a/tests/Util/ObjectAclManipulatorTest.php
+++ b/tests/Util/ObjectAclManipulatorTest.php
@@ -36,7 +36,7 @@ class ObjectAclManipulatorTest extends TestCase
             $this->prophesize(ObjectIdentityInterface::class)->reveal(),
             $this->prophesize(ObjectIdentityInterface::class)->reveal(),
         ]);
-        $this->securityIdentity = new UserSecurityIdentity('Michael', 'stdClass');
+        $this->securityIdentity = new UserSecurityIdentity('Michael', \stdClass::class);
     }
 
     public function testConfigureAclsIgnoresNonAclSecurityHandlers(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Some API update messages.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to #6005.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated returning other types than `array` in `AbstractAdmin::getFormGroups()`, `AbstractAdmin::getFormTabs()`, `AbstractAdmin::getShowTabs()`, `AbstractAdmin::getShowGroups()`.
```

## To do
- [x] Add deprecation messages;
- [x] Add the changelog entries.
- [x] Update the tests;
