### PR TITLE
Simplify setting help in field description (minor)

### DIFF
--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -131,14 +131,9 @@ class FormMapper extends BaseGroupedMapper
                 $options['label'] = $this->admin->getLabelTranslatorStrategy()->getLabel($name, 'form', 'label');
             }
 
-            $help = null;
             if (isset($options['help'])) {
-                $help = $options['help'];
+                $fieldDescription->setHelp($options['help']);
                 unset($options['help']);
-            }
-
-            if (null !== $help) {
-                $fieldDescription->setHelp($help);
             }
         }
 


### PR DESCRIPTION
## Subject

When looking at #6143 I noticed that the FormMapper uses convoluted logic to set the help text in a field description.

I am targeting this branch, because it is backwards compatible.

## Changelog

As this is a simple refactoring with no visible effect to the user I think no changelog entry should be added.