### PR TITLE
Rename getter

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2063,7 +2063,26 @@ EOT;
         $this->currentChild = $currentChild;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0
+     */
     public function getCurrentChild()
+    {
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated since version 3.x and will be removed in 4.0. Use %s::isCurrentChild() instead.',
+                __METHOD__,
+                __CLASS__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return $this->currentChild;
+    }
+
+    public function isCurrentChild(): bool
     {
         return $this->currentChild;
     }
@@ -2076,7 +2095,7 @@ EOT;
     public function getCurrentChildAdmin()
     {
         foreach ($this->children as $children) {
-            if ($children->getCurrentChild()) {
+            if ($children->isCurrentChild()) {
                 return $children;
             }
         }

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -624,6 +624,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     /**
      * Returns the current child status.
      *
+     * NEXT_MAJOR: Rename the function isCurrentChild()
+     *
      * @return bool
      */
     public function getCurrentChild();

--- a/tests/Admin/BreadcrumbsBuilderTest.php
+++ b/tests/Admin/BreadcrumbsBuilderTest.php
@@ -64,7 +64,6 @@ class BreadcrumbsBuilderTest extends TestCase
 
         $postAdmin = new PostAdmin('sonata.post.admin.post', DummySubject::class, 'Sonata\NewsBundle\Controller\PostAdminController');
         $commentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
-        $subCommentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
 
         $postAdmin->addChild($commentAdmin);
         $postAdmin->setRequest(new Request(['id' => $postAdminSubjectId]));
@@ -76,7 +75,7 @@ class BreadcrumbsBuilderTest extends TestCase
         $commentAdmin->initialize();
         $postAdmin->initialize();
 
-        $commentAdmin->setCurrentChild($subCommentAdmin);
+        $commentAdmin->setCurrentChild(true);
 
         $container
             ->method('getParameter')


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `BaseAdmin::IsCurrentChild` method

### Deprecated
- ` BaseAdmin::GetCurrentChild` method
```