### PR TITLE
Deprecate getParentFieldDescription from ModelManagerInterface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+### Deprecated `Sonata\AdminBundle\Model\ModelManagerInterface::getParentFieldDescription`
+
+Use `Sonata\AdminBundle\Admin\AdminInterface::getParentFieldDescription` instead.
+
 UPGRADE FROM 3.71 to 3.72
 =========================
 

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -83,6 +83,11 @@ interface ModelManagerInterface extends DatagridManagerInterface
     public function batchDelete($class, ProxyQueryInterface $queryProxy);
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x. To be removed in 4.0.
+     * Use AdminInterface::getParentFieldDescription instead.
+     *
      * @param array  $parentAssociationMapping
      * @param string $class
      */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Taking a look at the method [`ModelManager::getParentFieldDescription()` from SonataDoctrineMongoDBAdminBundle](https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/src/Model/ModelManager.php#L243) (and the one in [SonataDoctrineORMBundle](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/src/Model/ModelManager.php#L315)), looks like they are not used anymore, in fact, the first parameter they receive (`$parentAssociationMapping`) is an array and then there is this code (which would fail because of using an `array` as a key):
```php
$associatingMapping = $metadata->associationMappings[$parentAssociationMapping];
```
This method was added in https://github.com/sonata-project/SonataAdminBundle/commit/b0df44f9894b08ea1ac526231990547919da375f, and the `$parentAssociationMapping` parameter back then was a `string`. There was this call in the `AbstractAdmin` class (previously known as `Admin`):
```php
$fieldDescription = $this->getModelManager()->getParentFieldDescription($this->getParentAssociationMapping(), $this->getClass());
```

Then in https://github.com/sonata-project/SonataAdminBundle/commit/789802d1a80ca95f571edc3a8103f0df25ca3f57 that call was replaced by calling to the `getParentFieldDescription` within the `Admin` class.

There are maybe other uses of this method I haven't found, but looks like this method is not used.


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `ModelManagerInterface::getParentFieldDescription`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
