### PR TITLE
Add a check if the class is not null in `ExtensionCompilerPass.php` file

### DIFF
--- a/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -110,7 +110,7 @@ class ExtensionCompilerPass implements CompilerPassInterface
                     }
                 } else {
                     $class = $this->getManagedClass($admin, $container);
-                    if (!class_exists($class)) {
+                    if (!$class || !class_exists($class)) {
                         continue;
                     }
                     $classReflection = new \ReflectionClass($class);

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -254,6 +254,7 @@ class ExtensionCompilerPassTest extends TestCase
         $this->assertTrue($container->hasDefinition('sonata_post_admin'));
         $this->assertTrue($container->hasDefinition('sonata_article_admin'));
         $this->assertTrue($container->hasDefinition('sonata_news_admin'));
+        $this->assertTrue($container->hasDefinition('sonata_admin_without_entity'));
 
         $securityExtension = $container->get('sonata_extension_security');
         $publishExtension = $container->get('sonata_extension_publish');
@@ -285,6 +286,11 @@ class ExtensionCompilerPassTest extends TestCase
         $this->assertSame($securityExtension, $extensions[1]);
         $this->assertSame($filterExtension, $extensions[2]);
         $this->assertSame($orderExtension, $extensions[4]);
+
+        $def = $container->get('sonata_admin_without_entity');
+        $extensions = $def->getExtensions();
+        $this->assertCount(2, $extensions);
+        $this->assertSame($securityExtension, $extensions[0]);
     }
 
     /**
@@ -410,6 +416,12 @@ class ExtensionCompilerPassTest extends TestCase
             ->setPublic(true)
             ->setClass(MockAdmin::class)
             ->setArguments(['', Article::class, CRUDController::class])
+            ->addTag('sonata.admin');
+        $container
+            ->register('sonata_admin_without_entity')
+            ->setPublic(true)
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', null, CRUDController::class])
             ->addTag('sonata.admin');
         $container
             ->register('event_dispatcher')


### PR DESCRIPTION
Fix refered to #6189
Useful when an admin doesn't have entity managed and add some extensions to other specific admin
Add some tests

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch because this is a patch. The whole description is explained in #6189 

Closes #6189 .

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
Check if the return of `getManagedClass` function in `ExtensionCompilerPass.php` is not null.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
