### PR TITLE
Replace `$absolute` arguments with `$referenceType`

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -14,9 +14,8 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Admin;
 
 use Doctrine\Common\Util\ClassUtils;
-use Knp\Menu\FactoryInterface as MenuFactoryInterface;
+use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
-use Knp\Menu\ItemInterface as MenuItemInterface;
 use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
@@ -375,12 +374,12 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     protected $configurationPool;
 
     /**
-     * @var MenuItemInterface
+     * @var ItemInterface
      */
     protected $menu;
 
     /**
-     * @var MenuFactoryInterface
+     * @var FactoryInterface
      */
     protected $menuFactory;
 
@@ -1227,21 +1226,21 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return ($admin->getBaseRouteName().'_'.$name) === $route;
     }
 
-    public function generateObjectUrl($name, $object, array $parameters = [], $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH)
+    public function generateObjectUrl($name, $object, array $parameters = [], $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH)
     {
         $parameters['id'] = $this->getUrlsafeIdentifier($object);
 
-        return $this->generateUrl($name, $parameters, $absolute);
+        return $this->generateUrl($name, $parameters, $referenceType);
     }
 
-    public function generateUrl($name, array $parameters = [], $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH)
+    public function generateUrl($name, array $parameters = [], $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        return $this->routeGenerator->generateUrl($this, $name, $parameters, $absolute);
+        return $this->routeGenerator->generateUrl($this, $name, $parameters, $referenceType);
     }
 
-    public function generateMenuUrl($name, array $parameters = [], $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH)
+    public function generateMenuUrl($name, array $parameters = [], $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        return $this->routeGenerator->generateMenuUrl($this, $name, $parameters, $absolute);
+        return $this->routeGenerator->generateMenuUrl($this, $name, $parameters, $referenceType);
     }
 
     final public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry)
@@ -2005,7 +2004,7 @@ EOT;
      *
      * @return array
      */
-    public function buildBreadcrumbs($action, MenuItemInterface $menu = null)
+    public function buildBreadcrumbs($action, ItemInterface $menu = null)
     {
         @trigger_error(
             'The '.__METHOD__.' method is deprecated since version 3.2 and will be removed in 4.0.',
@@ -2496,7 +2495,7 @@ EOT;
         return $this->extensions;
     }
 
-    public function setMenuFactory(MenuFactoryInterface $menuFactory)
+    public function setMenuFactory(FactoryInterface $menuFactory)
     {
         $this->menuFactory = $menuFactory;
     }
@@ -2950,7 +2949,7 @@ EOT;
      *
      * @deprecated Use configureTabMenu instead
      */
-    protected function configureSideMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
+    protected function configureSideMenu(ItemInterface $menu, $action, AdminInterface $childAdmin = null)
     {
     }
 
@@ -2959,7 +2958,7 @@ EOT;
      *
      * @param string $action
      */
-    protected function configureTabMenu(MenuItemInterface $menu, $action, AdminInterface $childAdmin = null)
+    protected function configureTabMenu(ItemInterface $menu, $action, AdminInterface $childAdmin = null)
     {
         // Use configureSideMenu not to mess with previous overrides
         // NEXT_MAJOR: remove this line

--- a/src/Admin/UrlGeneratorInterface.php
+++ b/src/Admin/UrlGeneratorInterface.php
@@ -46,7 +46,7 @@ interface UrlGeneratorInterface
      * @param string               $name
      * @param object               $object
      * @param array<string, mixed> $parameters
-     * @param int                  $absolute
+     * @param int                  $referenceType
      *
      * @return string return a complete url
      */
@@ -54,7 +54,7 @@ interface UrlGeneratorInterface
         $name,
         $object,
         array $parameters = [],
-        $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH
+        $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH
     );
 
     /**
@@ -62,22 +62,22 @@ interface UrlGeneratorInterface
      *
      * @param string               $name
      * @param array<string, mixed> $parameters
-     * @param int                  $absolute
+     * @param int                  $referenceType
      *
      * @return string return a complete url
      */
-    public function generateUrl($name, array $parameters = [], $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH);
+    public function generateUrl($name, array $parameters = [], $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH);
 
     /**
      * Generates a url for the given parameters.
      *
      * @param string               $name
      * @param array<string, mixed> $parameters
-     * @param int                  $absolute
+     * @param int                  $referenceType
      *
      * @return array return url parts: 'route', 'routeParameters', 'routeAbsolute'
      */
-    public function generateMenuUrl($name, array $parameters = [], $absolute = RoutingUrlGeneratorInterface::ABSOLUTE_PATH);
+    public function generateMenuUrl($name, array $parameters = [], $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH);
 
     /**
      * @param mixed $entity

--- a/src/Route/DefaultRouteGenerator.php
+++ b/src/Route/DefaultRouteGenerator.php
@@ -50,18 +50,18 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
         $this->cache = $cache;
     }
 
-    public function generate($name, array $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
+    public function generate($name, array $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        return $this->router->generate($name, $parameters, $absolute);
+        return $this->router->generate($name, $parameters, $referenceType);
     }
 
     public function generateUrl(
         AdminInterface $admin,
         $name,
         array $parameters = [],
-        $absolute = UrlGeneratorInterface::ABSOLUTE_PATH
+        $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH
     ) {
-        $arrayRoute = $this->generateMenuUrl($admin, $name, $parameters, $absolute);
+        $arrayRoute = $this->generateMenuUrl($admin, $name, $parameters, $referenceType);
 
         return $this->router->generate(
             $arrayRoute['route'],
@@ -74,7 +74,7 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
         AdminInterface $admin,
         $name,
         array $parameters = [],
-        $absolute = UrlGeneratorInterface::ABSOLUTE_PATH
+        $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH
     ) {
         // if the admin is a child we automatically append the parent's id
         if ($admin->isChild() && $admin->hasRequest()) {
@@ -120,7 +120,7 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
         return [
             'route' => $this->caches[$code],
             'routeParameters' => $parameters,
-            'routeAbsolute' => UrlGeneratorInterface::ABSOLUTE_URL === $absolute,
+            'routeAbsolute' => UrlGeneratorInterface::ABSOLUTE_URL === $referenceType,
         ];
     }
 

--- a/src/Route/RouteGeneratorInterface.php
+++ b/src/Route/RouteGeneratorInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Route;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -23,29 +24,29 @@ interface RouteGeneratorInterface
     /**
      * @param string               $name
      * @param array<string, mixed> $parameters
-     * @param bool                 $absolute
+     * @param int                  $referenceType
      *
      * @return string
      */
-    public function generateUrl(AdminInterface $admin, $name, array $parameters = [], $absolute = false);
+    public function generateUrl(AdminInterface $admin, $name, array $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH);
 
     /**
      * @param string               $name
      * @param array<string, mixed> $parameters
-     * @param bool                 $absolute
+     * @param int                  $referenceType
      *
      * @return array
      */
-    public function generateMenuUrl(AdminInterface $admin, $name, array $parameters = [], $absolute = false);
+    public function generateMenuUrl(AdminInterface $admin, $name, array $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH);
 
     /**
      * @param string               $name
      * @param array<string, mixed> $parameters
-     * @param bool                 $absolute
+     * @param int                  $referenceType
      *
      * @return string
      */
-    public function generate($name, array $parameters = [], $absolute = false);
+    public function generate($name, array $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH);
 
     /**
      * @param string               $name

--- a/src/Twig/GlobalVariables.php
+++ b/src/Twig/GlobalVariables.php
@@ -81,15 +81,15 @@ class GlobalVariables
      * @param string $code
      * @param string $action
      * @param array  $parameters
-     * @param int    $absolute
+     * @param int    $referenceType
      *
      * @return string
      */
-    public function url($code, $action, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
+    public function url($code, $action, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
         list($action, $code) = $this->getCodeAction($code, $action);
 
-        return $this->getAdminPool()->getAdminByAdminCode($code)->generateUrl($action, $parameters, $absolute);
+        return $this->getAdminPool()->getAdminByAdminCode($code)->generateUrl($action, $parameters, $referenceType);
     }
 
     /**
@@ -97,15 +97,15 @@ class GlobalVariables
      * @param string $action
      * @param object $object
      * @param array  $parameters
-     * @param int    $absolute
+     * @param int    $referenceType
      *
      * @return string
      */
-    public function objectUrl($code, $action, $object, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
+    public function objectUrl($code, $action, $object, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
         list($action, $code) = $this->getCodeAction($code, $action);
 
-        return $this->getAdminPool()->getAdminByAdminCode($code)->generateObjectUrl($action, $object, $parameters, $absolute);
+        return $this->getAdminPool()->getAdminByAdminCode($code)->generateObjectUrl($action, $object, $parameters, $referenceType);
     }
 
     public function getMosaicBackground(): ?string


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Replace `$absolute` argument names with `$referenceType` in order to be consistent with [`UrlGeneratorInterface`](https://github.com/symfony/routing/blob/0f562fa613e288d7dbae6c63abbc9b33ed75a8f8/Generator/UrlGeneratorInterface.php#L85).
Docblocks and default values at `RouteGeneratorInterface` were updated too.
Additionally, even if that's not related to the previous changes, I've removed useless class aliases at `AbstractAdmin` (`MenuItemInterface`, `MenuFactoryInterface`).
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
