### PR TITLE
Can't use datetime field type as editable

### DIFF
--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Action;
 
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -119,8 +120,8 @@ final class SetObjectFieldValueAction
             $propertyPath = new PropertyPath($field);
         }
 
-        // Handle date and datetime types have setter expecting a DateTime object
-        if ('' !== $value && \in_array($fieldDescription->getType(), ['date', 'datetime'], true)) {
+        // Handle date type has setter expect a DateTime object
+        if ('' !== $value && TemplateRegistry::TYPE_DATE === $fieldDescription->getType()) {
             $inputTimezone = new \DateTimeZone(date_default_timezone_get());
             $outputTimezone = $fieldDescription->getOption('timezone');
 
@@ -133,13 +134,13 @@ final class SetObjectFieldValueAction
         }
 
         // Handle boolean type transforming the value into a boolean
-        if ('' !== $value && 'boolean' === $fieldDescription->getType()) {
+        if ('' !== $value && TemplateRegistry::TYPE_BOOLEAN === $fieldDescription->getType()) {
             $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
         }
 
         // Handle entity choice association type, transforming the value into entity
         if ('' !== $value
-            && 'choice' === $fieldDescription->getType()
+            && TemplateRegistry::TYPE_CHOICE === $fieldDescription->getType()
             && null !== $fieldDescription->getOption('class')
             // NEXT_MAJOR: Replace this call with "$fieldDescription->getOption('class') === $fieldDescription->getTargetModel()".
             && $this->hasFieldDescriptionAssociationWithClass($fieldDescription, $fieldDescription->getOption('class'))

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -55,6 +55,7 @@ file that was distributed with this source code.
             ) %}
 
             {% if field_description.type == constant('Sonata\\AdminBundle\\Templating\\TemplateRegistry::TYPE_DATE') and value is not empty %}
+                {# it is a x-editable format https://vitalets.github.io/x-editable/docs.html#date #}
                 {% set data_value = value|date('Y-m-d', options.timezone|default(null)) %}
             {% elseif field_description.type == constant('Sonata\\AdminBundle\\Templating\\TemplateRegistry::TYPE_BOOLEAN') and value is empty %}
                 {% set data_value = 0 %}
@@ -69,6 +70,9 @@ file that was distributed with this source code.
                   data-value="{{ data_value }}"
                   {% if field_description.label is not same as(false) %}
                     data-title="{{ field_description.label|trans({}, field_description.translationDomain) }}"
+                  {% endif %}
+                  {% if field_description.type == constant('Sonata\\AdminBundle\\Templating\\TemplateRegistry::TYPE_DATE') %}
+                    data-format="yyyy-mm-dd"
                   {% endif %}
                   data-pk="{{ admin.id(object) }}"
                   data-url="{{ url }}" {% endblock %}>

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -200,65 +200,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->assertSame($defaultTimezone->getName(), $object->getDateProp()->getTimezone()->getName());
     }
 
-    /**
-     * @dataProvider getTimeZones
-     */
-    public function testSetObjectFieldValueActionWithDateTime($timezone, \DateTimeZone $expectedTimezone): void
-    {
-        $object = new Bafoo();
-        $request = new Request([
-            'code' => 'sonata.post.admin',
-            'objectId' => 42,
-            'field' => 'datetimeProp',
-            'value' => '2020-12-12 23:11:23',
-            'context' => 'list',
-        ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
-
-        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
-        $pool = $this->prophesize(Pool::class);
-        $translator = $this->prophesize(TranslatorInterface::class);
-        $propertyAccessor = new PropertyAccessor();
-        $templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
-        $container = $this->prophesize(ContainerInterface::class);
-
-        $this->admin->getObject(42)->willReturn($object);
-        $this->admin->getCode()->willReturn('sonata.post.admin');
-        $this->admin->hasAccess('edit', $object)->willReturn(true);
-        $this->admin->getListFieldDescription('datetimeProp')->willReturn($fieldDescription->reveal());
-        $this->admin->update($object)->shouldBeCalled();
-
-        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
-        $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
-        $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
-        $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
-        $this->twig->addExtension(new SonataAdminExtension(
-            $pool->reveal(),
-            null,
-            $translator->reveal(),
-            $container->reveal()
-        ));
-        $fieldDescription->getOption('editable')->willReturn(true);
-        $fieldDescription->getOption('timezone')->willReturn($timezone);
-        $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
-        $fieldDescription->getType()->willReturn('datetime');
-        $fieldDescription->getTemplate()->willReturn('field_template');
-        $fieldDescription->getValue(Argument::cetera())->willReturn('some value');
-
-        $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
-
-        $response = ($this->action)($request);
-
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-
-        $defaultTimezone = new \DateTimeZone(date_default_timezone_get());
-        $expectedDate = new \DateTime($request->query->get('value'), $expectedTimezone);
-        $expectedDate->setTimezone($defaultTimezone);
-
-        $this->assertInstanceOf(\DateTime::class, $object->getDatetimeProp());
-        $this->assertSame($expectedDate->format('Y-m-d H:i:s'), $object->getDatetimeProp()->format('Y-m-d H:i:s'));
-        $this->assertSame($defaultTimezone->getName(), $object->getDatetimeProp()->getTimezone()->getName());
-    }
-
     public function testSetObjectFieldValueActionOnARelationField(): void
     {
         $object = new Baz();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
~~In PR #6071 added hendleing a `datetime` field type to `SetObjectFieldValueAction`, but this type is not really editable.~~

Unfortunately, i want to say that it is not possible to use the datetime type as editable due to the conflict of dependencies in [X-editable](https://vitalets.github.io/x-editable/). Attempting to use the datetime type as editable will result in an error in JavaScript at [this line](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Resources/public/vendor/x-editable/dist/bootstrap3-editable/js/bootstrap-editable.js#L6552).

```
Uncaught TypeError: Cannot read property 'parseFormat' of undefined
    at DateTime.initPicker (bootstrap-editable.min.js:6554)
    at new DateTime (bootstrap-editable.min.js:6522)
    at Object.createInput (bootstrap-editable.min.js:859)
    at Editable.init (bootstrap-editable.min.js:1498)
    at new Editable (bootstrap-editable.min.js:1477)
    at HTMLSpanElement.<anonymous> (bootstrap-editable.min.js:2139)
    at Function.each (jquery.js:374)
    at n.fn.init.each (jquery.js:139)
    at n.fn.init.$.fn.editable (bootstrap-editable.min.js:2125)
    at Object.setup_xeditable (Admin.js:211)
```

Attempting to update the X-editable code to the latest version (1.5.1 => 1.5.3) will fail. This code has [not changed](https://github.com/vitalets/x-editable/blob/develop/dist/bootstrap3-editable/js/bootstrap-editable.js#L6628) in the original library.

Problem due to [dependency](https://vitalets.github.io/x-editable/docs.html#datetime):

> Based on [smalot bootstrap-datetimepicker plugin](https://github.com/smalot/bootstrap-datetimepicker). Before usage you should manually include dependent js and css:
>
> ```html
> <link href="css/datetimepicker.css" rel="stylesheet" type="text/css"></link> 
> <script src="js/bootstrap-datetimepicker.js"></script>
> ```

The [link](https://github.com/smalot/bootstrap-datetimepicker) indicates a project (`bootstrap-datetime-picker`) that is deprecated in favour of [eonasdan-bootstrap-datetimepicker](https://eonasdan.github.io/bootstrap-datetimepicker/). The `eonasdan-bootstrap-datetimepicker` is [already used](https://github.com/sonata-project/SonataCoreBundle/tree/3.x/src/CoreBundle/Resources/public/vendor/eonasdan-bootstrap-datetimepicker) in the SonataCoreBundle, but it is not compatible with X-editable.

For X-editable, the old version of the library is needed because the [next line](https://github.com/smalot/bootstrap-datetimepicker/blob/master/js/bootstrap-datetimepicker.js#L1939) is there. X-editable breaks because variable `$.fn.datetimepicker.DPGlobal` is not defined.

Connecting both libraries is not possible. They will conflict.

I also updated the documentation because it is outdated.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

<!--
Closes #6071.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Can't use `datetime` field type as editable
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
