### PR TITLE
Allow to use empty create/edit form

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -694,16 +694,6 @@ class CRUDController implements ContainerAwareInterface
         $fields = $this->admin->getShow();
         \assert($fields instanceof FieldDescriptionCollection);
 
-        // NEXT_MAJOR: replace deprecation with exception
-        if (!\is_array($fields->getElements()) || 0 === $fields->count()) {
-            @trigger_error(
-                'Calling this method without implementing "configureShowFields"'
-                .' is not supported since sonata-project/admin-bundle 3.40.0'
-                .' and will no longer be possible in 4.0',
-                E_USER_DEPRECATED
-            );
-        }
-
         // NEXT_MAJOR: Remove this line and use commented line below it instead
         $template = $this->admin->getTemplate('show');
         //$template = $this->templateRegistry->getTemplate('show');

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -279,7 +279,6 @@ class CRUDController implements ContainerAwareInterface
      * @param int|string|null $deprecatedId
      *
      * @throws NotFoundHttpException If the object does not exist
-     * @throws \RuntimeException     If no editable field is defined
      * @throws AccessDeniedException If access is not granted
      *
      * @return Response|RedirectResponse
@@ -320,12 +319,6 @@ class CRUDController implements ContainerAwareInterface
         $objectId = $this->admin->getNormalizedIdentifier($existingObject);
 
         $form = $this->admin->getForm();
-
-        if (!\is_array($fields = $form->all()) || 0 === \count($fields)) {
-            throw new \RuntimeException(
-                'No editable field defined. Did you forget to implement the "configureFormFields" method?'
-            );
-        }
 
         $form->setData($existingObject);
         $form->handleRequest($request);
@@ -547,7 +540,6 @@ class CRUDController implements ContainerAwareInterface
      * Create action.
      *
      * @throws AccessDeniedException If access is not granted
-     * @throws \RuntimeException     If no editable field is defined
      *
      * @return Response
      */
@@ -583,12 +575,6 @@ class CRUDController implements ContainerAwareInterface
         $this->admin->setSubject($newObject);
 
         $form = $this->admin->getForm();
-
-        if (!\is_array($fields = $form->all()) || 0 === \count($fields)) {
-            throw new \RuntimeException(
-                'No editable field defined. Did you forget to implement the "configureFormFields" method?'
-            );
-        }
 
         $form->setData($newObject);
         $form->handleRequest($request);

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -68,7 +68,7 @@
                             </div>
                             <input type="hidden" name="_tab" value="{{ app.request.query.get('_tab') }}">
                         </div>
-                    {% else %}
+                    {% elseif admin.formtabs['default'] is defined %}
                         {{ form_helper.render_groups(admin, form, admin.formtabs['default'].groups, has_tab) }}
                     {% endif %}
                 </div>

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -28,7 +28,9 @@
 
             {% block sonata_tab_content %}
                 {% import "@SonataAdmin/CRUD/base_edit_form_macro.html.twig" as form_helper %}
-                {% set has_tab = ((admin.formtabs|length == 1 and admin.formtabs|keys[0] != 'default') or admin.formtabs|length > 1 ) %}
+                {# NEXT_MAJOR: Remove the sonata_deprecation_mute param. #}
+                {% set formtabs = admin.getformtabs('sonata_deprecation_mute') %}
+                {% set has_tab = ((formtabs|length == 1 and formtabs|keys[0] != 'default') or formtabs|length > 1 ) %}
 
                 <div class="col-md-12">
                     {% if has_tab %}
@@ -36,7 +38,7 @@
                         {% set tab_query_index = app.request.query.get('_tab', 0)|split("_")|last %}
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">
-                                {% for name, form_tab in admin.formtabs %}
+                                {% for name, form_tab in formtabs %}
                                     {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                                     <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (tab_query_index == loop.index) %} class="active"{% endif %}>
                                         <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
@@ -46,7 +48,7 @@
                                 {% endfor %}
                             </ul>
                             <div class="tab-content">
-                                {% for code, form_tab in admin.formtabs %}
+                                {% for code, form_tab in formtabs %}
                                     {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                                     <div
                                         class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (tab_query_index == loop.index) %} in active{% endif %}"
@@ -68,8 +70,8 @@
                             </div>
                             <input type="hidden" name="_tab" value="{{ app.request.query.get('_tab') }}">
                         </div>
-                    {% elseif admin.formtabs['default'] is defined %}
-                        {{ form_helper.render_groups(admin, form, admin.formtabs['default'].groups, has_tab) }}
+                    {% elseif formtabs['default'] is defined %}
+                        {{ form_helper.render_groups(admin, form, formtabs['default'].groups, has_tab) }}
                     {% endif %}
                 </div>
             {% endblock %}

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -35,14 +35,16 @@ file that was distributed with this source code.
 
         {{ sonata_block_render_event('sonata.admin.show.top', { 'admin': admin, 'object': object }) }}
 
-        {% set has_tab = (admin.showtabs|length == 1 and admin.showtabs|keys[0] != 'default') or admin.showtabs|length > 1 %}
+        {# NEXT_MAJOR: Remove the sonata_deprecation_mute param. #}
+        {% set showtabs = admin.getshowtabs('sonata_deprecation_mute') %}
+        {% set has_tab = (showtabs|length == 1 and showtabs|keys[0] != 'default') or showtabs|length > 1 %}
 
         {% if has_tab %}
             {% set tab_prefix = 'tab_' ~ admin.uniqid ~ '_' ~ random() %}
             {% set tab_query_index = app.request.query.get('_tab', 0)|split("_")|last %}
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs" role="tablist">
-                    {% for name, show_tab in admin.showtabs %}
+                    {% for name, show_tab in showtabs %}
                         {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                         <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (tab_query_index == loop.index) %} class="active"{% endif %}>
                             <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
@@ -53,7 +55,7 @@ file that was distributed with this source code.
                 </ul>
 
                 <div class="tab-content">
-                    {% for code, show_tab in admin.showtabs %}
+                    {% for code, show_tab in showtabs %}
                         {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                         <div
                             class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (tab_query_index == loop.index) %} in active{% endif %}"
@@ -73,8 +75,8 @@ file that was distributed with this source code.
                     {% endfor %}
                 </div>
             </div>
-        {% elseif admin.showtabs is iterable %}
-            {% set groups = admin.showtabs.default.groups %}
+        {% elseif showtabs['default'] is defined %}
+            {% set groups = showtabs['default'].groups %}
             {{ block('show_groups') }}
         {% endif %}
 

--- a/tests/App/Admin/EmptyAdmin.php
+++ b/tests/App/Admin/EmptyAdmin.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Show\ShowMapper;
+
+final class EmptyAdmin extends AbstractAdmin
+{
+    protected $baseRoutePattern = 'empty';
+    protected $baseRouteName = 'admin_empty';
+
+    protected function configureListFields(ListMapper $list)
+    {
+        // Empty
+    }
+
+    protected function configureFormFields(FormMapper $form)
+    {
+        // Empty
+    }
+
+    protected function configureShowFields(ShowMapper $show)
+    {
+        // Empty
+    }
+}

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -38,3 +38,8 @@ services:
         arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
         tags:
             - {name: sonata.admin, manager_type: test, label: Foo}
+
+    Sonata\AdminBundle\Tests\App\Admin\EmptyAdmin:
+        arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
+        tags:
+            - {name: sonata.admin, manager_type: test, label: Empty}

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -1400,32 +1400,6 @@ class CRUDControllerTest extends TestCase
         $this->controller->editAction(null);
     }
 
-    public function testEditActionRuntimeException(): void
-    {
-        $this->expectException(\RuntimeException::class);
-
-        $this->admin->expects($this->once())
-            ->method('getObject')
-            ->willReturn(new \stdClass());
-
-        $this->admin->expects($this->once())
-            ->method('checkAccess')
-            ->with($this->equalTo('edit'))
-            ->willReturn(true);
-
-        $form = $this->createMock(Form::class);
-
-        $this->admin->expects($this->once())
-            ->method('getForm')
-            ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn([]);
-
-        $this->controller->editAction(null);
-    }
-
     public function testEditActionAccessDenied(): void
     {
         $this->expectException(AccessDeniedException::class);
@@ -1489,10 +1463,6 @@ class CRUDControllerTest extends TestCase
             ->method('createView')
             ->willReturn($formView);
 
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
         $this->assertInstanceOf(Response::class, $this->controller->editAction(null));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
@@ -1553,10 +1523,6 @@ class CRUDControllerTest extends TestCase
             ->method('isValid')
             ->willReturn(true);
 
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
         $this->admin->expects($this->once())
             ->method('toString')
             ->with($this->equalTo($object))
@@ -1602,10 +1568,6 @@ class CRUDControllerTest extends TestCase
         $form->expects($this->once())
             ->method('isValid')
             ->willReturn(false);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $this->admin->expects($this->once())
             ->method('toString')
@@ -1671,10 +1633,6 @@ class CRUDControllerTest extends TestCase
             ->method('getData')
             ->willReturn($object);
 
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
         $this->admin
             ->method('getNormalizedIdentifier')
             ->with($this->equalTo($object))
@@ -1720,10 +1678,6 @@ class CRUDControllerTest extends TestCase
         $form->expects($this->once())
             ->method('isValid')
             ->willReturn(false);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $formError = $this->createMock(FormError::class);
         $formError->expects($this->atLeastOnce())
@@ -1773,10 +1727,6 @@ class CRUDControllerTest extends TestCase
         $form->expects($this->once())
             ->method('isValid')
             ->willReturn(false);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $this->request->setMethod(Request::METHOD_POST);
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
@@ -1836,10 +1786,6 @@ class CRUDControllerTest extends TestCase
         $form->expects($this->once())
             ->method('getData')
             ->willReturn($object);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $this->admin->expects($this->once())
             ->method('toString')
@@ -1911,10 +1857,6 @@ class CRUDControllerTest extends TestCase
             ->method('isValid')
             ->willReturn(true);
 
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
         $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('btn_preview', 'Preview');
 
@@ -1960,10 +1902,6 @@ class CRUDControllerTest extends TestCase
             ->method('getData')
             ->willReturn($object);
 
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
         $this->admin
             ->method('getForm')
             ->willReturn($form);
@@ -2005,36 +1943,6 @@ class CRUDControllerTest extends TestCase
             ->method('checkAccess')
             ->with($this->equalTo('create'))
             ->will($this->throwException(new AccessDeniedException()));
-
-        $this->controller->createAction();
-    }
-
-    public function testCreateActionRuntimeException(): void
-    {
-        $this->expectException(\RuntimeException::class);
-
-        $this->admin->expects($this->once())
-            ->method('checkAccess')
-            ->with($this->equalTo('create'))
-            ->willReturn(true);
-
-        $this->admin
-            ->method('getClass')
-            ->willReturn(\stdClass::class);
-
-        $this->admin->expects($this->once())
-            ->method('getNewInstance')
-            ->willReturn(new \stdClass());
-
-        $form = $this->createMock(Form::class);
-
-        $this->admin->expects($this->once())
-            ->method('getForm')
-            ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn([]);
 
         $this->controller->createAction();
     }
@@ -2087,10 +1995,6 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $formView = $this->createMock(FormView::class);
 
@@ -2166,10 +2070,6 @@ class CRUDControllerTest extends TestCase
             ->willReturn($form);
 
         $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
-        $form->expects($this->once())
             ->method('isSubmitted')
             ->willReturn(true);
 
@@ -2231,10 +2131,6 @@ class CRUDControllerTest extends TestCase
             ->willReturn($form);
 
         $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
-        $form->expects($this->once())
             ->method('isSubmitted')
             ->willReturn(true);
 
@@ -2276,10 +2172,6 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $form->expects($this->once())
             ->method('isSubmitted')
@@ -2343,10 +2235,6 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $form->expects($this->once())
             ->method('isValid')
@@ -2424,10 +2312,6 @@ class CRUDControllerTest extends TestCase
             ->willReturn($form);
 
         $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
-        $form->expects($this->once())
             ->method('isSubmitted')
             ->willReturn(true);
 
@@ -2486,10 +2370,6 @@ class CRUDControllerTest extends TestCase
             ->willReturn($form);
 
         $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
-        $form->expects($this->once())
             ->method('isSubmitted')
             ->willReturn(true);
 
@@ -2541,10 +2421,6 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $form->expects($this->once())
             ->method('isSubmitted')
@@ -2601,10 +2477,6 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $this->admin->expects($this->once())
             ->method('supportsPreviewMode')

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -754,40 +754,6 @@ class CRUDControllerTest extends TestCase
         $this->controller->showAction(null);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Calling this method without implementing "configureShowFields" is not supported since sonata-project/admin-bundle 3.40.0 and will no longer be possible in 4.0
-     */
-    public function testShowActionDeprecation(): void
-    {
-        $object = new \stdClass();
-
-        $this->admin->expects($this->once())
-            ->method('getObject')
-            ->willReturn($object);
-
-        $this->admin->expects($this->once())
-            ->method('checkAccess')
-            ->with($this->equalTo('show'))
-            ->willReturn(true);
-
-        $show = $this->createMock(FieldDescriptionCollection::class);
-
-        $this->admin->expects($this->once())
-            ->method('getShow')
-            ->willReturn($show);
-
-        $show->expects($this->once())
-            ->method('getElements')
-            ->willReturn([]);
-
-        $show->expects($this->once())
-            ->method('count')
-            ->willReturn(0);
-
-        $this->controller->showAction(null);
-    }
-
     public function testPreShow(): void
     {
         $object = new \stdClass();
@@ -828,10 +794,6 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getShow')
             ->willReturn($show);
-
-        $show->expects($this->once())
-            ->method('getElements')
-            ->willReturn(['field' => 'fielddata']);
 
         $this->assertInstanceOf(Response::class, $this->controller->showAction(null));
 

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -32,6 +32,14 @@ final class CRUDControllerTest extends WebTestCase
         );
     }
 
+    public function testEmptyList(): void
+    {
+        $client = static::createClient();
+        $client->request(Request::METHOD_GET, '/admin/empty/list');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+    }
+
     public function testCreate(): void
     {
         $client = static::createClient();
@@ -42,6 +50,14 @@ final class CRUDControllerTest extends WebTestCase
             1,
             $crawler->filter('.sonata-ba-collapsed-fields label:contains("Name")')->count()
         );
+    }
+
+    public function testEmptyCreate(): void
+    {
+        $client = static::createClient();
+        $client->request(Request::METHOD_GET, '/admin/empty/create');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }
 
     public function testShow(): void
@@ -56,6 +72,14 @@ final class CRUDControllerTest extends WebTestCase
         );
     }
 
+    public function testEmptyShow(): void
+    {
+        $client = static::createClient();
+        $client->request(Request::METHOD_GET, '/admin/empty/test_id/show');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+    }
+
     public function testEdit(): void
     {
         $client = static::createClient();
@@ -66,6 +90,14 @@ final class CRUDControllerTest extends WebTestCase
             1,
             $crawler->filter('.sonata-ba-collapsed-fields label:contains("Name")')->count()
         );
+    }
+
+    public function testEmptyEdit(): void
+    {
+        $client = static::createClient();
+        $client->request(Request::METHOD_GET, '/admin/empty/test_id/edit');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }
 
     protected static function getKernelClass()


### PR DESCRIPTION
## Subject

Technically it's possible to create/edit an object with no form field. I see no reason to throw a RuntimeException. Plus you can have use case with some data automatically set in PrePersist/PreUpdate method without anything to be filled by the user.

This PR allow to edit or create an object when the form has no field.

I am targeting this branch, because BC.

## Changelog

```markdown
### Added
- The possibility to edit/create an object without any field set in the configureFormField.
```