### PR TITLE
Show and edit date in the same timezone

### DIFF
--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -121,7 +121,15 @@ final class SetObjectFieldValueAction
 
         // Handle date and datetime types have setter expecting a DateTime object
         if ('' !== $value && \in_array($fieldDescription->getType(), ['date', 'datetime'], true)) {
-            $value = new \DateTime($value);
+            $inputTimezone = new \DateTimeZone(date_default_timezone_get());
+            $outputTimezone = $fieldDescription->getOption('timezone');
+
+            if ($outputTimezone && !$outputTimezone instanceof \DateTimeZone) {
+                $outputTimezone = new \DateTimeZone($outputTimezone);
+            }
+
+            $value = new \DateTime($value, $outputTimezone ?: $inputTimezone);
+            $value->setTimezone($inputTimezone);
         }
 
         // Handle boolean type transforming the value into a boolean

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -55,7 +55,7 @@ file that was distributed with this source code.
             ) %}
 
             {% if field_description.type == constant('Sonata\\AdminBundle\\Templating\\TemplateRegistry::TYPE_DATE') and value is not empty %}
-                {% set data_value = value.format('Y-m-d') %}
+                {% set data_value = value|date('Y-m-d', options.timezone|default(null)) %}
             {% elseif field_description.type == constant('Sonata\\AdminBundle\\Templating\\TemplateRegistry::TYPE_BOOLEAN') and value is empty %}
                 {% set data_value = 0 %}
             {% elseif value is iterable %}

--- a/tests/Action/Bafoo.php
+++ b/tests/Action/Bafoo.php
@@ -31,7 +31,7 @@ class Bafoo
         return $this;
     }
 
-    public function getDatetimeProp(): \DateTime
+    public function getDatetimeProp(): ?\DateTime
     {
         return $this->datetimeProp;
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

The `date` and `datetime` field has a `timezone` option that is used as second argument for Twig's `date` function ([doc](https://symfony.com/doc/master/bundles/SonataAdminBundle/reference/action_list.html#available-types-and-associated-options)).

It seems wrong to me that the date is displayed in one time zone, and is being live-edited in another time zone. Due to the difference between the server time zone and the time zone specified in the options, we can get completely different dates, which can lead to administrative errors.

I assume that the time zone is used so that the administrator can specify his time zone and not look at all the dates in the server time zone. This is useful because JavaScript calendars do not know in which time zone the server is located and display the calendar in the user's time zone. If the time zone of the server and the user are different, this can also lead to problems.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Show and edit `date` and `datetime` in the same timezone
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
