### PR TITLE
Allow false as label

### DIFF
--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -405,14 +405,15 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
 
     public function getLabel()
     {
-        if (null !== $this->getOption('label') && !\is_string($this->getOption('label')) && 'sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+        $label = $this->getOption('label');
+        if (null !== $label && false !== $label && !\is_string($label) && 'sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
             @trigger_error(sprintf(
-                'Returning other type than string or null in method %s() is deprecated since sonata-project/admin-bundle 3.65. It will return only those types in version 4.0.',
+                'Returning other type than string, false or null in method %s() is deprecated since sonata-project/admin-bundle 3.65. It will return only those types in version 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }
 
-        return $this->getOption('label');
+        return $label;
     }
 
     public function isSortable()

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -26,7 +26,7 @@ interface FieldDescriptionInterface
     public function setFieldName($fieldName);
 
     /**
-     * return the field name.
+     * Returns the field name.
      *
      * @return string the field name
      */
@@ -40,14 +40,14 @@ interface FieldDescriptionInterface
     public function setName($name);
 
     /**
-     * Return the name, the name can be used as a form label or table header.
+     * Returns the name, the name can be used as a form label or table header.
      *
      * @return string the name
      */
     public function getName();
 
     /**
-     * Return the value represented by the provided name.
+     * Returns the value represented by the provided name.
      *
      * @param string     $name
      * @param mixed|null $default
@@ -74,28 +74,28 @@ interface FieldDescriptionInterface
     public function setOptions(array $options);
 
     /**
-     * return options.
+     * Returns options.
      *
      * @return array options
      */
     public function getOptions();
 
     /**
-     * return the template used to render the field.
+     * Returns the template used to render the field.
      *
      * @param string $template
      */
     public function setTemplate($template);
 
     /**
-     * return the template name.
+     * Returns the template name.
      *
      * @return string|null the template name
      */
     public function getTemplate();
 
     /**
-     * return the field type, the type is a mandatory field as it used to select the correct template
+     * Returns the field type, the type is a mandatory field as it used to select the correct template
      * or the logic associated to the current FieldDescription object.
      *
      * @param string $type
@@ -103,7 +103,7 @@ interface FieldDescriptionInterface
     public function setType($type);
 
     /**
-     * return the type.
+     * Returns the type.
      *
      * @return int|string
      */
@@ -115,7 +115,7 @@ interface FieldDescriptionInterface
     public function setParent(AdminInterface $parent);
 
     /**
-     * return the parent Admin (only used in nested admin).
+     * Returns the parent Admin (only used in nested admin).
      *
      * @return AdminInterface|null
      */
@@ -129,14 +129,14 @@ interface FieldDescriptionInterface
     public function setAssociationMapping($associationMapping);
 
     /**
-     * return the association mapping definition.
+     * Returns the association mapping definition.
      *
      * @return array
      */
     public function getAssociationMapping();
 
     /**
-     * return the related Target Entity.
+     * Returns the related Target Entity.
      *
      * @return string|null
      */
@@ -150,7 +150,7 @@ interface FieldDescriptionInterface
     public function setFieldMapping($fieldMapping);
 
     /**
-     * return the field mapping definition.
+     * Returns the field mapping definition.
      *
      * @return array the field mapping definition
      */
@@ -162,7 +162,7 @@ interface FieldDescriptionInterface
     public function setParentAssociationMappings(array $parentAssociationMappings);
 
     /**
-     * return the parent association mapping definitions.
+     * Returns the parent association mapping definitions.
      *
      * @return array the parent association mapping definitions
      */
@@ -176,21 +176,21 @@ interface FieldDescriptionInterface
     public function setAssociationAdmin(AdminInterface $associationAdmin);
 
     /**
-     * return the associated Admin instance (only used if the field is linked to an Admin).
+     * Returns the associated Admin instance (only used if the field is linked to an Admin).
      *
      * @return AdminInterface|null
      */
     public function getAssociationAdmin();
 
     /**
-     * return true if the FieldDescription is linked to an identifier field.
+     * Returns true if the FieldDescription is linked to an identifier field.
      *
      * @return bool
      */
     public function isIdentifier();
 
     /**
-     * return the value linked to the description.
+     * Returns the value linked to the description.
      *
      * @param object $object
      *
@@ -230,42 +230,43 @@ interface FieldDescriptionInterface
     public function setMappingType($mappingType);
 
     /**
-     * return the mapping type.
+     * Returns the mapping type.
      *
      * @return int|string
      */
     public function getMappingType();
 
     /**
-     * return the label to use for the current field.
+     * Returns the label to use for the current field.
+     * Use null to fallback to the default label and false to hide the label.
      *
      * @return string|false|null
      */
     public function getLabel();
 
     /**
-     * Return the translation domain to use for the current field.
+     * Returns the translation domain to use for the current field.
      *
      * @return string
      */
     public function getTranslationDomain();
 
     /**
-     * Return true if field is sortable.
+     * Returns true if field is sortable.
      *
      * @return bool
      */
     public function isSortable();
 
     /**
-     * return the field mapping definition used when sorting.
+     * Returns the field mapping definition used when sorting.
      *
      * @return array the field mapping definition
      */
     public function getSortFieldMapping();
 
     /**
-     * return the parent association mapping definitions used when sorting.
+     * Returns the parent association mapping definitions used when sorting.
      *
      * @return array the parent association mapping definitions
      */

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -239,7 +239,7 @@ interface FieldDescriptionInterface
     /**
      * return the label to use for the current field.
      *
-     * @return string|null
+     * @return string|false|null
      */
     public function getLabel();
 

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -79,7 +79,9 @@ file that was distributed with this source code.
                                                     {% if field_description.getOption('label_icon') %}
                                                         <i class="sonata-ba-list-field-header-label-icon {{ field_description.getOption('label_icon') }}" aria-hidden="true"></i>
                                                     {% endif %}
-                                                    {{ field_description.label|trans({}, field_description.translationDomain) }}
+                                                    {% if field_description.label is not same as(false) %}
+                                                        {{ field_description.label|trans({}, field_description.translationDomain) }}
+                                                    {% endif %}
                                                     {% if sortable %}</a>{% endif %}
                                                 </th>
                                             {% endapply %}
@@ -246,7 +248,10 @@ file that was distributed with this source code.
                         {% set filterActive = ((filter.isActive() or filter.options['show_filter']) and not admin.isDefaultFilter(filter.formName)) %}
                         <li>
                             <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
-                                <i class="fa {{ (filter.isActive() or filter.options['show_filter']) ? 'fa-check-square-o' : 'fa-square-o' }}"></i>{{ filter.label|trans({}, filter.translationDomain ?: admin.translationDomain) }}
+                                <i class="fa {{ (filter.isActive() or filter.options['show_filter']) ? 'fa-check-square-o' : 'fa-square-o' }}"></i>
+                                {% if filter.label is not same as(false) %}
+                                    {{ filter.label|trans({}, filter.translationDomain ?: admin.translationDomain) }}
+                                {% endif %}
                             </a>
                         </li>
                     {% endfor %}

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -67,7 +67,9 @@ file that was distributed with this source code.
             <span {% block field_span_attributes %}class="x-editable"
                   data-type="{{ x_editable_type }}"
                   data-value="{{ data_value }}"
-                  data-title="{{ field_description.label|trans({}, field_description.translationDomain) }}"
+                  {% if field_description.label is not same as(false) %}
+                    data-title="{{ field_description.label|trans({}, field_description.translationDomain) }}"
+                  {% endif %}
                   data-pk="{{ admin.id(object) }}"
                   data-url="{{ url }}" {% endblock %}>
                 {{ block('field') }}

--- a/src/Resources/views/CRUD/base_show_field.html.twig
+++ b/src/Resources/views/CRUD/base_show_field.html.twig
@@ -9,7 +9,15 @@ file that was distributed with this source code.
 
 #}
 
-<th{% if(is_diff|default(false)) %} class="diff"{% endif %}>{% block name %}{{ field_description.label|trans({}, field_description.translationDomain ?: admin.translationDomain) }}{% endblock %}</th>
+<th{% if(is_diff|default(false)) %} class="diff"{% endif %}>
+    {%- block name -%}
+        {% apply spaceless %}
+            {% if field_description.label is not same as(false) %}
+                {{ field_description.label|trans({}, field_description.translationDomain ?: admin.translationDomain) }}
+            {% endif %}
+        {% endapply %}
+    {%- endblock -%}
+</th>
 <td>
     {%- block field -%}
         {% apply spaceless %}

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -78,7 +78,7 @@ class ShowMapper extends BaseGroupedMapper
         }
 
         // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
-        if (!$fieldDescription->getLabel('sonata_deprecation_mute') && false !== $fieldDescription->getOption('label')) {
+        if (null === $fieldDescription->getLabel('sonata_deprecation_mute')) {
             $fieldDescription->setOption('label', $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'show', 'label'));
         }
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

`false` was already half-supported.
There was a check 
```
if (!$fieldDescription->getLabel('sonata_deprecation_mute') && false !== $fieldDescription->getOption('label')) {
```

So when you use `label => false`, you have no label. When you use `null` you get the default label. But since there was no check in the twig, `false` was translated. So the profiler report a missing translation `''`. Plus it will lead to issue with symfony 5 since `trans` only allow string.

Since the label option can be false, I modify the signature of `getLabel`.

I also modified the previous check because it was overriding some falsy label, like `'0'`.

Closes #6064

## Changelog

```markdown
### Fixed
- `label => false` doesn't lead to a missing `''` translation in the profiler.
- `label => '0'` and others non nullable falsy value are not overridden anymore.
```
