### PR TITLE
Added phpstan to v3

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,0 +1,12 @@
+on: [push, pull_request]
+name: Quality assurance
+jobs:
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: PHPStan
+        uses: "docker://oskarstark/phpstan-ga"
+        with:
+          args: analyse

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,9 @@
     "require-dev": {
         "jms/translation-bundle": "^1.4",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+        "mopa/bootstrap-bundle": "^3.3",
+        "phpstan/phpstan": "^0.12.29",
+        "psr/event-dispatcher": "^1.0",
         "sonata-project/intl-bundle": "^2.4",
         "symfony/browser-kit": "^4.3",
         "symfony/css-selector": "^4.3",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,17 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection not found\\.$#"
+			count: 1
+			path: src/Admin/AdminHelper.php
+
+		-
+			message: "#^Class Doctrine\\\\ORM\\\\PersistentCollection not found\\.$#"
+			count: 1
+			path: src/Admin/AdminHelper.php
+
+		-
+			message: "#^Instantiated class JMS\\\\DiExtraBundle\\\\DependencyInjection\\\\Configuration not found\\.$#"
+			count: 1
+			path: src/DependencyInjection/SonataAdminExtension.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,16 @@
+includes:
+    - phpstan-baseline.neon
+parameters:
+    level: 0
+
+    paths:
+        - src
+    excludes_analyse:
+        # Class Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList not found. I can't even find this class too
+        - src/Form/ChoiceList/ModelChoiceList.php
+        - src/Form/DataTransformer/LegacyModelsToArrayTransformer.php
+        - src/Form/DataTransformer/ModelsToArrayTransformer.php
+        - src/Annotation/Admin.php
+        - src/Form/Type/ModelType.php
+        # temporarily ignore template files
+        - src/Resources/**.tpl.php


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because {reason}.
- added dev dependencies (some code, for example src/SonataAdminBundle.php, uses other package dependencies (Mopa\Bundle\BootstrapBundle).
  Phpstan can't parse the class and throws error)
- added github workflow (mostly copy/paste the existing in 4.x version)
- ignore some classes (mostly because of "Class Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList not found."; ignored template files)
No code was touched, so that I'm only adding phpstan as dependency in this PR.
Closes #6152 


```markdown
### Added
- `phpstan` and it's github workflow
```
