### PR TITLE
Make consistent variables between `renderViewElement()` and `renderViewElementCompare()`

### DIFF
--- a/src/Resources/views/CRUD/base_show_compare.html.twig
+++ b/src/Resources/views/CRUD/base_show_compare.html.twig
@@ -11,10 +11,12 @@ file that was distributed with this source code.
 
 {% extends '@SonataAdmin/CRUD/base_show.html.twig' %}
 
-{% block show_field %}
-    <tr class="sonata-ba-view-container history-audit-compare">
-        {% if elements[field_name] is defined %}
-            {{ elements[field_name]|render_view_element_compare(object, object_compare) }}
-        {% endif %}
-    </tr>
-{% endblock %}
+{%- block show_field -%}
+    {% apply spaceless %}
+        <tr class="sonata-ba-view-container history-audit-compare">
+            {% if elements[field_name] is defined %}
+                {{ elements[field_name]|render_view_element_compare(object, object_compare) }}
+            {% endif %}
+        </tr>
+    {% endapply %}
+{%- endblock -%}

--- a/src/Resources/views/CRUD/base_show_field.html.twig
+++ b/src/Resources/views/CRUD/base_show_field.html.twig
@@ -38,11 +38,11 @@ file that was distributed with this source code.
     {%- endblock -%}
 </td>
 
-{% block field_compare %}
-    {% if(value_compare is defined) %}
-        <td>
+{%- block field_compare -%}
+    {% apply spaceless %}
+        {% if(value_compare is defined) %}
             {% set value = value_compare %}
-            {{ block('field') }}
-        </td>
-    {% endif %}
-{% endblock %}
+            <td>{{ block('field') }}</td>
+        {% endif %}
+    {% endapply %}
+{%- endblock -%}

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -358,12 +358,14 @@ class SonataAdminExtension extends AbstractExtension
             'admin' => $fieldDescription->getAdmin(),
             'field_description' => $fieldDescription,
             'value' => $baseValue,
+            'object' => $baseObject,
         ]);
 
         $compareValueOutput = $template->render([
             'field_description' => $fieldDescription,
             'admin' => $fieldDescription->getAdmin(),
             'value' => $compareValue,
+            'object' => $compareObject,
         ]);
 
         // Compare the rendered output of both objects by using the (possibly) overridden field block
@@ -375,6 +377,7 @@ class SonataAdminExtension extends AbstractExtension
             'value_compare' => $compareValue,
             'is_diff' => $isDiff,
             'admin' => $fieldDescription->getAdmin(),
+            'object' => $baseObject,
         ], $environment);
     }
 

--- a/tests/Fixtures/Resources/views/CRUD/custom_show_field.html.twig
+++ b/tests/Fixtures/Resources/views/CRUD/custom_show_field.html.twig
@@ -1,0 +1,7 @@
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
+
+{%- block field -%}
+    {{ object.name }}<br/>
+
+    {{- parent() -}}
+{%- endblock -%}

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -178,8 +178,10 @@ class SonataAdminExtensionTest extends TestCase
 
         $loader = new StubFilesystemLoader([
             __DIR__.'/../../../src/Resources/views/CRUD',
+            __DIR__.'/../../Fixtures/Resources/views/CRUD',
         ]);
         $loader->addPath(__DIR__.'/../../../src/Resources/views/', 'SonataAdmin');
+        $loader->addPath(__DIR__.'/../../Fixtures/Resources/views/', 'App');
 
         $this->environment = new Environment($loader, [
             'strict_variables' => true,
@@ -2887,6 +2889,123 @@ EOT
         );
         $this->assertTrue($this->twigExtension->isGrantedAffirmative('foo'));
         $this->assertTrue($this->twigExtension->isGrantedAffirmative('bar'));
+    }
+
+    /**
+     * @dataProvider getRenderViewElementCompareTests
+     */
+    public function testRenderViewElementCompare(string $expected, string $type, $value, array $options, ?string $objectName = null): void
+    {
+        $this->admin
+            ->method('getTemplate')
+            ->willReturn('@SonataAdmin/CRUD/base_show_compare.html.twig');
+
+        $this->fieldDescription
+            ->method('getValue')
+            ->willReturn($value);
+
+        $this->fieldDescription
+            ->method('getType')
+            ->willReturn($type);
+
+        $this->fieldDescription
+            ->method('getOptions')
+            ->willReturn($options);
+
+        $this->fieldDescription
+            ->method('getTemplate')
+            ->willReturnCallback(static function () use ($type, $options): ?string {
+                if (isset($options['template'])) {
+                    return $options['template'];
+                }
+
+                switch ($type) {
+                    case 'boolean':
+                        return '@SonataAdmin/CRUD/show_boolean.html.twig';
+                    case 'datetime':
+                        return '@SonataAdmin/CRUD/show_datetime.html.twig';
+                    case 'date':
+                        return '@SonataAdmin/CRUD/show_date.html.twig';
+                    case 'time':
+                        return '@SonataAdmin/CRUD/show_time.html.twig';
+                    case 'currency':
+                        return '@SonataAdmin/CRUD/show_currency.html.twig';
+                    case 'percent':
+                        return '@SonataAdmin/CRUD/show_percent.html.twig';
+                    case 'email':
+                        return '@SonataAdmin/CRUD/show_email.html.twig';
+                    case 'choice':
+                        return '@SonataAdmin/CRUD/show_choice.html.twig';
+                    case 'array':
+                        return '@SonataAdmin/CRUD/show_array.html.twig';
+                    case 'trans':
+                        return '@SonataAdmin/CRUD/show_trans.html.twig';
+                    case 'url':
+                        return '@SonataAdmin/CRUD/show_url.html.twig';
+                    case 'html':
+                        return '@SonataAdmin/CRUD/show_html.html.twig';
+                    default:
+                        return null;
+                }
+            });
+
+        $this->object->name = 'SonataAdmin';
+
+        $comparedObject = clone $this->object;
+
+        if (null !== $objectName) {
+            $comparedObject->name = $objectName;
+        }
+
+        $this->assertSame(
+            $this->removeExtraWhitespace($expected),
+            $this->removeExtraWhitespace(
+                $this->twigExtension->renderViewElementCompare(
+                    $this->environment,
+                    $this->fieldDescription,
+                    $this->object,
+                    $comparedObject
+                )
+            )
+        );
+    }
+
+    public function getRenderViewElementCompareTests(): iterable
+    {
+        return [
+            ['<th>Data</th> <td>Example</td><td>Example</td>', 'string', 'Example', ['safe' => false]],
+            ['<th>Data</th> <td>Example</td><td>Example</td>', 'text', 'Example', ['safe' => false]],
+            ['<th>Data</th> <td>Example</td><td>Example</td>', 'textarea', 'Example', ['safe' => false]],
+            ['<th>Data</th> <td>SonataAdmin<br/>Example</td><td>SonataAdmin<br/>Example</td>', 'virtual_field', 'Example', ['template' => 'custom_show_field.html.twig', 'safe' => false, 'SonataAdmin']],
+            ['<th class="diff">Data</th> <td>SonataAdmin<br/>Example</td><td>SonataAdmin<br/>Example</td>', 'virtual_field', 'Example', ['template' => 'custom_show_field.html.twig', 'safe' => false], 'sonata-project/admin-bundle'],
+            [
+                '<th>Data</th> <td><time datetime="2020-05-27T09:11:12+00:00" title="2020-05-27T09:11:12+00:00"> May 27, 2020 10:11 </time></td>'
+                .'<td><time datetime="2020-05-27T09:11:12+00:00" title="2020-05-27T09:11:12+00:00"> May 27, 2020 10:11 </time></td>',
+                'datetime',
+                new \DateTime('2020-05-27 10:11:12', new \DateTimeZone('Europe/London')), [],
+            ],
+            [
+                '<th>Data</th> <td><time datetime="2020-05-27T09:11:12+00:00" title="2020-05-27T09:11:12+00:00"> 27.05.2020 10:11:12 </time></td>'
+                .'<td><time datetime="2020-05-27T09:11:12+00:00" title="2020-05-27T09:11:12+00:00"> 27.05.2020 10:11:12 </time></td>',
+                'datetime',
+                new \DateTime('2020-05-27 10:11:12', new \DateTimeZone('Europe/London')),
+                ['format' => 'd.m.Y H:i:s'],
+            ],
+            [
+                '<th>Data</th> <td><time datetime="2020-05-27T10:11:12+00:00" title="2020-05-27T10:11:12+00:00"> May 27, 2020 18:11 </time></td>'
+                .'<td><time datetime="2020-05-27T10:11:12+00:00" title="2020-05-27T10:11:12+00:00"> May 27, 2020 18:11 </time></td>',
+                'datetime',
+                new \DateTime('2020-05-27 10:11:12', new \DateTimeZone('UTC')),
+                ['timezone' => 'Asia/Hong_Kong'],
+            ],
+            [
+                '<th>Data</th> <td><time datetime="2020-05-27" title="2020-05-27"> May 27, 2020 </time></td>'
+                .'<td><time datetime="2020-05-27" title="2020-05-27"> May 27, 2020 </time></td>',
+                'date',
+                new \DateTime('2020-05-27 10:11:12', new \DateTimeZone('Europe/London')),
+                [],
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Make consistent variables between `renderViewElement()` and `renderViewElementCompare()`.

Since both methods deal with the same templates, they should expose the same context.

I found an issue with the comparison view in conjunction with a virtual field and a custom template, where the variable `object` is required. In that scenario everything is working fine with the `showAction` and the `historyViewRevisionAction` actions, but the `historyCompareRevisionsAction` action is throwing an exception because the variable `object` is not available there.

```php
$showMapper->add('my_custom_field', 'virtual_field', [
    'template' => 'admin/CRUD/show_my_custom_field.html.twig',
])
```
```twig
{# admin/CRUD/show_my_custom_field.html.twig #}

{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}

{% block field %}
    {% set value = object|my_twig_filter %}

    {{ parent() }}
{% endblock %}
```

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed exposing missing `object` variable in history compare view.
```
    
## To do
    
- [x] Add tests.
