### PR TITLE
Prevent infinite recursion when mapping form fields with a help message

### DIFF
--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -140,7 +140,7 @@ class FormMapper extends BaseGroupedMapper
             }
 
             if (null !== $help) {
-                $this->admin->getFormFieldDescription($name)->setHelp($help);
+                $fieldDescription->setHelp($help);
             }
         }
 

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -112,8 +112,6 @@ class FormMapper extends BaseGroupedMapper
             $fieldDescription->setName($fieldName);
         }
 
-        $this->admin->addFormFieldDescription($fieldName, $fieldDescription);
-
         if ($name instanceof FormBuilderInterface) {
             $type = null;
             $options = [];
@@ -143,6 +141,8 @@ class FormMapper extends BaseGroupedMapper
                 $fieldDescription->setHelp($help);
             }
         }
+
+        $this->admin->addFormFieldDescription($fieldName, $fieldDescription);
 
         if (!isset($fieldDescriptionOptions['role']) || $this->admin->isGranted($fieldDescriptionOptions['role'])) {
             $this->formBuilder->add($name, $type, $options);

--- a/tests/App/Admin/FooAdmin.php
+++ b/tests/App/Admin/FooAdmin.php
@@ -28,7 +28,7 @@ final class FooAdmin extends AbstractAdmin
 
     protected function configureFormFields(FormMapper $form)
     {
-        $form->add('name', TextType::class);
+        $form->add('name', TextType::class, ['help' => 'Help me!']);
     }
 
     protected function configureShowFields(ShowMapper $show)


### PR DESCRIPTION
##  Subject

<!-- Describe your Pull Request content here -->
Avoid a call to `AbstractAdmin::getFormFieldDescription` in `FormMapper::add`. Instead call the already fetched form field description. This prevents an infinite recursion when the 'help' option is used to map form fields.

Added a naive test by modifying the fixtures. If there is a more proper way to test this bug then I am open to feedback. 
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a small bug fix suitable for a patch release.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6142.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Infinite recursion error when mapping form fields with a help option set.
```