### PR TITLE
Set defaults filters without request

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -808,7 +808,12 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     public function getFilterParameters()
     {
-        $parameters = [];
+        $parameters = array_merge(
+            $this->getModelManager()->getDefaultSortValues($this->getClass()),
+            $this->datagridValues, // NEXT_MAJOR: Remove this line.
+            $this->getDefaultSortValues(),
+            $this->getDefaultFilterValues()
+        );
 
         // build the values array
         if ($this->hasRequest()) {
@@ -837,23 +842,17 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
                 }
             }
 
-            $parameters = array_merge(
-                $this->getModelManager()->getDefaultSortValues($this->getClass()),
-                $this->datagridValues, // NEXT_MAJOR: Remove this line.
-                $this->getDefaultSortValues(),
-                $this->getDefaultFilterValues(),
-                $filters
-            );
-
-            if (!$this->determinedPerPageValue($parameters['_per_page'])) {
-                $parameters['_per_page'] = $this->getMaxPerPage();
-            }
+            $parameters = array_merge($parameters, $filters);
 
             // always force the parent value
             if ($this->isChild() && $this->getParentAssociationMapping()) {
                 $name = str_replace('.', '__', $this->getParentAssociationMapping());
                 $parameters[$name] = ['value' => $this->request->get($this->getParent()->getIdParameter())];
             }
+        }
+
+        if (!$this->determinedPerPageValue($parameters['_per_page'])) {
+            $parameters['_per_page'] = $this->getMaxPerPage();
         }
 
         return $parameters;

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1906,7 +1906,7 @@ class AdminTest extends TestCase
 
         $parameters = $commentAdmin->getFilterParameters();
 
-        $this->assertTrue(isset($parameters['post__author']));
+        $this->assertArrayHasKey('post__author', $parameters);
         $this->assertSame(['value' => $authorId], $parameters['post__author']);
     }
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1878,6 +1878,38 @@ class AdminTest extends TestCase
         $this->assertSame(['value' => $authorId], $parameters['post__author']);
     }
 
+    public function testGetFilterParametersWithoutRequest(): void
+    {
+        $authorId = uniqid();
+
+        $postAdmin = new PostAdmin(
+            'sonata.post.admin.post',
+            'Application\Sonata\NewsBundle\Entity\Post',
+            'Sonata\NewsBundle\Controller\PostAdminController'
+        );
+
+        $commentAdmin = new CommentAdmin(
+            'sonata.post.admin.comment',
+            'Application\Sonata\NewsBundle\Entity\Comment',
+            'Sonata\NewsBundle\Controller\CommentAdminController'
+        );
+        $commentAdmin->setParentAssociationMapping('post.author');
+        $commentAdmin->setParent($postAdmin);
+
+        $modelManager = $this->createMock(ModelManagerInterface::class);
+        $modelManager
+            ->method('getDefaultSortValues')
+            ->willReturn([])
+        ;
+
+        $commentAdmin->setModelManager($modelManager);
+
+        $parameters = $commentAdmin->getFilterParameters();
+
+        $this->assertTrue(isset($parameters['post__author']));
+        $this->assertSame(['value' => $authorId], $parameters['post__author']);
+    }
+
     public function testGetFilterFieldDescription(): void
     {
         $modelAdmin = new ModelAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'Sonata\FooBundle\Controller\ModelAdminController');
@@ -1887,6 +1919,10 @@ class AdminTest extends TestCase
         $bazFieldDescription = new FieldDescription();
 
         $modelManager = $this->createMock(ModelManagerInterface::class);
+        $modelManager
+            ->method('getDefaultSortValues')
+            ->willReturn([]);
+
         $modelManager->expects($this->exactly(3))
             ->method('getNewFieldDescriptionInstance')
             ->willReturnCallback(static function ($adminClass, string $name, $filterOptions) use ($fooFieldDescription, $barFieldDescription, $bazFieldDescription) {

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1896,7 +1896,7 @@ class AdminTest extends TestCase
         $commentAdmin->setParentAssociationMapping('post.author');
         $commentAdmin->setParent($postAdmin);
 
-        $modelManager = $this->createMock(ModelManagerInterface::class);
+        $modelManager = $this->createStub(ModelManagerInterface::class);
         $modelManager
             ->method('getDefaultSortValues')
             ->willReturn([])

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1880,7 +1880,7 @@ class AdminTest extends TestCase
 
     public function testGetFilterParametersWithoutRequest(): void
     {
-        $authorId = uniqid();
+        $authorId = 1001;
 
         $postAdmin = new PostAdmin(
             'sonata.post.admin.post',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

No request is needed to set default values. 

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
Setting default values ​​for filters and sorting without setting request
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--

-->
