### PR TITLE
Allow null param for StringExtension construct

### DIFF
--- a/src/Twig/Extension/StringExtension.php
+++ b/src/Twig/Extension/StringExtension.php
@@ -36,15 +36,18 @@ use Twig\TwigFilter;
 final class StringExtension extends AbstractExtension
 {
     /**
-     * @var AbstractExtension
+     * @var AbstractExtension|null
      */
     private $legacyExtension;
 
     public function __construct(?AbstractExtension $legacyExtension = null)
     {
-        if (!$legacyExtension instanceof TextExtension && !$legacyExtension instanceof DeprecatedTextExtension) {
+        if (null !== $legacyExtension
+            && !$legacyExtension instanceof TextExtension
+            && !$legacyExtension instanceof DeprecatedTextExtension
+        ) {
             throw new \TypeError(sprintf(
-                'Argument 1 passed to %s::__construct() must be instance of %s or %s',
+                'Argument 1 passed to %s::__construct() must be instance of %s or %s or null',
                 self::class,
                 TextExtension::class,
                 DeprecatedTextExtension::class


### PR DESCRIPTION
## Subject

<!-- Describe your Pull Request content here -->

Targeting this branch, because BC.

<!-- 
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6158

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Allow null argument for StringExtension construct
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
