### PR TITLE
Fix inline view with CKeditor field

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
@@ -64,10 +64,7 @@ file that was distributed with this source code.
                         {% for nested_group_field_name, nested_group_field in form.children %}
                             {% for field_name, nested_field in nested_group_field.children %}
                                 {% if sonata_admin.field_description.associationadmin.hasformfielddescriptions(field_name) is defined %}
-                                    {{ form_row(nested_field, {
-                                        'inline': 'natural',
-                                        'edit'  : 'inline'
-                                    }) }}
+                                    {{ form_row(nested_field) }}
                                     {% set dummy = nested_group_field.setrendered %}
                                 {% else %}
                                     {% if nested_field.vars.name == '_delete' %}

--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
@@ -38,10 +38,7 @@ file that was distributed with this source code.
                                         {% set nested_field = nested_group_field.children[field_name] %}
                                         <div class="sonata-ba-field-{{ id }}-{{ field_name }}">
                                             {% if associationAdmin.formfielddescriptions[field_name] is defined %}
-                                                {{ form_row(nested_field, {
-                                                    'inline': 'natural',
-                                                    'edit'  : 'inline'
-                                                }) }}
+                                                {{ form_row(nested_field) }}
                                                 {% set dummy = nested_group_field.setrendered %}
                                             {% else %}
                                                 {{ form_row(nested_field) }}


### PR DESCRIPTION
## Subject

I am targeting this branch, because maybe BC.

When I tried, this works well and didn't change the rendering of other field of the CollectionType. But I don't know enough this code/these options to be sure that this was not here for a reason.

For what I understood, both inline and edit value are not needed. The form render is not realized by sonata but the FormType::class used. So these value seems to be never used because no FormType has a edit option or an inline option.
It was just used by CKeditor, by chance, since CKeditor has an inline options.

I get
![image](https://user-images.githubusercontent.com/9052536/82728924-bff96500-9cf3-11ea-921e-eefdad5be4b6.png)

Instead of
![image](https://user-images.githubusercontent.com/9052536/82728896-9cceb580-9cf3-11ea-80df-d63c402d4e0d.png)

Closes #6101
Closes #5604

## Changelog

```markdown
### Fixed
- Render of CKeditor field when embedded in a collection with the `inline => natural` option.
```