### PR TITLE
Fix deprecation with SonataDoctrineBundle location

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "conflict": {
         "doctrine/doctrine-bundle": ">=3",
         "sonata-project/core-bundle": "<3.20",
-        "sonata-project/doctrine-extensions": "<1.1.3",
+        "sonata-project/doctrine-extensions": "<1.8",
         "sonata-project/media-bundle": "<3.7",
         "sonata-project/user-bundle": "<3.3"
     },

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -17,7 +17,7 @@ use Knp\Bundle\MenuBundle\KnpMenuBundle;
 use Sonata\AdminBundle\SonataAdminBundle;
 use Sonata\BlockBundle\SonataBlockBundle;
 use Sonata\CoreBundle\SonataCoreBundle;
-use Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle;
+use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle;
 use Sonata\Form\Bridge\Symfony\SonataFormBundle;
 use Sonata\Twig\Bridge\Symfony\SonataTwigBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

This is to prevent a deprecation on the tests, but also to avoid broken builds: https://github.com/sonata-project/SonataAdminBundle/pull/6263

I think something went wrong on last release of SonataDoctrineBundle
