### PR TITLE
Add default value for array properties

### DIFF
--- a/src/Action/DashboardAction.php
+++ b/src/Action/DashboardAction.php
@@ -25,7 +25,7 @@ final class DashboardAction
     /**
      * @var array
      */
-    private $dashboardBlocks;
+    private $dashboardBlocks = [];
 
     /**
      * @var BreadcrumbsBuilderInterface

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -85,17 +85,17 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     /**
      * @var array the ORM association mapping
      */
-    protected $associationMapping;
+    protected $associationMapping = [];
 
     /**
      * @var array the ORM field information
      */
-    protected $fieldMapping;
+    protected $fieldMapping = [];
 
     /**
      * @var array the ORM parent mapping association
      */
-    protected $parentAssociationMappings;
+    protected $parentAssociationMappings = [];
 
     /**
      * @var string the template name

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -71,7 +71,7 @@ class Pool
     /**
      * @var array
      */
-    protected $options;
+    protected $options = [];
 
     /**
      * @var PropertyAccessorInterface

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -40,7 +40,7 @@ class Datagrid implements DatagridInterface
     /**
      * @var array
      */
-    protected $values;
+    protected $values = [];
 
     /**
      * @var FieldDescriptionCollection
@@ -73,7 +73,7 @@ class Datagrid implements DatagridInterface
     protected $form;
 
     /**
-     * @var array
+     * @var array|null
      */
     protected $results;
 

--- a/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -38,7 +38,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
     /**
      * @var array
      */
-    protected $options;
+    protected $options = [];
 
     public function __construct(array $defaultClasses, array $options)
     {

--- a/src/Object/Metadata.php
+++ b/src/Object/Metadata.php
@@ -43,7 +43,7 @@ final class Metadata implements MetadataInterface
     /**
      * @var array<string, mixed>
      */
-    private $options;
+    private $options = [];
 
     /**
      * @param array<string, mixed> $options

--- a/src/Security/Handler/AclSecurityHandler.php
+++ b/src/Security/Handler/AclSecurityHandler.php
@@ -52,17 +52,17 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
     /**
      * @var array
      */
-    protected $superAdminRoles;
+    protected $superAdminRoles = [];
 
     /**
      * @var array
      */
-    protected $adminPermissions;
+    protected $adminPermissions = [];
 
     /**
      * @var array
      */
-    protected $objectPermissions;
+    protected $objectPermissions = [];
 
     /**
      * @var string

--- a/src/Security/Handler/RoleSecurityHandler.php
+++ b/src/Security/Handler/RoleSecurityHandler.php
@@ -32,7 +32,7 @@ class RoleSecurityHandler implements SecurityHandlerInterface
     /**
      * @var array
      */
-    protected $superAdminRoles;
+    protected $superAdminRoles = [];
 
     /**
      * @param AuthorizationCheckerInterface $authorizationChecker

--- a/src/Util/AdminObjectAclData.php
+++ b/src/Util/AdminObjectAclData.php
@@ -55,7 +55,7 @@ class AdminObjectAclData
     /**
      * @var array Cache of masks
      */
-    protected $masks;
+    protected $masks = [];
 
     /**
      * @var Form


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Multiple values are expected to be a not nullable array but are not explicitly set to `[]` by default.
This gave me error when I tried to use the master branch since getter was expecting to return an array.

## Changelog

```markdown
### Fixed
- Fixed default `[]` value for every non-nullable array class properties
```