### PR TITLE
Allow Twig 3

### DIFF
--- a/.phpstan/phpstan-baseline.neon
+++ b/.phpstan/phpstan-baseline.neon
@@ -222,6 +222,12 @@ parameters:
             count: 1
             path: ../src/Form/Extension/ChoiceTypeExtension.php
 
+        -
+            # will be fixed in v4. The file won't exist
+            message: "#^Call to static method load\\(\\) on an unknown class Symfony\\\\Component\\\\ClassLoader\\\\ClassCollectionLoader\\.$#"
+            count: 1
+            path: ../src/Command/CreateClassCacheCommand.php
+
 # next 6 errors are due to not installed Doctrine ORM\ODM
         -
             message: "#^Class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection not found\\.$#"

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,6 @@
     "require-dev": {
         "jms/translation-bundle": "^1.4",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
-        "mopa/bootstrap-bundle": "^3.3",
         "phpstan/phpstan": "^0.12.29",
         "psr/event-dispatcher": "^1.0",
         "sonata-project/intl-bundle": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "symfony/twig-bundle": "^4.4",
         "symfony/validator": "^4.4",
         "twig/string-extra": "^3.0",
-        "twig/twig": "^2.12.1"
+        "twig/twig": "^2.12.1 || ^3.0"
     },
     "conflict": {
         "doctrine/doctrine-bundle": ">=3",

--- a/src/SonataAdminBundle.php
+++ b/src/SonataAdminBundle.php
@@ -75,7 +75,7 @@ class SonataAdminBundle extends Bundle
             return;
         }
 
-        FormHelper::registerFormTypeMapping([
+        $formMapping = [
             'sonata_type_admin' => AdminType::class,
             'sonata_type_model' => ModelType::class,
             'sonata_type_model_list' => ModelListType::class,
@@ -91,8 +91,13 @@ class SonataAdminBundle extends Bundle
             'sonata_type_filter_date_range' => DateRangeType::class,
             'sonata_type_filter_datetime' => DateTimeType::class,
             'sonata_type_filter_datetime_range' => DateTimeRangeType::class,
-            'tab' => TabType::class,
-        ]);
+        ];
+
+        if (class_exists(TabType::class)) {
+            $formMapping['tab'] = TabType::class;
+        }
+
+        FormHelper::registerFormTypeMapping($formMapping);
 
         FormHelper::registerFormExtensionMapping('form', [
             'sonata.admin.form.extension.field',

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -2432,7 +2432,7 @@ EOT
             'object' => $this->object,
         ];
 
-        $template = $this->environment->loadTemplate('@SonataAdmin/CRUD/base_list_field.html.twig');
+        $template = $this->environment->load('@SonataAdmin/CRUD/base_list_field.html.twig')->unwrap();
 
         $this->assertSame(
             '<td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> foo </td>',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Since https://github.com/sonata-project/SonataAdminBundle/pull/6212 the only package preventing this is `mopa/bootstrap-bundle`, that was added in https://github.com/sonata-project/SonataAdminBundle/pull/6154 to pass phpstan check, I've removed the dependency and check if the class exist. 

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added compatibility with Twig 3.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

~**Edit**: I'll take a look later at phpstan~