### PR TITLE
Added missing argument for sonata.admin.block.search_result

### DIFF
--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -12,6 +12,7 @@
             <argument type="service" id="twig"/>
             <argument type="service" id="sonata.admin.pool"/>
             <argument type="service" id="sonata.admin.search.handler"/>
+            <argument type="service" id="sonata.admin.global_template_registry"/>
         </service>
         <service id="sonata.admin.block.stats" class="Sonata\AdminBundle\Block\AdminStatsBlockService" public="true">
             <tag name="sonata.block"/>

--- a/tests/Block/AdminSearchBlockServiceTest.php
+++ b/tests/Block/AdminSearchBlockServiceTest.php
@@ -47,8 +47,8 @@ class AdminSearchBlockServiceTest extends BlockServiceTestCase
 
         $this->pool = $this->createMock(Pool::class);
         $this->searchHandler = $this->createMock(SearchHandler::class);
-        $this->templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
-        $this->templateRegistry->getTemplate('search_result_block')->willReturn('@SonataAdmin/Block/block_search_result.html.twig');
+        $this->templateRegistry = $this->createMock(TemplateRegistryInterface::class);
+        $this->templateRegistry->method('getTemplate')->willReturn('@SonataAdmin/Block/block_search_result.html.twig');
     }
 
     public function testDefaultSettings(): void
@@ -69,7 +69,7 @@ class AdminSearchBlockServiceTest extends BlockServiceTestCase
     {
         $admin = $this->createMock(AbstractAdmin::class);
 
-        $blockService = new AdminSearchBlockService($this->twig, $this->pool, $this->searchHandler, $this->templateRegistry->reveal());
+        $blockService = new AdminSearchBlockService($this->twig, $this->pool, $this->searchHandler, $this->templateRegistry);
         $blockContext = $this->getBlockContext($blockService);
 
         $this->searchHandler->expects(self::once())->method('search')->willReturn(true);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Added missing argument for sonata.admin.block.search_result

Added missing argument ($templateRegistry > sonata.admin.global_template_registry) for sonata.admin.block.search_result service.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this argument was added (but not set?) in master.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Added missing argument ($templateRegistry > sonata.admin.global_template_registry) for sonata.admin.block.search_result service.
```
