### PR TITLE
Fix links in documentation

### DIFF
--- a/docs/cookbook/recipe_file_uploads.rst
+++ b/docs/cookbook/recipe_file_uploads.rst
@@ -310,4 +310,4 @@ happening.
 
 To learn how to add an image preview to your ``ImageAdmin`` take a look at the related cookbook entry.
 
-.. _`uploading files with Doctrine and Symfony`: http://symfony.com/doc/current/cookbook/doctrine/file_uploads.html
+.. _`uploading files with Doctrine and Symfony`: https://symfony.com/doc/4.4/controller/upload_file.html

--- a/docs/cookbook/recipe_knp_menu.rst
+++ b/docs/cookbook/recipe_knp_menu.rst
@@ -297,5 +297,5 @@ Your can't use this option for two or more items at the same time:
 In this case you have an exception: "You can't use ``on_top`` option with multiple same name groups".
 
 .. _KnpMenu: https://github.com/KnpLabs/KnpMenu
-.. _Knp documentation: http://symfony.com/doc/current/bundles/KnpMenuBundle/index.html#create-your-first-menu
-.. _Using events to allow a menu to be extended: http://symfony.com/doc/master/bundles/KnpMenuBundle/events.html
+.. _Knp documentation: https://symfony.com/doc/current/bundles/KnpMenuBundle/index.html#create-your-first-menu
+.. _Using events to allow a menu to be extended: https://symfony.com/doc/master/bundles/KnpMenuBundle/events.html

--- a/docs/cookbook/recipe_lock_protection.rst
+++ b/docs/cookbook/recipe_lock_protection.rst
@@ -70,7 +70,7 @@ Using XML:
         </entity>
     </doctrine-mapping>
 
-For more information about this visit the `Doctrine docs <http://doctrine-orm.readthedocs.org/en/latest/reference/transactions-and-concurrency.html?highlight=optimistic#optimistic-locking>`_
+For more information about this visit the `Doctrine docs <https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/reference/transactions-and-concurrency.html#optimistic-locking>`_
 
 .. note::
 

--- a/docs/cookbook/recipe_select2.rst
+++ b/docs/cookbook/recipe_select2.rst
@@ -1,7 +1,7 @@
 Select2
 =======
 
-The admin comes with `select2 <http://ivaynberg.github.io/select2/>`_ integration
+The admin comes with `select2 <https://select2.org/>`_ integration
 since version 2.2.6. Select2 is a jQuery based replacement for select boxes.
 It supports searching, remote data sets, and infinite scrolling of results.
 

--- a/docs/cookbook/recipe_sonata_admin_without_user_bundle.rst
+++ b/docs/cookbook/recipe_sonata_admin_without_user_bundle.rst
@@ -24,7 +24,7 @@ User Entity
 ^^^^^^^^^^^
 
 This represents your security user, you can read more about it
-`here <http://symfony.com/doc/current/security/entity_provider.html#create-your-user-entity>`__::
+`here <https://symfony.com/doc/4.4/security.html#a-create-your-user-class>`__::
 
     namespace App\Entity;
 
@@ -63,7 +63,7 @@ UserProvider
 ^^^^^^^^^^^^
 
 This represents your user provider, it will be used to load your security users, read
-more about it `here <http://symfony.com/doc/current/security/custom_provider.html#create-a-user-provider>`__::
+more about it `here <https://symfony.com/doc/4.4/security.html#b-the-user-provider>`__::
 
     namespace App\Security;
 
@@ -154,7 +154,7 @@ AdminLoginAuthenticator
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 This represents your custom authentication system, read
-more about it `here <https://symfony.com/doc/current/security/guard_authentication.html#step-1-create-the-authenticator-class>`__::
+more about it `here <https://symfony.com/doc/4.4/security/guard_authentication.html#step-2-create-the-authenticator-class>`__::
 
     namespace App\Security;
 

--- a/docs/cookbook/recipe_sortable_sonata_type_model.rst
+++ b/docs/cookbook/recipe_sortable_sonata_type_model.rst
@@ -349,7 +349,7 @@ Now update the ``UserBundle\Admin\UserAdmin.php`` by adding the ``sonata_type_mo
 
 There is two important things that we need to show here :
 * We use the field ``userHasExpectations`` of the user, but we need a list of ``Expectation`` to be displayed, that's explain the use of ``query``.
-* We want to persist ``UserHasExpectations``Entities, but we manage ``Expectation``, so we need to use a custom `ModelTransformer <http://symfony.com/doc/current/cookbook/form/data_transformers.html>`_ to deal with it.
+* We want to persist ``UserHasExpectations``Entities, but we manage ``Expectation``, so we need to use a custom `ModelTransformer <https://symfony.com/doc/4.4/form/data_transformers.html>`_ to deal with it.
 
 Part 4 : Data Transformer
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/cookbook/recipe_workflow_integration.rst
+++ b/docs/cookbook/recipe_workflow_integration.rst
@@ -94,4 +94,4 @@ you will see something like this:
    :alt: Sonata Admin with Workflow
    :width: 700px
 
-.. _`Workflow Component`: https://symfony.com/doc/current/components/workflow.html
+.. _`Workflow Component`: https://symfony.com/doc/4.4/components/workflow.html

--- a/docs/getting_started/creating_an_admin.rst
+++ b/docs/getting_started/creating_an_admin.rst
@@ -212,4 +212,4 @@ entity and learn more about this class.
     If you're not seeing the nice labels, but instead something like
     "link_add", you should make sure that you've `enabled the translator`_.
 
-.. _`enabled the translator`: http://symfony.com/doc/current/book/translation.html#configuration
+.. _`enabled the translator`: https://symfony.com/doc/4.4/translation.html#configuration

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -76,7 +76,7 @@ Enable the "translator" service
 -------------------------------
 
 The translator service is required by SonataAdmin to display all labels properly.
-For more information: http://symfony.com/doc/current/translation.html#configuration
+For more information: https://symfony.com/doc/4.4/translation.html#configuration
 
 .. configuration-block::
 
@@ -157,6 +157,6 @@ provided admin functionality for the admin bundle yet. Fortunately, you'll
 learn how to do this in the :doc:`next chapter <creating_an_admin>`.
 
 .. _`installation chapter`: https://getcomposer.org/doc/00-intro.md
-.. _SonataDoctrineORMAdminBundle: http://sonata-project.org/bundles/doctrine-orm-admin/master/doc/index.html
-.. _SonataDoctrineMongoDBAdminBundle: http://sonata-project.org/bundles/mongo-admin/master/doc/index.html
-.. _SonataDoctrinePhpcrAdminBundle: http://sonata-project.org/bundles/doctrine-phpcr-admin/master/doc/index.html
+.. _SonataDoctrineORMAdminBundle: https://sonata-project.org/bundles/doctrine-orm-admin/master/doc/index.html
+.. _SonataDoctrineMongoDBAdminBundle: https://sonata-project.org/bundles/mongo-admin/master/doc/index.html
+.. _SonataDoctrinePhpcrAdminBundle: https://sonata-project.org/bundles/doctrine-phpcr-admin/master/doc/index.html

--- a/docs/getting_started/the_form_view.rst
+++ b/docs/getting_started/the_form_view.rst
@@ -263,8 +263,7 @@ started by creating a form and ended up with a nice edit page for your admin.
 In the :doc:`next chapter <the_list_view>`, you're going to look at the list
 and datagrid actions.
 
-.. _`Symfony Form component`: http://symfony.com/doc/current/book/forms.html
-.. _`field type reference`: http://symfony.com/doc/current/reference/forms/types.html
-.. _`entity field type`: http://symfony.com/doc/current/reference/forms/types/entity.html
-.. _`choice_label`: http://symfony.com/doc/current/reference/forms/types/entity.html#choice-label
-.. _`property`: http://symfony.com/doc/2.6/reference/forms/types/entity.html#property
+.. _`Symfony Form component`: https://symfony.com/doc/4.4/forms.html
+.. _`field type reference`: https://symfony.com/doc/4.4/reference/forms/types.html
+.. _`entity field type`: https://symfony.com/doc/4.4/reference/forms/types/entity.html
+.. _`choice_label`: https://symfony.com/doc/4.4/reference/forms/types/entity.html#choice-label

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Admin Bundle
 * `SonataDoctrineMongoDBAdminBundle <https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle>`_: integrates MongoDB with the core admin bundle
 * `SonataDoctrinePhpcrAdminBundle <https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle>`_: integrates PHPCR with the core admin bundle
 
-The demo website can be found at http://demo.sonata-project.org.
+The demo website can be found at https://demo.sonata-project.org.
 
 **Usage examples:**
 

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -579,4 +579,4 @@ Checkbox range selection
     then a second one with shift + click.
 
 .. _`SonataDoctrineORMAdminBundle Documentation`: https://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/list_field_definition.html
-.. _`here`: https://github.com/sonata-project/SonataCoreBundle/tree/3.x/src/Form/Type
+.. _`here`: https://github.com/sonata-project/form-extensions/tree/1.x/src/Type

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -450,4 +450,4 @@ by overriding ``checkAccess`` function::
         }
     }
 
-.. _`Core's documentation`: http://sonata-project.org/bundles/core/master/doc/reference/form_types.html#sonata-type-translatable-choice
+.. _`Core's documentation`: https://sonata-project.org/bundles/core/master/doc/reference/form_types.html#sonata-type-translatable-choice

--- a/docs/reference/architecture.rst
+++ b/docs/reference/architecture.rst
@@ -329,5 +329,5 @@ DIC, handles the ``Admin`` classes, lazy-loading them on demand (to reduce overh
 and matching each of them to a group. It is also responsible for handling the top level
 template files, administration panel title and logo.
 
-.. _`Django Project Website`: http://www.djangoproject.com/
-.. _`CRUD`: http://en.wikipedia.org/wiki/CRUD
+.. _`Django Project Website`: https://www.djangoproject.com/
+.. _`CRUD`: https://en.wikipedia.org/wiki/CRUD

--- a/docs/reference/conditional_validation.rst
+++ b/docs/reference/conditional_validation.rst
@@ -1,7 +1,7 @@
 Inline Validation
 =================
 
-The inline validation code is now part of the SonataCoreBundle.
+The inline validation code is now part of the Sonata Form Extensions.
 You can refer to the related documentation for more information.
 
 The above examples show how the integration has been done with the SonataAdminBundle.

--- a/docs/reference/field_types.rst
+++ b/docs/reference/field_types.rst
@@ -39,15 +39,15 @@ This is currently limited to scalar types (text, integer, url...) and choice typ
     will be changed to use localized information.
 
     Option for currency type must be an official ISO code, example : EUR for "euros".
-    List of ISO codes : `http://en.wikipedia.org/wiki/List_of_circulating_currencies <http://en.wikipedia.org/wiki/List_of_circulating_currencies>`_
+    List of ISO codes : `https://en.wikipedia.org/wiki/List_of_circulating_currencies <https://en.wikipedia.org/wiki/List_of_circulating_currencies>`_
 
     In ``TemplateRegistry::TYPE_DATE``, ``TemplateRegistry::TYPE_TIME`` and ``TemplateRegistry::TYPE_DATETIME`` field types, ``format`` pattern must match twig's
-    ``date`` filter specification, available at: `http://twig.sensiolabs.org/doc/filters/date.html <http://twig.sensiolabs.org/doc/filters/date.html>`_
+    ``date`` filter specification, available at: `https://twig.symfony.com/doc/2.x/filters/date.html <https://twig.symfony.com/doc/2.x/filters/date.html>`_
 
     In ``TemplateRegistry::TYPE_TIME`` and ``TemplateRegistry::TYPE_DATETIME`` field types, ``timezone`` syntax must match twig's
-    ``date`` filter specification, available at: `http://twig.sensiolabs.org/doc/filters/date.html <http://twig.sensiolabs.org/doc/filters/date.html>`_
-    and php timezone list: `https://php.net/manual/en/timezones.php <https://php.net/manual/en/timezones.php>`_
-    You can use in lists what `view-timezone <http://symfony.com/doc/current/reference/forms/types/datetime.html#view-timezone>`_ allows on forms,
+    ``date`` filter specification, available at: `https://twig.symfony.com/doc/2.x/filters/date.html <https://twig.symfony.com/doc/2.x/filters/date.html>`_
+    and php timezone list: `https://www.php.net/manual/en/timezones.php <https://www.php.net/manual/en/timezones.php>`_
+    You can use in lists what `view-timezone <https://symfony.com/doc/4.4/reference/forms/types/datetime.html#view-timezone>`_ allows on forms,
     a way to render the date in the user timezone::
 
         protected function configureListFields(ListMapper $listMapper)
@@ -278,7 +278,7 @@ You can use the following options:
 Option                      Description
 ========================    ==================================================================
 **strip**                   Strip HTML and PHP tags from a string
-**truncate**                Truncate a string to ``length`` characters beginning from start. Implies strip. Beware of HTML entities. Make sure to configure your HTML editor to disable entities if you want to use truncate. For instance, use `config.entities <http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-entities>`_ for ckeditor
+**truncate**                Truncate a string to ``length`` characters beginning from start. Implies strip. Beware of HTML entities. Make sure to configure your HTML editor to disable entities if you want to use truncate. For instance, use `config.entities <https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-entities>`_ for ckeditor
 **truncate.length**         The length to truncate the string to (default ``30``)
 **truncate.cut**            Determines if whole words must be cut (default ``true``)
 **truncate.ellipsis**       Ellipsis to be appended to the trimmed string (default ``...``)

--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -779,9 +779,9 @@ Symfony\\Component\\Form\\Extension\\Core\\Type\\ChoiceType
         }
     }
 
-.. _`Symfony field types`: http://symfony.com/doc/current/book/forms.html#built-in-field-types
-.. _`Symfony choice Field Type docs`: http://symfony.com/doc/current/reference/forms/types/choice.html
-.. _`Symfony PropertyPath`: http://api.symfony.com/2.0/Symfony/Component/Form/Util/PropertyPath.html
+.. _`Symfony field types`: https://symfony.com/doc/4.4/reference/forms/types.html
+.. _`Symfony choice Field Type docs`: https://symfony.com/doc/4.4/reference/forms/types.html#choice-fields
+.. _`Symfony PropertyPath`: https://github.com/symfony/property-access/blob/4.4/PropertyPath.php
 .. _`ORM`: https://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/form_field_definition.html
 .. _`PHPCR`: https://sonata-project.org/bundles/doctrine-phpcr-admin/master/doc/reference/form_field_definition.html
 .. _`MongoDB`: https://sonata-project.org/bundles/mongo-admin/master/doc/reference/form_field_definition.html

--- a/docs/reference/security.rst
+++ b/docs/reference/security.rst
@@ -502,7 +502,7 @@ Vocabulary used for Access Control Lists:
   prevent that multiple voters vote on the same class with overlapping bitmasks.
 
 See the cookbook article "`Advanced ACL concepts
-<http://symfony.com/doc/current/cookbook/security/acl_advanced.html#pre-authorization-decisions.>`_"
+<https://symfony.com/doc/current/cookbook/security/acl_advanced.html#pre-authorization-decisions.>`_"
 for the meaning of the different permissions.
 
 How is access granted?
@@ -764,5 +764,5 @@ service to use when retrieving your users.
                 acl_user_manager: my_user_manager
 
 .. _`SonataUserBundle's documentation area`: https://sonata-project.org/bundles/user/master/doc/reference/installation.html
-.. _`changing the access decision strategy`: http://symfony.com/doc/2.2/cookbook/security/voters.html#changing-the-access-decision-strategy
-.. _`create your own voter`: http://symfony.com/doc/2.2/cookbook/security/voters.html
+.. _`changing the access decision strategy`: https://symfony.com/doc/4.4/security/voters.html#changing-the-access-decision-strategy
+.. _`create your own voter`: https://symfony.com/doc/4.4/security/voters.html

--- a/docs/reference/troubleshooting.rst
+++ b/docs/reference/troubleshooting.rst
@@ -33,14 +33,14 @@ So in order to avoid any fatal error, you must return an empty string
         }
     }
 
-.. _`__toString`: http://www.php.net/manual/en/language.oop5.magic.php#object.tostring
+.. _`__toString`: https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
 
 Large filters and long URLs problem
 -----------------------------------
 
 If you will try to add hundreds of filters to a single admin class, you will get a problem - very long generated filter form URL.
 In most cases you will get server response like *Error 400 Bad Request* OR *Error 414 Request-URI Too Long*. According to
-`a StackOverflow discussion <http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers>`_
+`a StackOverflow discussion <https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers>`_
 "safe" URL length is around 2000 characters.
 You can fix this issue by adding a small JQuery piece of code to your edit template:
 


### PR DESCRIPTION
## Subject

I've run the Sphinx link check on the documentation and fixed most links and references to the core bundle.

I want to update https://sonata-project.org/bundles/core/master/doc/reference/form_types.html#sonata-type-translatable-choice as well, but I don't know where the new docs are located.

I have changed the links to the Symfony documentation to Symfony version 4.4 as this is the version supported by Sonata 3.

I am targeting this branch, because it is backwards compatible.

## Changelog

Doc changes don't need a changelog update.