### PR TITLE
Force to use hasser before getter

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1394,13 +1394,17 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         $adminCode = $fieldDescription->getOption('admin_code');
 
         if (null !== $adminCode) {
+            if (!$pool->hasAdminByAdminCode($adminCode)) {
+                return;
+            }
+
             $admin = $pool->getAdminByAdminCode($adminCode);
         } else {
-            $admin = $pool->getAdminByClass($fieldDescription->getTargetEntity());
-        }
+            if (!$pool->hasAdminByClass($fieldDescription->getTargetEntity())) {
+                return;
+            }
 
-        if (!$admin) {
-            return;
+            $admin = $pool->getAdminByClass($fieldDescription->getTargetEntity());
         }
 
         if ($this->hasRequest()) {
@@ -2072,7 +2076,24 @@ EOT;
 
     public function getChild($code)
     {
-        return $this->hasChild($code) ? $this->children[$code] : null;
+        if (!$this->hasChild($code)) {
+            @trigger_error(sprintf(
+                'Calling %s() when there is no child is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw an exception in 4.0. Use %s::hasChild() to know if the child exists.',
+                __METHOD__,
+                __CLASS__
+            ), E_USER_DEPRECATED);
+            // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare AdminInterface as return type
+            // throw new \LogicException(sprintf(
+            //    'Admin "%s" has no child for the code %s.',
+            //    static::class,
+            //    $code
+            // ));
+
+            return null;
+        }
+
+        return $this->children[$code];
     }
 
     public function setParent(AdminInterface $parent)

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -112,12 +112,12 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     protected $parent;
 
     /**
-     * @var AdminInterface the related admin instance
+     * @var AdminInterface|null the related admin instance
      */
     protected $admin;
 
     /**
-     * @var AdminInterface the associated admin class if the object is associated to another entity
+     * @var AdminInterface|null the associated admin class if the object is associated to another entity
      */
     protected $associationAdmin;
 
@@ -236,7 +236,26 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
 
     public function getParent()
     {
+        if (!$this->hasParent()) {
+            @trigger_error(
+                sprintf(
+                    'Calling %s() when there is no parent is deprecated since sonata-project/admin-bundle 3.x'
+                    .' and will throw an exception in 4.0. Use %s::hasParent() to know if there is a parent.',
+                    __METHOD__,
+                    __CLASS__
+                ),
+                E_USER_DEPRECATED
+            );
+            // NEXT_MAJOR : remove the previous `trigger_error()` call, uncomment the following exception and declare AdminInterface as return type
+            // throw new \LogicException(sprintf('%s has no parent.', static::class));
+        }
+
         return $this->parent;
+    }
+
+    public function hasParent()
+    {
+        return null !== $this->parent;
     }
 
     public function getAssociationMapping()
@@ -262,6 +281,20 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
 
     public function getAssociationAdmin()
     {
+        if (!$this->hasAssociationAdmin()) {
+            @trigger_error(
+                sprintf(
+                    'Calling %s() when there is no association admin is deprecated since sonata-project/admin-bundle 3.x'
+                    .' and will throw an exception in 4.0. Use %s::hasAssociationAdmin() to know if there is an association admin.',
+                    __METHOD__,
+                    __CLASS__
+                ),
+                E_USER_DEPRECATED
+            );
+            // NEXT_MAJOR : remove the previous `trigger_error()` call, uncomment the following exception and declare AdminInterface as return type
+            // throw new \LogicException(sprintf('%s has no association admin.', static::class));
+        }
+
         return $this->associationAdmin;
     }
 
@@ -335,7 +368,26 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
 
     public function getAdmin()
     {
+        if (!$this->hasAdmin()) {
+            @trigger_error(
+                sprintf(
+                    'Calling %s() when there is no admin is deprecated since sonata-project/admin-bundle 3.x'
+                    .' and will throw an exception in 4.0. Use %s::hasAdmin() to know if there is an admin.',
+                    __METHOD__,
+                    __CLASS__
+                ),
+                E_USER_DEPRECATED
+            );
+            // NEXT_MAJOR : remove the previous `trigger_error()` call, uncomment the following exception and declare AdminInterface as return type
+            // throw new \LogicException(sprintf('%s has no admin.', static::class));
+        }
+
         return $this->admin;
+    }
+
+    public function hasAdmin()
+    {
+        return null !== $this->admin;
     }
 
     public function mergeOption($name, array $options = [])

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -17,6 +17,9 @@ namespace Sonata\AdminBundle\Admin;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @method string|null getTargetModel()
+ * @method bool        hasAdmin()
+ * @method bool        hasParent()
+ * @method bool        hasAssociationAdmin()
  */
 interface FieldDescriptionInterface
 {
@@ -119,9 +122,12 @@ interface FieldDescriptionInterface
     /**
      * Returns the parent Admin (only used in nested admin).
      *
-     * @return AdminInterface|null
+     * @return AdminInterface|null // NEXT_MAJOR: Return AdminInterface
      */
     public function getParent();
+
+    // NEXT_MAJOR: Uncomment the following line
+    // public function hasParent(): bool;
 
     /**
      * Define the association mapping definition.
@@ -186,9 +192,12 @@ interface FieldDescriptionInterface
     /**
      * Returns the associated Admin instance (only used if the field is linked to an Admin).
      *
-     * @return AdminInterface|null
+     * @return AdminInterface|null // NEXT_MAJOR: Return AdminInterface
      */
     public function getAssociationAdmin();
+
+    // NEXT_MAJOR: Uncomment the following line
+    // public function hasAssociationAdmin(): bool;
 
     /**
      * Returns true if the FieldDescription is linked to an identifier field.
@@ -215,6 +224,9 @@ interface FieldDescriptionInterface
      * @return AdminInterface the admin class linked to this FieldDescription
      */
     public function getAdmin();
+
+    // NEXT_MAJOR: Uncomment the following line
+    // public function hasAdmin(): bool;
 
     /**
      * merge option values related to the provided option name.

--- a/src/Admin/ParentAdminInterface.php
+++ b/src/Admin/ParentAdminInterface.php
@@ -48,7 +48,7 @@ interface ParentAdminInterface
      *
      * @param string $code
      *
-     * @return AdminInterface|null
+     * @return AdminInterface|null // NEXT_MAJOR: Return AdminInterface
      */
     public function getChild($code);
 }

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -196,11 +196,24 @@ class Pool
      *
      * @param string $class
      *
-     * @return \Sonata\AdminBundle\Admin\AdminInterface|null
+     * @return AdminInterface|null
      */
     public function getAdminByClass($class)
     {
         if (!$this->hasAdminByClass($class)) {
+            @trigger_error(sprintf(
+                'Calling %s() when there is no admin for the class %s is deprecated since sonata-project/admin-bundle'
+                .' 3.x and will throw an exception in 4.0. Use %s::hasAdminByClass() to know if the admin exists.',
+                __METHOD__,
+                $class,
+                __CLASS__
+            ), E_USER_DEPRECATED);
+
+            // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement,
+            // uncomment the following exception and declare AdminInterface as return type
+            //
+            // throw new \LogicException(sprintf('Pool has no admin for the class %s.', $class));
+
             return null;
         }
 

--- a/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -215,7 +215,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
         try {
             $value = $fieldDescription->getValue($object);
         } catch (NoValueException $e) {
-            if ($fieldDescription->getAssociationAdmin()) {
+            if ($fieldDescription->hasAssociationAdmin()) {
                 $value = $fieldDescription->getAssociationAdmin()->getNewInstance();
             }
         }

--- a/src/Model/AuditManager.php
+++ b/src/Model/AuditManager.php
@@ -66,6 +66,7 @@ class AuditManager implements AuditManagerInterface
             }
         }
 
+        // NEXT_MAJOR: Throw a \LogicException instead.
         throw new \RuntimeException(sprintf('The class "%s" does not have any reader manager', $class));
     }
 }

--- a/src/Model/AuditManagerInterface.php
+++ b/src/Model/AuditManagerInterface.php
@@ -39,7 +39,7 @@ interface AuditManagerInterface
      *
      * @param string $class
      *
-     * @throws \RuntimeException
+     * @throws \RuntimeException // NEXT_MAJOR: Throw a \LogicException instead
      *
      * @return AuditReaderInterface
      */

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -440,7 +440,12 @@ class SonataAdminExtension extends AbstractExtension
     public function getUrlSafeIdentifier($model, ?AdminInterface $admin = null)
     {
         if (null === $admin) {
-            $admin = $this->pool->getAdminByClass(ClassUtils::getClass($model));
+            $class = ClassUtils::getClass($model);
+            if (!$this->pool->hasAdminByClass($class)) {
+                throw new \InvalidArgumentException('You must pass an admin.');
+            }
+
+            $admin = $this->pool->getAdminByClass($class);
         }
 
         return $admin->getUrlSafeIdentifier($model);

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -142,13 +142,6 @@ class PoolTest extends TestCase
         $this->assertCount(1, $this->pool->getAdminsByGroup('adminGroup2'));
     }
 
-    public function testGetAdminForClassWhenAdminClassIsNotSet(): void
-    {
-        $this->pool->setAdminClasses(['someclass' => 'sonata.user.admin.group1']);
-        $this->assertFalse($this->pool->hasAdminByClass('notexists'));
-        $this->assertNull($this->pool->getAdminByClass('notexists'));
-    }
-
     public function testGetAdminForClassWithInvalidFormat(): void
     {
         $this->expectException(\RuntimeException::class);


### PR DESCRIPTION
## Subject 

I am targeting this branch, because BC.

End of https://github.com/sonata-project/SonataAdminBundle/pull/6050 and https://github.com/sonata-project/SonataAdminBundle/pull/6104

Closes #6035.

## Changelog

```markdown
### Added
- Added `FieldDescriptionInterface::getParent()`.
- Added `FieldDescriptionInterface::getAssociationAdmin()`.
- Added `FieldDescriptionInterface::getAdmin()`.

### Deprecated
- Calling `AbstractAdmin::getChild()` when there is no child.
- Calling `BaseFieldDescription::getParent()` when there is no parent.
- Calling `BaseFieldDescription::getAssociationAdmin()` when there is no association admin.
- Calling `BaseFieldDescription::getAdmin()` when there is no admin.
- Calling `Pool::getAdminByClass()` when there is no admin for the class.
```