### PR TITLE
Handle field without mappedBy

### DIFF
--- a/src/Manipulator/ObjectManipulator.php
+++ b/src/Manipulator/ObjectManipulator.php
@@ -53,14 +53,18 @@ final class ObjectManipulator
         object $object,
         FieldDescriptionInterface $parentFieldDescription
     ): object {
-        $associationMapping = $parentFieldDescription->getAssociationMapping();
+        $mappedBy = $parentFieldDescription->getAssociationMapping()['mappedBy'];
+        if (null === $mappedBy) {
+            return $instance;
+        }
+
         $parentAssociationMappings = $parentFieldDescription->getParentAssociationMappings();
 
         foreach ($parentAssociationMappings as $parentAssociationMapping) {
             $object = self::callGetter($object, $parentAssociationMapping['fieldName']);
         }
 
-        return self::callSetter($instance, $object, $associationMapping['mappedBy']);
+        return self::callSetter($instance, $object, $mappedBy);
     }
 
     /**

--- a/tests/Manipulator/ObjectManipulatorTest.php
+++ b/tests/Manipulator/ObjectManipulatorTest.php
@@ -88,6 +88,14 @@ class ObjectManipulatorTest extends TestCase
         ObjectManipulator::setObject($instance, $object, $fieldDescription);
     }
 
+    public function testSetObjectWithoutMappedBy(): void
+    {
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
+        $fieldDescription->expects($this->once())->method('getAssociationMapping')->willReturn(['mappedBy' => null]);
+
+        ObjectManipulator::setObject(new \stdClass(), new \stdClass(), $fieldDescription);
+    }
+
     public function testSetObjectWithParentAssociation(): void
     {
         $fieldDescription = $this->createMock(FieldDescriptionInterface::class);


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.


Closes #6218.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Allow to use AdminType with unidirectional field.
```
