### PR TITLE
Fix GenerateObjectAclCommand error for symfony 3.4

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -893,7 +893,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     public function getParentAssociationMapping()
     {
         // NEXT_MAJOR: remove array check
-        if (\is_array($this->parentAssociationMapping) && $this->getParent()) {
+        if (\is_array($this->parentAssociationMapping) && $this->isChild()) {
             $parent = $this->getParent()->getCode();
 
             if (\array_key_exists($parent, $this->parentAssociationMapping)) {
@@ -1035,7 +1035,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     public function getClass()
     {
         if ($this->hasActiveSubClass()) {
-            if ($this->getParentFieldDescription()) {
+            if ($this->hasParentFieldDescription()) {
                 throw new \RuntimeException('Feature not implemented: an embedded admin cannot have subclass');
             }
 
@@ -1513,13 +1513,11 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      */
     public function getRoot()
     {
-        $parentFieldDescription = $this->getParentFieldDescription();
-
-        if (!$parentFieldDescription) {
+        if (!$this->hasParentFieldDescription()) {
             return $this;
         }
 
-        return $parentFieldDescription->getAdmin()->getRoot();
+        return $this->getParentFieldDescription()->getAdmin()->getRoot();
     }
 
     public function setBaseControllerName($baseControllerName)
@@ -1706,6 +1704,22 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     public function getParentFieldDescription()
     {
+        if (!$this->hasParentFieldDescription()) {
+            @trigger_error(sprintf(
+                'Calling %s() when there is no parent field description is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0. '.
+                'Use %s::hasParentFieldDescription() to know if there is a parent field description.',
+                __METHOD__,
+                __CLASS__
+            ), E_USER_DEPRECATED);
+            // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare FieldDescriptionInterface as return type
+            // throw new \LogicException(sprintf(
+            //    'Admin "%s" has no parent field description.',
+            //    static::class
+            // ));
+
+            return null;
+        }
+
         return $this->parentFieldDescription;
     }
 
@@ -1734,12 +1748,20 @@ EOT;
 
     public function getSubject()
     {
-        if (null === $this->subject && $this->request && !$this->hasParentFieldDescription()) {
-            $id = $this->request->get($this->getIdParameter());
+        if (!$this->hasSubject()) {
+            @trigger_error(sprintf(
+                'Calling %s() when there is no subject is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0. '.
+                'Use %s::hasSubject() to know if there is a subject.',
+                __METHOD__,
+                __CLASS__
+            ), E_USER_DEPRECATED);
+            // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and update the return type
+            // throw new \LogicException(sprintf(
+            //    'Admin "%s" has no subject.',
+            //    static::class
+            // ));
 
-            if (null !== $id) {
-                $this->subject = $this->getObject($id);
-            }
+            return null;
         }
 
         return $this->subject;
@@ -1747,7 +1769,15 @@ EOT;
 
     public function hasSubject()
     {
-        return (bool) $this->getSubject();
+        if (null === $this->subject && $this->hasRequest() && !$this->hasParentFieldDescription()) {
+            $id = $this->request->get($this->getIdParameter());
+
+            if (null !== $id) {
+                $this->subject = $this->getObject($id);
+            }
+        }
+
+        return null !== $this->subject;
     }
 
     public function getFormFieldDescriptions()
@@ -1839,7 +1869,25 @@ EOT;
 
     public function getListFieldDescription($name)
     {
-        return $this->hasListFieldDescription($name) ? $this->listFieldDescriptions[$name] : null;
+        if (!$this->hasListFieldDescription($name)) {
+            @trigger_error(sprintf(
+                'Calling %s() when there is no list field description is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0. '.
+                'Use %s::hasListFieldDescription(\'%s\') to know if there is a list field description.',
+                __METHOD__,
+                __CLASS__,
+                $name
+            ), E_USER_DEPRECATED);
+            // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare FieldDescriptionInterface as return type
+            // throw new \LogicException(sprintf(
+            //    'Admin "%s" has no list field description for %s.',
+            //    static::class,
+            //    $name
+            // ));
+
+            return null;
+        }
+
+        return $this->listFieldDescriptions[$name];
     }
 
     public function hasListFieldDescription($name)
@@ -1888,11 +1936,12 @@ EOT;
 
     public function addChild(AdminInterface $child)
     {
-        for ($parentAdmin = $this; null !== $parentAdmin; $parentAdmin = $parentAdmin->getParent()) {
-            if ($parentAdmin->getCode() !== $child->getCode()) {
-                continue;
-            }
+        $parentAdmin = $this;
+        while ($parentAdmin->isChild() && $parentAdmin->getCode() !== $child->getCode()) {
+            $parentAdmin = $parentAdmin->getParent();
+        }
 
+        if ($parentAdmin->getCode() === $child->getCode()) {
             throw new \RuntimeException(sprintf(
                 'Circular reference detected! The child admin `%s` is already in the parent tree of the `%s` admin.',
                 $child->getCode(),
@@ -1941,6 +1990,22 @@ EOT;
 
     public function getParent()
     {
+        if (!$this->isChild()) {
+            @trigger_error(sprintf(
+                'Calling %s() when there is no parent is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in 4.0. '.
+                'Use %s::isChild() to know if there is a parent.',
+                __METHOD__,
+                __CLASS__
+            ), E_USER_DEPRECATED);
+            // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare AdminInterface as return type
+            // throw new \LogicException(sprintf(
+            //    'Admin "%s" has no parent.',
+            //    static::class
+            // ));
+
+            return null;
+        }
+
         return $this->parent;
     }
 
@@ -2271,6 +2336,7 @@ EOT;
     public function getRequest()
     {
         if (!$this->request) {
+            // NEXT_MAJOR: Throw \LogicException instead.
             throw new \RuntimeException('The Request object has not been set');
         }
 
@@ -3162,6 +3228,7 @@ EOT;
             return $this->subClasses[$name];
         }
 
+        // NEXT_MAJOR: Throw \LogicException instead.
         throw new \RuntimeException(sprintf(
             'Unable to find the subclass `%s` for admin `%s`',
             $name,

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -143,6 +143,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function getForm();
 
     /**
+     * NEXT MAJOR: Remove the throws tag.
+     *
      * @throws \RuntimeException if no request is set
      *
      * @return Request
@@ -351,6 +353,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function setSubject($subject);
 
     /**
+     * NEXT MAJOR: return object.
+     *
      * @return object|null
      */
     public function getSubject();
@@ -443,7 +447,7 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function createObjectSecurity($object);
 
     /**
-     * @return AdminInterface|null
+     * @return AdminInterface|null NEXT_MAJOR: return AdminInterface
      */
     public function getParent();
 

--- a/src/Admin/BreadcrumbsBuilder.php
+++ b/src/Admin/BreadcrumbsBuilder.php
@@ -100,7 +100,7 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
 
         $childAdmin = $admin->getCurrentChildAdmin();
 
-        if ($childAdmin) {
+        if ($childAdmin && $admin->hasSubject()) {
             $id = $admin->getRequest()->get($admin->getIdParameter());
 
             $menu = $menu->addChild(

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -78,8 +78,8 @@ class CRUDController implements ContainerAwareInterface
      *
      * @see renderWithExtraParams()
      *
-     * @param string $view       The view name
-     * @param array  $parameters An array of parameters to pass to the view
+     * @param string               $view       The view name
+     * @param array<string, mixed> $parameters An array of parameters to pass to the view
      *
      * @return Response A Response instance
      *
@@ -98,25 +98,15 @@ class CRUDController implements ContainerAwareInterface
     /**
      * Renders a view while passing mandatory parameters on to the template.
      *
-     * @param string $view The view name
+     * @param string               $view       The view name
+     * @param array<string, mixed> $parameters An array of parameters to pass to the view
      *
      * @return Response A Response instance
      */
     public function renderWithExtraParams($view, array $parameters = [], ?Response $response = null)
     {
-        if (!$this->isXmlHttpRequest()) {
-            $parameters['breadcrumbs_builder'] = $this->get('sonata.admin.breadcrumbs_builder');
-        }
-        $parameters['admin'] = $parameters['admin'] ??
-            $this->admin;
-
-        $parameters['base_template'] = $parameters['base_template'] ??
-            $this->getBaseTemplate();
-
-        $parameters['admin_pool'] = $this->get('sonata.admin.pool');
-
         //NEXT_MAJOR: Remove method alias and use $this->render() directly.
-        return $this->originalRender($view, $parameters, $response);
+        return $this->originalRender($view, $this->addRenderExtraParams($parameters), $response);
     }
 
     /**
@@ -1057,6 +1047,24 @@ class CRUDController implements ContainerAwareInterface
     public function getRequest()
     {
         return $this->container->get('request_stack')->getCurrentRequest();
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     *
+     * @return array<string, mixed>
+     */
+    protected function addRenderExtraParams(array $parameters = []): array
+    {
+        if (!$this->isXmlHttpRequest()) {
+            $parameters['breadcrumbs_builder'] = $this->get('sonata.admin.breadcrumbs_builder');
+        }
+
+        $parameters['admin'] = $parameters['admin'] ?? $this->admin;
+        $parameters['base_template'] = $parameters['base_template'] ?? $this->getBaseTemplate();
+        $parameters['admin_pool'] = $this->get('sonata.admin.pool');
+
+        return $parameters;
     }
 
     /**

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -279,7 +279,6 @@ class CRUDController implements ContainerAwareInterface
      * @param int|string|null $deprecatedId
      *
      * @throws NotFoundHttpException If the object does not exist
-     * @throws \RuntimeException     If no editable field is defined
      * @throws AccessDeniedException If access is not granted
      *
      * @return Response|RedirectResponse
@@ -320,12 +319,6 @@ class CRUDController implements ContainerAwareInterface
         $objectId = $this->admin->getNormalizedIdentifier($existingObject);
 
         $form = $this->admin->getForm();
-
-        if (!\is_array($fields = $form->all()) || 0 === \count($fields)) {
-            throw new \RuntimeException(
-                'No editable field defined. Did you forget to implement the "configureFormFields" method?'
-            );
-        }
 
         $form->setData($existingObject);
         $form->handleRequest($request);
@@ -547,7 +540,6 @@ class CRUDController implements ContainerAwareInterface
      * Create action.
      *
      * @throws AccessDeniedException If access is not granted
-     * @throws \RuntimeException     If no editable field is defined
      *
      * @return Response
      */
@@ -583,12 +575,6 @@ class CRUDController implements ContainerAwareInterface
         $this->admin->setSubject($newObject);
 
         $form = $this->admin->getForm();
-
-        if (!\is_array($fields = $form->all()) || 0 === \count($fields)) {
-            throw new \RuntimeException(
-                'No editable field defined. Did you forget to implement the "configureFormFields" method?'
-            );
-        }
 
         $form->setData($newObject);
         $form->handleRequest($request);
@@ -707,16 +693,6 @@ class CRUDController implements ContainerAwareInterface
 
         $fields = $this->admin->getShow();
         \assert($fields instanceof FieldDescriptionCollection);
-
-        // NEXT_MAJOR: replace deprecation with exception
-        if (!\is_array($fields->getElements()) || 0 === $fields->count()) {
-            @trigger_error(
-                'Calling this method without implementing "configureShowFields"'
-                .' is not supported since sonata-project/admin-bundle 3.40.0'
-                .' and will no longer be possible in 4.0',
-                E_USER_DEPRECATED
-            );
-        }
 
         // NEXT_MAJOR: Remove this line and use commented line below it instead
         $template = $this->admin->getTemplate('show');

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1554,7 +1554,7 @@ class CRUDController implements ContainerAwareInterface
 
     private function checkParentChildAssociation(Request $request, $object): void
     {
-        if (!($parentAdmin = $this->admin->getParent())) {
+        if (!$this->admin->isChild()) {
             return;
         }
 
@@ -1563,6 +1563,7 @@ class CRUDController implements ContainerAwareInterface
             return;
         }
 
+        $parentAdmin = $this->admin->getParent();
         $parentId = $request->get($parentAdmin->getIdParameter());
 
         $propertyAccessor = PropertyAccess::createPropertyAccessor();

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -293,4 +293,49 @@ class Datagrid implements DatagridInterface
 
         return $this->form;
     }
+
+    public function getSortParameters(FieldDescriptionInterface $fieldDescription): array
+    {
+        $values = $this->getValues();
+
+        if ($this->isFieldAlreadySorted($fieldDescription)) {
+            if ('ASC' === $values['_sort_order']) {
+                $values['_sort_order'] = 'DESC';
+            } else {
+                $values['_sort_order'] = 'ASC';
+            }
+        } else {
+            $values['_sort_order'] = 'ASC';
+        }
+
+        $values['_sort_by'] = \is_string($fieldDescription->getOption('sortable'))
+            ? $fieldDescription->getOption('sortable')
+            : $fieldDescription->getName();
+
+        return ['filter' => $values];
+    }
+
+    public function getPaginationParameters(int $page): array
+    {
+        $values = $this->getValues();
+
+        if (isset($values['_sort_by']) && $values['_sort_by'] instanceof FieldDescriptionInterface) {
+            $values['_sort_by'] = $values['_sort_by']->getName();
+        }
+        $values['_page'] = $page;
+
+        return ['filter' => $values];
+    }
+
+    private function isFieldAlreadySorted(FieldDescriptionInterface $fieldDescription): bool
+    {
+        $values = $this->getValues();
+
+        if (!isset($values['_sort_by']) || !$values['_sort_by'] instanceof FieldDescriptionInterface) {
+            return false;
+        }
+
+        return $values['_sort_by']->getName() === $fieldDescription->getName()
+            || $values['_sort_by']->getName() === $fieldDescription->getOption('sortable');
+    }
 }

--- a/src/Datagrid/DatagridInterface.php
+++ b/src/Datagrid/DatagridInterface.php
@@ -14,11 +14,15 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Datagrid;
 
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Component\Form\FormInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @method array getSortParameters(FieldDescriptionInterface $fieldDescription)
+ * @method array getPaginationParameters(int $page)
  */
 interface DatagridInterface
 {
@@ -104,4 +108,11 @@ interface DatagridInterface
      * @return bool
      */
     public function hasDisplayableFilters();
+
+    /*
+     * NEXT_MAJOR: Uncomment getSortParameters and getPaginationParameters.
+     *
+     * public function getSortParameters(FieldDescriptionInterface $fieldDescription): array;
+     * public function getPaginationParameters(int $page): array;
+     */
 }

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -207,6 +207,11 @@ interface ModelManagerInterface
     /**
      * Returns the parameters used in the columns header.
      *
+     * NEXT_MAJOR: - Remove this function
+     *             - Replace admin.modelmanager.sortparameters to admin.datagrid.sortparameters
+     *
+     * @deprecated since sonata-project/sonata-admin-bundle 3.x. To be removed in 4.0.
+     *
      * @return array<string, mixed>
      */
     public function getSortParameters(FieldDescriptionInterface $fieldDescription, DatagridInterface $datagrid);
@@ -258,6 +263,11 @@ interface ModelManagerInterface
 
     /**
      * @param int $page
+     *
+     * NEXT_MAJOR: - Remove this function
+     *             - Replace admin.modelmanager.paginationparameters to admin.datagrid.paginationparameters
+     *
+     * @deprecated since sonata-project/sonata-admin-bundle 3.x. To be removed in 4.0.
      *
      * @return array<string, mixed>
      */

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -28,7 +28,9 @@
 
             {% block sonata_tab_content %}
                 {% import "@SonataAdmin/CRUD/base_edit_form_macro.html.twig" as form_helper %}
-                {% set has_tab = ((admin.formtabs|length == 1 and admin.formtabs|keys[0] != 'default') or admin.formtabs|length > 1 ) %}
+                {# NEXT_MAJOR: Remove the sonata_deprecation_mute param. #}
+                {% set formtabs = admin.getformtabs('sonata_deprecation_mute') %}
+                {% set has_tab = ((formtabs|length == 1 and formtabs|keys[0] != 'default') or formtabs|length > 1 ) %}
 
                 <div class="col-md-12">
                     {% if has_tab %}
@@ -36,7 +38,7 @@
                         {% set tab_query_index = app.request.query.get('_tab', 0)|split("_")|last %}
                         <div class="nav-tabs-custom">
                             <ul class="nav nav-tabs" role="tablist">
-                                {% for name, form_tab in admin.formtabs %}
+                                {% for name, form_tab in formtabs %}
                                     {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                                     <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (tab_query_index == loop.index) %} class="active"{% endif %}>
                                         <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
@@ -46,7 +48,7 @@
                                 {% endfor %}
                             </ul>
                             <div class="tab-content">
-                                {% for code, form_tab in admin.formtabs %}
+                                {% for code, form_tab in formtabs %}
                                     {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                                     <div
                                         class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (tab_query_index == loop.index) %} in active{% endif %}"
@@ -68,8 +70,8 @@
                             </div>
                             <input type="hidden" name="_tab" value="{{ app.request.query.get('_tab') }}">
                         </div>
-                    {% else %}
-                        {{ form_helper.render_groups(admin, form, admin.formtabs['default'].groups, has_tab) }}
+                    {% elseif formtabs['default'] is defined %}
+                        {{ form_helper.render_groups(admin, form, formtabs['default'].groups, has_tab) }}
                     {% endif %}
                 </div>
             {% endblock %}

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -35,14 +35,16 @@ file that was distributed with this source code.
 
         {{ sonata_block_render_event('sonata.admin.show.top', { 'admin': admin, 'object': object }) }}
 
-        {% set has_tab = (admin.showtabs|length == 1 and admin.showtabs|keys[0] != 'default') or admin.showtabs|length > 1 %}
+        {# NEXT_MAJOR: Remove the sonata_deprecation_mute param. #}
+        {% set showtabs = admin.getshowtabs('sonata_deprecation_mute') %}
+        {% set has_tab = (showtabs|length == 1 and showtabs|keys[0] != 'default') or showtabs|length > 1 %}
 
         {% if has_tab %}
             {% set tab_prefix = 'tab_' ~ admin.uniqid ~ '_' ~ random() %}
             {% set tab_query_index = app.request.query.get('_tab', 0)|split("_")|last %}
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs" role="tablist">
-                    {% for name, show_tab in admin.showtabs %}
+                    {% for name, show_tab in showtabs %}
                         {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                         <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (tab_query_index == loop.index) %} class="active"{% endif %}>
                             <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
@@ -53,7 +55,7 @@ file that was distributed with this source code.
                 </ul>
 
                 <div class="tab-content">
-                    {% for code, show_tab in admin.showtabs %}
+                    {% for code, show_tab in showtabs %}
                         {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                         <div
                             class="tab-pane fade{% if (not app.request.query.has('_tab') and loop.first) or (tab_query_index == loop.index) %} in active{% endif %}"
@@ -73,8 +75,8 @@ file that was distributed with this source code.
                     {% endfor %}
                 </div>
             </div>
-        {% elseif admin.showtabs is iterable %}
-            {% set groups = admin.showtabs.default.groups %}
+        {% elseif showtabs['default'] is defined %}
+            {% set groups = showtabs['default'].groups %}
             {{ block('show_groups') }}
         {% endif %}
 

--- a/src/Route/DefaultRouteGenerator.php
+++ b/src/Route/DefaultRouteGenerator.php
@@ -85,8 +85,10 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
                 unset($parameters['id']);
             }
 
-            for ($parentAdmin = $admin->getParent(); null !== $parentAdmin; $parentAdmin = $parentAdmin->getParent()) {
+            $parentAdmin = $admin->getParent();
+            while (null !== $parentAdmin) {
                 $parameters[$parentAdmin->getIdParameter()] = $admin->getRequest()->attributes->get($parentAdmin->getIdParameter());
+                $parentAdmin = $parentAdmin->isChild() ? $parentAdmin->getParent() : null;
             }
         }
 

--- a/src/Route/QueryStringBuilder.php
+++ b/src/Route/QueryStringBuilder.php
@@ -59,7 +59,7 @@ class QueryStringBuilder implements RouteBuilderInterface
         }
 
         // an admin can have only one level of nested child
-        if ($admin->getParent()) {
+        if ($admin->isChild()) {
             return;
         }
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1490,7 +1490,7 @@ class AdminTest extends TestCase
             ->method('getAdmin')
             ->willReturn($parentAdmin);
 
-        $this->assertNull($admin->getParentFieldDescription());
+        $this->assertFalse($admin->hasParentFieldDescription());
         $admin->setParentFieldDescription($parentFieldDescription);
         $this->assertSame($parentFieldDescription, $admin->getParentFieldDescription());
         $this->assertSame('sonata.post.admin.post.parent', $admin->getRootCode());
@@ -1508,7 +1508,7 @@ class AdminTest extends TestCase
             ->method('getAdmin')
             ->willReturn($parentAdmin);
 
-        $this->assertNull($admin->getParentFieldDescription());
+        $this->assertFalse($admin->hasParentFieldDescription());
         $admin->setParentFieldDescription($parentFieldDescription);
         $this->assertSame($parentFieldDescription, $admin->getParentFieldDescription());
         $this->assertSame($parentAdmin, $admin->getRoot());
@@ -1824,7 +1824,7 @@ class AdminTest extends TestCase
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
         $admin->setModelManager($modelManager);
 
-        $this->assertNull($admin->getSubject());
+        $this->assertFalse($admin->hasSubject());
     }
 
     public function testGetSideMenu(): void
@@ -1882,7 +1882,7 @@ class AdminTest extends TestCase
         $admin->setModelManager($modelManager);
 
         $admin->setRequest(new Request(['id' => $id]));
-        $this->assertNull($admin->getSubject());
+        $this->assertFalse($admin->hasSubject());
     }
 
     /**
@@ -1903,6 +1903,7 @@ class AdminTest extends TestCase
         $admin->setModelManager($modelManager);
 
         $admin->setRequest(new Request(['id' => $id]));
+        $this->assertTrue($admin->hasSubject());
         $this->assertSame($entity, $admin->getSubject());
         $this->assertSame($entity, $admin->getSubject()); // model manager must be used only once
     }
@@ -1928,12 +1929,13 @@ class AdminTest extends TestCase
         $commentAdmin->setRequest($request);
         $commentAdmin->setModelManager($modelManager);
 
+        $this->assertTrue($commentAdmin->hasSubject());
         $this->assertSame($comment, $commentAdmin->getSubject());
 
         $commentAdmin->setSubject(null);
         $commentAdmin->setParentFieldDescription(new FieldDescription());
 
-        $this->assertNull($commentAdmin->getSubject());
+        $this->assertFalse($commentAdmin->hasSubject());
     }
 
     /**

--- a/tests/App/Admin/EmptyAdmin.php
+++ b/tests/App/Admin/EmptyAdmin.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Show\ShowMapper;
+
+final class EmptyAdmin extends AbstractAdmin
+{
+    protected $baseRoutePattern = 'empty';
+    protected $baseRouteName = 'admin_empty';
+
+    protected function configureListFields(ListMapper $list)
+    {
+        // Empty
+    }
+
+    protected function configureFormFields(FormMapper $form)
+    {
+        // Empty
+    }
+
+    protected function configureShowFields(ShowMapper $show)
+    {
+        // Empty
+    }
+}

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -38,3 +38,8 @@ services:
         arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
         tags:
             - {name: sonata.admin, manager_type: test, label: Foo}
+
+    Sonata\AdminBundle\Tests\App\Admin\EmptyAdmin:
+        arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
+        tags:
+            - {name: sonata.admin, manager_type: test, label: Empty}

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -754,40 +754,6 @@ class CRUDControllerTest extends TestCase
         $this->controller->showAction(null);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Calling this method without implementing "configureShowFields" is not supported since sonata-project/admin-bundle 3.40.0 and will no longer be possible in 4.0
-     */
-    public function testShowActionDeprecation(): void
-    {
-        $object = new \stdClass();
-
-        $this->admin->expects($this->once())
-            ->method('getObject')
-            ->willReturn($object);
-
-        $this->admin->expects($this->once())
-            ->method('checkAccess')
-            ->with($this->equalTo('show'))
-            ->willReturn(true);
-
-        $show = $this->createMock(FieldDescriptionCollection::class);
-
-        $this->admin->expects($this->once())
-            ->method('getShow')
-            ->willReturn($show);
-
-        $show->expects($this->once())
-            ->method('getElements')
-            ->willReturn([]);
-
-        $show->expects($this->once())
-            ->method('count')
-            ->willReturn(0);
-
-        $this->controller->showAction(null);
-    }
-
     public function testPreShow(): void
     {
         $object = new \stdClass();
@@ -828,10 +794,6 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getShow')
             ->willReturn($show);
-
-        $show->expects($this->once())
-            ->method('getElements')
-            ->willReturn(['field' => 'fielddata']);
 
         $this->assertInstanceOf(Response::class, $this->controller->showAction(null));
 
@@ -1404,32 +1366,6 @@ class CRUDControllerTest extends TestCase
         $this->controller->editAction(null);
     }
 
-    public function testEditActionRuntimeException(): void
-    {
-        $this->expectException(\RuntimeException::class);
-
-        $this->admin->expects($this->once())
-            ->method('getObject')
-            ->willReturn(new \stdClass());
-
-        $this->admin->expects($this->once())
-            ->method('checkAccess')
-            ->with($this->equalTo('edit'))
-            ->willReturn(true);
-
-        $form = $this->createMock(Form::class);
-
-        $this->admin->expects($this->once())
-            ->method('getForm')
-            ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn([]);
-
-        $this->controller->editAction(null);
-    }
-
     public function testEditActionAccessDenied(): void
     {
         $this->expectException(AccessDeniedException::class);
@@ -1493,10 +1429,6 @@ class CRUDControllerTest extends TestCase
             ->method('createView')
             ->willReturn($formView);
 
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
         $this->assertInstanceOf(Response::class, $this->controller->editAction(null));
 
         $this->assertSame($this->admin, $this->parameters['admin']);
@@ -1557,10 +1489,6 @@ class CRUDControllerTest extends TestCase
             ->method('isValid')
             ->willReturn(true);
 
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
         $this->admin->expects($this->once())
             ->method('toString')
             ->with($this->equalTo($object))
@@ -1606,10 +1534,6 @@ class CRUDControllerTest extends TestCase
         $form->expects($this->once())
             ->method('isValid')
             ->willReturn(false);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $this->admin->expects($this->once())
             ->method('toString')
@@ -1675,10 +1599,6 @@ class CRUDControllerTest extends TestCase
             ->method('getData')
             ->willReturn($object);
 
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
         $this->admin
             ->method('getNormalizedIdentifier')
             ->with($this->equalTo($object))
@@ -1724,10 +1644,6 @@ class CRUDControllerTest extends TestCase
         $form->expects($this->once())
             ->method('isValid')
             ->willReturn(false);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $formError = $this->createMock(FormError::class);
         $formError->expects($this->atLeastOnce())
@@ -1777,10 +1693,6 @@ class CRUDControllerTest extends TestCase
         $form->expects($this->once())
             ->method('isValid')
             ->willReturn(false);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $this->request->setMethod(Request::METHOD_POST);
         $this->request->headers->set('X-Requested-With', 'XMLHttpRequest');
@@ -1840,10 +1752,6 @@ class CRUDControllerTest extends TestCase
         $form->expects($this->once())
             ->method('getData')
             ->willReturn($object);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $this->admin->expects($this->once())
             ->method('toString')
@@ -1915,10 +1823,6 @@ class CRUDControllerTest extends TestCase
             ->method('isValid')
             ->willReturn(true);
 
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
         $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('btn_preview', 'Preview');
 
@@ -1964,10 +1868,6 @@ class CRUDControllerTest extends TestCase
             ->method('getData')
             ->willReturn($object);
 
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
         $this->admin
             ->method('getForm')
             ->willReturn($form);
@@ -2009,36 +1909,6 @@ class CRUDControllerTest extends TestCase
             ->method('checkAccess')
             ->with($this->equalTo('create'))
             ->will($this->throwException(new AccessDeniedException()));
-
-        $this->controller->createAction();
-    }
-
-    public function testCreateActionRuntimeException(): void
-    {
-        $this->expectException(\RuntimeException::class);
-
-        $this->admin->expects($this->once())
-            ->method('checkAccess')
-            ->with($this->equalTo('create'))
-            ->willReturn(true);
-
-        $this->admin
-            ->method('getClass')
-            ->willReturn(\stdClass::class);
-
-        $this->admin->expects($this->once())
-            ->method('getNewInstance')
-            ->willReturn(new \stdClass());
-
-        $form = $this->createMock(Form::class);
-
-        $this->admin->expects($this->once())
-            ->method('getForm')
-            ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn([]);
 
         $this->controller->createAction();
     }
@@ -2091,10 +1961,6 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $formView = $this->createMock(FormView::class);
 
@@ -2170,10 +2036,6 @@ class CRUDControllerTest extends TestCase
             ->willReturn($form);
 
         $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
-        $form->expects($this->once())
             ->method('isSubmitted')
             ->willReturn(true);
 
@@ -2235,10 +2097,6 @@ class CRUDControllerTest extends TestCase
             ->willReturn($form);
 
         $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
-        $form->expects($this->once())
             ->method('isSubmitted')
             ->willReturn(true);
 
@@ -2280,10 +2138,6 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $form->expects($this->once())
             ->method('isSubmitted')
@@ -2347,10 +2201,6 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $form->expects($this->once())
             ->method('isValid')
@@ -2428,10 +2278,6 @@ class CRUDControllerTest extends TestCase
             ->willReturn($form);
 
         $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
-        $form->expects($this->once())
             ->method('isSubmitted')
             ->willReturn(true);
 
@@ -2490,10 +2336,6 @@ class CRUDControllerTest extends TestCase
             ->willReturn($form);
 
         $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
-
-        $form->expects($this->once())
             ->method('isSubmitted')
             ->willReturn(true);
 
@@ -2545,10 +2387,6 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $form->expects($this->once())
             ->method('isSubmitted')
@@ -2605,10 +2443,6 @@ class CRUDControllerTest extends TestCase
         $this->admin->expects($this->once())
             ->method('getForm')
             ->willReturn($form);
-
-        $form->expects($this->once())
-            ->method('all')
-            ->willReturn(['field' => 'fielddata']);
 
         $this->admin->expects($this->once())
             ->method('supportsPreviewMode')

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -1019,6 +1019,10 @@ class CRUDControllerTest extends TestCase
             ->willReturn($object);
 
         $this->admin->expects($this->once())
+            ->method('isChild')
+            ->willReturn(true);
+
+        $this->admin->expects($this->once())
             ->method('getParent')
             ->willReturn($admin);
 
@@ -1043,8 +1047,8 @@ class CRUDControllerTest extends TestCase
             ->willReturn($object);
 
         $this->admin->expects($this->once())
-            ->method('getParent')
-            ->willReturn($admin);
+            ->method('isChild')
+            ->willReturn(true);
 
         $this->admin->expects($this->once())
             ->method('getParentAssociationMapping')

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -563,4 +563,73 @@ class DatagridTest extends TestCase
             ['3', 50],
         ];
     }
+
+    public function testSortParameters(): void
+    {
+        $field1 = $this->createMock(FieldDescriptionInterface::class);
+        $field1->method('getName')->willReturn('field1');
+
+        $field2 = $this->createMock(FieldDescriptionInterface::class);
+        $field2->method('getName')->willReturn('field2');
+
+        $field3 = $this->createMock(FieldDescriptionInterface::class);
+        $field3->method('getName')->willReturn('field3');
+        $field3->method('getOption')->with('sortable')->willReturn('field3sortBy');
+
+        $this->datagrid = new Datagrid(
+            $this->query,
+            $this->columns,
+            $this->pager,
+            $this->formBuilder,
+            ['_sort_by' => $field1, '_sort_order' => 'ASC']
+        );
+
+        $parameters = $this->datagrid->getSortParameters($field1);
+
+        $this->assertSame('DESC', $parameters['filter']['_sort_order']);
+        $this->assertSame('field1', $parameters['filter']['_sort_by']);
+
+        $parameters = $this->datagrid->getSortParameters($field2);
+
+        $this->assertSame('ASC', $parameters['filter']['_sort_order']);
+        $this->assertSame('field2', $parameters['filter']['_sort_by']);
+
+        $parameters = $this->datagrid->getSortParameters($field3);
+
+        $this->assertSame('ASC', $parameters['filter']['_sort_order']);
+        $this->assertSame('field3sortBy', $parameters['filter']['_sort_by']);
+
+        $this->datagrid = new Datagrid(
+            $this->query,
+            $this->columns,
+            $this->pager,
+            $this->formBuilder,
+            ['_sort_by' => $field3, '_sort_order' => 'ASC']
+        );
+
+        $parameters = $this->datagrid->getSortParameters($field3);
+
+        $this->assertSame('DESC', $parameters['filter']['_sort_order']);
+        $this->assertSame('field3sortBy', $parameters['filter']['_sort_by']);
+    }
+
+    public function testGetPaginationParameters(): void
+    {
+        $field = $this->createMock(FieldDescriptionInterface::class);
+
+        $this->datagrid = new Datagrid(
+            $this->query,
+            $this->columns,
+            $this->pager,
+            $this->formBuilder,
+            ['_sort_by' => $field, '_sort_order' => 'ASC']
+        );
+
+        $field->expects($this->once())->method('getName')->willReturn($name = 'test');
+
+        $result = $this->datagrid->getPaginationParameters($page = 5);
+
+        $this->assertSame($page, $result['filter']['_page']);
+        $this->assertSame($name, $result['filter']['_sort_by']);
+    }
 }

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -32,6 +32,14 @@ final class CRUDControllerTest extends WebTestCase
         );
     }
 
+    public function testEmptyList(): void
+    {
+        $client = static::createClient();
+        $client->request(Request::METHOD_GET, '/admin/empty/list');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+    }
+
     public function testCreate(): void
     {
         $client = static::createClient();
@@ -42,6 +50,14 @@ final class CRUDControllerTest extends WebTestCase
             1,
             $crawler->filter('.sonata-ba-collapsed-fields label:contains("Name")')->count()
         );
+    }
+
+    public function testEmptyCreate(): void
+    {
+        $client = static::createClient();
+        $client->request(Request::METHOD_GET, '/admin/empty/create');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }
 
     public function testShow(): void
@@ -56,6 +72,14 @@ final class CRUDControllerTest extends WebTestCase
         );
     }
 
+    public function testEmptyShow(): void
+    {
+        $client = static::createClient();
+        $client->request(Request::METHOD_GET, '/admin/empty/test_id/show');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+    }
+
     public function testEdit(): void
     {
         $client = static::createClient();
@@ -66,6 +90,14 @@ final class CRUDControllerTest extends WebTestCase
             1,
             $crawler->filter('.sonata-ba-collapsed-fields label:contains("Name")')->count()
         );
+    }
+
+    public function testEmptyEdit(): void
+    {
+        $client = static::createClient();
+        $client->request(Request::METHOD_GET, '/admin/empty/test_id/edit');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }
 
     protected static function getKernelClass()

--- a/tests/Route/QueryStringBuilderTest.php
+++ b/tests/Route/QueryStringBuilderTest.php
@@ -30,7 +30,8 @@ class QueryStringBuilderTest extends TestCase
         $audit->expects($this->once())->method('hasReader')->willReturn($hasReader);
 
         $admin = $this->getMockForAbstractClass(AdminInterface::class);
-        $admin->expects($this->once())->method('getParent')->willReturn($getParent);
+        $admin->expects($this->once())->method('isChild')->willReturn($getParent instanceof AdminInterface);
+        $admin->method('getParent')->willReturn($getParent);
         $admin->method('getChildren')->willReturn([]);
         $admin->expects($this->once())->method('isAclEnabled')->willReturn($aclEnabled);
 
@@ -76,7 +77,7 @@ class QueryStringBuilderTest extends TestCase
         $child2->expects($this->once())->method('getRoutes')->willReturn($childRouteCollection2);
 
         $admin = $this->getMockForAbstractClass(AdminInterface::class);
-        $admin->expects($this->once())->method('getParent')->willReturn(null);
+        $admin->expects($this->once())->method('isChild')->willReturn(false);
         $admin->expects($this->once())->method('getChildren')->willReturn([$child1, $child2]);
         $admin->expects($this->once())->method('isAclEnabled')->willReturn(true);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When launching `bin/console sonata:admin:generate-object-acl`, the acl generation doesn't start, instead get output: `No manipulators are implemented : ignoring

`

The current `ObjectAclManipulatorCompilerPass` doesn't take into account that the class definition can use the %parameter% syntax, so the $availableManagers array remains empty.

I am targeting this branch, because this is BC.

Closes #6063

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
Manage class definition which is using "%parameter%" syntax.
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
