### PR TITLE
Make handle xml http request response protected

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1558,7 +1558,7 @@ class CRUDController implements ContainerAwareInterface
     protected function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): ?JsonResponse
     {
         if (empty(array_intersect(['application/json', '*/*'], $request->getAcceptableContentTypes()))) {
-            @trigger_error('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json` or `Accept: */*`', E_USER_DEPRECATED);
+            @trigger_error(sprintf('"%s" is not supported since sonata-project/admin-bundle 3.x and the status code 406 will be set in the returned response in 4.0. Use `application/json`.', implode('", "', $request->getAcceptableContentTypes())));
 
             return null;
         }
@@ -1580,7 +1580,7 @@ class CRUDController implements ContainerAwareInterface
     protected function handleXmlHttpRequestSuccessResponse(Request $request, $object): JsonResponse
     {
         if (empty(array_intersect(['application/json', '*/*'], $request->getAcceptableContentTypes()))) {
-            @trigger_error('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json` or `Accept: */*`', E_USER_DEPRECATED);
+            @trigger_error(sprintf('"%s" is not supported since sonata-project/admin-bundle 3.x and the status code 406 will be set in the returned response in 4.0. Use `application/json`.', implode('", "', $request->getAcceptableContentTypes())));
         }
 
         return $this->renderJson([

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1558,7 +1558,13 @@ class CRUDController implements ContainerAwareInterface
     protected function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): ?JsonResponse
     {
         if (empty(array_intersect(['application/json', '*/*'], $request->getAcceptableContentTypes()))) {
-            @trigger_error(sprintf('"%s" is not supported since sonata-project/admin-bundle 3.x and the status code 406 will be set in the returned response in 4.0. Use `application/json`.', implode('", "', $request->getAcceptableContentTypes())));
+            @trigger_error(sprintf(
+                'None of the passed values ("%s") in the "Accept" header when requesting %s %s is supported since sonata-project/admin-bundle 3.x.'
+                .' It will result in a response with the status code 406 (Not Acceptable) in 4.0. You must add "application/json".',
+                implode('", "', $request->getAcceptableContentTypes()),
+                $request->getMethod(),
+                $request->getUri()
+            ), E_USER_DEPRECATED);
 
             return null;
         }
@@ -1574,13 +1580,16 @@ class CRUDController implements ContainerAwareInterface
         ], Response::HTTP_BAD_REQUEST);
     }
 
-    /**
-     * @param object $object
-     */
-    protected function handleXmlHttpRequestSuccessResponse(Request $request, $object): JsonResponse
+    protected function handleXmlHttpRequestSuccessResponse(Request $request, object $object): JsonResponse
     {
         if (empty(array_intersect(['application/json', '*/*'], $request->getAcceptableContentTypes()))) {
-            @trigger_error(sprintf('"%s" is not supported since sonata-project/admin-bundle 3.x and the status code 406 will be set in the returned response in 4.0. Use `application/json`.', implode('", "', $request->getAcceptableContentTypes())));
+            @trigger_error(sprintf(
+                'None of the passed values ("%s") in the "Accept" header when requesting %s %s is supported since sonata-project/admin-bundle 3.x.'
+                .' It will result in a response with the status code 406 (Not Acceptable) in 4.0. You must add "application/json".',
+                implode('", "', $request->getAcceptableContentTypes()),
+                $request->getMethod(),
+                $request->getUri()
+            ), E_USER_DEPRECATED);
         }
 
         return $this->renderJson([

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -1745,7 +1745,13 @@ class CRUDControllerTest extends TestCase
             ->method('trans')
             ->willReturn('flash message');
 
-        $this->expectDeprecation('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json` or `Accept: */*`');
+        $this->expectDeprecation(sprintf(
+            'None of the passed values ("%s") in the "Accept" header when requesting %s %s is supported since sonata-project/admin-bundle 3.x.'
+            .' It will result in a response with the status code 406 (Not Acceptable) in 4.0. You must add "application/json".',
+            implode('", "', $this->request->getAcceptableContentTypes()),
+            $this->request->getMethod(),
+            $this->request->getUri()
+        ));
         $this->assertInstanceOf(Response::class, $response = $this->controller->editAction(null));
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/ajax_layout.html.twig', $this->parameters['base_template']);
@@ -2447,7 +2453,13 @@ class CRUDControllerTest extends TestCase
             ->method('trans')
             ->willReturn('flash message');
 
-        $this->expectDeprecation('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json` or `Accept: */*`');
+        $this->expectDeprecation(sprintf(
+            'None of the passed values ("%s") in the "Accept" header when requesting %s %s is supported since sonata-project/admin-bundle 3.x.'
+            .' It will result in a response with the status code 406 (Not Acceptable) in 4.0. You must add "application/json".',
+            implode('", "', $this->request->getAcceptableContentTypes()),
+            $this->request->getMethod(),
+            $this->request->getUri()
+        ));
         $this->assertInstanceOf(Response::class, $response = $this->controller->createAction());
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/ajax_layout.html.twig', $this->parameters['base_template']);


### PR DESCRIPTION
## Subject

Change the visibility of the CRUDController methodes `handleXmlHttpRequestSuccessResponse` and  `handleXmlHttpRequestErrorResponse` from private to protected to allow overriding.

In my application I want to extend the Xml Http response, but there is no way to override it. The only option is to override the editAction but that's not desirable.

I am targeting this branch, because the change is not backwards compatible.

## Changelog

```markdown
### Changed
- `CRUDController::handleXmlHttpRequestSuccessResponse` method is now protected
- `CRUDController::handleXmlHttpRequestErrorResponse` method is now protected
```