### PR TITLE
Menu label translation

### DIFF
--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -306,19 +306,19 @@ If you want to use the Tab Menu in a different way, you can replace the Menu Tem
 Translations
 ^^^^^^^^^^^^
 
-The translation parameters and domain can be customised by using the
-``translation_domain`` and ``translation_parameters`` keys of the extra array
+The label translation parameters and domain can be customised by using the
+``label_translation_parameters`` and ``label_catalogue`` keys of the extra array
 of data associated with the item, respectively::
 
     $menuItem->setExtras([
-        'translation_parameters' => ['myparam' => 'myvalue'],
-        'translation_domain' => 'My domain',
+        'label_translation_parameters' => ['myparam' => 'myvalue'],
+        'label_catalogue' => 'My domain',
     ]);
 
 You can also set the translation domain on the menu root, and children will
 inherit it::
 
-    $menu->setExtra('translation_domain', 'My domain');
+    $menu->setExtra('label_catalogue', 'My domain');
 
 Filter parameters
 ^^^^^^^^^^^^^^^^^

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -1,34 +1,34 @@
 {% extends 'knp_menu.html.twig' %}
 
 {% block root %}
-    {%- set listAttributes = item.childrenAttributes|merge({'class': 'sidebar-menu', 'data-widget': 'tree'}) %}
-    {%- set request        = item.extra('request') ?: app.request %}
+    {%- set listAttributes = item.childrenAttributes|merge({'class': 'sidebar-menu', 'data-widget': 'tree'}) -%}
+    {%- set request        = item.extra('request') ?: app.request -%}
     {{ block('list') -}}
 {% endblock %}
 
 {% block item %}
-    {%- if item.displayed %}
+    {%- if item.displayed -%}
         {#- check role of the group #}
-        {%- set display = item.extra('roles') is empty or is_granted(sonata_admin.adminPool.getOption('role_super_admin')) or item.extra('roles')|filter(role => is_granted(role))|length > 0 %}
-    {%- endif %}
+        {%- set display = item.extra('roles') is empty or is_granted(sonata_admin.adminPool.getOption('role_super_admin')) or item.extra('roles')|filter(role => is_granted(role))|length > 0 -%}
+    {%- endif -%}
 
-    {%- if item.displayed and display|default %}
-        {% set options = options|merge({branch_class: 'treeview', currentClass: "active", ancestorClass: "active"}) %}
-        {%- do item.setChildrenAttribute('class', (item.childrenAttribute('class')~' active')|trim) %}
-        {%- do item.setChildrenAttribute('class', (item.childrenAttribute('class')~' treeview-menu')|trim) %}
+    {%- if item.displayed and display|default -%}
+        {%- set options = options|merge({branch_class: 'treeview', currentClass: "active", ancestorClass: "active"}) -%}
+        {%- do item.setChildrenAttribute('class', (item.childrenAttribute('class')~' active')|trim) -%}
+        {%- do item.setChildrenAttribute('class', (item.childrenAttribute('class')~' treeview-menu')|trim) -%}
         {{ parent() }}
-    {% endif %}
+    {%- endif -%}
 {% endblock %}
 
 {% block linkElement %}
     {% apply spaceless %}
-        {% set translation_domain = item.extra('label_catalogue', 'messages') %}
-        {% if item.extra('on_top') is defined and not item.extra('on_top') %}
-            {% set icon = item.extra('icon')|default(item.level > 1 ? '<i class="fa fa-angle-double-right" aria-hidden="true"></i>' : '') %}
-        {% else %}
-            {% set icon = item.extra('icon') %}
-        {% endif %}
-        {% set is_link = true %}
+        {%- set translation_domain = item.extra('label_catalogue', 'messages') -%}
+        {%- if item.extra('on_top') is defined and not item.extra('on_top') -%}
+            {%- set icon = item.extra('icon')|default(item.level > 1 ? '<i class="fa fa-angle-double-right" aria-hidden="true"></i>' : '') -%}
+        {%- else -%}
+            {%- set icon = item.extra('icon') -%}
+        {%- endif -%}
+        {%- set is_link = true -%}
         {{ parent() }}
     {% endapply %}
 {% endblock %}
@@ -36,8 +36,8 @@
 {% block spanElement %}
     {% apply spaceless %}
         <a href="#">
-            {% set translation_domain = item.extra('label_catalogue') %}
-            {% set icon = item.extra('icon')|default('') %}
+            {%- set translation_domain = item.extra('label_catalogue', 'messages') -%}
+            {%- set icon = item.extra('icon')|default('') -%}
             {{ icon|raw }}
             {{ parent() }}
             {%- if item.extra('keep_open') is not defined or not item.extra('keep_open') -%}
@@ -47,4 +47,16 @@
     {% endapply %}
 {% endblock %}
 
-{% block label %}{% if is_link is defined and is_link %}{{ icon|default|raw }}{% endif %}{% if options.allow_safe_labels and item.extra('safe_label', false) %}{{ item.label|raw }}{% else %}{{ item.label|trans({}, translation_domain|default('messages')) }}{% endif %}{% endblock %}
+{% block label %}
+    {% apply spaceless %}
+        {%- if is_link|default(false) -%}
+            {{ icon|default|raw }}
+        {%- endif -%}
+        {%- if options.allow_safe_labels and item.extra('safe_label', false) -%}
+            {{ item.label|raw }}
+        {%- else -%}
+            {%- set translation_domain = item.extra('label_catalogue', 'messages') -%}
+            {{ item.label|trans(item.extra('label_translation_parameters', {}), translation_domain) }}
+        {%- endif -%}
+    {% endapply %}
+{% endblock %}


### PR DESCRIPTION
## Subject
Allow to use parameters/placeholders in (sidebar) menu label.

translations/messages.en.yaml
```yaml
item_label_translation: Translatable label with %placeholder%.
```

Menu builder:
```php
$group->addChild('item', [
    'label' => 'item_label_translation',
    'labelAttributes' => ['%placeholder%' => 'dynamic_value']
]);
```

## Changelog
```markdown
### Fixed
- Allow to use parameters/placeholders in (sidebar) menu label translation.
```