### PR TITLE
Add support for arrays containing additional database values in list views

### DIFF
--- a/docs/.doctor-rst.yaml
+++ b/docs/.doctor-rst.yaml
@@ -30,3 +30,7 @@ rules:
     #no_config_yaml: ~
     #kernel_instead_of_app_kernel: ~
     #no_app_console: ~
+
+whitelist:
+    lines:
+        - '.. versionadded:: 3.x'

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -578,5 +578,59 @@ Checkbox range selection
     You can check / uncheck a range of checkboxes by clicking a first one,
     then a second one with shift + click.
 
+Displaying a non-model field
+----------------------------
+
+.. versionadded:: 3.x
+
+  Support for displaying fields not part of the model class was introduced in version 3.x.
+
+The list view can also display fields that are not part of the model class.
+
+In some situations you can add a new getter to your model class to calculate
+a field based on the other fields of your model::
+
+    // src/Entity/User.php
+
+    public function getFullName(): string
+    {
+        return $this->getGivenName().' '.$this->getFamilyName();
+    }
+
+    // src/Admin/UserAdmin.php
+
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper->addIdentifier('fullName');
+    }
+
+In situations where the data are not available in the model or it is more performant
+to have the database calculate the value you can override the ``configureQuery()`` Admin
+class method to add fields to the result set.
+In ``configureListFields()`` these fields can be added using the alias given
+in the query.
+
+In the following example the number of comments for a post is added to the
+query and displayed::
+
+    // src/Admin/PostAdmin.php
+
+    protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface
+    {
+        $query = parent::configureQuery($query);
+
+        $query
+            ->leftJoin('n.Comments', 'c')
+            ->addSelect('COUNT(c.id) numberofcomments')
+            ->addGroupBy('n');
+
+        return $query;
+    }
+
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper->addIdentifier('numberofcomments');
+    }
+
 .. _`SonataDoctrineORMAdminBundle Documentation`: https://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/list_field_definition.html
 .. _`here`: https://github.com/sonata-project/SonataCoreBundle/tree/3.x/src/Form/Type

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -387,6 +387,68 @@ class SonataAdminExtensionTest extends TestCase
     }
 
     /**
+     * NEXT_MAJOR: Remove @expectedDeprecation.
+     *
+     * @group legacy
+     * @expectedDeprecation The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).
+     */
+    public function testRenderListElementWithAdditionalValuesInArray(): void
+    {
+        // NEXT_MAJOR: Remove this line
+        $this->admin
+            ->method('getTemplate')
+            ->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+
+        $this->templateRegistry->getTemplate('base_list_field')->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+
+        $this->fieldDescription
+            ->method('getTemplate')
+            ->willReturn('@SonataAdmin/CRUD/list_string.html.twig');
+
+        $this->assertSame(
+            $this->removeExtraWhitespace('<td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> Extra value </td>'),
+            $this->removeExtraWhitespace($this->twigExtension->renderListElement(
+                $this->environment,
+                [$this->object, 'fd_name' => 'Extra value'],
+                $this->fieldDescription
+            ))
+        );
+    }
+
+    /**
+     * NEXT_MAJOR: Remove @expectedDeprecation.
+     *
+     * @group legacy
+     * @expectedDeprecation Accessing a non existing value is deprecated since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.
+     */
+    public function testRenderListElementWithNoValueException(): void
+    {
+        // NEXT_MAJOR: Remove this line
+        $this->admin
+            ->method('getTemplate')
+            ->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+
+        $this->templateRegistry->getTemplate('base_list_field')->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+
+        $this->fieldDescription
+            ->method('getValue')
+            ->willReturnCallback(static function (): void {
+                throw new NoValueException();
+            });
+
+        $this->assertSame(
+            $this->removeExtraWhitespace('<td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> </td>'),
+            $this->removeExtraWhitespace($this->twigExtension->renderListElement(
+                $this->environment,
+                $this->object,
+                $this->fieldDescription
+            ))
+        );
+    }
+
+    /**
      * @dataProvider getDeprecatedRenderListElementTests
      * @group legacy
      */
@@ -2261,6 +2323,11 @@ EOT
         ];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetValueFromFieldDescription(): void
     {
         $object = new \stdClass();
@@ -2273,6 +2340,11 @@ EOT
         $this->assertSame('test123', $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetValueFromFieldDescriptionWithRemoveLoopException(): void
     {
         $object = $this->createMock(\ArrayAccess::class);
@@ -2288,7 +2360,7 @@ EOT
     }
 
     /**
-     * NEXT_MAJOR: Change this test to expect a NoValueException instead.
+     * NEXT_MAJOR: Remove this test.
      *
      * @group legacy
      * @expectedDeprecation Accessing a non existing value is deprecated since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.
@@ -2311,6 +2383,11 @@ EOT
         $this->assertNull($this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetValueFromFieldDescriptionWithNoValueExceptionNewAdminInstance(): void
     {
         $object = new \stdClass();


### PR DESCRIPTION
## Subject

I am trying to show additional fields in the list view. These fields are not part of the entity. Adding the field is no problem thanks to `configureQuery()`. However, Doctrine2 returns an array instead of an object when additional columns are present in the result set.

This was discussed previously in https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/399 and https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/501 with no result. The direction in those issues was to use a DTO. This PR does not add support for DTO's but for the arrays that Doctrine2 returns.

As mentioned briefly in #6198 I found several issues with the method `SonataAdminExtension::getValueFromFieldDescription()`:

- It contains an unused third parameter.
- It is public for no reason.
- The code block `if ($fieldDescription->getAssociationAdmin()) { ... }` is dysfunctional because it causes `$value` to be a model instance instead of a field value. Apparently nobody has noticed.

As such, I think it is best to leave this method alone for now and add functionality to `renderListElement()`.

I am targeting this branch, because it is backwards compatible.

## Changelog

```markdown
### Added
- Added support for columns not belonging to the model to the list view.

### Deprecated
- Calling `SonataAdminExtension::getValueFromFieldDescription()`
```

## To do

- [x] Update the documentation;

