### PR TITLE
Fix label catalogue default value for group

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -101,7 +101,7 @@ Full Configuration Options
                     id:
                         label: ~
                         label_catalogue: ~
-                        icon: '<i class="fa fa-folder"></i>'
+                        icon: ~
                         provider: ~
                         items:
                             admin: ~

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -50,6 +50,12 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         $pool = $container->getDefinition('sonata.admin.pool');
 
+        $defaultValues = [
+            'group' => $container->getParameter('sonata.admin.configuration.default_group'),
+            'label_catalogue' => $container->getParameter('sonata.admin.configuration.default_label_catalogue'),
+            'icon' => $container->getParameter('sonata.admin.configuration.default_icon'),
+        ];
+
         foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $tags) {
             foreach ($tags as $attributes) {
                 $definition = $container->getDefinition($id);
@@ -88,11 +94,9 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
                 $resolvedGroupName = isset($attributes['group']) ?
                     $parameterBag->resolveValue($attributes['group']) :
-                    $container->getParameter('sonata.admin.configuration.default_group');
-                $labelCatalogue = $attributes['label_catalogue'] ??
-                    $container->getParameter('sonata.admin.configuration.default_label_catalogue');
-                $icon = $attributes['icon'] ??
-                    $container->getParameter('sonata.admin.configuration.default_icon');
+                    $defaultValues['group'];
+                $labelCatalogue = $attributes['label_catalogue'] ?? $defaultValues['label_catalogue'];
+                $icon = $attributes['icon'] ?? $defaultValues['icon'];
                 $onTop = $attributes['on_top'] ?? false;
                 $keepOpen = $attributes['keep_open'] ?? false;
 
@@ -135,6 +139,8 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     $groupDefaults[$resolvedGroupName] = [
                         'items' => [],
                         'label' => $resolvedGroupName,
+                        'label_catalogue' => $defaultValues['label_catalogue'],
+                        'icon' => $defaultValues['icon'],
                         'roles' => [],
                         'on_top' => false,
                         'keep_open' => false,
@@ -150,7 +156,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                 }
 
                 if (empty($group['label_catalogue'])) {
-                    $groups[$resolvedGroupName]['label_catalogue'] = 'SonataAdminBundle';
+                    $groups[$resolvedGroupName]['label_catalogue'] = $groupDefaults[$resolvedGroupName]['label_catalogue'];
                 }
 
                 if (empty($group['icon'])) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -226,7 +226,7 @@ CASESENSITIVE;
                                 ->children()
                                     ->scalarNode('label')->end()
                                     ->scalarNode('label_catalogue')->end()
-                                    ->scalarNode('icon')->defaultValue('<i class="fa fa-folder"></i>')->end()
+                                    ->scalarNode('icon')->end()
                                     ->scalarNode('on_top')->defaultFalse()->info('Show menu item in side dashboard menu without treeview')->end()
                                     ->scalarNode('keep_open')->defaultFalse()->info('Keep menu group always open')->end()
                                     ->scalarNode('provider')->end()


### PR DESCRIPTION
## Subject

When `label_catalogue` wasn't set, the fallback value was `SonataAdminBundle` instead of using the default label catalogue value.
Same for `icon`.

I am targeting this branch, because it's a bug fix.

## Changelog

```markdown
### Fixed
- Menu item `label_catalogue` correctly use the default value `default_label_catalogue`
- Menu item `icon` correctly use the default value `default_icon`
```