### PR TITLE
Deprecate getModelIdentifier

### DIFF
--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -100,6 +100,10 @@ interface ModelManagerInterface
     /**
      * Get the identifier for the model type of this class.
      *
+     * NEXT_MAJOR: Remove this function in favor of getIdentifierFieldNames
+     *
+     * @deprecated Prefer to use getIdentifierFieldNames
+     *
      * @param string $class fully qualified class name
      *
      * @return string


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

This function is almost never used in the persistence bundle.
The only use was in the `getDefaultSortValues` function, but it won't be in 4.0.

Plus, the implementation does not respect the return typehint string:
- The doctrine orm return an array
- The mongo odm return a nullable string

## Changelog

```markdown
### Deprecated
- Deprecate `getModelIdentifier` in favor of  `getIdentifierFieldNames` in `ModelManagerInterface`.
```