### PR TITLE
Return TypeGuess instead of Guess on TypeGuesserInterface::guessType

### DIFF
--- a/src/Guesser/TypeGuesserChain.php
+++ b/src/Guesser/TypeGuesserChain.php
@@ -15,7 +15,6 @@ namespace Sonata\AdminBundle\Guesser;
 
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
-use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
 /**
@@ -50,26 +49,12 @@ class TypeGuesserChain implements TypeGuesserInterface
 
     public function guessType($class, $property, ModelManagerInterface $modelManager)
     {
-        return $this->guess(static function ($guesser) use ($class, $property, $modelManager) {
-            return $guesser->guessType($class, $property, $modelManager);
-        });
-    }
-
-    /**
-     * Executes a closure for each guesser and returns the best guess from the
-     * return values.
-     *
-     * @param \Closure $closure The closure to execute. Accepts a guesser
-     *                          as argument and should return a Guess instance
-     *
-     * @return TypeGuess The guess with the highest confidence
-     */
-    private function guess(\Closure $closure): Guess
-    {
         $guesses = [];
 
         foreach ($this->guessers as $guesser) {
-            if ($guess = $closure($guesser)) {
+            $guess = $guesser->guessType($class, $property, $modelManager);
+
+            if (null !== $guess) {
                 $guesses[] = $guess;
             }
         }

--- a/src/Guesser/TypeGuesserChain.php
+++ b/src/Guesser/TypeGuesserChain.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Guesser;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Guess\Guess;
+use Symfony\Component\Form\Guess\TypeGuess;
 
 /**
  * The code is based on Symfony2 Form Components.
@@ -61,7 +62,7 @@ class TypeGuesserChain implements TypeGuesserInterface
      * @param \Closure $closure The closure to execute. Accepts a guesser
      *                          as argument and should return a Guess instance
      *
-     * @return Guess The guess with the highest confidence
+     * @return TypeGuess The guess with the highest confidence
      */
     private function guess(\Closure $closure): Guess
     {
@@ -73,6 +74,6 @@ class TypeGuesserChain implements TypeGuesserInterface
             }
         }
 
-        return Guess::getBestGuess($guesses);
+        return TypeGuess::getBestGuess($guesses);
     }
 }

--- a/src/Guesser/TypeGuesserInterface.php
+++ b/src/Guesser/TypeGuesserInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Guesser;
 
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Symfony\Component\Form\Guess\Guess;
+use Symfony\Component\Form\Guess\TypeGuess;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -25,7 +25,7 @@ interface TypeGuesserInterface
      * @param string $class
      * @param string $property
      *
-     * @return Guess|null
+     * @return TypeGuess|null
      */
     public function guessType($class, $property, ModelManagerInterface $modelManager);
 }


### PR DESCRIPTION
Checking phpstan for the MongoDB Admin Bundle, I got this (among others):
```php
 ------ -------------------------------------------------------------------------------------------------------------
  Line   Builder/DatagridBuilder.php
 ------ -------------------------------------------------------------------------------------------------------------
  121    Call to an undefined method Symfony\Component\Form\Guess\Guess::getType().
  123    Call to an undefined method Symfony\Component\Form\Guess\Guess::getOptions().
 ------ -------------------------------------------------------------------------------------------------------------
```

The problem here is that the `TypeGuesserInterface::guessType()` returns `Guess|null`, but looking at the implementation of the [SonataDoctrineORMAdminBundle](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/src/Guesser/TypeGuesser.php#L44) and [SonataDoctrineMongoDBAdminBundle](https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/src/Guesser/TypeGuesser.php#L27), they use `TypeGuess` and also the interface is called `TypeGuesser`Interface.

When they are used as in [here](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/src/Builder/DatagridBuilder.php#L137) or [here](https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/src/Builder/DatagridBuilder.php#L101):
```php
$guessType = $this->guesser->guessType($admin->getClass(), $fieldDescription->getName(), $admin->getModelManager());

$type = $guessType->getType();

$fieldDescription->setType($type);

$options = $guessType->getOptions();
```

`getType()` and `getOptions()` are only available in [`TypeGuess` class](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Form/Guess/TypeGuess.php#L45).
