### PR TITLE
Improve description of RouteCollectionInterface::actionify()

### DIFF
--- a/src/Route/RouteCollectionInterface.php
+++ b/src/Route/RouteCollectionInterface.php
@@ -67,7 +67,9 @@ interface RouteCollectionInterface
     public function clear(): self;
 
     /**
-     * Convert a word in to the format for a symfony action action_name => actionName.
+     * Converts a word into the format required for a controller action. By instance,
+     * the argument "list_something" returns "listSomething" if the associated controller is not an action itself,
+     * otherwise, it will return "listSomethingAction".
      */
     public function actionify(string $action): string;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is pedantic but this interface was introduced on master.
