### PR TITLE
Add LogicException for getter with hasser

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -893,7 +893,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     public function getParentAssociationMapping()
     {
         // NEXT_MAJOR: remove array check
-        if (\is_array($this->parentAssociationMapping) && $this->getParent()) {
+        if (\is_array($this->parentAssociationMapping) && $this->isChild()) {
             $parent = $this->getParent()->getCode();
 
             if (\array_key_exists($parent, $this->parentAssociationMapping)) {
@@ -1035,7 +1035,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     public function getClass()
     {
         if ($this->hasActiveSubClass()) {
-            if ($this->getParentFieldDescription()) {
+            if ($this->hasParentFieldDescription()) {
                 throw new \RuntimeException('Feature not implemented: an embedded admin cannot have subclass');
             }
 
@@ -1513,13 +1513,11 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      */
     public function getRoot()
     {
-        $parentFieldDescription = $this->getParentFieldDescription();
-
-        if (!$parentFieldDescription) {
+        if (!$this->hasParentFieldDescription()) {
             return $this;
         }
 
-        return $parentFieldDescription->getAdmin()->getRoot();
+        return $this->getParentFieldDescription()->getAdmin()->getRoot();
     }
 
     public function setBaseControllerName($baseControllerName)
@@ -1706,6 +1704,22 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     public function getParentFieldDescription()
     {
+        if (!$this->hasParentFieldDescription()) {
+            @trigger_error(sprintf(
+                'Calling %s() when there is no parent field description is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0. '.
+                'Use %s::hasParentFieldDescription() to know if there is a parent field description.',
+                __METHOD__,
+                __CLASS__
+            ), E_USER_DEPRECATED);
+            // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare FieldDescriptionInterface as return type
+            // throw new \LogicException(sprintf(
+            //    'Admin "%s" has no parent field description.',
+            //    static::class
+            // ));
+
+            return null;
+        }
+
         return $this->parentFieldDescription;
     }
 
@@ -1734,12 +1748,20 @@ EOT;
 
     public function getSubject()
     {
-        if (null === $this->subject && $this->request && !$this->hasParentFieldDescription()) {
-            $id = $this->request->get($this->getIdParameter());
+        if (!$this->hasSubject()) {
+            @trigger_error(sprintf(
+                'Calling %s() when there is no subject is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0. '.
+                'Use %s::hasSubject() to know if there is a subject.',
+                __METHOD__,
+                __CLASS__
+            ), E_USER_DEPRECATED);
+            // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and update the return type
+            // throw new \LogicException(sprintf(
+            //    'Admin "%s" has no subject.',
+            //    static::class
+            // ));
 
-            if (null !== $id) {
-                $this->subject = $this->getObject($id);
-            }
+            return null;
         }
 
         return $this->subject;
@@ -1747,7 +1769,15 @@ EOT;
 
     public function hasSubject()
     {
-        return (bool) $this->getSubject();
+        if (null === $this->subject && $this->hasRequest() && !$this->hasParentFieldDescription()) {
+            $id = $this->request->get($this->getIdParameter());
+
+            if (null !== $id) {
+                $this->subject = $this->getObject($id);
+            }
+        }
+
+        return null !== $this->subject;
     }
 
     public function getFormFieldDescriptions()
@@ -1839,7 +1869,25 @@ EOT;
 
     public function getListFieldDescription($name)
     {
-        return $this->hasListFieldDescription($name) ? $this->listFieldDescriptions[$name] : null;
+        if (!$this->hasListFieldDescription($name)) {
+            @trigger_error(sprintf(
+                'Calling %s() when there is no list field description is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0. '.
+                'Use %s::hasListFieldDescription(\'%s\') to know if there is a list field description.',
+                __METHOD__,
+                __CLASS__,
+                $name
+            ), E_USER_DEPRECATED);
+            // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare FieldDescriptionInterface as return type
+            // throw new \LogicException(sprintf(
+            //    'Admin "%s" has no list field description for %s.',
+            //    static::class,
+            //    $name
+            // ));
+
+            return null;
+        }
+
+        return $this->listFieldDescriptions[$name];
     }
 
     public function hasListFieldDescription($name)
@@ -1888,11 +1936,12 @@ EOT;
 
     public function addChild(AdminInterface $child)
     {
-        for ($parentAdmin = $this; null !== $parentAdmin; $parentAdmin = $parentAdmin->getParent()) {
-            if ($parentAdmin->getCode() !== $child->getCode()) {
-                continue;
-            }
+        $parentAdmin = $this;
+        while ($parentAdmin->isChild() && $parentAdmin->getCode() !== $child->getCode()) {
+            $parentAdmin = $parentAdmin->getParent();
+        }
 
+        if ($parentAdmin->getCode() === $child->getCode()) {
             throw new \RuntimeException(sprintf(
                 'Circular reference detected! The child admin `%s` is already in the parent tree of the `%s` admin.',
                 $child->getCode(),
@@ -1941,6 +1990,22 @@ EOT;
 
     public function getParent()
     {
+        if (!$this->isChild()) {
+            @trigger_error(sprintf(
+                'Calling %s() when there is no parent is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0. '.
+                'Use %s::isChild() to know if there is a parent.',
+                __METHOD__,
+                __CLASS__
+            ), E_USER_DEPRECATED);
+            // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare AdminInterface as return type
+            // throw new \LogicException(sprintf(
+            //    'Admin "%s" has no parent.',
+            //    static::class
+            // ));
+
+            return null;
+        }
+
         return $this->parent;
     }
 
@@ -2271,6 +2336,7 @@ EOT;
     public function getRequest()
     {
         if (!$this->request) {
+            // NEXT_MAJOR: Throw \LogicException instead.
             throw new \RuntimeException('The Request object has not been set');
         }
 
@@ -3162,6 +3228,7 @@ EOT;
             return $this->subClasses[$name];
         }
 
+        // NEXT_MAJOR: Throw \LogicException instead.
         throw new \RuntimeException(sprintf(
             'Unable to find the subclass `%s` for admin `%s`',
             $name,

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -143,6 +143,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function getForm();
 
     /**
+     * NEXT MAJOR: Remove the throws tag.
+     *
      * @throws \RuntimeException if no request is set
      *
      * @return Request
@@ -351,6 +353,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function setSubject($subject);
 
     /**
+     * NEXT MAJOR: return object.
+     *
      * @return object|null
      */
     public function getSubject();
@@ -443,7 +447,7 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function createObjectSecurity($object);
 
     /**
-     * @return AdminInterface|null
+     * @return AdminInterface|null NEXT_MAJOR: return AdminInterface
      */
     public function getParent();
 

--- a/src/Admin/BreadcrumbsBuilder.php
+++ b/src/Admin/BreadcrumbsBuilder.php
@@ -100,7 +100,7 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
 
         $childAdmin = $admin->getCurrentChildAdmin();
 
-        if ($childAdmin) {
+        if ($childAdmin && $admin->hasSubject()) {
             $id = $admin->getRequest()->get($admin->getIdParameter());
 
             $menu = $menu->addChild(

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1554,7 +1554,7 @@ class CRUDController implements ContainerAwareInterface
 
     private function checkParentChildAssociation(Request $request, $object): void
     {
-        if (!($parentAdmin = $this->admin->getParent())) {
+        if (!$this->admin->isChild()) {
             return;
         }
 
@@ -1563,6 +1563,7 @@ class CRUDController implements ContainerAwareInterface
             return;
         }
 
+        $parentAdmin = $this->admin->getParent();
         $parentId = $request->get($parentAdmin->getIdParameter());
 
         $propertyAccessor = PropertyAccess::createPropertyAccessor();

--- a/src/Route/DefaultRouteGenerator.php
+++ b/src/Route/DefaultRouteGenerator.php
@@ -85,8 +85,10 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
                 unset($parameters['id']);
             }
 
-            for ($parentAdmin = $admin->getParent(); null !== $parentAdmin; $parentAdmin = $parentAdmin->getParent()) {
+            $parentAdmin = $admin->getParent();
+            while (null !== $parentAdmin) {
                 $parameters[$parentAdmin->getIdParameter()] = $admin->getRequest()->attributes->get($parentAdmin->getIdParameter());
+                $parentAdmin = $parentAdmin->isChild() ? $parentAdmin->getParent() : null;
             }
         }
 

--- a/src/Route/QueryStringBuilder.php
+++ b/src/Route/QueryStringBuilder.php
@@ -59,7 +59,7 @@ class QueryStringBuilder implements RouteBuilderInterface
         }
 
         // an admin can have only one level of nested child
-        if ($admin->getParent()) {
+        if ($admin->isChild()) {
             return;
         }
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1490,7 +1490,7 @@ class AdminTest extends TestCase
             ->method('getAdmin')
             ->willReturn($parentAdmin);
 
-        $this->assertNull($admin->getParentFieldDescription());
+        $this->assertFalse($admin->hasParentFieldDescription());
         $admin->setParentFieldDescription($parentFieldDescription);
         $this->assertSame($parentFieldDescription, $admin->getParentFieldDescription());
         $this->assertSame('sonata.post.admin.post.parent', $admin->getRootCode());
@@ -1508,7 +1508,7 @@ class AdminTest extends TestCase
             ->method('getAdmin')
             ->willReturn($parentAdmin);
 
-        $this->assertNull($admin->getParentFieldDescription());
+        $this->assertFalse($admin->hasParentFieldDescription());
         $admin->setParentFieldDescription($parentFieldDescription);
         $this->assertSame($parentFieldDescription, $admin->getParentFieldDescription());
         $this->assertSame($parentAdmin, $admin->getRoot());
@@ -1824,7 +1824,7 @@ class AdminTest extends TestCase
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->setModelManager($modelManager);
 
-        $this->assertNull($admin->getSubject());
+        $this->assertFalse($admin->hasSubject());
     }
 
     public function testGetSideMenu(): void
@@ -1882,7 +1882,7 @@ class AdminTest extends TestCase
         $admin->setModelManager($modelManager);
 
         $admin->setRequest(new Request(['id' => $id]));
-        $this->assertNull($admin->getSubject());
+        $this->assertFalse($admin->hasSubject());
     }
 
     /**
@@ -1903,6 +1903,7 @@ class AdminTest extends TestCase
         $admin->setModelManager($modelManager);
 
         $admin->setRequest(new Request(['id' => $id]));
+        $this->assertTrue($admin->hasSubject());
         $this->assertSame($entity, $admin->getSubject());
         $this->assertSame($entity, $admin->getSubject()); // model manager must be used only once
     }
@@ -1928,12 +1929,13 @@ class AdminTest extends TestCase
         $commentAdmin->setRequest($request);
         $commentAdmin->setModelManager($modelManager);
 
+        $this->assertTrue($commentAdmin->hasSubject());
         $this->assertSame($comment, $commentAdmin->getSubject());
 
         $commentAdmin->setSubject(null);
         $commentAdmin->setParentFieldDescription(new FieldDescription());
 
-        $this->assertNull($commentAdmin->getSubject());
+        $this->assertFalse($commentAdmin->hasSubject());
     }
 
     /**

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -1019,6 +1019,10 @@ class CRUDControllerTest extends TestCase
             ->willReturn($object);
 
         $this->admin->expects($this->once())
+            ->method('isChild')
+            ->willReturn(true);
+
+        $this->admin->expects($this->once())
             ->method('getParent')
             ->willReturn($admin);
 
@@ -1043,8 +1047,8 @@ class CRUDControllerTest extends TestCase
             ->willReturn($object);
 
         $this->admin->expects($this->once())
-            ->method('getParent')
-            ->willReturn($admin);
+            ->method('isChild')
+            ->willReturn(true);
 
         $this->admin->expects($this->once())
             ->method('getParentAssociationMapping')

--- a/tests/Route/QueryStringBuilderTest.php
+++ b/tests/Route/QueryStringBuilderTest.php
@@ -30,7 +30,8 @@ class QueryStringBuilderTest extends TestCase
         $audit->expects($this->once())->method('hasReader')->willReturn($hasReader);
 
         $admin = $this->getMockForAbstractClass(AdminInterface::class);
-        $admin->expects($this->once())->method('getParent')->willReturn($getParent);
+        $admin->expects($this->once())->method('isChild')->willReturn($getParent instanceof AdminInterface);
+        $admin->method('getParent')->willReturn($getParent);
         $admin->method('getChildren')->willReturn([]);
         $admin->expects($this->once())->method('isAclEnabled')->willReturn($aclEnabled);
 
@@ -76,7 +77,7 @@ class QueryStringBuilderTest extends TestCase
         $child2->expects($this->once())->method('getRoutes')->willReturn($childRouteCollection2);
 
         $admin = $this->getMockForAbstractClass(AdminInterface::class);
-        $admin->expects($this->once())->method('getParent')->willReturn(null);
+        $admin->expects($this->once())->method('isChild')->willReturn(false);
         $admin->expects($this->once())->method('getChildren')->willReturn([$child1, $child2]);
         $admin->expects($this->once())->method('isAclEnabled')->willReturn(true);
 


### PR DESCRIPTION
## Subject

Targeting this branch, because BC.

First step of https://github.com/sonata-project/SonataAdminBundle/issues/6035

## Changelog

```markdown
### Deprecated
- Deprecate the call of `AbstractAdmin::getParentFieldDescription` if the value is `null`. 
- Deprecate the call of `AbstractAdmin::getSubject` if the value is `null`.
- Deprecate the call of `AbstractAdmin::getListFieldDescription` if the value is `null`.
- Deprecate the call of `AbstractAdmin::getParent` if the value is `null`.
```