### PR TITLE
Use proper syntax for phpdoc

### DIFF
--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -140,7 +140,7 @@ interface FilterInterface
     /**
      * Returns the main widget used to render the filter.
      *
-     * @return array<string, mixed>
+     * @return array{0: string, 1: array<string, mixed>}
      */
     public function getRenderSettings();
 


### PR DESCRIPTION
## Subject

This fixes the documented return type of the `Sonata\AdminBundle\Filter\FilterInterface::getRenderSettings()`.

I am targeting this branch, because this is a back-compatible fix for 3.x.

Closes #6057

## Changelog

```markdown
### Fixed

- Fixed documented return type of `Sonata\AdminBundle\Filter\FilterInterface::getRenderSettings()`.
```