### PR TITLE
Show applied filter

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -3164,6 +3164,11 @@ EOT;
      */
     final public function isDefaultFilter($name)
     {
+        @trigger_error(sprintf(
+            'Method "%s" is deprecated since sonata-project/admin-bundle 3.x.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $filter = $this->getFilterParameters();
         $default = $this->getDefaultFilterValues();
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -3154,6 +3154,8 @@ EOT;
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * Checks if a filter type is set to a default value.
      *
      * @param string $name

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -744,7 +744,7 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     /*
      * Checks if a filter type is set to a default value
      */
-//    NEXT_MAJOR: uncomment this method in 4.0
+//    NEXT_MAJOR: remove this method
     // public function isDefaultFilter(string $name): bool;
 
 //    NEXT_MAJOR: uncomment this method in 4.0

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -42,7 +42,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @method array                           configureActionButtons(string $action, ?object $object = null)
  * @method string                          getSearchResultLink(object $object)
  * @method void                            showMosaicButton(bool $isShown)
- * @method bool                            isDefaultFilter(string $name)
+ * @method bool                            isDefaultFilter(string $name)                                         // NEXT_MAJOR: Remove this
  * @method bool                            isCurrentRoute(string $name, ?string $adminCode)
  * @method bool                            canAccessObject(string $action, object $object)
  * @method mixed                           getPersistentParameter(string $name)
@@ -740,12 +740,6 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 //     * Setting to false will hide mosaic button for the admin screen.
 //     */
 //    public function showMosaicButton(bool $isShown): void;
-
-    /*
-     * Checks if a filter type is set to a default value
-     */
-//    NEXT_MAJOR: remove this method
-    // public function isDefaultFilter(string $name): bool;
 
 //    NEXT_MAJOR: uncomment this method in 4.0
 //    public function setFilterPersister(?\Sonata\AdminBundle\Filter\Persister\FilterPersisterInterface\FilterPersisterInterface $filterPersister = null): void;

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -245,10 +245,10 @@ file that was distributed with this source code.
 
                 <ul class="dropdown-menu" role="menu">
                     {% for filter in admin.datagrid.filters|filter(filter => filter.options['show_filter'] is not same as (false)) %}
-                        {% set filterActive = filter.isActive() or filter.options['show_filter'] is same as (true) %}
+                        {% set filterDisplayed = filter.isActive() or filter.options['show_filter'] is same as (true) %}
                         <li>
                             <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
-                                <i class="fa {{ filterActive ? 'fa-check-square-o' : 'fa-square-o' }}"></i>
+                                <i class="fa {{ filterDisplayed ? 'fa-check-square-o' : 'fa-square-o' }}"></i>
                                 {% if filter.label is not same as(false) %}
                                     {{ filter.label|trans({}, filter.translationDomain ?: admin.translationDomain) }}
                                 {% endif %}
@@ -275,9 +275,9 @@ file that was distributed with this source code.
                             <div class="col-sm-9">
                                 {% set withAdvancedFilter = false %}
                                 {% for filter in admin.datagrid.filters %}
-                                    {% set filterActive = filter.isActive() or filter.options['show_filter'] is same as (true) %}
-                                    {% set filterVisible = filter.options['show_filter'] is not same as(false) %}
-                                    <div class="form-group {% block sonata_list_filter_group_class %}{% endblock %}" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ filterVisible ? 'true' : 'false' }}" style="display: {% if filterActive %}block{% else %}none{% endif %}">
+                                    {% set filterDisplayed = filter.isActive() or filter.options['show_filter'] is same as (true) %}
+                                    {% set filterCanBeDisplayed = filter.options['show_filter'] is not same as(false) %}
+                                    <div class="form-group {% block sonata_list_filter_group_class %}{% endblock %}" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ filterCanBeDisplayed ? 'true' : 'false' }}" style="display: {% if filterDisplayed %}block{% else %}none{% endif %}">
                                         {% if filter.label is not same as(false) %}
                                             <label for="{{ form[filter.formName].children['value'].vars.id }}" class="col-sm-3 control-label">{{ filter.label|trans({}, filter.translationDomain ?: admin.translationDomain) }}</label>
                                         {% endif %}

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -244,11 +244,11 @@ file that was distributed with this source code.
                 </a>
 
                 <ul class="dropdown-menu" role="menu">
-                    {% for filter in admin.datagrid.filters|filter(filter => filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null) %}
-                        {% set filterActive = ((filter.isActive() or filter.options['show_filter']) and not admin.isDefaultFilter(filter.formName)) %}
+                    {% for filter in admin.datagrid.filters|filter(filter => filter.options['show_filter'] is not same as (false)) %}
+                        {% set filterActive = filter.isActive() or filter.options['show_filter'] is same as (true) %}
                         <li>
                             <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
-                                <i class="fa {{ (filter.isActive() or filter.options['show_filter']) ? 'fa-check-square-o' : 'fa-square-o' }}"></i>
+                                <i class="fa {{ filterActive ? 'fa-check-square-o' : 'fa-square-o' }}"></i>
                                 {% if filter.label is not same as(false) %}
                                     {{ filter.label|trans({}, filter.translationDomain ?: admin.translationDomain) }}
                                 {% endif %}
@@ -275,8 +275,8 @@ file that was distributed with this source code.
                             <div class="col-sm-9">
                                 {% set withAdvancedFilter = false %}
                                 {% for filter in admin.datagrid.filters %}
-                                    {% set filterActive = ((filter.isActive() and filter.options['show_filter'] is null) or (filter.options['show_filter'] is same as(true))) and not admin.isDefaultFilter(filter.formName) %}
-                                    {% set filterVisible = filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null %}
+                                    {% set filterActive = filter.isActive() or filter.options['show_filter'] is same as (true) %}
+                                    {% set filterVisible = filter.options['show_filter'] is not same as(false) %}
                                     <div class="form-group {% block sonata_list_filter_group_class %}{% endblock %}" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ filterVisible ? 'true' : 'false' }}" style="display: {% if filterActive %}block{% else %}none{% endif %}">
                                         {% if filter.label is not same as(false) %}
                                             <label for="{{ form[filter.formName].children['value'].vars.id }}" class="col-sm-3 control-label">{{ filter.label|trans({}, filter.translationDomain ?: admin.translationDomain) }}</label>

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -2248,7 +2248,7 @@ class AdminTest extends TestCase
      *
      * @legacy
      *
-     * @expectDeprecation Method "Sonata\AdminBundle\Admin\AbstractAdmin::isDefaultFilter" is deprecated since sonata-project/admin-bundle 3.x.
+     * @expectedDeprecation Method "Sonata\AdminBundle\Admin\AbstractAdmin::isDefaultFilter" is deprecated since sonata-project/admin-bundle 3.x.
      */
     public function testDefaultFilters(): void
     {

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -2243,6 +2243,13 @@ class AdminTest extends TestCase
         $this->assertArrayHasKey('create', $admin->getDashboardActions());
     }
 
+    /**
+     * NEXT_MAJOR: Remove the assertion about isDefaultFilter method.
+     *
+     * @legacy
+     *
+     * @expectDeprecation Method "Sonata\AdminBundle\Admin\AbstractAdmin::isDefaultFilter" is deprecated since sonata-project/admin-bundle 3.x.
+     */
     public function testDefaultFilters(): void
     {
         $admin = new FilteredAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'Sonata\FooBundle\Controller\ModelAdminController');

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -2244,7 +2244,7 @@ class AdminTest extends TestCase
     }
 
     /**
-     * NEXT_MAJOR: Remove the assertion about isDefaultFilter method.
+     * NEXT_MAJOR: Remove the assertion about isDefaultFilter method and the legacy group.
      *
      * @group legacy
      *

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -2246,7 +2246,7 @@ class AdminTest extends TestCase
     /**
      * NEXT_MAJOR: Remove the assertion about isDefaultFilter method.
      *
-     * @legacy
+     * @group legacy
      *
      * @expectedDeprecation Method "Sonata\AdminBundle\Admin\AbstractAdmin::isDefaultFilter" is deprecated since sonata-project/admin-bundle 3.x.
      */


### PR DESCRIPTION
## Subject

Change the UX-behavior to stop hidding default filter and considering them as normal filters.

Closes #6217.
Closes #6137.
Closes #5745.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
## Changed:
- Stop to hide default filters in order to provide a more natural UX-behavior.

## Deprecate
- Abstract:: isDefaultFilter method.
```
