### PR TITLE
Update required dependancies in install doc after SonataCoreBundle became optionnal #6173

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -41,10 +41,12 @@ line in `bundles.php` file of your project::
     return [
         // ...
         Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
-        Sonata\CoreBundle\SonataCoreBundle::class => ['all' => true],
         Sonata\BlockBundle\SonataBlockBundle::class => ['all' => true],
         Knp\Bundle\MenuBundle\KnpMenuBundle::class => ['all' => true],
         Sonata\AdminBundle\SonataAdminBundle::class => ['all' => true],
+        Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle::class => ['all' => true],
+        Sonata\Form\Bridge\Symfony\SonataFormBundle::class => ['all' => true],
+        Sonata\Twig\Bridge\Symfony\SonataTwigBundle::class => ['all' => true],
     ];
 
 Configure the Installed Bundles

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -44,7 +44,7 @@ line in `bundles.php` file of your project::
         Sonata\BlockBundle\SonataBlockBundle::class => ['all' => true],
         Knp\Bundle\MenuBundle\KnpMenuBundle::class => ['all' => true],
         Sonata\AdminBundle\SonataAdminBundle::class => ['all' => true],
-        Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle::class => ['all' => true],
+        Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle::class => ['all' => true],
         Sonata\Form\Bridge\Symfony\SonataFormBundle::class => ['all' => true],
         Sonata\Twig\Bridge\Symfony\SonataTwigBundle::class => ['all' => true],
     ];


### PR DESCRIPTION
## Subject

Update install doc dependancies

I am targeting this branch 3.x, because it related to a change occured in 3.69.0 version.

Closes #6173.
