### PR TITLE
Deprecate unused form templates

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,19 @@
 UPGRADE 3.x
 ===========
 
+## The following templates have been deprecated
+
+ - `src/Resources/views/CRUD/base_filter_field.html.twig`
+ - `src/Resources/views/CRUD/base_inline_edit_field.html.twig`
+ - `src/Resources/views/CRUD/base_standard_edit_field.html.twig`
+ - `src/Resources/views/CRUD/edit_array.html.twig `
+ - `src/Resources/views/CRUD/edit_boolean.html.twig`
+ - `src/Resources/views/CRUD/edit_file.html.twig`
+ - `src/Resources/views/CRUD/edit_integer.html.twig`
+ - `src/Resources/views/CRUD/edit_sonata_type_immutable_array.html.twig`
+ - `src/Resources/views/CRUD/edit_string.html.twig`
+ - `src/Resources/views/CRUD/edit_text.html.twig`
+
 ## Deprecated `help` option in field description
 
 You MUST use Symfony's [`help`](https://symfony.com/doc/4.4/reference/forms/types/form.html#help) option instead.

--- a/src/Resources/views/CRUD/base_filter_field.html.twig
+++ b/src/Resources/views/CRUD/base_filter_field.html.twig
@@ -9,6 +9,7 @@ file that was distributed with this source code.
 
 #}
 
+{% deprecated 'The "base_filter_field.html.twig" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0' %}
 
 <div>
     {% block label %}

--- a/src/Resources/views/CRUD/base_inline_edit_field.html.twig
+++ b/src/Resources/views/CRUD/base_inline_edit_field.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{% deprecated 'The "base_inline_edit_field.html.twig" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0' %}
+
 <div id="sonata-ba-field-container-{{ field_element.vars.id }}" class="sonata-ba-field sonata-ba-field-{{ edit }}-{{ inline }}{% if field_element.vars.errors|length %} sonata-ba-field-error{% endif %}">
 
     {% block label %}

--- a/src/Resources/views/CRUD/base_standard_edit_field.html.twig
+++ b/src/Resources/views/CRUD/base_standard_edit_field.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{% deprecated 'The "base_standard_edit_field.html.twig" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0' %}
+
 <div class="form-group{% if field_element.var.errors|length > 0 %} has-error{% endif %}" id="sonata-ba-field-container-{{ field_element.vars.id }}">
     {% block label %}
         {% if field_description.options.name is defined %}

--- a/src/Resources/views/CRUD/edit_array.html.twig
+++ b/src/Resources/views/CRUD/edit_array.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{% deprecated 'The "edit_array.html.twig" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0' %}
+
 {% extends base_template %}
 
 {% block field %}

--- a/src/Resources/views/CRUD/edit_boolean.html.twig
+++ b/src/Resources/views/CRUD/edit_boolean.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{% deprecated 'The "edit_boolean.html.twig" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0' %}
+
 <div>
     <div class="sonata-ba-field{% if field_element.vars.errors|length > 0 %} sonata-ba-field-error{% endif %}">
         {% block field %}{{ form_widget(field_element) }}{% endblock %}

--- a/src/Resources/views/CRUD/edit_file.html.twig
+++ b/src/Resources/views/CRUD/edit_file.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{% deprecated 'The "edit_file.html.twig" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0' %}
+
 {% extends base_template %}
 
 {% block field %}{{ form_widget(field_element, {'attr': {'class' : 'title'}}) }}{% endblock %}

--- a/src/Resources/views/CRUD/edit_integer.html.twig
+++ b/src/Resources/views/CRUD/edit_integer.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{% deprecated 'The "edit_integer.html.twig" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0' %}
+
 {% extends base_template %}
 
 {% block field %}{{ form_widget(field_element, {'attr': {'class' : 'title'}}) }}{% endblock %}

--- a/src/Resources/views/CRUD/edit_sonata_type_immutable_array.html.twig
+++ b/src/Resources/views/CRUD/edit_sonata_type_immutable_array.html.twig
@@ -9,4 +9,6 @@ file that was distributed with this source code.
 
 #}
 
+{% deprecated 'The "edit_sonata_type_immutable_array.html.twig" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0' %}
+
 {% extends base_template %}

--- a/src/Resources/views/CRUD/edit_string.html.twig
+++ b/src/Resources/views/CRUD/edit_string.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{% deprecated 'The "edit_string.html.twig" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0' %}
+
 {% extends base_template %}
 
 {% block field %}{{ form_widget(field_element, {'attr': {'class' : 'title'}}) }}{% endblock %}

--- a/src/Resources/views/CRUD/edit_text.html.twig
+++ b/src/Resources/views/CRUD/edit_text.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{% deprecated 'The "edit_text.html.twig" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0' %}
+
 {% extends base_template %}
 
 {% block field %}{{ form_widget(field_element, {'attr': {'class' : 'title'}}) }}{% endblock %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I think these templates are not used anymore. The PR is draft because I still have to check better, but just in case someone has some knowledge about this. 

It makes sense to have templates for `list` and `show` for each field, but `edit` fields are configured through [`form_admin_fields.html.twig`](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Resources/views/Form/form_admin_fields.html.twig) and in the persistence bundles, that's why I think they are not used.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `base_filter_field.html.twig` template
- Deprecated `base_inline_edit_field.html.twig` template
- Deprecated `base_standard_edit_field.html.twig` template
- Deprecated `edit_array.html.twig ` template
- Deprecated `edit_boolean.html.twig` template
- Deprecated `edit_file.html.twig` template
- Deprecated `edit_integer.html.twig` template
- Deprecated `edit_sonata_type_immutable_array.html.twig` template
- Deprecated `edit_string.html.twig` template
- Deprecated `edit_text.html.twig` template
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
**Edit**:

Looks like in https://github.com/sonata-project/SonataAdminBundle/commit/0dc07aea65a973812126462e91af4a5db918083a some things happened: 
- [this call was removed](https://github.com/sonata-project/SonataAdminBundle/commit/0dc07aea65a973812126462e91af4a5db918083a#diff-58f7b4bf16afdd2ec540811005cfbfeeL289):
```php
$fieldDescription->setTemplate(sprintf('SonataAdminBundle:CRUD:edit_%s.html.twig', $fieldDescription->getType()));
```
- Some edit_* templates [were also removed](https://github.com/sonata-project/SonataAdminBundle/commit/0dc07aea65a973812126462e91af4a5db918083a#diff-ae56515cc30e37bdccba5a6c60468959L1).
- `admin_fields.html.twig` template [was added](https://github.com/sonata-project/SonataAdminBundle/commit/0dc07aea65a973812126462e91af4a5db918083a#diff-27e771cf6f0d0adfe9a1f7830e9efea0R1).
- A method called `renderFormElement` [was also removed](https://github.com/sonata-project/SonataAdminBundle/commit/0dc07aea65a973812126462e91af4a5db918083a#diff-cef2694e8930be6237942530aa1b1135L195) which had these calls:
```php
$template = $this->getTemplate($fieldDescription, 'SonataAdminBundle:CRUD:base_standard_edit_field.html.twig');
$base_template = sprintf('SonataAdminBundle:CRUD:base_%s_edit_field.html.twig', 'standard');
```

Following a normal request for create for example:

- First [from CRUDController it renders](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Controller/CRUDController.php#L642) the [`edit.html.twig` template](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Resources/views/CRUD/edit.html.twig#L12) with extends [base_edit.html.twig](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Resources/views/CRUD/base_edit.html.twig).
- base_edit.html.twig uses [base_edit_form.html.twig](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Resources/views/CRUD/base_edit_form.html.twig#L30) which uses a macro defined in [base_edit_form_macro.html.twig](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Resources/views/CRUD/base_edit_form_macro.html.twig#L21) to render the forms (with `form_row` function).