### PR TITLE
Set subject on admin instance when extracting translatable strings

### DIFF
--- a/src/Translator/Extractor/AdminExtractor.php
+++ b/src/Translator/Extractor/AdminExtractor.php
@@ -96,6 +96,7 @@ final class AdminExtractor implements ExtractorInterface, LabelTranslatorStrateg
             }
 
             $admin->setLabelTranslatorStrategy($this);
+            $admin->setSubject($admin->getNewInstance());
 
             foreach (self::PUBLIC_ADMIN_METHODS as $method) {
                 $admin->$method();

--- a/tests/Translator/Extractor/AdminExtractorTest.php
+++ b/tests/Translator/Extractor/AdminExtractorTest.php
@@ -121,4 +121,18 @@ final class AdminExtractorTest extends TestCase
 
         $this->adminExtractor->extract([], $catalogue);
     }
+
+    public function testExtractSetsSubject(): void
+    {
+        $this->fooAdmin
+            ->expects($this->exactly(1))
+            ->method('setSubject');
+        $this->fooAdmin
+            ->expects($this->exactly(1))
+            ->method('getNewInstance');
+
+        $catalogue = new MessageCatalogue('en');
+
+        $this->adminExtractor->extract([], $catalogue);
+    }
 }


### PR DESCRIPTION
## Subject

After #6040 was added commands like `php bin/console debug:translation` execute methods on Admin class instances to extract translatable strings.

One of the methods is `getForm`, which calls `configureFormFields`. To tailor my forms I access `$this->getSubject()` in several of these methods. I hope this is not unusual or against best practices.

When the AdminExtractor calls `getForm()` no subject is present.

I added this code to make sure a basic model is available:

```php
$admin->setSubject($admin->getNewInstance());
```

I am targeting this branch, because it is backwards compatible.

Closes #6221.

## Changelog

```markdown
### Fixed
- AdminExtractor sets subject created by `getNewInstance()` on Admin instance before extracting translatable strings.
```
