### PR TITLE
[PoC] Use options resolver in `BaseFieldDescription`

### DIFF
--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Admin;
 
 use Doctrine\Common\Inflector\Inflector;
 use Sonata\AdminBundle\Exception\NoValueException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * A FieldDescription hold the information about a field. A typical
@@ -127,9 +128,73 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     protected $help;
 
     /**
+     * @var OptionsResolver
+     */
+    protected $resolver;
+
+    /**
      * @var array[] cached object field getters
      */
     private static $fieldGetters = [];
+
+    public function __construct()
+    {
+        $this->resolver = new OptionsResolver();
+        $this->resolver
+            ->setDefaults([
+                'placeholder' => 'short_object_description_placeholder',
+                'link_parameters' => [],
+            ])
+            ->setDefined([
+                'actions',
+                'associated_property',
+                'code',
+                'field_name',
+                'field_options',
+                'field_type',
+                'header_class',
+                'header_style',
+                'help',
+                'identifier',
+                'label',
+                'parameters',
+                'role',
+                'route',
+                'safe',
+                'sort_field_mapping',
+                'sort_parent_association_mappings',
+                'sortable',
+                'template',
+                'translation_domain',
+                'type',
+                'virtual_field',
+            ])
+            ->setAllowedTypes('actions', ['array[]'])
+            ->setAllowedTypes('associated_property', 'string')
+            ->setAllowedTypes('code', 'string')
+            ->setAllowedTypes('field_name', 'string')
+            ->setAllowedTypes('field_options', 'array')
+            ->setAllowedTypes('field_type', 'string')
+            ->setAllowedTypes('header_class', 'string')
+            ->setAllowedTypes('header_style', 'string')
+            ->setAllowedTypes('help', 'string')
+            ->setAllowedTypes('identifier', 'bool')
+            ->setAllowedTypes('label', ['bool', 'null', 'string'])
+            ->setAllowedTypes('link_parameters', 'array')
+            ->setAllowedTypes('parameters', 'array')
+            ->setAllowedTypes('placeholder', 'string')
+            ->setAllowedTypes('role', ['string', 'string[]'])
+            ->setAllowedTypes('route', 'array')
+            ->setAllowedTypes('safe', 'bool')
+            ->setAllowedTypes('sort_field_mapping', 'array')
+            ->setAllowedTypes('sort_parent_association_mappings', 'array')
+            ->setAllowedTypes('sortable', 'bool')
+            ->setAllowedTypes('template', 'string')
+            ->setAllowedTypes('translation_domain', 'string')
+            ->setAllowedTypes('type', 'string')
+            ->setAllowedTypes('virtual_field', 'bool')
+            ->setDeprecated('header_style', 'The option "header_style" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.x. Use "header_class" instead.');
+    }
 
     public function setFieldName($fieldName): void
     {
@@ -162,11 +227,13 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
 
     public function setOption($name, $value): void
     {
-        $this->options[$name] = $value;
+        $this->options[$name] = $this->resolver->resolve([$name => $value])[$name];
     }
 
     public function setOptions(array $options): void
     {
+        $options = $this->resolver->resolve($options);
+
         // set the type if provided
         if (isset($options['type'])) {
             $this->setType($options['type']);
@@ -183,15 +250,6 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         if (isset($options['help'])) {
             $this->setHelp($options['help']);
             unset($options['help']);
-        }
-
-        // set default placeholder
-        if (!isset($options['placeholder'])) {
-            $options['placeholder'] = 'short_object_description_placeholder';
-        }
-
-        if (!isset($options['link_parameters'])) {
-            $options['link_parameters'] = [];
         }
 
         $this->options = $options;

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -193,7 +193,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
             ->setAllowedTypes('translation_domain', 'string')
             ->setAllowedTypes('type', 'string')
             ->setAllowedTypes('virtual_field', 'bool')
-            ->setDeprecated('header_style', 'The option "header_style" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.x. Use "header_class" instead.');
+            ->setDeprecated('header_style', 'The option "header_style" is deprecated since sonata-project/admin-bundle 3.52 and will be removed in version 4.x. Use "header_class" instead.');
     }
 
     public function setFieldName($fieldName): void

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -278,8 +278,8 @@ class ListMapperTest extends TestCase
             [
                 'associated_property' => 'fooAssociatedProperty',
                 'sortable' => false,
-                'sort_parent_association_mappings' => 'fooSortParentAssociationMapping',
-                'sort_field_mapping' => 'fooSortFieldMapping',
+                'sort_parent_association_mappings' => [['fieldName' => 'fooSortParentAssociationMapping']],
+                'sort_field_mapping' => ['fieldName' => 'fooSortFieldMapping'],
             ]
         );
 
@@ -299,8 +299,8 @@ class ListMapperTest extends TestCase
 
         $this->assertSame('fooAssociatedProperty', $fieldManualSort->getOption('associated_property'));
         $this->assertFalse($fieldManualSort->getOption('sortable'));
-        $this->assertSame('fooSortParentAssociationMapping', $fieldManualSort->getOption('sort_parent_association_mappings'));
-        $this->assertSame('fooSortFieldMapping', $fieldManualSort->getOption('sort_field_mapping'));
+        $this->assertSame([['fieldName' => 'fooSortParentAssociationMapping']], $fieldManualSort->getOption('sort_parent_association_mappings'));
+        $this->assertSame(['fieldName' => 'fooSortFieldMapping'], $fieldManualSort->getOption('sort_field_mapping'));
     }
 
     public function testKeys(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change breaks BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->

```markdown
### Added
- Leverage options resolver at `BaseFieldDescription`.
```

## To do
    
- [ ] Fix tests;
- [ ] Decide how to deal with the invalid values (array) generated by `BaseFieldDescription::mergeOptions()`.

Since `BaseFieldDescription::mergeOptions()` calls to [`array_merge_recursive()`](https://www.php.net/manual/en/function.array-merge-recursive.php), the previously set options are being overridden as array:
>If the input arrays have the same string keys, then the values for these keys are merged together into an array, and this is done recursively, so that if one of the values is an array itself, the function will merge it with a corresponding entry in another array too.

This, by instance, is causing "virtual_field" option to hold an array instead of a boolean at `ListMapper::add()`.
