### PR TITLE
Expose field type constant and update documentation

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,29 @@
 UPGRADE 3.x
 ===========
 
+## Added constants for "show" and "list" templating types
+
+You can use `TemplateRegistry` constants, like
+```
+$showMapper->add('foo', TemplateRegistry::TYPE_STRING)
+```
+instead of using directly a string value.
+```
+$showMapper->add('foo', 'string')
+```
+
+The list of available types can be found in [the documentation](docs/reference/field_types.rst).
+
+## Deprecated templating types
+
+- `text`: deprecated in favor of `TemplateRegistry::TYPE_STRING`
+- `decimal`: deprecated in favor of `TemplateRegistry::TYPE_FLOAT`
+- `smallint`: deprecated in favor of `TemplateRegistry::TYPE_INTEGER`
+- `bigint`: deprecated in favor of `TemplateRegistry::TYPE_INTEGER`
+
+UPGRADE FROM 3.66 to 3.67
+=========================
+
 ## Deprecated accessing to a non existing value when adding field to `showMapper` and `listMapper`.
 
 Before:
@@ -20,9 +43,15 @@ In the next major an exception will be thrown if no getter/isser/hasser is found
 of the time the error is coming from a typo, this will allow the developer to catch it as fast as possible.
 Currently this will only trigger a deprecation if the field value is not found.
 
+UPGRADE FROM 3.65 to 3.66
+=========================
+
 ## Deprecated not passing a `Sonata\AdminBundle\Admin\AdminHelper` instance to `Sonata\AdminBundle\Form\Type\AdminType::__construct()`
 
 When instantiating a `Sonata\AdminBundle\Form\Type\AdminType` object, please use the 1 parameter signature `($adminHelper)`.
+
+UPGRADE FROM 3.63 to 3.64
+=========================
 
 ## Deprecated not setting as `false` the configuration option `sonata_admin.options.legacy_twig_text_extension`
 
@@ -68,6 +97,9 @@ $showMapper
     ])
 ;
 ```
+
+UPGRADE FROM 3.59 to 3.60
+=========================
 
 ## Deprecated not setting "sonata.admin.manager" tag in model manager services
 

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -51,7 +51,7 @@ Here is an example::
 
             // you may specify the field type directly as the
             // second argument instead of in the options
-            ->add('isVariation', 'boolean')
+            ->add('isVariation', TemplateRegistry::TYPE_BOOLEAN)
 
             // if null, the type will be guessed
             ->add('enabled', null, [
@@ -59,7 +59,7 @@ Here is an example::
             ])
 
             // editable association field
-            ->add('status', 'choice', [
+            ->add('status', TemplateRegistry::TYPE_CHOICE, [
                 'editable' => true,
                 'class' => 'Vendor\ExampleBundle\Entity\ExampleStatus',
                 'choices' => [
@@ -70,7 +70,7 @@ Here is an example::
             ])
 
             // editable multiple field
-            ->add('winner', 'choice', [
+            ->add('winner', TemplateRegistry::TYPE_CHOICE, [
                 'editable' => true,
                 'multiple' => true,
                 'choices' => [
@@ -81,7 +81,7 @@ Here is an example::
             ])
 
             // we can add options to the field depending on the type
-            ->add('price', 'currency', [
+            ->add('price', TemplateRegistry::TYPE_CURRENCY, [
                 'currency' => $this->currencyDetector->getCurrency()->getLabel()
             ])
 
@@ -555,10 +555,10 @@ Example::
                 'header_style' => 'width: 5%; text-align: center',
                 'row_align' => 'center'
             ])
-            ->add('name', 'text', [
+            ->add('name', TemplateRegistry::TYPE_STRING, [
                 'header_style' => 'width: 35%'
             ])
-            ->add('description', 'text', [
+            ->add('description', TemplateRegistry::TYPE_STRING, [
                 'header_style' => 'width: 35%',
                 'collapse' => true
             ])

--- a/docs/reference/action_show.rst
+++ b/docs/reference/action_show.rst
@@ -116,9 +116,9 @@ The following is a working example of a ShowAction::
                  // The boolean option is actually very cool
                  // true   shows a check mark and the 'yes' label
                  // false  shows a check mark and the 'no' label
-                ->add('dateCafe', 'boolean')
-                ->add('datePub', 'boolean')
-                ->add('dateClub', 'boolean')
+                ->add('dateCafe', TemplateRegistry::TYPE_BOOLEAN)
+                ->add('datePub', TemplateRegistry::TYPE_BOOLEAN)
+                ->add('dateClub', TemplateRegistry::TYPE_BOOLEAN)
             ;
 
         }

--- a/docs/reference/field_types.rst
+++ b/docs/reference/field_types.rst
@@ -6,24 +6,29 @@ List and Show Actions
 
 There are many field types that can be used in the list and show action :
 
-============    =============================================
-Fieldtype       Description
-============    =============================================
-array           display value from an array
-boolean         display a green or red picture dependant on the boolean value
-date            display a formatted date. Accepts an optional ``format`` parameter
-datetime        display a formatted date and time. Accepts an optional ``format`` and ``timezone`` parameter
-text            display a text
-textarea        display a textarea
-trans           translate the value with a provided ``catalogue`` (translation domain) and ``format`` (sprintf format) option
-string          display a text
-number          display a number
-currency        display a number with a provided ``currency`` option
-percent         display a percentage
-choice          uses the given value as index for the ``choices`` array and displays (and optionally translates) the matching value
-url             display a link
-html            display (and optionally truncate or strip tags from) raw html
-============    =============================================
+=======================================    =============================================
+Fieldtype                                  Description
+=======================================    =============================================
+``TemplateRegistry::TYPE_ARRAY``           display value from an array
+``TemplateRegistry::TYPE_BOOLEAN``         display a green or red picture dependant on the boolean value
+``TemplateRegistry::TYPE_DATE``            display a formatted date. Accepts an optional ``format`` parameter
+``TemplateRegistry::TYPE_TIME``            display a formatted time. Accepts an optional ``format`` and ``timezone`` parameter
+``TemplateRegistry::TYPE_DATETIME``        display a formatted date and time. Accepts an optional ``format`` and ``timezone`` parameter
+``TemplateRegistry::TYPE_STRING``          display a text
+``TemplateRegistry::TYPE_EMAIL``           display a mailto link
+``TemplateRegistry::TYPE_TEXTAREA``        display a textarea
+``TemplateRegistry::TYPE_TRANS``           translate the value with a provided ``catalogue`` (translation domain) and ``format`` (sprintf format) option
+``TemplateRegistry::TYPE_FLOAT``           display a number
+``TemplateRegistry::TYPE_CURRENCY``        display a number with a provided ``currency`` option
+``TemplateRegistry::TYPE_PERCENT``         display a percentage
+``TemplateRegistry::TYPE_CHOICE``          uses the given value as index for the ``choices`` array and displays (and optionally translates) the matching value
+``TemplateRegistry::TYPE_URL``             display a link
+``TemplateRegistry::TYPE_HTML``            display (and optionally truncate or strip tags from) raw html
+``TemplateRegistry::TYPE_MANY_TO_MANY``    used for relational tables
+``TemplateRegistry::TYPE_MANY_TO_ONE``     used for relational tables
+``TemplateRegistry::TYPE_ONE_TO_MANY``     used for relational tables
+``TemplateRegistry::TYPE_ONE_TO_ONE``      used for relational tables
+=======================================    =============================================
 
 Theses types accept an ``editable`` parameter to edit the value from within the list action.
 This is currently limited to scalar types (text, integer, url...) and choice types with association field.
@@ -36,10 +41,10 @@ This is currently limited to scalar types (text, integer, url...) and choice typ
     Option for currency type must be an official ISO code, example : EUR for "euros".
     List of ISO codes : `http://en.wikipedia.org/wiki/List_of_circulating_currencies <http://en.wikipedia.org/wiki/List_of_circulating_currencies>`_
 
-    In ``date`` and ``datetime`` field types, ``format`` pattern must match twig's
+    In ``TemplateRegistry::TYPE_DATE``, ``TemplateRegistry::TYPE_TIME`` and ``TemplateRegistry::TYPE_DATETIME`` field types, ``format`` pattern must match twig's
     ``date`` filter specification, available at: `http://twig.sensiolabs.org/doc/filters/date.html <http://twig.sensiolabs.org/doc/filters/date.html>`_
 
-    In ``datetime`` field types, ``timezone`` syntax must match twig's
+    In ``TemplateRegistry::TYPE_TIME`` and ``TemplateRegistry::TYPE_DATETIME`` field types, ``timezone`` syntax must match twig's
     ``date`` filter specification, available at: `http://twig.sensiolabs.org/doc/filters/date.html <http://twig.sensiolabs.org/doc/filters/date.html>`_
     and php timezone list: `https://php.net/manual/en/timezones.php <https://php.net/manual/en/timezones.php>`_
     You can use in lists what `view-timezone <http://symfony.com/doc/current/reference/forms/types/datetime.html#view-timezone>`_ allows on forms,
@@ -57,11 +62,8 @@ This is currently limited to scalar types (text, integer, url...) and choice typ
             ;
         }
 
-More types might be provided based on the persistency layer defined. Please refer to their
-related documentations.
-
-Array
-^^^^^^
+``TemplateRegistry::TYPE_ARRAY``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can use the following parameters:
 
@@ -97,7 +99,7 @@ Parameter                               Description
     protected function configureListFields(ListMapper $listMapper): void
     {
         $listMapper
-            ->add('options', 'array', [
+            ->add('options', TemplateRegistry::TYPE_ARRAY, [
                 'inline' => true,
                 'display' => 'both',
                 'key_translation_domain' => true,
@@ -106,8 +108,8 @@ Parameter                               Description
         ;
     }
 
-Choice
-^^^^^^
+``TemplateRegistry::TYPE_CHOICE``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can use the following parameters:
 
@@ -126,7 +128,7 @@ Parameter                               Description
     {
         // For the value `prog`, the displayed text is `In progress`. The `App` catalogue will be used to translate `In progress` message.
         $listMapper
-            ->add('status', 'choice', [
+            ->add('status', TemplateRegistry::TYPE_CHOICE, [
                 'choices' => [
                     'prep' => 'Prepared',
                     'prog' => 'In progress',
@@ -137,13 +139,13 @@ Parameter                               Description
         ;
     }
 
-The ``choice`` field type also supports multiple values that can be separated by a ``delimiter``::
+The ``TemplateRegistry::TYPE_CHOICE`` field type also supports multiple values that can be separated by a ``delimiter``::
 
     protected function configureListFields(ListMapper $listMapper)
     {
         // For the value `['r', 'b']`, the displayed text ist `red | blue`.
         $listMapper
-            ->add('colors', 'choice', [
+            ->add('colors', TemplateRegistry::TYPE_CHOICE, [
                 'multiple' => true,
                 'delimiter' => ' | ',
                 'choices' => [
@@ -159,8 +161,8 @@ The ``choice`` field type also supports multiple values that can be separated by
 
     The default delimiter is a comma ``,``.
 
-URL
-^^^
+``TemplateRegistry::TYPE_URL``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Display URL link to external website or controller action.
 
@@ -185,29 +187,29 @@ Parameter                               Description
         $listMapper
             // Output for value `http://example.com`:
             // `<a href="http://example.com">http://example.com</a>`
-            ->add('targetUrl', 'url')
+            ->add('targetUrl', TemplateRegistry::TYPE_URL)
 
             // Output for value `http://example.com`:
             // `<a href="http://example.com" target="_blank">example.com</a>`
-            ->add('targetUrl', 'url', [
+            ->add('targetUrl', TemplateRegistry::TYPE_URL, [
                 'attributes' => ['target' => '_blank']
             ])
 
             // Output for value `http://example.com`:
             // `<a href="http://example.com">example.com</a>`
-            ->add('targetUrl', 'url', [
+            ->add('targetUrl', TemplateRegistry::TYPE_URL, [
                 'hide_protocol' => true
             ])
 
             // Output for value `Homepage of example.com` :
             // `<a href="http://example.com">Homepage of example.com</a>`
-            ->add('title', 'url', [
+            ->add('title', TemplateRegistry::TYPE_URL, [
                 'url' => 'http://example.com'
             ])
 
             // Output for value `Acme Blog Homepage`:
             // `<a href="http://blog.example.com">Acme Blog Homepage</a>`
-            ->add('title', 'url', [
+            ->add('title', TemplateRegistry::TYPE_URL, [
                 'route' => [
                     'name' => 'acme_blog_homepage',
                     'absolute' => true
@@ -216,7 +218,7 @@ Parameter                               Description
 
             // Output for value `Sonata is great!` (related object has identifier `123`):
             // `<a href="http://blog.example.com/xml/123">Sonata is great!</a>`
-            ->add('title', 'url', [
+            ->add('title', TemplateRegistry::TYPE_URL, [
                 'route' => [
                     'name' => 'acme_blog_article',
                     'absolute' => true,
@@ -229,10 +231,10 @@ Parameter                               Description
 
 .. note::
 
-    Do not use ``url`` type with ``addIdentifier()`` method, because it will create invalid nested URLs.
+    Do not use ``TemplateRegistry::TYPE_URL`` type with ``addIdentifier()`` method, because it will create invalid nested URLs.
 
-HTML
-^^^^
+``TemplateRegistry::TYPE_HTML``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Display (and optionally truncate or strip tags from) raw html.
 
@@ -256,23 +258,23 @@ Parameter                   Description
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `<p><strong>Creating a Template for the Field</strong> and form</p>` (no escaping is done)
-            ->add('content', 'html')
+            ->add('content', TemplateRegistry::TYPE_HTML)
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `Creating a Template for the Fi...`
-            ->add('content', 'html', [
+            ->add('content', TemplateRegistry::TYPE_HTML, [
                 'strip' => true
             ])
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `Creating a Template for...`
-            ->add('content', 'html', [
+            ->add('content', TemplateRegistry::TYPE_HTML, [
                 'truncate' => true
             ])
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `Creating a...`
-            ->add('content', 'html', [
+            ->add('content', TemplateRegistry::TYPE_HTML, [
                 'truncate' => [
                     'length' => 10
                 ]
@@ -280,7 +282,7 @@ Parameter                   Description
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `Creating a Template for the Field...`
-            ->add('content', 'html', [
+            ->add('content', TemplateRegistry::TYPE_HTML, [
                 'truncate' => [
                     'cut' => false
                 ]
@@ -288,7 +290,7 @@ Parameter                   Description
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `Creating a Template for the Fi, etc.`
-            ->add('content', 'html', [
+            ->add('content', TemplateRegistry::TYPE_HTML, [
                 'truncate' => [
                     'ellipsis' => ', etc.'
                 ]
@@ -296,7 +298,7 @@ Parameter                   Description
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `Creating a Template for***`
-            ->add('content', 'html', [
+            ->add('content', TemplateRegistry::TYPE_HTML, [
                 'truncate' => [
                     'length' => 20,
                     'cut' => false,

--- a/src/DependencyInjection/AbstractSonataAdminExtension.php
+++ b/src/DependencyInjection/AbstractSonataAdminExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\DependencyInjection;
 
+use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
@@ -33,54 +34,64 @@ abstract class AbstractSonataAdminExtension extends Extension
             'templates' => [
                 'types' => [
                     'list' => [
-                        'array' => '@SonataAdmin/CRUD/list_array.html.twig',
-                        'boolean' => '@SonataAdmin/CRUD/list_boolean.html.twig',
-                        'date' => '@SonataAdmin/CRUD/list_date.html.twig',
-                        'time' => '@SonataAdmin/CRUD/list_time.html.twig',
-                        'datetime' => '@SonataAdmin/CRUD/list_datetime.html.twig',
-                        'text' => '@SonataAdmin/CRUD/list_string.html.twig',
-                        'textarea' => '@SonataAdmin/CRUD/list_string.html.twig',
-                        'email' => '@SonataAdmin/CRUD/list_email.html.twig',
-                        'trans' => '@SonataAdmin/CRUD/list_trans.html.twig',
-                        'string' => '@SonataAdmin/CRUD/list_string.html.twig',
-                        'smallint' => '@SonataAdmin/CRUD/list_string.html.twig',
-                        'bigint' => '@SonataAdmin/CRUD/list_string.html.twig',
-                        'integer' => '@SonataAdmin/CRUD/list_string.html.twig',
-                        'decimal' => '@SonataAdmin/CRUD/list_string.html.twig',
-                        'identifier' => '@SonataAdmin/CRUD/list_string.html.twig',
-                        'currency' => '@SonataAdmin/CRUD/list_currency.html.twig',
-                        'percent' => '@SonataAdmin/CRUD/list_percent.html.twig',
-                        'choice' => '@SonataAdmin/CRUD/list_choice.html.twig',
-                        'url' => '@SonataAdmin/CRUD/list_url.html.twig',
-                        'html' => '@SonataAdmin/CRUD/list_html.html.twig',
-                        'many_to_many' => '@SonataAdmin/CRUD/Association/list_many_to_many.html.twig',
-                        'many_to_one' => '@SonataAdmin/CRUD/Association/list_many_to_one.html.twig',
-                        'one_to_many' => '@SonataAdmin/CRUD/Association/list_one_to_many.html.twig',
-                        'one_to_one' => '@SonataAdmin/CRUD/Association/list_one_to_one.html.twig',
+                        TemplateRegistry::TYPE_ARRAY => '@SonataAdmin/CRUD/list_array.html.twig',
+                        TemplateRegistry::TYPE_BOOLEAN => '@SonataAdmin/CRUD/list_boolean.html.twig',
+                        TemplateRegistry::TYPE_DATE => '@SonataAdmin/CRUD/list_date.html.twig',
+                        TemplateRegistry::TYPE_TIME => '@SonataAdmin/CRUD/list_time.html.twig',
+                        TemplateRegistry::TYPE_DATETIME => '@SonataAdmin/CRUD/list_datetime.html.twig',
+                        /* NEXT_MAJOR: Remove this line. */
+                        TemplateRegistry::TYPE_TEXT => '@SonataAdmin/CRUD/list_string.html.twig',
+                        TemplateRegistry::TYPE_TEXTAREA => '@SonataAdmin/CRUD/list_string.html.twig',
+                        TemplateRegistry::TYPE_EMAIL => '@SonataAdmin/CRUD/list_email.html.twig',
+                        TemplateRegistry::TYPE_TRANS => '@SonataAdmin/CRUD/list_trans.html.twig',
+                        TemplateRegistry::TYPE_STRING => '@SonataAdmin/CRUD/list_string.html.twig',
+                        /* NEXT_MAJOR: Remove this line. */
+                        TemplateRegistry::TYPE_SMALLINT => '@SonataAdmin/CRUD/list_string.html.twig',
+                        /* NEXT_MAJOR: Remove this line. */
+                        TemplateRegistry::TYPE_BIGINT => '@SonataAdmin/CRUD/list_string.html.twig',
+                        TemplateRegistry::TYPE_INTEGER => '@SonataAdmin/CRUD/list_string.html.twig',
+                        /* NEXT_MAJOR: Remove this line. */
+                        TemplateRegistry::TYPE_DECIMAL => '@SonataAdmin/CRUD/list_string.html.twig',
+                        TemplateRegistry::TYPE_FLOAT => '@SonataAdmin/CRUD/list_string.html.twig',
+                        TemplateRegistry::TYPE_IDENTIFIER => '@SonataAdmin/CRUD/list_string.html.twig',
+                        TemplateRegistry::TYPE_CURRENCY => '@SonataAdmin/CRUD/list_currency.html.twig',
+                        TemplateRegistry::TYPE_PERCENT => '@SonataAdmin/CRUD/list_percent.html.twig',
+                        TemplateRegistry::TYPE_CHOICE => '@SonataAdmin/CRUD/list_choice.html.twig',
+                        TemplateRegistry::TYPE_URL => '@SonataAdmin/CRUD/list_url.html.twig',
+                        TemplateRegistry::TYPE_HTML => '@SonataAdmin/CRUD/list_html.html.twig',
+                        TemplateRegistry::TYPE_MANY_TO_MANY => '@SonataAdmin/CRUD/Association/list_many_to_many.html.twig',
+                        TemplateRegistry::TYPE_MANY_TO_ONE => '@SonataAdmin/CRUD/Association/list_many_to_one.html.twig',
+                        TemplateRegistry::TYPE_ONE_TO_MANY => '@SonataAdmin/CRUD/Association/list_one_to_many.html.twig',
+                        TemplateRegistry::TYPE_ONE_TO_ONE => '@SonataAdmin/CRUD/Association/list_one_to_one.html.twig',
                     ],
                     'show' => [
-                        'array' => '@SonataAdmin/CRUD/show_array.html.twig',
-                        'boolean' => '@SonataAdmin/CRUD/show_boolean.html.twig',
-                        'date' => '@SonataAdmin/CRUD/show_date.html.twig',
-                        'time' => '@SonataAdmin/CRUD/show_time.html.twig',
-                        'datetime' => '@SonataAdmin/CRUD/show_datetime.html.twig',
-                        'text' => '@SonataAdmin/CRUD/base_show_field.html.twig',
-                        'email' => '@SonataAdmin/CRUD/show_email.html.twig',
-                        'trans' => '@SonataAdmin/CRUD/show_trans.html.twig',
-                        'string' => '@SonataAdmin/CRUD/base_show_field.html.twig',
-                        'smallint' => '@SonataAdmin/CRUD/base_show_field.html.twig',
-                        'bigint' => '@SonataAdmin/CRUD/base_show_field.html.twig',
-                        'integer' => '@SonataAdmin/CRUD/base_show_field.html.twig',
-                        'decimal' => '@SonataAdmin/CRUD/base_show_field.html.twig',
-                        'currency' => '@SonataAdmin/CRUD/show_currency.html.twig',
-                        'percent' => '@SonataAdmin/CRUD/show_percent.html.twig',
-                        'choice' => '@SonataAdmin/CRUD/show_choice.html.twig',
-                        'url' => '@SonataAdmin/CRUD/show_url.html.twig',
-                        'html' => '@SonataAdmin/CRUD/show_html.html.twig',
-                        'many_to_many' => '@SonataAdmin/CRUD/Association/show_many_to_many.html.twig',
-                        'many_to_one' => '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig',
-                        'one_to_many' => '@SonataAdmin/CRUD/Association/show_one_to_many.html.twig',
-                        'one_to_one' => '@SonataAdmin/CRUD/Association/show_one_to_one.html.twig',
+                        TemplateRegistry::TYPE_ARRAY => '@SonataAdmin/CRUD/show_array.html.twig',
+                        TemplateRegistry::TYPE_BOOLEAN => '@SonataAdmin/CRUD/show_boolean.html.twig',
+                        TemplateRegistry::TYPE_DATE => '@SonataAdmin/CRUD/show_date.html.twig',
+                        TemplateRegistry::TYPE_TIME => '@SonataAdmin/CRUD/show_time.html.twig',
+                        TemplateRegistry::TYPE_DATETIME => '@SonataAdmin/CRUD/show_datetime.html.twig',
+                        /* NEXT_MAJOR: Remove this line. */
+                        TemplateRegistry::TYPE_TEXT => '@SonataAdmin/CRUD/base_show_field.html.twig',
+                        TemplateRegistry::TYPE_EMAIL => '@SonataAdmin/CRUD/show_email.html.twig',
+                        TemplateRegistry::TYPE_TRANS => '@SonataAdmin/CRUD/show_trans.html.twig',
+                        TemplateRegistry::TYPE_STRING => '@SonataAdmin/CRUD/base_show_field.html.twig',
+                        /* NEXT_MAJOR: Remove this line. */
+                        TemplateRegistry::TYPE_SMALLINT => '@SonataAdmin/CRUD/base_show_field.html.twig',
+                        /* NEXT_MAJOR: Remove this line. */
+                        TemplateRegistry::TYPE_BIGINT => '@SonataAdmin/CRUD/base_show_field.html.twig',
+                        TemplateRegistry::TYPE_INTEGER => '@SonataAdmin/CRUD/base_show_field.html.twig',
+                        /* NEXT_MAJOR: Remove this line. */
+                        TemplateRegistry::TYPE_DECIMAL => '@SonataAdmin/CRUD/base_show_field.html.twig',
+                        TemplateRegistry::TYPE_FLOAT => '@SonataAdmin/CRUD/base_show_field.html.twig',
+                        TemplateRegistry::TYPE_CURRENCY => '@SonataAdmin/CRUD/show_currency.html.twig',
+                        TemplateRegistry::TYPE_PERCENT => '@SonataAdmin/CRUD/show_percent.html.twig',
+                        TemplateRegistry::TYPE_CHOICE => '@SonataAdmin/CRUD/show_choice.html.twig',
+                        TemplateRegistry::TYPE_URL => '@SonataAdmin/CRUD/show_url.html.twig',
+                        TemplateRegistry::TYPE_HTML => '@SonataAdmin/CRUD/show_html.html.twig',
+                        TemplateRegistry::TYPE_MANY_TO_MANY => '@SonataAdmin/CRUD/Association/show_many_to_many.html.twig',
+                        TemplateRegistry::TYPE_MANY_TO_ONE => '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig',
+                        TemplateRegistry::TYPE_ONE_TO_MANY => '@SonataAdmin/CRUD/Association/show_one_to_many.html.twig',
+                        TemplateRegistry::TYPE_ONE_TO_ONE => '@SonataAdmin/CRUD/Association/show_one_to_one.html.twig',
                     ],
                 ],
             ],
@@ -90,25 +101,33 @@ abstract class AbstractSonataAdminExtension extends Extension
         $bundles = $container->getParameter('kernel.bundles');
         if (isset($bundles['SonataIntlBundle'])) {
             $defaultConfig['templates']['types']['list'] = array_merge($defaultConfig['templates']['types']['list'], [
-                'date' => '@SonataIntl/CRUD/list_date.html.twig',
-                'datetime' => '@SonataIntl/CRUD/list_datetime.html.twig',
-                'smallint' => '@SonataIntl/CRUD/list_decimal.html.twig',
-                'bigint' => '@SonataIntl/CRUD/list_decimal.html.twig',
-                'integer' => '@SonataIntl/CRUD/list_decimal.html.twig',
-                'decimal' => '@SonataIntl/CRUD/list_decimal.html.twig',
-                'currency' => '@SonataIntl/CRUD/list_currency.html.twig',
-                'percent' => '@SonataIntl/CRUD/list_percent.html.twig',
+                TemplateRegistry::TYPE_DATE => '@SonataIntl/CRUD/list_date.html.twig',
+                TemplateRegistry::TYPE_DATETIME => '@SonataIntl/CRUD/list_datetime.html.twig',
+                /* NEXT_MAJOR: Remove this line. */
+                TemplateRegistry::TYPE_SMALLINT => '@SonataIntl/CRUD/list_decimal.html.twig',
+                /* NEXT_MAJOR: Remove this line. */
+                TemplateRegistry::TYPE_BIGINT => '@SonataIntl/CRUD/list_decimal.html.twig',
+                TemplateRegistry::TYPE_INTEGER => '@SonataIntl/CRUD/list_decimal.html.twig',
+                /* NEXT_MAJOR: Remove this line. */
+                TemplateRegistry::TYPE_DECIMAL => '@SonataIntl/CRUD/list_decimal.html.twig',
+                TemplateRegistry::TYPE_FLOAT => '@SonataIntl/CRUD/list_decimal.html.twig',
+                TemplateRegistry::TYPE_CURRENCY => '@SonataIntl/CRUD/list_currency.html.twig',
+                TemplateRegistry::TYPE_PERCENT => '@SonataIntl/CRUD/list_percent.html.twig',
             ]);
 
             $defaultConfig['templates']['types']['show'] = array_merge($defaultConfig['templates']['types']['show'], [
-                'date' => '@SonataIntl/CRUD/show_date.html.twig',
-                'datetime' => '@SonataIntl/CRUD/show_datetime.html.twig',
-                'smallint' => '@SonataIntl/CRUD/show_decimal.html.twig',
-                'bigint' => '@SonataIntl/CRUD/show_decimal.html.twig',
-                'integer' => '@SonataIntl/CRUD/show_decimal.html.twig',
-                'decimal' => '@SonataIntl/CRUD/show_decimal.html.twig',
-                'currency' => '@SonataIntl/CRUD/show_currency.html.twig',
-                'percent' => '@SonataIntl/CRUD/show_percent.html.twig',
+                TemplateRegistry::TYPE_DATE => '@SonataIntl/CRUD/show_date.html.twig',
+                TemplateRegistry::TYPE_DATETIME => '@SonataIntl/CRUD/show_datetime.html.twig',
+                /* NEXT_MAJOR: Remove this line. */
+                TemplateRegistry::TYPE_SMALLINT => '@SonataIntl/CRUD/show_decimal.html.twig',
+                /* NEXT_MAJOR: Remove this line. */
+                TemplateRegistry::TYPE_BIGINT => '@SonataIntl/CRUD/show_decimal.html.twig',
+                TemplateRegistry::TYPE_INTEGER => '@SonataIntl/CRUD/show_decimal.html.twig',
+                /* NEXT_MAJOR: Remove this line. */
+                TemplateRegistry::TYPE_DECIMAL => '@SonataIntl/CRUD/show_decimal.html.twig',
+                TemplateRegistry::TYPE_FLOAT => '@SonataIntl/CRUD/list_decimal.html.twig',
+                TemplateRegistry::TYPE_CURRENCY => '@SonataIntl/CRUD/show_currency.html.twig',
+                TemplateRegistry::TYPE_PERCENT => '@SonataIntl/CRUD/show_percent.html.twig',
             ]);
         }
 

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -54,9 +54,9 @@ file that was distributed with this source code.
                 })
             ) %}
 
-            {% if field_description.type == 'date' and value is not empty %}
+            {% if field_description.type == constant('Sonata\\AdminBundle\\Templating\\TemplateRegistry::TYPE_DATE') and value is not empty %}
                 {% set data_value = value.format('Y-m-d') %}
-            {% elseif field_description.type == 'boolean' and value is empty %}
+            {% elseif field_description.type == constant('Sonata\\AdminBundle\\Templating\\TemplateRegistry::TYPE_BOOLEAN') and value is empty %}
                 {% set data_value = 0 %}
             {% elseif value is iterable %}
                 {% set data_value = value|json_encode %}

--- a/src/Resources/views/CRUD/display_time.html.twig
+++ b/src/Resources/views/CRUD/display_time.html.twig
@@ -14,7 +14,7 @@ file that was distributed with this source code.
         &nbsp;
     {%- else -%}
         <time datetime="{{ value|date('H:i:sP', 'UTC') }}" title="{{ value|date('H:i:sP', 'UTC') }}">
-            {{ value|date('H:i:s', field_description.options.timezone|default(null)) }}
+            {{ value|date(field_description.options.format|default('H:i:s'), field_description.options.timezone|default(null)) }}
         </time>
     {%- endif -%}
 {% endapply -%}

--- a/src/Templating/TemplateRegistry.php
+++ b/src/Templating/TemplateRegistry.php
@@ -18,6 +18,52 @@ namespace Sonata\AdminBundle\Templating;
  */
 final class TemplateRegistry implements MutableTemplateRegistryInterface
 {
+    public const TYPE_ARRAY = 'array';
+    public const TYPE_BOOLEAN = 'boolean';
+    public const TYPE_DATE = 'date';
+    public const TYPE_TIME = 'time';
+    public const TYPE_DATETIME = 'datetime';
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_STRING instead.
+     */
+    public const TYPE_TEXT = 'text';
+    public const TYPE_TEXTAREA = 'textarea';
+    public const TYPE_EMAIL = 'email';
+    public const TYPE_TRANS = 'trans';
+    public const TYPE_STRING = 'string';
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_INTEGER instead.
+     */
+    public const TYPE_SMALLINT = 'smallint';
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_INTEGER instead.
+     */
+    public const TYPE_BIGINT = 'bigint';
+    public const TYPE_INTEGER = 'integer';
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_FLOAT instead.
+     */
+    public const TYPE_DECIMAL = 'decimal';
+    public const TYPE_FLOAT = 'float';
+    public const TYPE_IDENTIFIER = 'identifier';
+    public const TYPE_CURRENCY = 'currency';
+    public const TYPE_PERCENT = 'percent';
+    public const TYPE_CHOICE = 'choice';
+    public const TYPE_URL = 'url';
+    public const TYPE_HTML = 'html';
+    public const TYPE_MANY_TO_MANY = 'many_to_many';
+    public const TYPE_MANY_TO_ONE = 'many_to_one';
+    public const TYPE_ONE_TO_MANY = 'one_to_many';
+    public const TYPE_ONE_TO_ONE = 'one_to_one';
+
     /**
      * @var string[]
      */


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

This allow to be used in project or others bundle.
Maybe these constant are better somewhere else, you'll say.


This will avoid using non-existent field type, like
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/src/Guesser/TypeGuesser.php#L36
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/src/Guesser/TypeGuesser.php#L68

I also updated lot of documentation.

## Changelog

```markdown
### Added
- Added `TemplateRegistry::TYPE_*` constant to be used instead of string value.
- Added `format` option for `time` field type.

### Deprecated
- Deprecated `smallint` type for template ; use `integer` instead.
- Deprecated `bigint` type for template ; use `integer` instead.
- Deprecated `decimal` type for template ; use `float` instead.
- Deprecated `text` type for template ; use `string` instead.
```