### PR TITLE
Improve child admin documentation wrt URL generation

### DIFF
--- a/docs/reference/child_admin.rst
+++ b/docs/reference/child_admin.rst
@@ -61,20 +61,14 @@ class::
             $admin = $this->isChild() ? $this->getParent() : $this;
             $id = $admin->getRequest()->get('id');
 
-            $menu->addChild('View Playlist', [
-                'uri' => $admin->generateUrl('show', ['id' => $id])
-            ]);
+            $menu->addChild('View Playlist', $admin->generateMenuUrl('show', ['id' => $id]));
 
             if ($this->isGranted('EDIT')) {
-                $menu->addChild('Edit Playlist', [
-                    'uri' => $admin->generateUrl('edit', ['id' => $id])
-                ]);
+                $menu->addChild('Edit Playlist', $admin->generateMenuUrl('edit', ['id' => $id]));
             }
 
             if ($this->isGranted('LIST')) {
-                $menu->addChild('Manage Videos', [
-                    'uri' => $admin->generateUrl('App\Admin\VideoAdmin.list', ['id' => $id])
-                ]);
+                $menu->addChild('Manage Videos', $admin->generateMenuUrl('App\Admin\VideoAdmin.list', ['id' => $id]));
             }
         }
     }


### PR DESCRIPTION
## Subject

When adding items to the tab menu according to the documentation the built-in functionality of Knp Menu to highlight the current item is not used. The reason is that only works when using `generateMenuUrl` to add the menu item.

I've updated the documentation to reflect this.

I am targeting this branch, because it's a documentation change.
