### PR TITLE
Fix form one-to-many tabs translations

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
@@ -20,7 +20,7 @@ file that was distributed with this source code.
                                 data-toggle="tab"
                             >
                                 <i class="icon-exclamation-sign has-errors hide"></i>
-                                {{ name|trans({}, form_group.translation_domain) }}
+                                {{ form_group.label|trans({}, form_group.translation_domain|default(associationAdmin.translationDomain)) }}
                             </a>
                         </li>
                     {% endfor %}


### PR DESCRIPTION
## Subject

Currently, the tabs in a one-to-many form are not correctly translated. The groups `name` is used, instead of the `label` (like in the other templates). This is wrong especially when using the `translate_group_label: true` option.

This is BC because the `label` contains the `name` by default (see https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Mapper/BaseGroupedMapper.php#L79).

I am targeting this branch, because it's a BC bug fix.

## Changelog

```markdown
### Fixed
- Fix form one-to-many tabs translations
```

**Before**
![image](https://user-images.githubusercontent.com/663607/86456116-df87a280-bd21-11ea-820b-33593d8509e3.png)

**After**
![image](https://user-images.githubusercontent.com/663607/86456065-d1d21d00-bd21-11ea-8e28-83466af31104.png)