### PR TITLE
Use FieldDescriptionInterface::getTargetModel if exists

### DIFF
--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -190,7 +190,14 @@ final class RetrieveAutocompleteItemsAction
             throw new \RuntimeException(sprintf('The field "%s" does not exist.', $field));
         }
 
-        if (null === $fieldDescription->getTargetModel()) {
+        // NEXT_MAJOR: Remove the check and use `getTargetModel`.
+        if (method_exists($fieldDescription, 'getTargetModel')) {
+            $targetModel = $fieldDescription->getTargetModel();
+        } else {
+            $targetModel = $fieldDescription->getTargetEntity();
+        }
+
+        if (null === $targetModel) {
             throw new \RuntimeException(sprintf('No associated entity with field "%s".', $field));
         }
 
@@ -212,7 +219,14 @@ final class RetrieveAutocompleteItemsAction
             throw new \RuntimeException(sprintf('The field "%s" does not exist.', $field));
         }
 
-        if (null === $fieldDescription->getTargetModel()) {
+        // NEXT_MAJOR: Remove the check and use `getTargetModel`.
+        if (method_exists($fieldDescription, 'getTargetModel')) {
+            $targetModel = $fieldDescription->getTargetModel();
+        } else {
+            $targetModel = $fieldDescription->getTargetEntity();
+        }
+
+        if (null === $targetModel) {
             throw new \RuntimeException(sprintf('No associated entity with field "%s".', $field));
         }
 

--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Action;
 
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -132,7 +133,8 @@ final class SetObjectFieldValueAction
         if ('' !== $value
             && 'choice' === $fieldDescription->getType()
             && null !== $fieldDescription->getOption('class')
-            && $fieldDescription->getOption('class') === $fieldDescription->getTargetModel()
+            // NEXT_MAJOR: Replace this call with "$fieldDescription->getOption('class') === $fieldDescription->getTargetModel()".
+            && $this->hasFieldDescriptionAssociationWithClass($fieldDescription, $fieldDescription->getOption('class'))
         ) {
             $value = $admin->getModelManager()->find($fieldDescription->getOption('class'), $value);
 
@@ -169,5 +171,11 @@ final class SetObjectFieldValueAction
         $content = $extension->renderListElement($this->twig, $rootObject, $fieldDescription);
 
         return new JsonResponse($content, Response::HTTP_OK);
+    }
+
+    private function hasFieldDescriptionAssociationWithClass(FieldDescriptionInterface $fieldDescription, string $class): bool
+    {
+        return (method_exists($fieldDescription, 'getTargetModel') && $class === $fieldDescription->getTargetModel())
+            || $class === $fieldDescription->getTargetEntity();
     }
 }

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1434,11 +1434,18 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
             $admin = $pool->getAdminByAdminCode($adminCode);
         } else {
-            if (!$pool->hasAdminByClass($fieldDescription->getTargetModel())) {
+            // NEXT_MAJOR: Remove the check and use `getTargetModel`.
+            if (method_exists($fieldDescription, 'getTargetModel')) {
+                $targetModel = $fieldDescription->getTargetModel();
+            } else {
+                $targetModel = $fieldDescription->getTargetEntity();
+            }
+
+            if (!$pool->hasAdminByClass($targetModel)) {
                 return;
             }
 
-            $admin = $pool->getAdminByClass($fieldDescription->getTargetModel());
+            $admin = $pool->getAdminByClass($targetModel);
         }
 
         if ($this->hasRequest()) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataAdminBundle/pull/6187#issuecomment-660012644

`FieldDescriptionInterface::getTargetModel` is not yet in the interface, this PR checks if that method exists and if not it calls the deprecated `FieldDescriptionInterface::getTargetEntity`.

Any suggestion for a cleaner way is accepted!

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed checking if `FieldDescriptionInterface::getTargetModel()` exists before calling it.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
