### PR TITLE
bugfix: repair http _method overriding

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1115,7 +1115,7 @@ class CRUDController implements ContainerAwareInterface
     {
         $request = $this->getRequest();
 
-        if (Request::getHttpMethodParameterOverride() || !$request->request->has('_method')) {
+        if (!Request::getHttpMethodParameterOverride() || !$request->request->has('_method')) {
             return $request->getMethod();
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

deleteAction does not do it

Closes #6046

## Changelog
### Fixed
Sonata\AdminBundle\Controller\CRUDController::getRestMethod()