### PR TITLE
Fix BC after drop twig/extensions

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -34,13 +34,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('sonata_admin');
-
-        // Keep compatibility with symfony/config < 4.2
-        if (!method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->root('sonata_admin');
-        } else {
-            $rootNode = $treeBuilder->getRootNode();
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $caseSensitiveInfo = <<<'CASESENSITIVE'
 Whether the global search should behave case sensitive or not.
@@ -176,6 +170,7 @@ CASESENSITIVE;
                         // NEXT_MAJOR : remove this option
                         ->booleanNode('legacy_twig_text_extension')
                             ->info('Use text filters from "twig/extensions" instead of those provided by "twig/string-extra".')
+                            ->setDeprecated('The child node "%node%" at path "%path%" is deprecated since sonata-project/admin-bundle 3.x and will be remove in 4.0.')
                             ->defaultValue(static function (): bool {
                                 @trigger_error(
                                     'Using `true` as value for "sonata_admin.options.legacy_twig_text_extension" option is deprecated since sonata-project/admin-bundle 3.64. '.
@@ -188,8 +183,8 @@ CASESENSITIVE;
                                 ->ifTrue()
                                 ->then(static function (bool $v): bool {
                                     @trigger_error(
-                                        'Using `true` as value for "sonata_admin.options.legacy_twig_text_extension" option is deprecated since sonata-project/admin-bundle 3.64. '.
-                                        'You should set it to `false`, which will be the default value since version 4.0.'
+                                        'Using `true` as value for "sonata_admin.options.legacy_twig_text_extension" option is deprecated since sonata-project/admin-bundle 3.64 and will be remove in 4.0'.
+                                        'You should set it to `false` before upgrade process.'
                                     );
 
                                     return $v;

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -323,21 +323,18 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $modelChoice->replaceArgument(0, new Reference('form.property_accessor'));
     }
 
+    /**
+     * NEXT_MAJOR: remove this method.
+     */
     private function configureTwigTextExtension(ContainerBuilder $container, XmlFileLoader $loader, array $config): void
     {
-        $bundles = $container->getParameter('kernel.bundles');
-
         $container->setParameter('sonata.admin.configuration.legacy_twig_text_extension', $config['options']['legacy_twig_text_extension']);
         $loader->load('twig_string.xml');
 
-        if (isset($bundles['SonataCoreBundle']) && false !== $config['options']['legacy_twig_text_extension']) {
-            $stringExtension = $container->getDefinition('sonata.string.twig.extension');
-            $stringExtension->replaceArgument(0, new Reference('sonata.core.twig.extension.text'));
-        } elseif (isset($bundles['SonataTwigBundle']) && false !== $config['options']['legacy_twig_text_extension']) {
-            if ($container->getDefinition('sonata.twig.extension.deprecated_text_extension')) {
-                $stringExtension = $container->getDefinition('sonata.string.twig.extension');
-                $stringExtension->replaceArgument(0, new Reference('sonata.twig.extension.deprecated_text_extension'));
-            }
+        if (false !== $config['options']['legacy_twig_text_extension']) {
+            $container
+                ->getDefinition('sonata.string.twig.extension')
+                ->replaceArgument(0, new Reference('sonata.deprecated_text.twig.extension'));
         }
     }
 }

--- a/src/Resources/config/twig_string.xml
+++ b/src/Resources/config/twig_string.xml
@@ -5,5 +5,9 @@
             <tag name="twig.extension"/>
             <argument>null</argument>
         </service>
+        <service id="sonata.deprecated_text.twig.extension" class="Sonata\AdminBundle\Twig\Extension\DeprecatedTextExtension">
+            <deprecated/>
+            <tag name="twig.extension"/>
+        </service>
     </services>
 </container>

--- a/src/Twig/Extension/DeprecatedTextExtension.php
+++ b/src/Twig/Extension/DeprecatedTextExtension.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig\Extension;
+
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+
+/**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @internal
+ *
+ * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+ *
+ * This class is used to support `Sonata\AdminBundle\Twig\Extension\StringExtensions` when `sonata_admin.options.legacy_twig_text_extension`
+ * is set to true and deprecated `twig/extensions` is not installed. It is copy of required function, which keep BC for `sonata_truncate`
+ * twig filter until sonata-project/admin-bundle 4.0 where this filter will be dropped.
+ */
+final class DeprecatedTextExtension extends AbstractExtension
+{
+    public function twigTruncateFilter(Environment $env, ?string $value, int $length = 30, bool $preserve = false, $separator = '...')
+    {
+        if (\function_exists('mb_get_info')) {
+            if (mb_strlen($value, $env->getCharset()) > $length) {
+                if ($preserve) {
+                    // If breakpoint is on the last word, return the value without separator.
+                    if (false === ($breakpoint = mb_strpos($value, ' ', $length, $env->getCharset()))) {
+                        return $value;
+                    }
+
+                    $length = $breakpoint;
+                }
+
+                return rtrim(mb_substr($value, 0, $length, $env->getCharset())).$separator;
+            }
+        } else {
+            if (\strlen($value) > $length) {
+                if ($preserve) {
+                    if (false !== ($breakpoint = strpos($value, ' ', $length))) {
+                        $length = $breakpoint;
+                    }
+                }
+
+                return rtrim(substr($value, 0, $length)).$separator;
+            }
+        }
+
+        return $value;
+    }
+}

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -342,15 +342,13 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
     {
         $this->load();
 
-        $bundles = $this->container->getParameter('kernel.bundles');
         $this->assertTrue($this->container->getParameter('sonata.admin.configuration.legacy_twig_text_extension'));
         $this->assertContainerBuilderHasService('sonata.string.twig.extension');
 
-        if (isset($bundles['SonataCoreBundle'])) {
-            $this->assertSame('sonata.core.twig.extension.text', (string) $this->container->getDefinition('sonata.string.twig.extension')->getArgument(0));
-        } else {
-            $this->assertNull($this->container->getDefinition('sonata.string.twig.extension')->getArgument(0));
-        }
+        $this->assertSame(
+            'sonata.deprecated_text.twig.extension',
+            (string) $this->container->getDefinition('sonata.string.twig.extension')->getArgument(0)
+        );
 
         $this->load([
             'options' => [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This issue resolve problem with missing TextExtension after drop CoreBundle and upgrate sonata-project/twig-extensions to 1.x when `sonata_admin.options.legacy_twig_text_extension` is set to __true__. It is resolve by copy truncate function to new `DeprecatedTextExtension` class.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change repsect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataPageBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `sonata_admin.options.legacy_twig_text_extension` configuration
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

