### PR TITLE
Fix checkbox/radio button layout when iCheck is disabled

### DIFF
--- a/src/Resources/public/css/styles.css
+++ b/src/Resources/public/css/styles.css
@@ -370,7 +370,15 @@ td.sonata-ba-list-field .editable-empty:not(.editable-open) {
 .checkbox label,
 .radio label {
     font-weight: 700;
-    margin-left: -20px;
+}
+
+/**
+ * Undo Bootstrap styling for checkboxes and radio buttons when iCheck is in use.
+ */
+body.sonata-icheck .checkbox label,
+body.sonata-icheck .radio label {
+  padding-left: 0;
+  margin-left: 0;
 }
 
 /**

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -21,6 +21,8 @@ file that was distributed with this source code.
 {% set _actions = block('actions') is defined ? block('actions')|trim : null %}
 {% set _navbar_title = block('navbar_title') is defined ? block('navbar_title')|trim : null %}
 {% set _list_filters_actions = block('list_filters_actions') is defined ? block('list_filters_actions')|trim : null -%}
+{% set _use_select2 = sonata_admin.adminPool.getOption('use_select2') %}
+{% set _use_icheck = sonata_admin.adminPool.getOption('use_icheck') %}
 
 <!DOCTYPE html>
 <html {% block html_attributes %}class="no-js"{% endblock %}>
@@ -34,8 +36,8 @@ file that was distributed with this source code.
         <meta data-sonata-admin='{{ {
             config: {
                 CONFIRM_EXIT: sonata_admin.adminPool.getOption('confirm_exit'),
-                USE_SELECT2: sonata_admin.adminPool.getOption('use_select2'),
-                USE_ICHECK: sonata_admin.adminPool.getOption('use_icheck'),
+                USE_SELECT2: _use_select2,
+                USE_ICHECK: _use_icheck,
                 USE_STICKYFORMS: sonata_admin.adminPool.getOption('use_stickyforms'),
                 DEBUG: sonata_admin.adminPool.getOption('js_debug'),
             },
@@ -112,6 +114,8 @@ file that was distributed with this source code.
     <body
             {% block body_attributes -%}
                 class="sonata-bc skin-black fixed
+                {% if _use_select2 %}sonata-select2{% endif %}
+                {% if _use_icheck %}sonata-icheck{% endif %}
                 {% if app.request.cookies.get('sonata_sidebar_hide') -%}
                     sidebar-collapse
                 {%- endif -%}"


### PR DESCRIPTION
## Subject

I have disabled iCheck because it conflicts with some of the React components I've added to my admin pages.

In styles.css some of the bootstrap styling is overridden to make iCheck checkboxes display properly, as Bootstrap uses negative margins and padding to style checkboxes and radio buttons. However, these overrides are still present when iCheck is disabled, causing the following layout bug:

![image](https://user-images.githubusercontent.com/521449/83729150-8c013680-a647-11ea-9a9b-40aa066674e3.png)

This PR adds a body class when iCheck is enabled (also done for Select2 for completeness) and activates the CSS override only when this class is present.

I am targeting this branch, because it is backwards compatible.

## Changelog

```markdown
### Added
- Body classes `sonata-icheck` and `sonata-select2` when iCheck or Select2 are enabled.

### Fixed
- Styling of checkboxes and radio buttons when iCheck is disabled.

```
