### PR TITLE
Deprecate help option in FieldDescription

### DIFF
--- a/.phpstan/phpstan-baseline.neon
+++ b/.phpstan/phpstan-baseline.neon
@@ -90,6 +90,12 @@ parameters:
             count: 1
             path: ../src/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
 
+        -
+            # NEXT_MAJOR: Remove this error
+            message: "#^Call to an undefined method Sonata\\\\AdminBundle\\\\Admin\\\\FieldDescriptionInterface\\:\\:setHelp\\(\\)\\.$#"
+            count: 1
+            path: ../src/Form/FormMapper.php
+
 # next 6 errors are due to not installed Doctrine ORM\ODM
         -
             message: "#^Class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection not found\\.$#"

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,27 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated `help` option in field description
+
+You MUST use Symfony's [`help`](https://symfony.com/doc/4.4/reference/forms/types/form.html#help) option instead.
+
+Before:
+```php
+$formMapper
+    ->add('field', null, [
+        'help' => 'Help text <small>Please!</small>',
+    ]);
+```
+
+After:
+```php
+$formMapper
+    ->add('field', null, [
+        'help' => 'Help text <small>Please!</small>',
+        'help_html' => true,
+    ]);
+```
+
 UPGRADE FROM 3.72 to 3.73
 =========================
 

--- a/docs/cookbook/recipe_image_previews.rst
+++ b/docs/cookbook/recipe_image_previews.rst
@@ -22,14 +22,14 @@ Pre-requisites
 The recipe
 ----------
 
-SonataAdmin lets us put raw HTML into the 'help' option for any given form field.
+You can use Symfony 'help' and 'help_html' options to put raw HTML into any given form field.
 We are going to use this functionality to embed an image tag when an image exists.
 
 To do this we need to:
 
 - get access to the ``Image`` instance from within ``ImageAdmin``
 - create an image tag based on the Image's URL
-- add a 'help' option to a field on the Image form to display the image tag
+- add a 'help' and 'help_html' option to a field on the Image form to display the image tag
 
 For the sake of this example we will use some basic CSS to restrict the size of
 the preview image (we are not going to generate and save special thumbnails).
@@ -48,19 +48,20 @@ we are manipulating form fields we do this from within ``ImageAdmin::configureFo
             // get the current Image instance
             $image = $this->getSubject();
 
-            // use $fileFieldOptions so we can add other options to the field
-            $fileFieldOptions = ['required' => false];
+            // use $fileFormOptions so we can add other options to the field
+            $fileFormOptions = ['required' => false];
             if ($image && ($webPath = $image->getWebPath())) {
                 // get the container so the full path to the image can be set
                 $container = $this->getConfigurationPool()->getContainer();
                 $fullPath = $container->get('request_stack')->getCurrentRequest()->getBasePath().'/'.$webPath;
 
                 // add a 'help' option containing the preview's img tag
-                $fileFieldOptions['help'] = '<img src="'.$fullPath.'" class="admin-preview"/>';
+                $fileFormOptions['help'] = '<img src="'.$fullPath.'" class="admin-preview"/>';
+                $fileFormOptions['help_html'] = true;
             }
 
             $formMapper
-                ->add('file', 'file', $fileFieldOptions)
+                ->add('file', 'file', $fileFormOptions)
             ;
         }
     }
@@ -77,7 +78,7 @@ We then use CSS to restrict the max size of the image:
 And that is all there is to it!
 
 However, this method does not work when the ``ImageAdmin`` can be embedded in other
-Admins using the ``sonata_type_admin`` field type. For that we need...
+Admins using the ``Sonata\\AdminBundle\\Form\\Type\\AdminType`` field type. For that we need...
 
 Advanced example - works with embedded Admins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -105,15 +106,16 @@ Admin class is embedded and use a different method::
                 $image = $this->getSubject();
             }
 
-            // use $fileFieldOptions so we can add other options to the field
-            $fileFieldOptions = ['required' => false];
+            // use $fileFormOptions so we can add other options to the field
+            $fileFormOptions = ['required' => false];
             if ($image && ($webPath = $image->getWebPath())) {
                 // add a 'help' option containing the preview's img tag
-                $fileFieldOptions['help'] = '<img src="'.$webPath.'" class="admin-preview"/>';
+                $fileFormOptions['help'] = '<img src="'.$webPath.'" class="admin-preview"/>';
+                $fileFormOptions['help_html'] = true;
             }
 
             $formMapper
-                ->add('file', 'file', $fileFieldOptions)
+                ->add('file', 'file', $fileFormOptions)
             ;
         }
     }

--- a/docs/reference/form_help_message.rst
+++ b/docs/reference/form_help_message.rst
@@ -4,10 +4,9 @@ Form Help Messages and Descriptions
 Help Messages
 -------------
 
-Help messages are short notes that are rendered together with form fields.
+You can use `Symfony 'help' option`_ to add help messages that are rendered together with form fields.
 They are generally used to show additional information so the user can complete
-the form element faster and more accurately. The text is not escaped,
-so HTML can be used.
+the form element faster and more accurately.
 
 Example
 ^^^^^^^
@@ -36,100 +35,6 @@ Example
 .. figure:: ../images/help_message.png
    :align: center
    :alt: Example of the two form fields with help messages.
-
-Alternative Ways To Define Help Messages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-All at once::
-
-    // src/Admin/PostAdmin.php
-
-    final class PostAdmin extends AbstractAdmin
-    {
-        protected function configureFormFields(FormMapper $formMapper)
-        {
-            $formMapper
-                ->with('General')
-                    ->add('title')
-                    ->add('keywords')
-                    ->setHelps([
-                        'title' => 'Set the title of a web page',
-                        'keywords' => 'Set the keywords of a web page',
-                    ])
-                ->end()
-            ;
-        }
-    }
-
-or step by step::
-
-    // src/Admin/PostAdmin.php
-
-    final class PostAdmin extends AbstractAdmin
-    {
-        protected function configureFormFields(FormMapper $formMapper)
-        {
-            $formMapper
-                ->with('General')
-                    ->add('title')
-                    ->add('keywords')
-                    ->setHelp('title', 'Set the title of a web page')
-                    ->setHelp('keywords', 'Set the keywords of a web page')
-                ->end()
-            ;
-        }
-    }
-
-This can be very useful if you want to apply general help messages via an ``AdminExtension``.
-This Extension for example adds a note field to some entities which use a custom trait::
-
-    namespace App\Admin\Extension;
-
-    use Sonata\AdminBundle\Admin\AbstractAdminExtension;
-    use Sonata\AdminBundle\Datagrid\DatagridMapper;
-    use Sonata\AdminBundle\Form\FormMapper;
-    use Sonata\AdminBundle\Show\ShowMapper;
-
-    final class NoteAdminExtension extends AbstractAdminExtension
-    {
-        // add this field to the datagrid every time its available
-        /**
-         * @param DatagridMapper $datagridMapper
-         */
-        protected function configureDatagridFilters(DatagridMapper $datagridMapper)
-        {
-            $datagridMapper
-                ->add('note')
-            ;
-        }
-
-        // here we don't add the field, because we would like to define
-        // the place manually in the admin. But if the filed is available,
-        // we want to add the following help message to the field.
-        /**
-         * @param FormMapper $formMapper
-         */
-        protected function configureFormFields(FormMapper $formMapper)
-        {
-            $formMapper
-                ->addHelp('note', 'Use this field for an internal note.')
-            ;
-        }
-
-        // if the field exists, add it in a special tab on the show view.
-        /**
-         * @param ShowMapper $showMapper
-         */
-        protected function configureShowFields(ShowMapper $showMapper)
-        {
-            $showMapper
-                ->with('Internal')
-                    ->add('note')
-                ->end()
-            ;
-        }
-    }
-
 
 Advanced usage
 ^^^^^^^^^^^^^^
@@ -170,3 +75,5 @@ Example
             ;
         }
     }
+
+.. _`Symfony 'help' option`: https://symfony.com/doc/4.4/reference/forms/types/form.html#help

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -180,9 +180,17 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
             unset($options['template']);
         }
 
+        // NEXT_MAJOR: Remove this block.
         // set help if provided
         if (isset($options['help'])) {
-            $this->setHelp($options['help']);
+            @trigger_error(sprintf(
+                'Passing "help" option to "%s()" is deprecated since sonata-project/admin-bundle 3.x'
+                .' and the option will be removed in 4.0.'
+                .' Use Symfony Form "help" option instead.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+
+            $this->setHelp($options['help'], 'sonata_deprecation_mute');
             unset($options['help']);
         }
 
@@ -448,15 +456,33 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     /**
      * Defines the help message.
      *
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0. Use Symfony Form "help" option instead.
+     *
      * @param string $help
      */
     public function setHelp($help)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The "%s()" method is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.'
+                .' Use Symfony Form "help" option instead.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         $this->help = $help;
     }
 
     public function getHelp()
     {
+        @trigger_error(sprintf(
+            'The "%s()" method is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.'
+            .' Use Symfony Form "help" option instead.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->help;
     }
 

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -20,7 +20,6 @@ namespace Sonata\AdminBundle\Admin;
  * @method bool        hasAdmin()
  * @method bool        hasParent()
  * @method bool        hasAssociationAdmin()
- * @method void        setHelp(string $help)
  */
 interface FieldDescriptionInterface
 {
@@ -300,10 +299,4 @@ interface FieldDescriptionInterface
      * @return mixed
      */
     public function getFieldValue($object, $fieldName);
-
-//    NEXT_MAJOR: uncomment this method in 4.0
-//    /**
-//     * Defines the help message.
-//     */
-//    public function setHelp(string $help): void;
 }

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -136,9 +136,19 @@ class FormMapper extends BaseGroupedMapper
                 $options['label'] = $this->admin->getLabelTranslatorStrategy()->getLabel($name, 'form', 'label');
             }
 
+            // NEXT_MAJOR: Remove this block.
             if (isset($options['help'])) {
-                $fieldDescription->setHelp($options['help']);
-                unset($options['help']);
+                $containsHtml = $options['help'] !== strip_tags($options['help']);
+
+                if (!isset($options['help_html']) && $containsHtml) {
+                    @trigger_error(
+                        'Using HTML syntax within the "help" option and not setting the "help_html" option to "true" is deprecated'
+                        .' since sonata-project/admin-bundle 3.x and it will not work in version 4.0.',
+                        E_USER_DEPRECATED
+                    );
+
+                    $options['help_html'] = true;
+                }
             }
         }
 
@@ -241,24 +251,46 @@ class FormMapper extends BaseGroupedMapper
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0. Use Symfony Form "help" option instead.
+     *
      * @return FormMapper
      */
     public function setHelps(array $helps = [])
     {
+        @trigger_error(sprintf(
+            'The "%s()" method is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.'
+            .' Use Symfony Form "help" option instead.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         foreach ($helps as $name => $help) {
-            $this->addHelp($name, $help);
+            $this->addHelp($name, $help, 'sonata_deprecation_mute');
         }
 
         return $this;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0. Use Symfony Form "help" option instead.
+     *
      * @return FormMapper
      */
     public function addHelp($name, $help)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'The "%s()" method is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.'
+                .' Use Symfony Form "help" option instead.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         if ($this->admin->hasFormFieldDescription($name)) {
-            $this->admin->getFormFieldDescription($name)->setHelp($help);
+            $this->admin->getFormFieldDescription($name)->setHelp($help, 'sonata_deprecation_mute');
         }
 
         return $this;

--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
@@ -48,9 +48,11 @@ file that was distributed with this source code.
                         {% if sonata_admin.field_description.associationadmin.formfielddescriptions[field_name] is defined %}
                             {{ form_widget(nested_field) }}
 
+                            {# NEXT_MAJOR: Remove this block #}
                             {% if sonata_admin.field_description.associationadmin.formfielddescriptions[field_name].help %}
                                 <span class="help-block">
                                     {%- block help %}
+                                        {% deprecated 'The "help" option is deprecated in field description since sonata-project/admin-bundle 3.x, to be removed in 4.0. Use Symfony Form "help" option instead.' %}
                                         {{- sonata_admin.field_description.associationadmin.formfielddescriptions[field_name].help|trans(
                                             {},
                                             sonata_admin.field_description.associationadmin.formfielddescriptions[field_name].translationDomain
@@ -58,6 +60,8 @@ file that was distributed with this source code.
                                     {% endblock -%}
                                 </span>
                             {% endif %}
+
+                            {{ form_help(nested_field) }}
 
                             {% set dummy = nested_group_field.setrendered %}
                         {% else %}

--- a/src/Resources/views/CRUD/base_standard_edit_field.html.twig
+++ b/src/Resources/views/CRUD/base_standard_edit_field.html.twig
@@ -22,9 +22,13 @@ file that was distributed with this source code.
 
         {% block field %}{{ form_widget(field_element) }}{% endblock %}
 
+        {# NEXT_MAJOR: Remove this block #}
         {% if field_description.help %}
+            {% deprecated 'The "help" option is deprecated in field description since sonata-project/admin-bundle 3.x, to be removed in 4.0. Use Symfony Form "help" option instead.' %}
             <span class="help-block">{% block help %}{{ field_description.help|raw }}{% endblock %}</span>
         {% endif %}
+
+        {{ form_help(field_element) }}
 
         <div class="sonata-ba-field-error-messages">
             {% block errors %}{{ form_errors(field_element) }}{% endblock %}

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -35,7 +35,7 @@ file that was distributed with this source code.
 
 {% block form_help %}
     {% apply spaceless %}
-        <span class="help-block sonata-ba-field-widget-help">{{ parent() }}</span>
+        <span class="help-block sonata-ba-field-widget-help sonata-ba-field-help">{{ parent() }}</span>
     {% endapply %}
 {% endblock %}
 
@@ -400,7 +400,9 @@ file that was distributed with this source code.
                 </div>
             {% endif %}
 
+            {# NEXT_MAJOR: Remove this block #}
             {% if sonata_admin is defined and sonata_admin_enabled and sonata_admin.field_description.help|default(false) %}
+                {% deprecated 'The "help" option is deprecated in field description since sonata-project/admin-bundle 3.x, to be removed in 4.0. Use Symfony Form "help" option instead.' %}
                 <span class="help-block sonata-ba-field-help">{{ sonata_admin.field_description.help|trans(help_translation_parameters, sonata_admin.field_description.translationDomain ?: admin.translationDomain)|raw }}</span>
             {% endif %}
 

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -56,16 +56,12 @@ class BaseFieldDescriptionTest extends TestCase
         $description->setOption('label', 'trucmuche');
         $this->assertSame('trucmuche', $description->getLabel());
         $this->assertNull($description->getTemplate());
-        $description->setOptions(['type' => 'integer', 'template' => 'foo.twig.html', 'help' => 'fooHelp']);
+        $description->setOptions(['type' => 'integer', 'template' => 'foo.twig.html']);
 
         $this->assertSame('integer', $description->getType());
         $this->assertSame('foo.twig.html', $description->getTemplate());
-        $this->assertSame('fooHelp', $description->getHelp());
 
         $this->assertCount(2, $description->getOptions());
-
-        $description->setHelp('Please enter an integer');
-        $this->assertSame('Please enter an integer', $description->getHelp());
 
         $description->setMappingType('int');
         $this->assertSame('int', $description->getMappingType());
@@ -79,6 +75,22 @@ class BaseFieldDescriptionTest extends TestCase
 
         $description->setOption('sortable', 'field_name');
         $this->assertTrue($description->isSortable());
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testHelpOptions(): void
+    {
+        $description = new FieldDescription();
+
+        $description->setHelp('Please enter an integer');
+        $this->assertSame('Please enter an integer', $description->getHelp());
+
+        $description->setOptions(['help' => 'fooHelp']);
+        $this->assertSame('fooHelp', $description->getHelp());
     }
 
     public function testAdmin(): void

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -101,6 +101,7 @@ final class AppKernel extends Kernel
         $containerBuilder->loadFromExtension('twig', [
             'strict_variables' => '%kernel.debug%',
             'exception_controller' => null,
+            'form_themes' => ['@SonataAdmin/Form/form_admin_fields.html.twig'],
         ]);
 
         $loader->load(sprintf('%s/config/services.yml', $this->getProjectDir()));

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -50,6 +50,10 @@ final class CRUDControllerTest extends WebTestCase
             1,
             $crawler->filter('.sonata-ba-collapsed-fields label:contains("Name")')->count()
         );
+        $this->assertCount(
+            1,
+            $crawler->filter('.sonata-ba-field-help:contains("Help me!")')
+        );
     }
 
     public function testEmptyCreate(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataAdminBundle/pull/6206#issuecomment-660129939

I haven't seen any use case rather than showing help messages in form fields.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6207.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `BaseFieldDescription::setHelp()` and `BaseFieldDescription::getHelp()`.
- Deprecated passing `help` option to `BaseFieldDescription::setOptions()`.
- Deprecated `FormMapper::setHelps()` and `FormMapper:: addHelp()`.
- Deprecated passing `help` option to `FormMapper::add()` third argument containing HTML code without also passing `help_html` with `true` value.
```

I have to check if it works fine with nested fields.
