### PR TITLE
Add doctrine/common 3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,10 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "doctrine/common": "^2.7",
+        "doctrine/collections": "^1.6",
+        "doctrine/common": "^2.7 || ^3.0",
         "doctrine/inflector": "^1.4 || ^2.0",
-        "doctrine/persistence": "^1.3.3",
+        "doctrine/persistence": "^1.3.6 || ^2.0",
         "knplabs/knp-menu-bundle": "^2.2.2",
         "sonata-project/block-bundle": "^3.20 || ^4.0",
         "sonata-project/exporter": "^1.11 || ^2.0",

--- a/src/Command/GenerateObjectAclCommand.php
+++ b/src/Command/GenerateObjectAclCommand.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Command;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Util\ObjectAclManipulatorInterface;

--- a/tests/Command/GenerateObjectAclCommandTest.php
+++ b/tests/Command/GenerateObjectAclCommandTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Command;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sonata\AdminBundle\Admin\AbstractAdmin;


### PR DESCRIPTION
## Subject

This PR adds support for `doctrine/common` 3. It follows the upgrade instructions in Doctrine's [release notes](https://github.com/doctrine/common/releases/tag/3.0.0).

I am targeting this branch, because the change is back-compatible.

Closes #6121.

## Changelog

```markdown
### Added
- Added support for `doctrine/common` 3.
```