### PR TITLE
Batch action $allItems needs to be an boolean

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -423,15 +423,12 @@ class CRUDController implements ContainerAwareInterface
         if ($data = json_decode((string) $request->get('data'), true)) {
             $action = $data['action'];
             $idx = $data['idx'];
-            $allElements = $data['all_elements'];
+            $allElements = (bool) $data['all_elements'];
             $request->request->replace(array_merge($request->request->all(), $data));
         } else {
-            $request->request->set('idx', $request->get('idx', []));
-            $request->request->set('all_elements', $request->get('all_elements', false));
-
-            $action = $request->get('action');
-            $idx = $request->get('idx');
-            $allElements = $request->get('all_elements');
+            $action = $request->request->getAlnum('action');
+            $idx = $request->request->get('idx', []);
+            $allElements = $request->request->getBoolean('all_elements');
             $data = $request->request->all();
 
             unset($data['_sonata_csrf_token']);


### PR DESCRIPTION
## Batch action $allItems needs to be an boolean

Exception:

_Argument 4 passed to Sonata\AdminBundle\Admin\AbstractAdmin::preBatchAction() must be of the type bool, string given, called in /projects/sonata-sandbox/vendor/sonata-project/admin-bundle/src/Controller/CRUDController.php on line 452_

I am targeting this branch, because there is the typehint added.

## Changelog

```markdown
### Changed
- Cast $allItems to an boolean to prevent typehint error.
```