### PR TITLE
Allow correctly modelManager to configure sortValues and perPageOptions.

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -102,7 +102,11 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     protected $filterFieldDescriptions = [];
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * The number of result to display in the list.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x.
      *
      * @var int
      */
@@ -158,7 +162,11 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     protected $formOptions = [];
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * Default values to the datagrid.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, use configureDefaultSortValues() instead.
      *
      * @var array
      */
@@ -168,7 +176,11 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     ];
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * Predefined per page options.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x.
      *
      * @var array
      */
@@ -601,7 +613,10 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         }
         $this->baseControllerName = $baseControllerName;
 
+        // NEXT_MAJOR: Remove this line.
         $this->predefinePerPageOptions();
+
+        // NEXT_MAJOR: Remove this line.
         $this->datagridValues['_per_page'] = $this->maxPerPage;
     }
 
@@ -810,13 +825,14 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
             $parameters = array_merge(
                 $this->getModelManager()->getDefaultSortValues($this->getClass()),
-                $this->datagridValues,
+                $this->datagridValues, // NEXT_MAJOR: Remove this line.
+                $this->getDefaultSortValues(),
                 $this->getDefaultFilterValues(),
                 $filters
             );
 
             if (!$this->determinedPerPageValue($parameters['_per_page'])) {
-                $parameters['_per_page'] = $this->maxPerPage;
+                $parameters['_per_page'] = $this->getMaxPerPage();
             }
 
             // always force the parent value
@@ -1570,10 +1586,19 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since since sonata-project/sonata-admin-bundle 3.x, to be removed in 4.0.
+     *
      * @param int $maxPerPage
      */
     public function setMaxPerPage($maxPerPage)
     {
+        @trigger_error(sprintf(
+            'The method %s is deprecated since sonata-project/sonata-admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $this->maxPerPage = $maxPerPage;
     }
 
@@ -1582,7 +1607,11 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      */
     public function getMaxPerPage()
     {
+        // NEXT_MAJOR: Remove this line and uncomment the following.
         return $this->maxPerPage;
+        // $sortValues = $this->getModelManager()->getDefaultSortValues($this->class);
+
+        // return $sortValues['_per_page'] ?? 25;
     }
 
     /**
@@ -2612,10 +2641,19 @@ EOT;
     }
 
     /**
+     * NEXT_MAJOR: Remove this.
+     *
+     * @deprecated since since sonata-project/sonata-admin-bundle 3.x, to be removed in 4.0.
+     *
      * Set custom per page options.
      */
     public function setPerPageOptions(array $options)
     {
+        @trigger_error(sprintf(
+            'The method %s is deprecated since sonata-project/sonata-admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $this->perPageOptions = $options;
     }
 
@@ -2626,7 +2664,15 @@ EOT;
      */
     public function getPerPageOptions()
     {
+        // NEXT_MAJOR: Remove this line and uncomment the following
         return $this->perPageOptions;
+//        $perPageOptions = $this->getModelManager()->getDefaultPerPageOptions($this->class);
+//        $perPageOptions[] = $this->getMaxPerPage();
+//
+//        $perPageOptions = array_unique($perPageOptions);
+//        sort($perPageOptions);
+//
+//        return $perPageOptions;
     }
 
     /**
@@ -2658,7 +2704,7 @@ EOT;
      */
     public function determinedPerPageValue($perPage)
     {
-        return \in_array($perPage, $this->perPageOptions, true);
+        return \in_array($perPage, $this->getPerPageOptions(), true);
     }
 
     public function isAclEnabled()
@@ -2960,6 +3006,27 @@ EOT;
     }
 
     /**
+     * Returns a list of default sort values.
+     *
+     * @return array{_page?: int, _per_page?: int, _sort_by?: string, _sort_order?: string}
+     */
+    final protected function getDefaultSortValues(): array
+    {
+        $defaultSortValues = [];
+
+        $this->configureDefaultSortValues($defaultSortValues);
+
+        foreach ($this->getExtensions() as $extension) {
+            // NEXT_MAJOR: remove method check
+            if (method_exists($extension, 'configureDefaultSortValues')) {
+                $extension->configureDefaultSortValues($this, $defaultSortValues);
+            }
+        }
+
+        return $defaultSortValues;
+    }
+
+    /**
      * Returns a list of default filters.
      *
      * @return array
@@ -3201,6 +3268,10 @@ EOT;
     }
 
     /**
+     * NEXT_MAJOR: Remove this function.
+     *
+     * @deprecated since since sonata-project/sonata-admin-bundle 3.x, to be removed in 4.0.
+     *
      * Predefine per page options.
      */
     protected function predefinePerPageOptions()
@@ -3245,6 +3316,17 @@ EOT;
      * Configures a list of default filters.
      */
     protected function configureDefaultFilterValues(array &$filterValues)
+    {
+    }
+
+    /**
+     * Configures a list of default sort values.
+     *
+     * Example:
+     *   $sortValues['_sort_by'] = 'foo'
+     *   $sortValues['_sort_order'] = 'DESC'
+     */
+    protected function configureDefaultSortValues(array &$sortValues)
     {
     }
 

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -130,10 +130,11 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
         return $list;
     }
 
-    /**
-     * Returns a list of default filters.
-     */
     public function configureDefaultFilterValues(AdminInterface $admin, array &$filterValues)
+    {
+    }
+
+    public function configureDefaultSortValues(AdminInterface $admin, array &$sortValues): void
     {
     }
 }

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -30,6 +30,7 @@ use Sonata\Form\Validator\ErrorElement;
  * @method array configureExportFields(AdminInterface $admin, array $fields)
  * @method array configureActionButtons(AdminInterface $admin, array $list, string $action, object $object)
  * @method void  configureDefaultFilterValues(AdminInterface $admin, array &$filterValues)
+ * @method void  configureDefaultSortValues(AdminInterface $admin, array &$sortValues)
  */
 interface AdminExtensionInterface
 {
@@ -164,6 +165,13 @@ interface AdminExtensionInterface
      * Returns a list of default filters
      */
     // public function configureDefaultFilterValues(AdminInterface $admin, array &$filterValues): void;
+
+    /*
+     * NEXT_MAJOR: Uncomment this method
+     *
+     * Returns a list of default sort values
+     */
+    // public function configureDefaultSortValues(AdminInterface $admin, array &$sortValues): void;
 }
 
 class_exists(\Sonata\Form\Validator\ErrorElement::class);

--- a/src/Model/DatagridManagerInterface.php
+++ b/src/Model/DatagridManagerInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Model;
+
+/**
+ * A datagrid manager is a bridge between the model classes and the admin datagrid functionality.
+ *
+ * @method array getDefaultPerPageOptions(string $class)
+ */
+interface DatagridManagerInterface
+{
+    /**
+     * Return _sort_order, _sort_by, _page and _per_page values.
+     *
+     * @param string $class
+     *
+     * @return array<string, int|string>
+     */
+    public function getDefaultSortValues($class);
+
+//    NEXT_MAJOR: Uncomment the following lines.
+//    /**
+//     * Return all the allowed _per_page values.
+//     *
+//     * @return array<int>
+//     */
+//    public function getDefaultPerPageOptions(string $class): array;
+}

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -20,10 +20,9 @@ use Sonata\AdminBundle\Exception\ModelManagerException;
 use Sonata\Exporter\Source\SourceIteratorInterface;
 
 /**
- * A model manager is a bridge between the model classes and the admin
- * functionality.
+ * A model manager is a bridge between the model classes and the admin functionality.
  */
-interface ModelManagerInterface
+interface ModelManagerInterface extends DatagridManagerInterface
 {
     /**
      * @param string $class
@@ -210,13 +209,6 @@ interface ModelManagerInterface
      * @return array<string, mixed>
      */
     public function getSortParameters(FieldDescriptionInterface $fieldDescription, DatagridInterface $datagrid);
-
-    /**
-     * @param string $class
-     *
-     * @return array<string, string>
-     */
-    public function getDefaultSortValues($class);
 
     /**
      * @param string $class

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -825,6 +825,9 @@ class AdminTest extends TestCase
         $admin->addSubClass('whatever');
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetPerPageOptions(): void
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
@@ -1163,6 +1166,9 @@ class AdminTest extends TestCase
         $this->assertSame(14, $admin->getMaxPageLinks());
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetMaxPerPage(): void
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
@@ -1287,10 +1293,6 @@ class AdminTest extends TestCase
         $this->assertFalse($admin->determinedPerPageValue('foo'));
         $this->assertFalse($admin->determinedPerPageValue(123));
         $this->assertTrue($admin->determinedPerPageValue(16));
-
-        $admin->setPerPageOptions([101, 102, 103]);
-        $this->assertFalse($admin->determinedPerPageValue(16));
-        $this->assertTrue($admin->determinedPerPageValue(101));
     }
 
     public function testIsGranted(): void


### PR DESCRIPTION
## Subject

I am targeting this branch, because I tried to be BC.

I tried to fix the issue explained here: https://github.com/sonata-project/SonataAdminBundle/issues/5929#issuecomment-599972301

ATM, the modelManager provide a `getSortValues` method, but it's overriden by the `datagridValues`. So I would recommend to deprecate `datagridValues` and provide a `getDefaultSortValues` instead.
 And the `perPageOptions` should come from the modelManager since he's already providing the `_per_page` value.
 The `maxPerPage` property seems to be a duplicate of the datagridValues[`_per_page`].

~~I need to test this on my project.~~
Edit: I tested it on my project and:
- The actual state of the PR seems to breaks nothing.
- If I update all the "Next_major" code, and I implement the `getDefaultPerPageOptions` in the ModelManager ; everything works as expected. The `maxPerPage` and `perPageOptions` values are correctly coming from the ModelManger.

## Changelog

```markdown
### Added
- Added some `AbstractAdmin::configureDefaultSortValues` to override $datagridValues.
- Added some `AbstractAdminExtension::configureDefaultSortValues` to override $datagridValues.

### Deprecated
- Deprecate the `AbstractAdmin::maxPerPage` property
- Deprecate the `AbstractAdmin::setMaxPerPage` method
- Deprecate the `AbstractAdmin::perPageOption` property
- Deprecate the `AbstractAdmin::setPerPageOption` method
- Deprecate the `AbstractAdmin::predefinePerPageOptions` method
- Deprecate the `AbstractAdmin::datagridValues` property
- Deprecate implementing `ModelManagerInterface` without implementing `DatagridManagerInterface`
```