### PR TITLE
Set ParentSubject to new Instance in FormType

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated not passing a `Sonata\AdminBundle\Admin\AdminHelper` instance to `Sonata\AdminBundle\Form\Type\AdminType::__construct()`
+
+When instantiating a `Sonata\AdminBundle\Form\Type\AdminType` object, please use the 1 parameter signature `($adminHelper)`.
+
 ## Deprecated not setting as `false` the configuration option `sonata_admin.options.legacy_twig_text_extension`
 
 This option controls which Twig text extension will be used to provide filters like

--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Form\Type;
 
+use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Form\DataTransformer\ArrayToModelTransformer;
@@ -34,6 +35,29 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
  */
 class AdminType extends AbstractType
 {
+    /**
+     * @var AdminHelper
+     */
+    private $adminHelper;
+
+    /**
+     * NEXT_MAJOR: Allow only `AdminHelper` for argument 1 and remove the default null value.
+     */
+    public function __construct(?AdminHelper $adminHelper = null)
+    {
+        // NEXT_MAJOR: Remove this condition.
+        if (null === $adminHelper) {
+            @trigger_error(sprintf(
+                'Calling %s without passing an %s as argument is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw an exception in 4.0.',
+                __METHOD__,
+                AdminHelper::class
+            ), E_USER_DEPRECATED);
+        }
+
+        $this->adminHelper = $adminHelper;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $admin = clone $this->getAdmin($options);
@@ -55,8 +79,10 @@ class AdminType extends AbstractType
         if (null === $builder->getData()) {
             $p = new PropertyAccessor(false, true);
 
-            try {
-                $parentAdmin = $admin->getParentFieldDescription()->getAdmin();
+            if ($admin->hasParentFieldDescription()) {
+                $parentFieldDescription = $admin->getParentFieldDescription();
+                $parentAdmin = $parentFieldDescription->getAdmin();
+
                 if ($parentAdmin->hasSubject() && isset($options['property_path'])) {
                     // this check is to work around duplication issue in property path
                     // https://github.com/sonata-project/SonataAdminBundle/issues/4425
@@ -75,18 +101,21 @@ class AdminType extends AbstractType
                             $this->getFieldDescription($options)->getParentAssociationMappings()
                         )
                     );
+                    $parentSubject = $parentAdmin->getSubject();
 
-                    $subject = $p->getValue($parentAdmin->getSubject(), $parentPath.$path);
-                    $builder->setData($subject);
-                } else {
-                    $subject = $admin->getNewInstance();
-                    $builder->setData($subject);
+                    try {
+                        $subject = $p->getValue($parentSubject, $parentPath.$path);
+                    } catch (NoSuchIndexException $e) {
+                        // no object here, we create a new one
+                        // NEXT_MAJOR: Remove the null check.
+                        if (null !== $this->adminHelper) {
+                            $subject = $this->adminHelper->addNewInstance($parentSubject, $parentFieldDescription);
+                        }
+                    }
                 }
-            } catch (NoSuchIndexException $e) {
-                // no object here, we create a new one
-                $subject = $admin->getNewInstance();
-                $builder->setData($subject);
             }
+
+            $builder->setData($subject ?? $admin->getNewInstance());
         }
 
         $admin->setSubject($builder->getData());

--- a/src/Resources/config/form_types.xml
+++ b/src/Resources/config/form_types.xml
@@ -4,6 +4,7 @@
         <!-- Form Widget-->
         <service id="sonata.admin.form.type.admin" class="Sonata\AdminBundle\Form\Type\AdminType" public="true">
             <tag name="form.type" alias="sonata_type_admin"/>
+            <argument type="service" id="sonata.admin.helper"/>
         </service>
         <service id="sonata.admin.form.type.model_choice" class="Sonata\AdminBundle\Form\Type\ModelType" public="true">
             <argument type="service" id="property_accessor"/>

--- a/tests/Form/Type/LegacyAdminTypeTest.php
+++ b/tests/Form/Type/LegacyAdminTypeTest.php
@@ -14,11 +14,9 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use PHPUnit\Framework\MockObject\MockObject;
 use Prophecy\Argument;
 use Prophecy\Argument\Token\AnyValueToken;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
-use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension;
@@ -27,18 +25,15 @@ use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
 use Sonata\AdminBundle\Tests\Fixtures\TestExtension;
 use Symfony\Component\Form\FormTypeGuesserInterface;
-use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 
-class AdminTypeTest extends TypeTestCase
+/**
+ * @group legacy
+ */
+class LegacyAdminTypeTest extends TypeTestCase
 {
-    /**
-     * @var AdminHelper|MockObject
-     */
-    private $adminHelper;
-
     /**
      * @var AdminType
      */
@@ -46,12 +41,14 @@ class AdminTypeTest extends TypeTestCase
 
     protected function setUp(): void
     {
-        $this->adminHelper = $this->createMock(AdminHelper::class);
-        $this->adminType = new AdminType($this->adminHelper);
+        $this->adminType = new AdminType();
 
         parent::setUp();
     }
 
+    /**
+     * @expectedDeprecation Calling Sonata\AdminBundle\Form\Type\AdminType::__construct without passing an Sonata\AdminBundle\Admin\AdminHelper as argument is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.
+     */
     public function testGetDefaultOptions(): void
     {
         $optionResolver = new OptionsResolver();
@@ -68,6 +65,9 @@ class AdminTypeTest extends TypeTestCase
         $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);
     }
 
+    /**
+     * @expectedDeprecation Calling Sonata\AdminBundle\Form\Type\AdminType::__construct without passing an Sonata\AdminBundle\Admin\AdminHelper as argument is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.
+     */
     public function testSubmitValidData(): void
     {
         $parentAdmin = $this->prophesize(AdminInterface::class);
@@ -110,6 +110,9 @@ class AdminTypeTest extends TypeTestCase
         $this->assertTrue($form->isSynchronized());
     }
 
+    /**
+     * @expectedDeprecation Calling Sonata\AdminBundle\Form\Type\AdminType::__construct without passing an Sonata\AdminBundle\Admin\AdminHelper as argument is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.
+     */
     public function testDotFields(): void
     {
         $foo = new \stdClass();
@@ -153,6 +156,9 @@ class AdminTypeTest extends TypeTestCase
         }
     }
 
+    /**
+     * @expectedDeprecation Calling Sonata\AdminBundle\Form\Type\AdminType::__construct without passing an Sonata\AdminBundle\Admin\AdminHelper as argument is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.
+     */
     public function testArrayCollection(): void
     {
         $foo = new Foo();
@@ -195,6 +201,9 @@ class AdminTypeTest extends TypeTestCase
         }
     }
 
+    /**
+     * @expectedDeprecation Calling Sonata\AdminBundle\Form\Type\AdminType::__construct without passing an Sonata\AdminBundle\Admin\AdminHelper as argument is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.
+     */
     public function testArrayCollectionNotFound(): void
     {
         $parentSubject = new \stdClass();
@@ -247,8 +256,6 @@ class AdminTypeTest extends TypeTestCase
 
         $extension->addTypeExtension(new FormTypeFieldExtension([], []));
         $extensions[] = $extension;
-
-        $extensions[] = new PreloadedExtension([$this->adminType], []);
 
         return $extensions;
     }


### PR DESCRIPTION
## Subject 

Let's say I have a Father, multiple children and each child can have multiple dogs.

Let's say in a FatherAdmin, I add the following field in the `configureFormField` method.
```
$formMapper->add('child.dog', CollectionType, ...);
```
Of couse, there is a ChildAdmin and DogAdmin.

When I try to add a new dog to the child of some father, I can access the child/father data in the DogAdmin, thanks to some code in `AdminHelper::appendFormFieldElement`.

If I try to add a second dog without saving the first one, the whole collection is reloaded and the form is hydrated with the values already provided. But the AdminType::buildForm try to access the property in the database and get a `NoSuchIndexException`. In this situation, a newInstance of dog was created, but the child wasn't added to the dog and then wasn't accessible in the DogAdmin.

This should fix the issue.

I am targeting this branch, because I tried to be BC.

## Changelog

```markdown
### Deprecated
- not passing a `Sonata\AdminBundle\Admin\AdminHelper` instance to `Sonata\AdminBundle\Form\Type\AdminType::__construct()`

### Fixed
- Do not lose the `parentSubject` in case of multiple calls to the `AppendFormFieldElementAction`.
```