### PR TITLE
Fix \Knp\Menu\MenuItem @label issue

### DIFF
--- a/src/Resources/views/Core/tab_menu_template.html.twig
+++ b/src/Resources/views/Core/tab_menu_template.html.twig
@@ -119,8 +119,8 @@
 {% endblock %}
 
 {% block label %}
-{{-
-    # We use method accessor instead of ".label" since `item` implements `ArrayAccess` and could have a property called "label".
+    {# We use method accessor instead of ".label" since `item` implements `ArrayAccess` and could have a property called "label".#}
+    {{-
     item.getLabel()|trans(
         item.getExtra('translation_params', {}),
         item.getExtra(

--- a/src/Resources/views/Core/tab_menu_template.html.twig
+++ b/src/Resources/views/Core/tab_menu_template.html.twig
@@ -120,6 +120,7 @@
 
 {% block label %}
 {{-
+    # We use method accessor instead of ".label" since `item` implements `ArrayAccess` and could have a property called "label".
     item.getLabel()|trans(
         item.getExtra('translation_params', {}),
         item.getExtra(

--- a/src/Resources/views/Core/tab_menu_template.html.twig
+++ b/src/Resources/views/Core/tab_menu_template.html.twig
@@ -120,7 +120,7 @@
 
 {% block label %}
 {{-
-    item.label|trans(
+    item.getLabel()|trans(
         item.getExtra('translation_params', {}),
         item.getExtra(
             'translation_domain',

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -47,5 +47,5 @@
     {% endapply %}
 {% endblock %}
 
-# We use method accessor instead of ".label" since `item` implements `ArrayAccess` and could have a property called "label".
+{# We use method accessor instead of ".label" since `item` implements `ArrayAccess` and could have a property called "label".#}
 {% block label %}{% if is_link is defined and is_link %}{{ icon|default|raw }}{% endif %}{% if options.allow_safe_labels and item.extra('safe_label', false) %}{{ item.getLabel()|raw }}{% else %}{{ item.getLabel()|trans({}, translation_domain|default('messages')) }}{% endif %}{% endblock %}

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -47,4 +47,5 @@
     {% endapply %}
 {% endblock %}
 
+# We use method accessor instead of ".label" since `item` implements `ArrayAccess` and could have a property called "label".
 {% block label %}{% if is_link is defined and is_link %}{{ icon|default|raw }}{% endif %}{% if options.allow_safe_labels and item.extra('safe_label', false) %}{{ item.getLabel()|raw }}{% else %}{{ item.getLabel()|trans({}, translation_domain|default('messages')) }}{% endif %}{% endblock %}

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -47,4 +47,4 @@
     {% endapply %}
 {% endblock %}
 
-{% block label %}{% if is_link is defined and is_link %}{{ icon|default|raw }}{% endif %}{% if options.allow_safe_labels and item.extra('safe_label', false) %}{{ item.label|raw }}{% else %}{{ item.label|trans({}, translation_domain|default('messages')) }}{% endif %}{% endblock %}
+{% block label %}{% if is_link is defined and is_link %}{{ icon|default|raw }}{% endif %}{% if options.allow_safe_labels and item.extra('safe_label', false) %}{{ item.getLabel()|raw }}{% else %}{{ item.getLabel()|trans({}, translation_domain|default('messages')) }}{% endif %}{% endblock %}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -96,7 +96,7 @@ file that was distributed with this source code.
                             {% endif %}
 
                             {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
-                            # We use method accessor instead of ".label" since `menu` implements `ArrayAccess` and could have a property called "label".
+                            {# We use method accessor instead of ".label" since `menu` implements `ArrayAccess` and could have a property called "label".#}
                             {%- set label = menu.getLabel() -%}
                             {%- if translation_domain is not same as(false) -%}
                                 {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
@@ -158,7 +158,7 @@ file that was distributed with this source code.
                                                 {% if action is defined %}
                                                     {% for menu in breadcrumbs_builder.breadcrumbs(admin, action) %}
                                                         {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
-                                                        # We use method accessor instead of ".label" since `menu` implements `ArrayAccess` and could have a property called "label".
+                                                        {# We use method accessor instead of ".label" since `menu` implements `ArrayAccess` and could have a property called "label".#}
                                                         {%- set label = menu.getLabel() -%}
                                                         {%- if translation_domain is not same as(false) -%}
                                                             {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -157,7 +157,7 @@ file that was distributed with this source code.
                                                 {% if action is defined %}
                                                     {% for menu in breadcrumbs_builder.breadcrumbs(admin, action) %}
                                                         {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
-                                                        {%- set label = menu.label -%}
+                                                        {%- set label = menu.getLabel() -%}
                                                         {%- if translation_domain is not same as(false) -%}
                                                             {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
                                                         {%- endif -%}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -96,7 +96,7 @@ file that was distributed with this source code.
                             {% endif %}
 
                             {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
-                            {%- set label = menu.label -%}
+                            {%- set label = menu.getLabel() -%}
                             {%- if translation_domain is not same as(false) -%}
                                 {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
                             {%- endif -%}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -96,6 +96,7 @@ file that was distributed with this source code.
                             {% endif %}
 
                             {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
+                            # We use method accessor instead of ".label" since `menu` implements `ArrayAccess` and could have a property called "label".
                             {%- set label = menu.getLabel() -%}
                             {%- if translation_domain is not same as(false) -%}
                                 {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
@@ -157,6 +158,7 @@ file that was distributed with this source code.
                                                 {% if action is defined %}
                                                     {% for menu in breadcrumbs_builder.breadcrumbs(admin, action) %}
                                                         {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
+                                                        # We use method accessor instead of ".label" since `menu` implements `ArrayAccess` and could have a property called "label".
                                                         {%- set label = menu.getLabel() -%}
                                                         {%- if translation_domain is not same as(false) -%}
                                                             {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}

--- a/tests/App/Admin/FooAdmin.php
+++ b/tests/App/Admin/FooAdmin.php
@@ -17,10 +17,16 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\AdminBundle\Tests\App\Model\Foo;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 final class FooAdmin extends AbstractAdmin
 {
+    public function getNewInstance()
+    {
+        return new Foo('test_id', 'foo_name');
+    }
+
     protected function configureListFields(ListMapper $list)
     {
         $list->add('name', 'string');

--- a/tests/App/Admin/PR6031Admin.php
+++ b/tests/App/Admin/PR6031Admin.php
@@ -44,7 +44,7 @@ final class PR6031Admin extends AbstractAdmin
         $show->add('name', 'string');
     }
 
-    protected function configureTabMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
+    protected function configureTabMenu(MenuItemInterface $menu, $action, ?AdminInterface $childAdmin = null)
     {
         $menu
             ->addChild('label')->addChild('label');

--- a/tests/App/Admin/PR6031Admin.php
+++ b/tests/App/Admin/PR6031Admin.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Admin;
+
+use Knp\Menu\ItemInterface as MenuItemInterface;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\AdminBundle\Tests\App\Model\PR6031;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+final class PR6031Admin extends AbstractAdmin
+{
+    public function getNewInstance()
+    {
+        return new PR6031('pr_6031', 'pr_6031');
+    }
+
+    protected function configureListFields(ListMapper $list)
+    {
+        $list->add('name', 'string');
+    }
+
+    protected function configureFormFields(FormMapper $form)
+    {
+        $form->add('name', TextType::class);
+    }
+
+    protected function configureShowFields(ShowMapper $show)
+    {
+        $show->add('name', 'string');
+    }
+
+    protected function configureTabMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
+    {
+        $menu
+            ->addChild('label')->addChild('label');
+    }
+}

--- a/tests/App/Model/FooRepository.php
+++ b/tests/App/Model/FooRepository.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\App\Model;
 
-final class FooRepository
+final class FooRepository implements RepositoryInterface
 {
+    /**
+     * @var array<class-string, Foo>
+     */
     private $elements;
 
     public function __construct()

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -118,7 +118,7 @@ final class ModelManager implements ModelManagerInterface
 
     public function getModelInstance($class)
     {
-        return new $class();
+        return new Foo('test_id', 'foo_name');
     }
 
     public function getModelCollectionInstance($class)

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -24,7 +24,7 @@ final class ModelManager implements ModelManagerInterface
     /**
      * @var array array<class-string, RepositoryInterface>
      */
-    private $repositories;
+    private $repositories = [];
 
     /**
      * @param array<class-string, RepositoryInterface> $repositories

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -21,11 +21,17 @@ use Sonata\AdminBundle\Tests\App\Admin\FieldDescription;
 
 final class ModelManager implements ModelManagerInterface
 {
-    private $repository;
+    /**
+     * @var array array<class-string, RepositoryInterface>
+     */
+    private $repositories;
 
-    public function __construct(FooRepository $repository)
+    /**
+     * @param array<class-string, RepositoryInterface> $repositories
+     */
+    public function __construct(array $repositories)
     {
-        $this->repository = $repository;
+        $this->repositories = $repositories;
     }
 
     public function getNewFieldDescriptionInstance($class, $name, array $options = [])
@@ -69,7 +75,7 @@ final class ModelManager implements ModelManagerInterface
 
     public function find($class, $id)
     {
-        return $this->repository->byId($id);
+        return $this->repositories[$class]->byId($id);
     }
 
     public function batchDelete($class, ProxyQueryInterface $queryProxy)
@@ -112,7 +118,7 @@ final class ModelManager implements ModelManagerInterface
 
     public function getModelInstance($class)
     {
-        return new Foo('test_id', 'foo_name');
+        return new $class();
     }
 
     public function getModelCollectionInstance($class)

--- a/tests/App/Model/PR6031.php
+++ b/tests/App/Model/PR6031.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Model;
+
+final class PR6031
+{
+    private $id;
+
+    private $name;
+
+    public function __construct(string $id, string $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function __toString(): string
+    {
+        return 'label';
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/tests/App/Model/PR6031Repository.php
+++ b/tests/App/Model/PR6031Repository.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Model;
+
+final class PR6031Repository implements RepositoryInterface
+{
+    /**
+     * @var array<class-string, Foo>
+     */
+    private $elements;
+
+    public function __construct()
+    {
+        $this->elements = [
+            'pr_6031' => new PR6031('pr_6031', 'pr_6031'),
+        ];
+    }
+
+    public function byId(string $id): ?PR6031
+    {
+        return $this->elements[$id] ?? null;
+    }
+
+    public function all(): array
+    {
+        return $this->elements;
+    }
+}

--- a/tests/App/Model/PR6031Repository.php
+++ b/tests/App/Model/PR6031Repository.php
@@ -16,9 +16,9 @@ namespace Sonata\AdminBundle\Tests\App\Model;
 final class PR6031Repository implements RepositoryInterface
 {
     /**
-     * @var array<class-string, Foo>
+     * @var array<class-string, PR6031>
      */
-    private $elements;
+    private $elements = [];
 
     public function __construct()
     {

--- a/tests/App/Model/RepositoryInterface.php
+++ b/tests/App/Model/RepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Model;
+
+interface RepositoryInterface
+{
+    /**
+     * @return object|null
+     */
+    public function byId(string $id);
+
+    public function all(): array;
+}

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -8,7 +8,8 @@ services:
     sonata.admin.manager.test:
         class: Sonata\AdminBundle\Tests\App\Model\ModelManager
         arguments:
-            - '@Sonata\AdminBundle\Tests\App\Model\FooRepository'
+            $repositories:
+                'Sonata\AdminBundle\Tests\App\Model\Foo': '@Sonata\AdminBundle\Tests\App\Model\FooRepository'
         tags:
             - {name: sonata.admin.manager}
 

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -4,12 +4,14 @@ services:
         class: Sonata\AdminBundle\Tests\Fixtures\DoctrineBundle\Connection
 
     Sonata\AdminBundle\Tests\App\Model\FooRepository: ~
+    Sonata\AdminBundle\Tests\App\Model\PR6031Repository: ~
 
     sonata.admin.manager.test:
         class: Sonata\AdminBundle\Tests\App\Model\ModelManager
         arguments:
             $repositories:
                 'Sonata\AdminBundle\Tests\App\Model\Foo': '@Sonata\AdminBundle\Tests\App\Model\FooRepository'
+                'Sonata\AdminBundle\Tests\App\Model\PR6031': '@Sonata\AdminBundle\Tests\App\Model\PR6031Repository'
         tags:
             - {name: sonata.admin.manager}
 
@@ -44,3 +46,8 @@ services:
         arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
         tags:
             - {name: sonata.admin, manager_type: test, label: Empty}
+
+    Sonata\AdminBundle\Tests\App\Admin\PR6031Admin:
+        arguments: [~, Sonata\AdminBundle\Tests\App\Model\PR6031, ~]
+        tags:
+            - {name: sonata.admin, manager_type: test, label: label}

--- a/tests/Functional/Ticket/PR6031Test.php
+++ b/tests/Functional/Ticket/PR6031Test.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Sonata\AdminBundle\Tests\Functional\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class PR6031Test extends WebTestCase
+{
+    public function testLabelInShowAction(): void
+    {
+        $client = static::createClient();
+
+        $client->request(Request::METHOD_GET, '/admin/tests/app/pr6031/pr_6031/edit');
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request(Request::METHOD_GET, '/admin/tests/app/pr6031/pr_6031/show');
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request(Request::METHOD_GET, '/admin/tests/app/pr6031/create');
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request(Request::METHOD_GET, '/admin/tests/app/pr6031/list');
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Functional/WebTestCase.php
+++ b/tests/Functional/WebTestCase.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Functional;
+
+use Sonata\AdminBundle\Tests\App\AppKernel;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
+
+abstract class WebTestCase extends BaseWebTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return AppKernel::class;
+    }
+}

--- a/tests/Menu/Integration/TabMenuTest.php
+++ b/tests/Menu/Integration/TabMenuTest.php
@@ -95,18 +95,6 @@ class TabMenuTest extends BaseMenuTest
         $this->assertStringContainsString('my-other-translation', $html);
     }
 
-    public function testLabelAccessorErrorCase(): void
-    {
-        $translatorProphecy = $this->prophesize(TranslatorInterface::class);
-        $this->translator = $translatorProphecy->reveal();
-        $factory = new MenuFactory();
-        $menu = new MenuItem('test-menu', $factory);
-        $menu->addChild('some-label', ['uri' => '/whatever']);
-        $menu->getFirstChild()->addChild('label', ['uri' => '/whatever']);
-        $this->expectException(\TypeError::class);
-        $this->renderMenu($menu);
-    }
-
     protected function getTemplate()
     {
         return 'Core/tab_menu_template.html.twig';

--- a/tests/Menu/Integration/TabMenuTest.php
+++ b/tests/Menu/Integration/TabMenuTest.php
@@ -95,6 +95,18 @@ class TabMenuTest extends BaseMenuTest
         $this->assertStringContainsString('my-other-translation', $html);
     }
 
+    public function testLabelAccessorErrorCase(): void
+    {
+        $translatorProphecy = $this->prophesize(TranslatorInterface::class);
+        $this->translator = $translatorProphecy->reveal();
+        $factory = new MenuFactory();
+        $menu = new MenuItem('test-menu', $factory);
+        $menu->addChild('some-label', ['uri' => '/whatever']);
+        $menu->getFirstChild()->addChild('label', ['uri' => '/whatever']);
+        $this->expectException(\TypeError::class);
+        $this->renderMenu($menu);
+    }
+
     protected function getTemplate()
     {
         return 'Core/tab_menu_template.html.twig';


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is a bug fix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Call \Knp\Menu\MenuItem::getLabel() method directly in twig template to avoid a possible side effect from \ArrayAccess.
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->


## Description:

\Knp\Menu\MenuItem in knplabs/knp-menu-bundle implements \ArrayAccess and defines its offsetGet method as follows:
```php
    /**
     * Implements ArrayAccess
     */
    public function offsetGet($name)
    {
        return $this->getChild($name);
    }

    public function getChild($name)
    {
        return isset($this->children[$name]) ? $this->children[$name] : null;
    }

```

It has a property `$label` with its getter: 
```php
    /**
     * Label to output, name is used by default
     *
     * @var string|null
     */
    protected $label;

    public function getLabel()
    {
        return (null !== $this->label) ? $this->label : $this->name;
    }
```
## Problem :

If a MenuItem object has a child with the key `label`, the twig expression `menu.label` will trigger the `offsetGet` method of the \ArrayAccess and return the child instead of the `$label` property of the MenuItem object.

This would result in Catchable Fatal Error: Object of class Knp\Menu\MenuItem could not be converted to string.

## Solution:

Call the getter of the `$label` property directly:
```twig
menu.getLabel()
```
