### PR TITLE
Stop building show/list/form when accessing fieldDescription

### DIFF
--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -184,8 +184,6 @@ final class RetrieveAutocompleteItemsAction
         AdminInterface $admin,
         string $field
     ): FieldDescriptionInterface {
-        $admin->getFilterFieldDescriptions();
-
         $fieldDescription = $admin->getFilterFieldDescription($field);
 
         if (!$fieldDescription) {
@@ -208,8 +206,6 @@ final class RetrieveAutocompleteItemsAction
         AdminInterface $admin,
         string $field
     ): FieldDescriptionInterface {
-        $admin->getFormFieldDescriptions();
-
         $fieldDescription = $admin->getFormFieldDescription($field);
 
         if (!$fieldDescription) {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -399,10 +399,14 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      * @var array<string, bool>
      */
     protected $loaded = [
-        'view_fields' => false,
-        'view_groups' => false,
+        'view_fields' => false, // NEXT_MAJOR: Remove this unused value.
+        'view_groups' => false, // NEXT_MAJOR: Remove this unused value.
         'routes' => false,
         'tab_menu' => false,
+        'show' => false,
+        'list' => false,
+        'form' => false,
+        'datagrid' => false,
     ];
 
     /**
@@ -845,11 +849,16 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return $parameters;
     }
 
+    /**
+     * NEXT_MAJOR: Change the visibility to protected (similar to buildShow, buildForm, ...).
+     */
     public function buildDatagrid()
     {
-        if ($this->datagrid) {
+        if ($this->loaded['datagrid']) {
             return;
         }
+
+        $this->loaded['datagrid'] = true;
 
         $filterParameters = $this->getFilterParameters();
 
@@ -3255,9 +3264,11 @@ EOT;
      */
     protected function buildShow()
     {
-        if ($this->show) {
+        if ($this->loaded['show']) {
             return;
         }
+
+        $this->loaded['show'] = true;
 
         $this->show = $this->getShowBuilder()->getBaseList();
         $mapper = new ShowMapper($this->getShowBuilder(), $this->show, $this);
@@ -3274,9 +3285,11 @@ EOT;
      */
     protected function buildList()
     {
-        if ($this->list) {
+        if ($this->loaded['list']) {
             return;
         }
+
+        $this->loaded['list'] = true;
 
         $this->list = $this->getListBuilder()->getBaseList();
         $mapper = new ListMapper($this->getListBuilder(), $this->list, $this);
@@ -3333,9 +3346,11 @@ EOT;
      */
     protected function buildForm()
     {
-        if ($this->form) {
+        if ($this->loaded['form']) {
             return;
         }
+
+        $this->loaded['form'] = true;
 
         // append parent object if any
         // todo : clean the way the Admin class can retrieve set the object

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -33,18 +33,19 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
- * @method array  configureActionButtons(string $action, ?object $object = null)
- * @method string getSearchResultLink(object $object)
- * @method void   showMosaicButton(bool $isShown)
- * @method bool   isDefaultFilter(string $name)
- * @method bool   isCurrentRoute(string $name, ?string $adminCode)
- * @method bool   canAccessObject(string $action, object $object)
- * @method mixed  getPersistentParameter(string $name)
- * @method array            getExportFields
- * @method array            getSubClasses
- * @method AdminInterface   getRoot
- * @method string           getRootCode
- * @method array getActionButtons(string $action, ?object $object)
+ * @method array                           configureActionButtons(string $action, ?object $object = null)
+ * @method string                          getSearchResultLink(object $object)
+ * @method void                            showMosaicButton(bool $isShown)
+ * @method bool                            isDefaultFilter(string $name)
+ * @method bool                            isCurrentRoute(string $name, ?string $adminCode)
+ * @method bool                            canAccessObject(string $action, object $object)
+ * @method mixed                           getPersistentParameter(string $name)
+ * @method array                           getExportFields()
+ * @method array                           getSubClasses()
+ * @method AdminInterface                  getRoot()
+ * @method string                          getRootCode()
+ * @method array                           getActionButtons(string $action, ?object $object)
+ * @method FieldDescriptionCollection|null getList()
  */
 interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface
 {
@@ -270,6 +271,9 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function getShow();
 
+//    NEXT_MAJOR: uncomment this method in 4.0
+//    public function getList(): ?FieldDescriptionCollection;
+
     public function setFormTheme(array $formTheme);
 
     /**
@@ -360,6 +364,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function getSubject();
 
     /**
+     * NEXT_MAJOR: Remove this method, since it's already in FieldDescriptionRegistryInterface.
+     *
      * Returns a list FieldDescription.
      *
      * @param string $name
@@ -369,6 +375,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function getListFieldDescription($name);
 
     /**
+     * NEXT_MAJOR: Remove this method, since it's already in FieldDescriptionRegistryInterface.
+     *
      * Returns true if the list FieldDescription exists.
      *
      * @param string $name
@@ -378,6 +386,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function hasListFieldDescription($name);
 
     /**
+     * NEXT_MAJOR: Remove this method, since it's already in FieldDescriptionRegistryInterface.
+     *
      * Returns the collection of list FieldDescriptions.
      *
      * @return array
@@ -542,6 +552,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function reorderShowGroup($group, array $keys);
 
     /**
+     * NEXT_MAJOR: Remove this method, since it's already in FieldDescriptionRegistryInterface.
+     *
      * add a FieldDescription.
      *
      * @param string $name
@@ -549,6 +561,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function addFormFieldDescription($name, FieldDescriptionInterface $fieldDescription);
 
     /**
+     * NEXT_MAJOR: Remove this method, since it's already in FieldDescriptionRegistryInterface.
+     *
      * Remove a FieldDescription.
      *
      * @param string $name

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1597,6 +1597,13 @@ class AdminTest extends TestCase
         $this->assertInstanceOf(Collection::class, $tag->getPosts());
         $this->assertCount(2, $tag->getPosts());
         $this->assertContains($post, $tag->getPosts());
+    }
+
+    public function testGetFormWithArrayParentValue(): void
+    {
+        $post = new Post();
+        $tagAdmin = $this->createTagAdmin($post);
+        $tag = $tagAdmin->getSubject();
 
         // Case of an array
         $tag->setPosts([]);

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -43,6 +43,11 @@ use Sonata\AdminBundle\Route\RoutesCache;
 use Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface;
 use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
+use Sonata\AdminBundle\Tests\App\Builder\DatagridBuilder;
+use Sonata\AdminBundle\Tests\App\Builder\FormContractor;
+use Sonata\AdminBundle\Tests\App\Builder\ListBuilder;
+use Sonata\AdminBundle\Tests\App\Builder\ShowBuilder;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\AvoidInfiniteLoopAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentVoteAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentWithCustomRouteAdmin;
@@ -67,6 +72,9 @@ use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\FormRegistry;
+use Symfony\Component\Form\ResolvedFormTypeFactory;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -2500,6 +2508,37 @@ class AdminTest extends TestCase
         $admin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', null);
 
         $this->assertNull($admin->getBaseControllerName());
+    }
+
+    public function testAdminAvoidInifiniteLoop(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $formFactory = new FormFactory(new FormRegistry([], new ResolvedFormTypeFactory()));
+
+        $admin = new AvoidInfiniteLoopAdmin('code', \stdClass::class, null);
+        $admin->setSubject(new \stdClass());
+
+        $admin->setFormContractor(new FormContractor($formFactory));
+
+        $admin->setShowBuilder(new ShowBuilder());
+
+        $admin->setListBuilder(new ListBuilder());
+
+        $pager = $this->createStub(PagerInterface::class);
+        $admin->setDatagridBuilder(new DatagridBuilder($formFactory, $pager));
+
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->method('getMetadataFor')->willReturn($this->createStub(MemberMetadata::class));
+        $admin->setValidator($validator);
+
+        $routeGenerator = $this->createStub(RouteGeneratorInterface::class);
+        $admin->setRouteGenerator($routeGenerator);
+
+        $admin->getForm();
+        $admin->getShow();
+        $admin->getList();
+        $admin->getDatagrid();
     }
 
     /**

--- a/tests/Fixtures/Admin/AvoidInfiniteLoopAdmin.php
+++ b/tests/Fixtures/Admin/AvoidInfiniteLoopAdmin.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Show\ShowMapper;
+
+final class AvoidInfiniteLoopAdmin extends AbstractAdmin
+{
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+    {
+        $this->getFilterFieldDescriptions();
+        $this->hasFilterFieldDescription('help');
+    }
+
+    protected function configureListFields(ListMapper $listMapper): void
+    {
+        $this->getListFieldDescriptions();
+        $this->hasFilterFieldDescription('help');
+    }
+
+    protected function configureFormFields(FormMapper $formMapper): void
+    {
+        $this->getFormFieldDescriptions();
+        $this->hasFilterFieldDescription('help');
+    }
+
+    protected function configureShowFields(ShowMapper $showMapper): void
+    {
+        $this->getShowFieldDescriptions();
+        $this->hasFilterFieldDescription('help');
+    }
+}


### PR DESCRIPTION
## Subject

I am targeting this branch, because I think I have found a BC-way to fix the bug (https://github.com/sonata-project/SonataAdminBundle/issues/6142) which can easily occur and create infinite loop.

Currently methods `getFormFieldDescriptions`, `getFormFieldDescription` and `hasFormFieldDescription` are calling `this->buildForm`.
But the `buildForm` method is calling lot of things, as shown in the issue, we may find
```
if (null !== $help) {
    $this->admin->getFormFieldDescription($name)->setHelp($help);
}
```
in the FormMapper->add, or
```
$formMapper->setHelps(['name' => 'help_page_name']);
```
in the SonataPageBundle configureFormField method witch lead to a `hasFormFieldDescriptions` call.

The developper could also possibly use the `getFormFieldDescriptions`, `getFormFieldDescription` and `hasFormFieldDescription` in the configureFormField and create an infinite loop.

Before we didn't try to build the form if the form was already build.
By adding a state, I now do not try to build the form if the build of the form already started.

Closes #6142.

## Changelog

```markdown
### Fixed
- `getFormFieldDescriptions`, `getFormFieldDescription` and `hasFormFieldDescription` doesn't build form anymore if the build already started, avoiding an infinite loop.
- `getShowFieldDescriptions`, `getShowFieldDescription` and `hasShowFieldDescription` doesn't build show anymore if the build already started, avoiding an infinite loop.
- `getListFieldDescriptions`, `getListFieldDescription` and `hasListFieldDescription` doesn't build list anymore if the build already started, avoiding an infinite loop.
- `getFilterFieldDescriptions`, `getFilterFieldDescription` and `hasFilterFieldDescription` doesn't build datagrid anymore if the build already started, avoiding an infinite loop.
```