### PR TITLE
Move function from ModelManager to Datagrid

### DIFF
--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -293,4 +293,49 @@ class Datagrid implements DatagridInterface
 
         return $this->form;
     }
+
+    public function getSortParameters(FieldDescriptionInterface $fieldDescription): array
+    {
+        $values = $this->getValues();
+
+        if ($this->isFieldAlreadySorted($fieldDescription)) {
+            if ('ASC' === $values['_sort_order']) {
+                $values['_sort_order'] = 'DESC';
+            } else {
+                $values['_sort_order'] = 'ASC';
+            }
+        } else {
+            $values['_sort_order'] = 'ASC';
+        }
+
+        $values['_sort_by'] = \is_string($fieldDescription->getOption('sortable'))
+            ? $fieldDescription->getOption('sortable')
+            : $fieldDescription->getName();
+
+        return ['filter' => $values];
+    }
+
+    public function getPaginationParameters(int $page): array
+    {
+        $values = $this->getValues();
+
+        if (isset($values['_sort_by']) && $values['_sort_by'] instanceof FieldDescriptionInterface) {
+            $values['_sort_by'] = $values['_sort_by']->getName();
+        }
+        $values['_page'] = $page;
+
+        return ['filter' => $values];
+    }
+
+    private function isFieldAlreadySorted(FieldDescriptionInterface $fieldDescription): bool
+    {
+        $values = $this->getValues();
+
+        if (!isset($values['_sort_by']) || !$values['_sort_by'] instanceof FieldDescriptionInterface) {
+            return false;
+        }
+
+        return $values['_sort_by']->getName() === $fieldDescription->getName()
+            || $values['_sort_by']->getName() === $fieldDescription->getOption('sortable');
+    }
 }

--- a/src/Datagrid/DatagridInterface.php
+++ b/src/Datagrid/DatagridInterface.php
@@ -14,11 +14,15 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Datagrid;
 
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Component\Form\FormInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @method array getSortParameters(FieldDescriptionInterface $fieldDescription)
+ * @method array getPaginationParameters(int $page)
  */
 interface DatagridInterface
 {
@@ -104,4 +108,11 @@ interface DatagridInterface
      * @return bool
      */
     public function hasDisplayableFilters();
+
+    /*
+     * NEXT_MAJOR: Uncomment getSortParameters and getPaginationParameters.
+     *
+     * public function getSortParameters(FieldDescriptionInterface $fieldDescription): array;
+     * public function getPaginationParameters(int $page): array;
+     */
 }

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -207,6 +207,11 @@ interface ModelManagerInterface
     /**
      * Returns the parameters used in the columns header.
      *
+     * NEXT_MAJOR: - Remove this function
+     *             - Replace admin.modelmanager.sortparameters to admin.datagrid.sortparameters
+     *
+     * @deprecated since sonata-project/sonata-admin-bundle 3.x. To be removed in 4.0.
+     *
      * @return array<string, mixed>
      */
     public function getSortParameters(FieldDescriptionInterface $fieldDescription, DatagridInterface $datagrid);
@@ -258,6 +263,11 @@ interface ModelManagerInterface
 
     /**
      * @param int $page
+     *
+     * NEXT_MAJOR: - Remove this function
+     *             - Replace admin.modelmanager.paginationparameters to admin.datagrid.paginationparameters
+     *
+     * @deprecated since sonata-project/sonata-admin-bundle 3.x. To be removed in 4.0.
      *
      * @return array<string, mixed>
      */

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -563,4 +563,73 @@ class DatagridTest extends TestCase
             ['3', 50],
         ];
     }
+
+    public function testSortParameters(): void
+    {
+        $field1 = $this->createMock(FieldDescriptionInterface::class);
+        $field1->method('getName')->willReturn('field1');
+
+        $field2 = $this->createMock(FieldDescriptionInterface::class);
+        $field2->method('getName')->willReturn('field2');
+
+        $field3 = $this->createMock(FieldDescriptionInterface::class);
+        $field3->method('getName')->willReturn('field3');
+        $field3->method('getOption')->with('sortable')->willReturn('field3sortBy');
+
+        $this->datagrid = new Datagrid(
+            $this->query,
+            $this->columns,
+            $this->pager,
+            $this->formBuilder,
+            ['_sort_by' => $field1, '_sort_order' => 'ASC']
+        );
+
+        $parameters = $this->datagrid->getSortParameters($field1);
+
+        $this->assertSame('DESC', $parameters['filter']['_sort_order']);
+        $this->assertSame('field1', $parameters['filter']['_sort_by']);
+
+        $parameters = $this->datagrid->getSortParameters($field2);
+
+        $this->assertSame('ASC', $parameters['filter']['_sort_order']);
+        $this->assertSame('field2', $parameters['filter']['_sort_by']);
+
+        $parameters = $this->datagrid->getSortParameters($field3);
+
+        $this->assertSame('ASC', $parameters['filter']['_sort_order']);
+        $this->assertSame('field3sortBy', $parameters['filter']['_sort_by']);
+
+        $this->datagrid = new Datagrid(
+            $this->query,
+            $this->columns,
+            $this->pager,
+            $this->formBuilder,
+            ['_sort_by' => $field3, '_sort_order' => 'ASC']
+        );
+
+        $parameters = $this->datagrid->getSortParameters($field3);
+
+        $this->assertSame('DESC', $parameters['filter']['_sort_order']);
+        $this->assertSame('field3sortBy', $parameters['filter']['_sort_by']);
+    }
+
+    public function testGetPaginationParameters(): void
+    {
+        $field = $this->createMock(FieldDescriptionInterface::class);
+
+        $this->datagrid = new Datagrid(
+            $this->query,
+            $this->columns,
+            $this->pager,
+            $this->formBuilder,
+            ['_sort_by' => $field, '_sort_order' => 'ASC']
+        );
+
+        $field->expects($this->once())->method('getName')->willReturn($name = 'test');
+
+        $result = $this->datagrid->getPaginationParameters($page = 5);
+
+        $this->assertSame($page, $result['filter']['_page']);
+        $this->assertSame($name, $result['filter']['_sort_by']);
+    }
 }


### PR DESCRIPTION
## Subject

This two function should be in the Datagrid instead of be implemented 3 times the same way in the PersistenceBundle.

I am targeting this branch, because BC.

## Changelog
```markdown
### Added
- `Datagrid::getPaginationParameters` and `Datagrid::getSortParameters`

### Deprecated
- `ModelManagerInterface::getPaginationParameters` and `ModelManagerInterface::getSortParameters`
```