### PR TITLE
Replace truncate filter with u.truncate

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated `sonata_truncate` Twig filter
+
+This filter has been deprecated in favor of the [`u` filter](https://twig.symfony.com/doc/2.x/filters/u.html):
+
 ## Deprecated `SonataAdminBundle\Twig\Extension\UnicodeString`
 
 Use `Symfony\Component\String\UnicodeString` instead.

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated `SonataAdminBundle\Twig\Extension\UnicodeString`
+
+Use `Symfony\Component\String\UnicodeString` instead.
+
 UPGRADE FROM 3.67 to 3.68
 =========================
 

--- a/composer.json
+++ b/composer.json
@@ -48,11 +48,11 @@
         "symfony/security-bundle": "^4.3",
         "symfony/security-core": "^4.3",
         "symfony/security-csrf": "^4.3",
+        "symfony/string": "^5.1",
         "symfony/translation": "^4.3",
         "symfony/twig-bridge": "^4.3",
         "symfony/twig-bundle": "^4.3",
         "symfony/validator": "^4.3",
-        "twig/extensions": "^1.5",
         "twig/extra-bundle": "^3.0",
         "twig/string-extra": "^3.0",
         "twig/twig": "^2.12.1"

--- a/docs/cookbook/recipe_customizing_a_mosaic_list.rst
+++ b/docs/cookbook/recipe_customizing_a_mosaic_list.rst
@@ -18,7 +18,7 @@ It is possible to configure the default view by creating a dedicated template.
    please use the following configuration:
 
     .. code-block:: yaml
-    
+
         # config/packages/sonata_admin.yaml
 
         sonata_admin:
@@ -89,11 +89,11 @@ The ``list_outer_rows_mosaic.html.twig`` is the name of one mosaic's tile. You s
 
     {% block sonata_mosaic_description %}
         {% if admin.hasAccess('edit', object) and admin.hasRoute('edit') %}
-            <a href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|truncate(40) }}</a>
+            <a href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|u.truncate(40) }}</a>
         {% elseif admin.hasAccess('show', object) and admin.hasRoute('show') %}
-            <a href="{{ admin.generateUrl('show', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|truncate(40) }}</a>
+            <a href="{{ admin.generateUrl('show', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|u.truncate(40) }}</a>
         {% else %}
-            {{ meta.title|truncate(40) }}
+            {{ meta.title|u.truncate(40) }}
         {% endif %}
     {% endblock %}
 

--- a/src/Resources/views/CRUD/base_edit.html.twig
+++ b/src/Resources/views/CRUD/base_edit.html.twig
@@ -14,18 +14,18 @@ file that was distributed with this source code.
 {% block title %}
     {# NEXT_MAJOR: remove default filter #}
     {% if objectId|default(admin.id(object)) is not null %}
-        {{ 'title_edit'|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
+        {{ 'title_edit'|trans({'%name%': admin.toString(object)|u.truncate(15) }, 'SonataAdminBundle') }}
     {% else %}
-        {{ 'title_create'|trans({}, 'SonataAdminBundle')|truncate(15) }}
+        {{ 'title_create'|trans({}, 'SonataAdminBundle')|u.truncate(15) }}
     {% endif %}
 {% endblock %}
 
 {% block navbar_title %}
     {# NEXT_MAJOR: remove default filter #}
     {% if objectId|default(admin.id(object)) is not null %}
-        {{ 'title_edit'|trans({'%name%': admin.toString(object)|truncate(100) }, 'SonataAdminBundle') }}
+        {{ 'title_edit'|trans({'%name%': admin.toString(object)|u.truncate(100) }, 'SonataAdminBundle') }}
     {% else %}
-        {{ 'title_create'|trans({}, 'SonataAdminBundle')|truncate(100) }}
+        {{ 'title_create'|trans({}, 'SonataAdminBundle')|u.truncate(100) }}
     {% endif %}
 {% endblock %}
 

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -23,11 +23,11 @@ file that was distributed with this source code.
 {%- endblock -%}
 
 {% block title %}
-    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject)|truncate(15) }, 'SonataAdminBundle') : '' }}
+    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject)|u.truncate(15) }, 'SonataAdminBundle') : '' }}
 {% endblock %}
 
 {% block navbar_title %}
-    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject)|truncate(100) }, 'SonataAdminBundle') : '' }}
+    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject)|u.truncate(100) }, 'SonataAdminBundle') : '' }}
 {% endblock %}
 
 {% block list_table %}

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -12,11 +12,11 @@ file that was distributed with this source code.
 {% extends base_template %}
 
 {% block title %}
-    {{ 'title_show'|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
+    {{ 'title_show'|trans({'%name%': admin.toString(object)|u.truncate(15) }, 'SonataAdminBundle') }}
 {% endblock %}
 
 {% block navbar_title %}
-    {{ 'title_show'|trans({'%name%': admin.toString(object)|truncate(100) }, 'SonataAdminBundle') }}
+    {{ 'title_show'|trans({'%name%': admin.toString(object)|u.truncate(100) }, 'SonataAdminBundle') }}
 {% endblock %}
 
 {%- block actions -%}

--- a/src/Resources/views/CRUD/list_html.html.twig
+++ b/src/Resources/views/CRUD/list_html.html.twig
@@ -15,7 +15,7 @@
                 {% deprecated 'The "truncate.separator" option is deprecated since sonata-project/admin-bundle 3.65, to be removed in 4.0. Use "truncate.ellipsis" instead.' %}
             {% endif %}
             {% set ellipsis = truncate.ellipsis is defined ? truncate.ellipsis : (truncate.separator is defined ? truncate.separator : '...') %}
-            {{ value|striptags|sonata_truncate(length, cut == false, ellipsis)|raw }}
+            {{ value|striptags|u.truncate(length, ellipsis, cut)|raw }}
         {%- else -%}
             {%- if field_description.options.strip is defined -%}
                 {% set value = value|striptags %}

--- a/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
+++ b/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
@@ -62,7 +62,7 @@ This template can be customized to match your needs. You should only extends the
                             {% endif %}
 
                             {% block sonata_mosaic_description %}
-                                {{ meta.title|truncate(40) }}
+                                {{ meta.title|u.truncate(40) }}
                             {% endblock %}
                         </div>
                     </div>

--- a/src/Resources/views/CRUD/show_html.html.twig
+++ b/src/Resources/views/CRUD/show_html.html.twig
@@ -15,7 +15,7 @@
                 {% deprecated 'The "truncate.separator" option is deprecated since sonata-project/admin-bundle 3.65, to be removed in 4.0. Use "truncate.ellipsis" instead.' %}
             {% endif %}
             {% set ellipsis = truncate.ellipsis is defined ? truncate.ellipsis : (truncate.separator is defined ? truncate.separator : '...') %}
-            {{ value|striptags|sonata_truncate(length, cut == false, ellipsis)|raw }}
+            {{ value|striptags|u.truncate(length, ellipsis, cut)|raw }}
         {%- else -%}
             {%- if field_description.options.strip is defined -%}
                 {% set value = value|striptags %}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -173,15 +173,15 @@ file that was distributed with this source code.
                                                                         {% if menu.extra('safe_label', true) %}
                                                                             {{- label|raw -}}
                                                                         {% else %}
-                                                                            {{- label|truncate(100) -}}
+                                                                            {{- label|u.truncate(100) -}}
                                                                         {% endif %}
                                                                     </a>
                                                                 {% else %}
-                                                                    <span>{{ label|truncate(100) }}</span>
+                                                                    <span>{{ label|u.truncate(100) }}</span>
                                                                 {% endif %}
                                                             </li>
                                                         {% else %}
-                                                            <li class="active"><span>{{ label|truncate(100) }}</span></li>
+                                                            <li class="active"><span>{{ label|u.truncate(100) }}</span></li>
                                                         {% endif %}
                                                     {% endfor %}
                                                 {% endif %}

--- a/src/Twig/Extension/StringExtension.php
+++ b/src/Twig/Extension/StringExtension.php
@@ -14,11 +14,14 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Twig\Extension;
 
 use Symfony\Component\String\UnicodeString as SymfonyUnicodeString;
+use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Extensions\TextExtension;
 use Twig\TwigFilter;
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
  * Decorates `Twig\Extra\String\StringExtension` in order to provide the `$cut`
  * argument for `Symfony\Component\String\UnicodeString::truncate()`.
  * This class must be removed when the component ships this feature.
@@ -46,15 +49,27 @@ final class StringExtension extends AbstractExtension
      */
     public function getFilters(): array
     {
+        return [
+            new TwigFilter('sonata_truncate', [$this, 'deprecatedTruncate'], ['needs_environment' => true]),
+        ];
+    }
+
+    /**
+     * @return SymfonyUnicodeString|string
+     */
+    public function deprecatedTruncate(Environment $env, ?string $text, int $length = 30, bool $preserve = false, string $ellipsis = '...')
+    {
+        @trigger_error(
+            'The "sonata_truncate" twig filter is deprecated'
+            .' since sonata-project/admin-bundle 3.x and will be removed in 4.0. Use "u.truncate" instead.',
+            E_USER_DEPRECATED
+        );
+
         if (null !== $this->legacyExtension) {
-            return [
-                new TwigFilter('sonata_truncate', 'twig_truncate_filter', ['needs_environment' => true]),
-            ];
+            return twig_truncate_filter($env, $text, $length, $preserve, $ellipsis);
         }
 
-        return [
-            new TwigFilter('sonata_truncate', [$this, 'legacyTruncteWithUnicodeString']),
-        ];
+        return $this->legacyTruncteWithUnicodeString($text, $length, $preserve, $ellipsis);
     }
 
     /**

--- a/src/Twig/Extension/StringExtension.php
+++ b/src/Twig/Extension/StringExtension.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Twig\Extension;
 
-use Symfony\Component\String\UnicodeString as DecoratedUnicodeString;
+use Symfony\Component\String\UnicodeString as SymfonyUnicodeString;
 use Twig\Extension\AbstractExtension;
 use Twig\Extensions\TextExtension;
 use Twig\TwigFilter;
@@ -60,8 +60,8 @@ final class StringExtension extends AbstractExtension
     /**
      * NEXT_MAJOR: Fix the arguments in order to respect the signature at `UnicodeString::truncate()`.
      */
-    public function legacyTruncteWithUnicodeString(?string $text, int $length = 30, bool $preserve = false, string $ellipsis = '...'): DecoratedUnicodeString
+    public function legacyTruncteWithUnicodeString(?string $text, int $length = 30, bool $preserve = false, string $ellipsis = '...'): SymfonyUnicodeString
     {
-        return (new UnicodeString($text ?? ''))->truncate($length, $ellipsis, $preserve);
+        return (new SymfonyUnicodeString($text ?? ''))->truncate($length, $ellipsis, $preserve);
     }
 }

--- a/src/Twig/Extension/UnicodeString.php
+++ b/src/Twig/Extension/UnicodeString.php
@@ -23,6 +23,9 @@ use Symfony\Component\String\UnicodeString as DecoratedUnicodeString;
  *
  * @see https://github.com/symfony/symfony/pull/35649
  *
+ * NEXT_MAJOR: Remove this class
+ * @deprecated since sonata-project/admin-bundle 3.x, use Symfony\Component\String\UnicodeString instead.
+ *
  * @throws ExceptionInterface
  *
  * @author Javier Spagnoletti <phansys@gmail.com>

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -25,7 +25,6 @@ use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
 use Sonata\AdminBundle\Tests\Fixtures\StubFilesystemLoader;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
-use Sonata\AdminBundle\Twig\Extension\StringExtension;
 use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
@@ -42,7 +41,7 @@ use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterfa
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 use Twig\Error\LoaderError;
-use Twig\Extensions\TextExtension;
+use Twig\Extra\String\StringExtension;
 
 /**
  * Test for SonataAdminExtension.
@@ -204,7 +203,6 @@ class SonataAdminExtensionTest extends TestCase
         $requestContext = new RequestContext();
         $urlGenerator = new UrlGenerator($routeCollection, $requestContext);
         $this->environment->addExtension(new RoutingExtension($urlGenerator));
-        $this->environment->addExtension(new TextExtension());
         $this->environment->addExtension(new StringExtension());
 
         // initialize object
@@ -2203,7 +2201,7 @@ EOT
         ]);
         $environment->addExtension($this->twigExtension);
         $environment->addExtension(new TranslationExtension($this->translator));
-        $environment->addExtension(new StringExtension(new TextExtension()));
+        $environment->addExtension(new StringExtension());
 
         $this->admin
             ->method('getTemplate')
@@ -2250,7 +2248,7 @@ EOT
         ];
 
         yield 'custom_length' => [
-            '<th>Data</th> <td> Creating a Template for[...] </td>',
+            '<th>Data</th> <td> Creating a Template[...] </td>',
             'html',
             '<p><strong>Creating a Template for the Field</strong> and form</p>',
             [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

[Symfony 5.1 was released](https://github.com/symfony/symfony/releases/tag/v5.1.0) one week ago, so we can use `truncate` method from `u` filter ([preserving the last word](https://github.com/symfony/symfony/pull/35649)).

Ref: https://github.com/sonata-project/SonataAdminBundle/pull/5865

I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed use of `truncate` filter with `u` filter.
### Deprecated
- Deprecated `Sonata\AdminBundle\Twig\Extension\UnicodeString` in favor of `Symfony\Component\String\UnicodeString`.
- Deprecated `sonata_truncate` in favor of `u.truncate`.
```

Since [our StringExtension is internal](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Twig/Extension/StringExtension.php#L26)... can we remove it? The problem I see is that I guess using `sonata_truncate` filter didn't  trigger any warning.
