### PR TITLE
fix: add datetime in editable date form types for SetObjectFieldValue…

### DIFF
--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -113,8 +113,8 @@ final class SetObjectFieldValueAction
             $propertyPath = new PropertyPath($field);
         }
 
-        // Handle date type has setter expect a DateTime object
-        if ('' !== $value && 'date' === $fieldDescription->getType()) {
+        // Handle date and datetime types have setter expecting a DateTime object
+        if ('' !== $value && \in_array($fieldDescription->getType(), ['date', 'datetime'], true)) {
             $value = new \DateTime($value);
         }
 

--- a/tests/Action/Bafoo.php
+++ b/tests/Action/Bafoo.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Action;
+
+class Bafoo
+{
+    private $dateProp;
+
+    private $datetimeProp;
+
+    public function getDateProp(): ?\DateTime
+    {
+        return $this->dateProp;
+    }
+
+    public function setDateProp(\DateTime $dateProp): self
+    {
+        $this->dateProp = $dateProp;
+
+        return $this;
+    }
+
+    public function getDatetimeProp(): \DateTime
+    {
+        return $this->datetimeProp;
+    }
+
+    public function setDatetimeProp(\DateTime $datetimeProp): self
+    {
+        $this->datetimeProp = $datetimeProp;
+
+        return $this;
+    }
+}

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -116,7 +116,101 @@ final class SetObjectFieldValueActionTest extends TestCase
         $fieldDescription->getOption('editable')->willReturn(true);
         $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
         $fieldDescription->getType()->willReturn('boolean');
-        $fieldDescription->getTemplate()->willReturn(false);
+        $fieldDescription->getTemplate()->willReturn('field_template');
+        $fieldDescription->getValue(Argument::cetera())->willReturn('some value');
+
+        $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
+
+        $response = ($this->action)($request);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testSetObjectFieldValueActionWithDate(): void
+    {
+        $object = new Bafoo();
+        $request = new Request([
+            'code' => 'sonata.post.admin',
+            'objectId' => 42,
+            'field' => 'dateProp',
+            'value' => '2020-12-12',
+            'context' => 'list',
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+
+        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
+        $pool = $this->prophesize(Pool::class);
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $propertyAccessor = new PropertyAccessor();
+        $templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $this->admin->getObject(42)->willReturn($object);
+        $this->admin->getCode()->willReturn('sonata.post.admin');
+        $this->admin->hasAccess('edit', $object)->willReturn(true);
+        $this->admin->getListFieldDescription('dateProp')->willReturn($fieldDescription->reveal());
+        $this->admin->update($object)->shouldBeCalled();
+
+        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
+        $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
+        $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
+        $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
+        $this->twig->addExtension(new SonataAdminExtension(
+            $pool->reveal(),
+            null,
+            $translator->reveal(),
+            $container->reveal()
+        ));
+        $fieldDescription->getOption('editable')->willReturn(true);
+        $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
+        $fieldDescription->getType()->willReturn('date');
+        $fieldDescription->getTemplate()->willReturn('field_template');
+        $fieldDescription->getValue(Argument::cetera())->willReturn('some value');
+
+        $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
+
+        $response = ($this->action)($request);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testSetObjectFieldValueActionWithDateTime(): void
+    {
+        $object = new Bafoo();
+        $request = new Request([
+            'code' => 'sonata.post.admin',
+            'objectId' => 42,
+            'field' => 'datetimeProp',
+            'value' => '2020-12-12 23:11:23',
+            'context' => 'list',
+        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+
+        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
+        $pool = $this->prophesize(Pool::class);
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $propertyAccessor = new PropertyAccessor();
+        $templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $this->admin->getObject(42)->willReturn($object);
+        $this->admin->getCode()->willReturn('sonata.post.admin');
+        $this->admin->hasAccess('edit', $object)->willReturn(true);
+        $this->admin->getListFieldDescription('datetimeProp')->willReturn($fieldDescription->reveal());
+        $this->admin->update($object)->shouldBeCalled();
+
+        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
+        $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
+        $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
+        $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
+        $this->twig->addExtension(new SonataAdminExtension(
+            $pool->reveal(),
+            null,
+            $translator->reveal(),
+            $container->reveal()
+        ));
+        $fieldDescription->getOption('editable')->willReturn(true);
+        $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
+        $fieldDescription->getType()->willReturn('datetime');
+        $fieldDescription->getTemplate()->willReturn('field_template');
         $fieldDescription->getValue(Argument::cetera())->willReturn('some value');
 
         $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
@@ -251,7 +345,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $fieldDescription->getOption('multiple')->willReturn(true);
         $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
         $fieldDescription->getType()->willReturn('boolean');
-        $fieldDescription->getTemplate()->willReturn(false);
+        $fieldDescription->getTemplate()->willReturn('field_template');
         $fieldDescription->getValue(Argument::cetera())->willReturn(['some value']);
 
         $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));


### PR DESCRIPTION
Credit to https://github.com/sonata-project/SonataAdminBundle/pull/6034
I just rebase 3.x and squash commit. The fork doesn't allow pushes from maintainers.

## Fix datetime not handled correctly in editable formtypes of SetObjectFieldValueAction

We have found a bug introduced in 3.38 with SetObjectFieldValueAction.
When using editable datetime formtype in datagrid configuration
the case was not handled correctly anymore since Action introduction (3.38.0)

Until now only editable "date" fields were correctly handled.

This PR fix this behaviour and add the datetime formtype as
transformable to DateTime to be correctly handled in typehinted setters

Tests have been added to illustrate the case
Without the PR
testSetObjectFieldValueActionWithDateTime wouldn't pass.

I am targeting this branch, because this patch is backward compatible up to 3.38

## Changelog

```markdown
### Fixed
- Bug when trying to edit a datetime formtype in datagrid
```

Closes #6034 