### PR TITLE
Allow to set a null template

### DIFF
--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -97,7 +97,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     protected $parentAssociationMappings = [];
 
     /**
-     * @var string the template name
+     * @var string|null the template name
      */
     protected $template;
 
@@ -202,7 +202,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         return $this->options;
     }
 
-    public function setTemplate(string $template): void
+    public function setTemplate(?string $template): void
     {
         $this->template = $template;
     }

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -85,7 +85,7 @@ interface FieldDescriptionInterface
     /**
      * Sets the template used to render the field.
      */
-    public function setTemplate(string $template): void;
+    public function setTemplate(?string $template): void;
 
     /**
      * Returns the template name.


### PR DESCRIPTION
## Subject

Targeting this branch, because the typehint was added in master.

SonataDoctrineOrmBundle call this setter with a possible null value.
Since the template is `null` by default, I updated the phpdoc and I don't see any problem with allowing to set `null`.