### PR TITLE
Edit many script error without subclass gives an exception

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -302,7 +302,7 @@ This code manages the many-to-[one|many] association field popup
                         jQuery('#field_widget_{{ id }}').closest('form').ajaxSubmit({
                             url: '{{ path('sonata_admin_retrieve_form_element', {
                                 'elementId': id,
-                                'subclass':  sonata_admin.admin.getActiveSubclassCode(),
+                                'subclass':  sonata_admin.admin.hasActiveSubClass() ? sonata_admin.admin.getActiveSubclassCode() : null,
                                 'objectId':  sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
                                 'uniqid':    sonata_admin.admin.root.uniqid,
                                 'code':      sonata_admin.admin.root.code


### PR DESCRIPTION
## Edit many script error without subclass givens an exception

**Exception:**
An exception has been thrown during the rendering of a template ("Admin "..." has no active subclass."). 

This exception is thrown after adding a ModelType field the the admin.

I am targeting this branch, because "The error is introduced in master, but a deprecation is introduce in 3.x.".

## Changelog

```markdown
### Fixed
- Admin has no active subclass exception in *edit_many_script.html.twig* after adding a ModelType field.
```