### PR TITLE
Process deprecation of FieldDescriptionInterface::getTargetEntity()

### DIFF
--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -190,7 +190,7 @@ final class RetrieveAutocompleteItemsAction
             throw new \RuntimeException(sprintf('The field "%s" does not exist.', $field));
         }
 
-        if (null === $fieldDescription->getTargetEntity()) {
+        if (null === $fieldDescription->getTargetModel()) {
             throw new \RuntimeException(sprintf('No associated entity with field "%s".', $field));
         }
 
@@ -212,7 +212,7 @@ final class RetrieveAutocompleteItemsAction
             throw new \RuntimeException(sprintf('The field "%s" does not exist.', $field));
         }
 
-        if (null === $fieldDescription->getTargetEntity()) {
+        if (null === $fieldDescription->getTargetModel()) {
             throw new \RuntimeException(sprintf('No associated entity with field "%s".', $field));
         }
 

--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -132,7 +132,7 @@ final class SetObjectFieldValueAction
         if ('' !== $value
             && 'choice' === $fieldDescription->getType()
             && null !== $fieldDescription->getOption('class')
-            && $fieldDescription->getOption('class') === $fieldDescription->getTargetEntity()
+            && $fieldDescription->getOption('class') === $fieldDescription->getTargetModel()
         ) {
             $value = $admin->getModelManager()->find($fieldDescription->getOption('class'), $value);
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1430,11 +1430,11 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
             $admin = $pool->getAdminByAdminCode($adminCode);
         } else {
-            if (!$pool->hasAdminByClass($fieldDescription->getTargetEntity())) {
+            if (!$pool->hasAdminByClass($fieldDescription->getTargetModel())) {
                 return;
             }
 
-            $admin = $pool->getAdminByClass($fieldDescription->getTargetEntity());
+            $admin = $pool->getAdminByClass($fieldDescription->getTargetModel());
         }
 
         if ($this->hasRequest()) {

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -94,7 +94,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $this->admin->getFormFieldDescriptions()->willReturn(null);
         $this->admin->getFormFieldDescription('barField')->willReturn($fieldDescription->reveal());
 
-        $fieldDescription->getTargetEntity()->willReturn(Foo::class);
+        $fieldDescription->getTargetModel()->willReturn(Foo::class);
         $fieldDescription->getName()->willReturn('barField');
 
         ($this->action)($request);
@@ -120,7 +120,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $this->admin->getFormFieldDescription('barField')->willReturn($fieldDescription->reveal());
         $this->admin->getFormFieldDescriptions()->willReturn(null);
         $targetAdmin->checkAccess('list')->willReturn(null);
-        $fieldDescription->getTargetEntity()->willReturn(Foo::class);
+        $fieldDescription->getTargetModel()->willReturn(Foo::class);
         $fieldDescription->getName()->willReturn('barField');
         $fieldDescription->getAssociationAdmin()->willReturn($targetAdmin->reveal());
 
@@ -241,7 +241,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $datagrid->getPager()->willReturn($pager->reveal());
         $pager->getResults()->willReturn([$model]);
         $pager->isLastPage()->willReturn(true);
-        $fieldDescription->getTargetEntity()->willReturn(Foo::class);
+        $fieldDescription->getTargetModel()->willReturn(Foo::class);
         $fieldDescription->getName()->willReturn('barField');
         $fieldDescription->getAssociationAdmin()->willReturn($targetAdmin->reveal());
 

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -260,7 +260,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $fieldDescription->getType()->willReturn('choice');
         $fieldDescription->getOption('editable')->willReturn(true);
         $fieldDescription->getOption('class')->willReturn(Bar::class);
-        $fieldDescription->getTargetEntity()->willReturn(Bar::class);
+        $fieldDescription->getTargetModel()->willReturn(Bar::class);
         $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
         $fieldDescription->getTemplate()->willReturn('field_template');
         $fieldDescription->getValue(Argument::cetera())->willReturn('some value');

--- a/tests/App/Admin/FieldDescription.php
+++ b/tests/App/Admin/FieldDescription.php
@@ -26,6 +26,11 @@ final class FieldDescription extends BaseFieldDescription
         return null;
     }
 
+    public function getTargetModel()
+    {
+        return null;
+    }
+
     public function setFieldMapping($fieldMapping)
     {
     }

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -270,7 +270,7 @@ class HelperControllerTest extends TestCase
         $fieldDescription->getType()->willReturn('choice');
         $fieldDescription->getOption('editable')->willReturn(true);
         $fieldDescription->getOption('class')->willReturn(AdminControllerHelper_Bar::class);
-        $fieldDescription->getTargetEntity()->willReturn(AdminControllerHelper_Bar::class);
+        $fieldDescription->getTargetModel()->willReturn(AdminControllerHelper_Bar::class);
         $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
         $fieldDescription->getTemplate()->willReturn('field_template');
         $fieldDescription->getValue(Argument::cetera())->willReturn('some value');
@@ -426,7 +426,7 @@ class HelperControllerTest extends TestCase
         $this->admin->getFormFieldDescriptions()->willReturn(null);
         $this->admin->getFormFieldDescription('barField')->willReturn($fieldDescription->reveal());
 
-        $fieldDescription->getTargetEntity()->willReturn(Foo::class);
+        $fieldDescription->getTargetModel()->willReturn(Foo::class);
         $fieldDescription->getName()->willReturn('barField');
 
         $this->controller->retrieveAutocompleteItemsAction($request);
@@ -452,7 +452,7 @@ class HelperControllerTest extends TestCase
         $this->admin->getFormFieldDescription('barField')->willReturn($fieldDescription->reveal());
         $this->admin->getFormFieldDescriptions()->willReturn(null);
         $targetAdmin->checkAccess('list')->willReturn(null);
-        $fieldDescription->getTargetEntity()->willReturn(Foo::class);
+        $fieldDescription->getTargetModel()->willReturn(Foo::class);
         $fieldDescription->getName()->willReturn('barField');
         $fieldDescription->getAssociationAdmin()->willReturn($targetAdmin->reveal());
 
@@ -573,7 +573,7 @@ class HelperControllerTest extends TestCase
         $datagrid->getPager()->willReturn($pager->reveal());
         $pager->getResults()->willReturn([$model]);
         $pager->isLastPage()->willReturn(true);
-        $fieldDescription->getTargetEntity()->willReturn(Foo::class);
+        $fieldDescription->getTargetModel()->willReturn(Foo::class);
         $fieldDescription->getName()->willReturn('barField');
         $fieldDescription->getAssociationAdmin()->willReturn($targetAdmin->reveal());
 

--- a/tests/Fixtures/Admin/FieldDescription.php
+++ b/tests/Fixtures/Admin/FieldDescription.php
@@ -27,6 +27,11 @@ class FieldDescription extends BaseFieldDescription
         // TODO: Implement getTargetEntity() method.
     }
 
+    public function getTargetModel(): ?string
+    {
+        throw new \BadMethodCallException(sprintf('Implement %s() method.', __METHOD__));
+    }
+
     public function setFieldMapping($fieldMapping): void
     {
         // TODO: Implement setFieldMapping() method.


### PR DESCRIPTION
## Subject

It seems that the change from `getTargetEntity()` to `getTargetModel()` in #6108 was not fully implemented in the rest of the code. This changeset fixes some deprecation notices I get on runtime and some notices about test classes not implementing `FieldDescriptionInterface`.

## Changelog

I think this internal change does not need a changelog entry.