### PR TITLE
Deprecate $params in SonataAdminExtension::getValueFromFieldDescription

### DIFF
--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -234,6 +234,8 @@ class SonataAdminExtension extends AbstractExtension
      * return the value related to FieldDescription, if the associated object does no
      * exists => a temporary one is created.
      *
+     * NEXT_MAJOR: remove $params parameter and @throws \RuntimeException.
+     *
      * @param object $object
      *
      * @throws \RuntimeException
@@ -245,6 +247,15 @@ class SonataAdminExtension extends AbstractExtension
         FieldDescriptionInterface $fieldDescription,
         array $params = []
     ) {
+        if (isset(\func_get_args()[2])) {
+            @trigger_error(sprintf(
+                'Passing argument 3 to %s() is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will be ignored in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        // NEXT_MAJOR: remove this check
         if (isset($params['loop']) && $object instanceof \ArrayAccess) {
             throw new \RuntimeException('remove the loop requirement');
         }

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -2273,6 +2273,12 @@ EOT
         $this->assertSame('test123', $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     * @expectedDeprecation Passing argument 3 to Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::getValueFromFieldDescription() is deprecated since sonata-project/admin-bundle 3.x and will be ignored in version 4.0.
+     */
     public function testGetValueFromFieldDescriptionWithRemoveLoopException(): void
     {
         $object = $this->createMock(\ArrayAccess::class);


### PR DESCRIPTION
## Subject

While investigating the possibility of adding some functionality to SonataAdminExtension I noticed that the condition checking for 'loop' on the $params parameter of getValueFromFieldDescription is unused. In fact, the entire argument is never used since a refactoring in 2011 (0dc07aea65a973812126462e91af4a5db918083a).

This PR removes the code. I hope it can be merged while I contemplate a fast solution to a problem similar to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/399.

Also, the getValueFromFieldDescription method doesn't even need to be public and the way `$value = $fieldDescription->getAssociationAdmin()->getNewInstance();` is called is not going to work because `$value` must be the value of a model and not the entire model, but that is for another PR.

I am targeting this branch, because it's backwards compatible.

## Changelog

```markdown
### Deprecated
- Third parameter of SonataAdminExtension::getValueFromFieldDescription().