### PR TITLE
Improve deprecation message for legacy_twig_text_extension

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -178,7 +178,7 @@ CASESENSITIVE;
                             ->info('Use text filters from "twig/extensions" instead of those provided by "twig/string-extra".')
                             ->defaultValue(static function (): bool {
                                 @trigger_error(
-                                    'Using `true` as value for "sonata.admin.configuration.legacy_twig_text_extension" option is deprecated since sonata-project/admin-bundle 3.64.'.
+                                    'Using `true` as value for "sonata_admin.options.legacy_twig_text_extension" option is deprecated since sonata-project/admin-bundle 3.64. '.
                                     'You should set it to `false`, which will be the default value since version 4.0.'
                                 );
 
@@ -188,7 +188,7 @@ CASESENSITIVE;
                                 ->ifTrue()
                                 ->then(static function (bool $v): bool {
                                     @trigger_error(
-                                        'Using `true` as value for "sonata.admin.configuration.legacy_twig_text_extension" option is deprecated since sonata-project/admin-bundle 3.64.'.
+                                        'Using `true` as value for "sonata_admin.options.legacy_twig_text_extension" option is deprecated since sonata-project/admin-bundle 3.64. '.
                                         'You should set it to `false`, which will be the default value since version 4.0.'
                                     );
 


### PR DESCRIPTION
## Subject

When `sonata_admin.options.legacy_twig_text_extension` is not set to `false` the following deprecation message is logged:

> Using `true` as value for "sonata.admin.configuration.legacy_twig_text_extension" option is deprecated since sonata-project/admin-bundle 3.64.You should set it to `false`, which will be the default value since version 4.0.

The configuration option mentioned is the name of the container parameter, not the configuration variable. This makes it a little hard for users to address this deprecation. Also, because of string concatenation a space is missing between the two sentences.

This PR fixes those two minor issues.

I am targeting this branch, because it is backwards compatible.

## Changelog

```markdown
### Fixed
- Reference to configuration option in `legacy_twig_text_extension` deprecation message.
```
