### PR TITLE
Apply latest cs fixes

### DIFF
--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -150,7 +150,7 @@ class CRUDControllerTest extends TestCase
     private $translator;
 
     /**
-     * @var LoggerInterface&MockObject
+     * @var LoggerInterface|MockObject
      */
     private $logger;
 

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -46,10 +46,10 @@ use Symfony\Component\Validator\ContainerConstraintValidatorFactory;
  */
 class AddDependencyCallsCompilerPassTest extends TestCase
 {
-    /** @var SonataAdminExtension $extension */
+    /** @var SonataAdminExtension */
     private $extension;
 
-    /** @var array $config */
+    /** @var array */
     private $config;
 
     public function setUp(): void

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -41,10 +41,10 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class ExtensionCompilerPassTest extends TestCase
 {
-    /** @var SonataAdminExtension $extension */
+    /** @var SonataAdminExtension */
     private $extension;
 
-    /** @var array $config */
+    /** @var array */
     private $config;
 
     /**


### PR DESCRIPTION
The removal of &MockObject is a known bug in PHP-CS-Fixer, but I am not
sure we can afford to wait for it to be fixed and released. Since this
was the only occurence of this in the project, I think it is acceptable
to drop it for now.

See https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4913
See https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4915