### PR TITLE
Add correct accept header to ajaxSubmit to prevent 406 error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "symfony/css-selector": "^4.4",
         "symfony/filesystem": "^4.4",
         "symfony/maker-bundle": "^1.17",
-        "symfony/phpunit-bridge": "^5.1",
+        "symfony/phpunit-bridge": "^5.1.1",
         "symfony/yaml": "^4.4"
     },
     "suggest": {

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1563,8 +1563,8 @@ class CRUDController implements ContainerAwareInterface
 
     private function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): ?JsonResponse
     {
-        if (!\in_array('application/json', $request->getAcceptableContentTypes(), true)) {
-            @trigger_error('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json`', E_USER_DEPRECATED);
+        if (empty(array_intersect(['application/json', '*/*'], $request->getAcceptableContentTypes()))) {
+            @trigger_error('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json` or `Accept: */*`', E_USER_DEPRECATED);
 
             return null;
         }
@@ -1585,8 +1585,8 @@ class CRUDController implements ContainerAwareInterface
      */
     private function handleXmlHttpRequestSuccessResponse(Request $request, $object): JsonResponse
     {
-        if (!\in_array('application/json', $request->getAcceptableContentTypes(), true)) {
-            @trigger_error('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json`', E_USER_DEPRECATED);
+        if (empty(array_intersect(['application/json', '*/*'], $request->getAcceptableContentTypes()))) {
+            @trigger_error('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json` or `Accept: */*`', E_USER_DEPRECATED);
         }
 
         return $this->renderJson([

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -279,6 +279,9 @@ This code manages the many-to-[one|many] association field popup
         jQuery(form).ajaxSubmit({
             url: url,
             type: type,
+            headers: {
+                Accept: 'application/json'
+            },
             data: data,
             success: function(data) {
                 Admin.log('[{{ id }}|field_dialog_form_action] ajax success');

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -40,6 +40,7 @@ use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
 use Sonata\Exporter\Exporter;
 use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Exporter\Writer\JsonWriter;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine;
 use Symfony\Component\DependencyInjection\Container;
@@ -74,6 +75,8 @@ use Twig\Environment;
  */
 class CRUDControllerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var CRUDController
      */
@@ -1665,7 +1668,6 @@ class CRUDControllerTest extends TestCase
 
     /**
      * @legacy
-     * @expectedDeprecation In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json`
      */
     public function testEditActionAjaxErrorWithoutAcceptApplicationJson(): void
     {
@@ -1706,6 +1708,7 @@ class CRUDControllerTest extends TestCase
             ->method('trans')
             ->willReturn('flash message');
 
+        $this->expectDeprecation('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json` or `Accept: */*`');
         $this->assertInstanceOf(Response::class, $response = $this->controller->editAction(null));
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/ajax_layout.html.twig', $this->parameters['base_template']);
@@ -2363,7 +2366,6 @@ class CRUDControllerTest extends TestCase
 
     /**
      * @legacy
-     * @expectedDeprecation In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json`
      */
     public function testCreateActionAjaxErrorWithoutAcceptApplicationJson(): void
     {
@@ -2408,6 +2410,7 @@ class CRUDControllerTest extends TestCase
             ->method('trans')
             ->willReturn('flash message');
 
+        $this->expectDeprecation('In next major version response will return 406 NOT ACCEPTABLE without `Accept: application/json` or `Accept: */*`');
         $this->assertInstanceOf(Response::class, $response = $this->controller->createAction());
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/ajax_layout.html.twig', $this->parameters['base_template']);


### PR DESCRIPTION
## Add correct accept header to ajaxSubmit to prevent 406 error

The modeltype save request gives a 406 (Not acceptable) error in my browser. This is causes because my browser sends an wildcard Accept header `*/*` and the code checks on an exact match of `application/json`. To fix this I set the accept header before the ajax request.

I am targeting this branch, because the deprecation is introduce in **3.x** and the error is given in the master branch.

## Changelog

```markdown
### Fixed
- Set the Accept header for ajaxSubmit in `Resources/views/CRUD/Association/edit_many_script.html.twig` to  "application/json" to prevent 406 (Not acceptable)  error.
- CRUDController::handleXmlHttpRequestErrorResponse also accepts the wildcard Accept header  "*/*".
- CRUDController::handleXmlHttpRequestSuccessResponse also accepts the wildcard Accept header  "*/*".
```