### PR TITLE
Bump doctrine/inflector to 1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.2",
         "doctrine/common": "^2.7",
-        "doctrine/inflector": "^1.1",
+        "doctrine/inflector": "^1.4 || ^2.0",
         "knplabs/knp-menu-bundle": "^2.2.2",
         "sonata-project/block-bundle": "^3.18",
         "sonata-project/core-bundle": "^3.18.0",

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Admin;
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Inflector\Inflector;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\ORM\PersistentCollection as DoctrinePersistentCollection;
 use Sonata\AdminBundle\Exception\NoValueException;
@@ -227,8 +227,10 @@ class AdminHelper
         $mapping = $fieldDescription->getAssociationMapping();
         $parentMappings = $fieldDescription->getParentAssociationMappings();
 
+        $inflector = InflectorFactory::create()->build();
+
         foreach ($parentMappings as $parentMapping) {
-            $method = sprintf('get%s', Inflector::classify($parentMapping['fieldName']));
+            $method = sprintf('get%s', $inflector->classify($parentMapping['fieldName']));
 
             if (!(\is_callable([$object, $method]) && method_exists($object, $method))) {
                 /*
@@ -242,13 +244,13 @@ class AdminHelper
             $object = $object->$method();
         }
 
-        $method = sprintf('add%s', Inflector::classify($mapping['fieldName']));
+        $method = sprintf('add%s', $inflector->classify($mapping['fieldName']));
 
         if (!(\is_callable([$object, $method]) && method_exists($object, $method))) {
             $method = rtrim($method, 's');
 
             if (!(\is_callable([$object, $method]) && method_exists($object, $method))) {
-                $method = sprintf('add%s', Inflector::classify(Inflector::singularize($mapping['fieldName'])));
+                $method = sprintf('add%s', $inflector->classify($inflector->singularize($mapping['fieldName'])));
 
                 if (!(\is_callable([$object, $method]) && method_exists($object, $method))) {
                     /*
@@ -277,20 +279,20 @@ class AdminHelper
      *
      * @return string
      *
-     * @deprecated since sonata-project/admin-bundle 3.1. Use \Doctrine\Common\Inflector\Inflector::classify() instead
+     * @deprecated since sonata-project/admin-bundle 3.1. Use \Doctrine\Inflector\Inflector::classify() instead
      */
     public function camelize($property)
     {
         @trigger_error(
             sprintf(
                 'The %s method is deprecated since 3.1 and will be removed in 4.0. '.
-                'Use \Doctrine\Common\Inflector\Inflector::classify() instead.',
+                'Use \Doctrine\Inflector\Inflector::classify() instead.',
                 __METHOD__
             ),
             E_USER_DEPRECATED
         );
 
-        return Inflector::classify($property);
+        return InflectorFactory::create()->build()->classify($property);
     }
 
     /**

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Admin;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Sonata\AdminBundle\Exception\NoValueException;
 
 /**
@@ -293,7 +293,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
                 return $this->callCachedGetter($object, $fieldName, $parameters);
             }
 
-            $camelizedFieldName = Inflector::classify($fieldName);
+            $camelizedFieldName = InflectorFactory::create()->build()->classify($fieldName);
 
             $getters[] = 'get'.$camelizedFieldName;
             $getters[] = 'is'.$camelizedFieldName;
@@ -377,20 +377,20 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
      *
      * @return string
      *
-     * @deprecated since sonata-project/admin-bundle 3.1. Use \Doctrine\Common\Inflector\Inflector::classify() instead
+     * @deprecated since sonata-project/admin-bundle 3.1. Use \Doctrine\Inflector\Inflector::classify() instead
      */
     public static function camelize($property)
     {
         @trigger_error(
             sprintf(
                 'The %s method is deprecated since 3.1 and will be removed in 4.0. '.
-                'Use \Doctrine\Common\Inflector\Inflector::classify() instead.',
+                'Use \Doctrine\Inflector\Inflector::classify() instead.',
                 __METHOD__
             ),
             E_USER_DEPRECATED
         );
 
-        return Inflector::classify($property);
+        return InflectorFactory::create()->build()->classify($property);
     }
 
     /**

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Controller;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sonata\AdminBundle\Admin\AdminInterface;
@@ -444,7 +444,7 @@ class CRUDController implements ContainerAwareInterface
             throw new \RuntimeException(sprintf('The `%s` batch action is not defined', $action));
         }
 
-        $camelizedAction = Inflector::classify($action);
+        $camelizedAction = InflectorFactory::create()->build()->classify($action);
         $isRelevantAction = sprintf('batchAction%sIsRelevant', $camelizedAction);
 
         if (method_exists($this, $isRelevantAction)) {

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\AdminBundle\Templating\TemplateRegistry;
@@ -236,7 +236,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         ];
 
         foreach ($keys as $key) {
-            $method = 'set'.Inflector::classify($key);
+            $method = $this->generateSetterMethodName($key);
             if (!isset($attributes[$key]) || $definition->hasMethodCall($method)) {
                 continue;
             }
@@ -283,7 +283,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $definition->addMethodCall('setManagerType', [$managerType]);
 
         foreach ($defaultAddServices as $attr => $addServiceId) {
-            $method = 'set'.Inflector::classify($attr);
+            $method = $this->generateSetterMethodName($attr);
 
             if (isset($overwriteAdminConfiguration[$attr]) || !$definition->hasMethodCall($method)) {
                 $args = [new Reference($overwriteAdminConfiguration[$attr] ?? $addServiceId)];
@@ -437,5 +437,10 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         }
 
         $definition->setArguments($arguments);
+    }
+
+    private function generateSetterMethodName(string $key): string
+    {
+        return 'set'.InflectorFactory::create()->build()->classify($key);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Since [doctrine/inflector 1.4](https://github.com/doctrine/inflector/releases/tag/1.4.0), the API is deprecated, this PR updates the calls removing lots of deprecations and allows 2.0 version.

I am targeting this branch, because these changes are BC.

## Changelog

```markdown
### Changed
- Update `doctrine/inflection` to ^1.4 || ^2.0
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
