### PR TITLE
Fix nesting a Twig block definition under a non-capturing node

### DIFF
--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -34,16 +34,16 @@ file that was distributed with this source code.
             {% endblock -%}
         </a>
     {% else %}
-        {% set isEditable = field_description.options.editable is defined and field_description.options.editable and admin.hasAccess('edit', object) %}
-        {% if isEditable and field_description.options.multiple is defined and field_description.options.multiple and value is iterable %}
+        {% set is_editable = field_description.options.editable is defined and field_description.options.editable and admin.hasAccess('edit', object) %}
+        {% if is_editable and field_description.options.multiple is defined and field_description.options.multiple and value is iterable %}
             {# multiple editable field should be real multiple #}
             {# https://vitalets.github.io/x-editable/docs.html#checklist #}
-            {% set xEditableType = 'checklist' %}
+            {% set x_editable_type = 'checklist' %}
         {% else %}
-            {% set xEditableType = field_description.type|sonata_xeditable_type %}
+            {% set x_editable_type = field_description.type|sonata_xeditable_type %}
         {% endif %}
 
-        {% if isEditable and xEditableType %}
+        {% if is_editable and x_editable_type %}
             {% set url = path(
                 'sonata_admin_set_object_field_value',
                 admin.getPersistentParameters|default([])|merge({
@@ -65,7 +65,7 @@ file that was distributed with this source code.
             {% endif %}
 
             <span {% block field_span_attributes %}class="x-editable"
-                  data-type="{{ xEditableType }}"
+                  data-type="{{ x_editable_type }}"
                   data-value="{{ data_value }}"
                   data-title="{{ field_description.label|trans({}, field_description.translationDomain) }}"
                   data-pk="{{ admin.id(object) }}"

--- a/src/Resources/views/CRUD/list_boolean.html.twig
+++ b/src/Resources/views/CRUD/list_boolean.html.twig
@@ -11,17 +11,17 @@ file that was distributed with this source code.
 
 {% extends get_admin_template('base_list_field', admin.code) %}
 
-{% set isEditable = field_description.options.editable is defined and field_description.options.editable and admin.hasAccess('edit', object) %}
-{% set xEditableType = field_description.type|sonata_xeditable_type %}
+{% set is_editable = field_description.options.editable is defined and field_description.options.editable and admin.hasAccess('edit', object) %}
+{% set x_editable_type = field_description.type|sonata_xeditable_type %}
 
-{% if isEditable and xEditableType %}
-    {% block field_span_attributes %}
+{% block field_span_attributes %}
+    {% if is_editable and x_editable_type %}
         {% apply spaceless %}
             {{ parent() }}
             data-source="[{value: 0, text: '{%- trans from 'SonataAdminBundle' %}label_type_no{% endtrans -%}'},{value: 1, text: '{%- trans from 'SonataAdminBundle' %}label_type_yes{% endtrans -%}'}]"
         {% endapply %}
-    {% endblock %}
-{% endif %}
+    {% endif %}
+{% endblock %}
 
 {% block field %}
     {%- include '@SonataAdmin/CRUD/display_boolean.html.twig' -%}

--- a/src/Resources/views/CRUD/list_choice.html.twig
+++ b/src/Resources/views/CRUD/list_choice.html.twig
@@ -18,14 +18,14 @@ file that was distributed with this source code.
 %}
 {% set x_editable_type = field_description.type|sonata_xeditable_type %}
 
-{% if is_editable and x_editable_type %}
-    {% block field_span_attributes %}
+{% block field_span_attributes %}
+    {% if is_editable and x_editable_type %}
         {% apply spaceless %}
             {{ parent() }}
             data-source="{{ field_description|sonata_xeditable_choices|json_encode }}"
         {% endapply %}
-    {% endblock %}
-{% endif %}
+    {% endif %}
+{% endblock %}
 
 {% block field %}
 {% apply spaceless %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fixed nesting Twig block definitions under a non-capturing nodes (deprecated since Twig 2.5.0).
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5362.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed nesting Twig block definitions under a non-capturing nodes.
```