### PR TITLE
Prettify array field on show and list actions

### DIFF
--- a/docs/reference/field_types.rst
+++ b/docs/reference/field_types.rst
@@ -60,6 +60,52 @@ This is currently limited to scalar types (text, integer, url...) and choice typ
 More types might be provided based on the persistency layer defined. Please refer to their
 related documentations.
 
+Array
+^^^^^^
+
+You can use the following parameters:
+
+======================================  ============================================================
+Parameter                               Description
+======================================  ============================================================
+**inline**                              If `true`, the array will be displayed as a single line,
+                                        the whole array and each array level will be wrapped up with square brackets.
+                                        If `false`, the array will be displayed as an unordered list.
+                                        For the `show` action, the default value is `true` and for the `list` action
+                                        it's `false`.
+**display**                             Define what should be displayed: keys, values or both.
+                                        Defaults to `'both'`.
+                                        Available options are: `'both'`, `'keys'`, `'values'`.
+**key_translation_domain**              This option determines if the keys should be translated and
+                                        in which translation domain.
+
+                                        The values of this option can be `true` (use admin
+                                        translation domain), `false` (disable translation), `null`
+                                        (uses the parent translation domain or the default domain)
+                                        or a string which represents the exact translation domain to use.
+**value_translation_domain**            This option determines if the values should be translated and
+                                        in which translation domain.
+
+                                        The values of this option can be `true` (use admin
+                                        translation domain), `false` (disable translation), `null`
+                                        (uses the parent translation domain or the default domain)
+                                        or a string which represents the exact translation domain to use.
+======================================  ============================================================
+
+.. code-block:: php
+
+    protected function configureListFields(ListMapper $listMapper): void
+    {
+        $listMapper
+            ->add('options', 'array', [
+                'inline' => true,
+                'display' => 'both',
+                'key_translation_domain' => true,
+                'value_translation_domain' => null
+            ])
+        ;
+    }
+
 Choice
 ^^^^^^
 

--- a/src/Resources/views/CRUD/base_array_macro.html.twig
+++ b/src/Resources/views/CRUD/base_array_macro.html.twig
@@ -8,17 +8,80 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% macro render_array(value, inline) %}
-    {% from _self import render_array %}
-    {% for key, val in value %}
-        {% if val is iterable %}
-            [{{ key }} => {{ render_array(val, inline) }}]
-        {% else %}
-            [{{ key }} => {{ val }}]
-        {% endif %}
+{# NEXT_MAJOR: move inline parameter under options #}
+{% macro render_array(value, inline, options = []) %}
+    {% set options = {
+        'key_translation_domain': false,
+        'value_translation_domain': false,
+        'display': 'both'
+    }|merge(options) %}
+    {%- apply spaceless -%}
+        {%- from _self import render_array -%}
 
-        {% if not loop.last and not inline %}
-            <br>
-        {% endif %}
-    {% endfor %}
+        {%- if not inline -%}
+            <ul>
+        {%- else -%}
+            [
+        {%- endif -%}
+
+        {%- for key, val in value -%}
+            {%- if not inline -%}
+                <li>
+            {%- endif -%}
+
+            {%- if options.display in ['both', 'keys'] -%}
+                {%- if options.key_translation_domain is same as(false) -%}
+                    {{- key -}}
+                {%- else -%}
+                    {%- if options.key_translation_domain is same as(true) -%}
+                        {%- set key_translation_domain = options.default_translation_domain -%}
+                    {%- elseif options.key_translation_domain is same as(null) -%}
+                        {%- set key_translation_domain = null -%}
+                    {%- else -%}
+                        {%- set key_translation_domain = options.key_translation_domain -%}
+                    {%- endif -%}
+
+                    {{- key|trans({}, key_translation_domain) -}}
+                {%- endif -%}
+            {%- endif -%}
+
+            {%- if options.display == 'both' -%}
+                &nbsp;=>&nbsp;
+            {%- endif -%}
+
+            {%- if val is iterable -%}
+                {{ render_array(val, inline, options) }}
+            {%- else -%}
+                {%- if options.display in ['both', 'values'] -%}
+                    {%- if options.value_translation_domain is same as(false) -%}
+                        {{ val }}
+                    {%- else -%}
+                        {%- if options.value_translation_domain is same as(true) -%}
+                            {%- set value_translation_domain = options.default_translation_domain -%}
+                        {%- elseif options.value_translation_domain is same as(null) -%}
+                            {%- set value_translation_domain = null -%}
+                        {%- else -%}
+                            {%- set value_translation_domain = options.value_translation_domain -%}
+                        {%- endif -%}
+
+                        {{- val|trans({}, value_translation_domain) -}}
+                    {%- endif -%}
+                {%- endif -%}
+            {%- endif -%}
+
+            {%- if not inline -%}
+                </li>
+            {%- endif -%}
+
+            {%- if inline == true and not loop.last -%}
+                ,
+            {% endif -%}
+        {%- endfor -%}
+
+        {%- if not inline -%}
+            </ul>
+        {%- else -%}
+            ]
+        {%- endif -%}
+    {%- endapply -%}
 {% endmacro %}

--- a/src/Resources/views/CRUD/list_array.html.twig
+++ b/src/Resources/views/CRUD/list_array.html.twig
@@ -13,5 +13,9 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {{ list.render_array(value, field_description.options.inline is not defined or field_description.options.inline) }}
+    {{ list.render_array(
+        value,
+        field_description.options.inline is not defined or field_description.options.inline,
+        { default_translation_domain : admin.translationDomain }|merge(field_description.options)
+    ) }}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_array.html.twig
+++ b/src/Resources/views/CRUD/show_array.html.twig
@@ -13,5 +13,9 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {{ show.render_array(value, field_description.options.inline|default(false)) }}
+    {{ show.render_array(
+        value,
+        field_description.options.inline|default(false),
+        { default_translation_domain : admin.translationDomain }|merge(field_description.options)
+    ) }}
 {% endblock %}

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -732,14 +732,14 @@ class SonataAdminExtensionTest extends TestCase
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-array" objectId="12345">
-                    [1 => First] [2 => Second]
+                    [1&nbsp;=>&nbsp;First, 2&nbsp;=>&nbsp;Second]
                 </td>',
                 'array',
                 [1 => 'First', 2 => 'Second'],
                 [],
             ],
             [
-                '<td class="sonata-ba-list-field sonata-ba-list-field-array" objectId="12345"> </td>',
+                '<td class="sonata-ba-list-field sonata-ba-list-field-array" objectId="12345"> [] </td>',
                 'array',
                 null,
                 [],
@@ -1611,13 +1611,13 @@ EOT
             ['<th>Data</th> <td> EUR 10.746135 </td>', 'currency', 10.746135, ['currency' => 'EUR']],
             ['<th>Data</th> <td> GBP 51.23456 </td>', 'currency', 51.23456, ['currency' => 'GBP']],
             [
-                '<th>Data</th> <td> [1 => First] <br> [2 => Second] </td>',
+                '<th>Data</th> <td> <ul><li>1&nbsp;=>&nbsp;First</li><li>2&nbsp;=>&nbsp;Second</li></ul> </td>',
                 'array',
                 [1 => 'First', 2 => 'Second'],
                 ['safe' => false],
             ],
             [
-                '<th>Data</th> <td> [1 => First] [2 => Second] </td>',
+                '<th>Data</th> <td> [1&nbsp;=>&nbsp;First, 2&nbsp;=>&nbsp;Second] </td>',
                 'array',
                 [1 => 'First', 2 => 'Second'],
                 ['safe' => false, 'inline' => true],
@@ -2034,7 +2034,7 @@ EOT
             ['<th>Data</th> <td> 0 % </td>', 'percent', new NoValueException(), []],
             ['<th>Data</th> <td> </td>', 'currency', new NoValueException(), ['currency' => 'EUR']],
             ['<th>Data</th> <td> </td>', 'currency', new NoValueException(), ['currency' => 'GBP']],
-            ['<th>Data</th> <td> </td>', 'array', new NoValueException(), ['safe' => false]],
+            ['<th>Data</th> <td> <ul></ul> </td>', 'array', new NoValueException(), ['safe' => false]],
             [
                 '<th>Data</th> <td><span class="label label-danger">no</span></td>',
                 'boolean',


### PR DESCRIPTION
## Prettify array field on show and list actions

Generally here is just a prettifying of the array field type. I described new field options in the documentation.

Here is an example of how it can look now:

![image](https://user-images.githubusercontent.com/617002/78694810-e1e68600-7905-11ea-89ea-884a1a40a557.png)

![image](https://user-images.githubusercontent.com/617002/78756438-780cc180-7983-11ea-8616-31997a976a4a.png)

Inline view:

![image](https://user-images.githubusercontent.com/617002/78694772-d2673d00-7905-11ea-95ee-03dc433bd6dd.png)

![image](https://user-images.githubusercontent.com/617002/78756466-8529b080-7983-11ea-9617-a50510114d76.png)

Screenshot from the translation tab of Symfony profiler:

![image](https://user-images.githubusercontent.com/617002/78756744-f5d0cd00-7983-11ea-8783-89b8e95e46a9.png)

with these options:

![image](https://user-images.githubusercontent.com/617002/78756789-08e39d00-7984-11ea-98f0-2d3e2ee135ca.png)



I am targeting this branch, because it extends current functionality and no breaking changes here.

Closes #5908.

## Changelog
```markdown
### Added
- Added new options (display, key_translation_domain and value_translation_domain) to the array field on Show and List pages.
```