### PR TITLE
Narrow Form and Mapper API

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2574,10 +2574,6 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     /**
      * Gets the subclass corresponding to the given name.
      *
-     * @param string $name The name of the sub class
-     *
-     * @return string the subclass
-     *
      * @phpstan-return class-string<T>
      */
     protected function getSubClass(string $name): string

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -145,7 +145,10 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     public function setParentFieldDescription(FieldDescriptionInterface $parentFieldDescription): void;
 
-    public function getParentFieldDescription(): ?FieldDescriptionInterface;
+    /**
+     * @throws \LogicException
+     */
+    public function getParentFieldDescription(): FieldDescriptionInterface;
 
     /**
      * Returns true if the Admin is linked to a parent FieldDescription.

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -146,7 +146,7 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function setParentFieldDescription(FieldDescriptionInterface $parentFieldDescription): void;
 
     /**
-     * @throws \LogicException
+     * @throws \LogicException if there is no parent field description
      */
     public function getParentFieldDescription(): FieldDescriptionInterface;
 

--- a/src/Form/ChoiceList/ModelChoiceLoader.php
+++ b/src/Form/ChoiceList/ModelChoiceLoader.php
@@ -20,9 +20,7 @@ use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\Exception\RuntimeException;
-use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
-use Symfony\Component\PropertyAccess\PropertyPath;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -35,9 +33,14 @@ final class ModelChoiceLoader implements ChoiceLoaderInterface
     private $modelManager;
 
     /**
-     * @var string
+     * @var PropertyAccessorInterface
+     */
+    private $propertyAccessor;
+
+    /**
+     * @var string|null
      *
-     * @phpstan-var class-string
+     * @phpstan-var class-string|null
      */
     private $class;
 
@@ -52,19 +55,9 @@ final class ModelChoiceLoader implements ChoiceLoaderInterface
     private $query;
 
     /**
-     * @var object[]
+     * @var object[]|null
      */
     private $choices;
-
-    /**
-     * @var PropertyPath|null
-     */
-    private $propertyPath;
-
-    /**
-     * @var PropertyAccessorInterface
-     */
-    private $propertyAccessor;
 
     /**
      * @var ChoiceListInterface|null
@@ -72,20 +65,17 @@ final class ModelChoiceLoader implements ChoiceLoaderInterface
     private $choiceList;
 
     /**
-     * @param string      $class
-     * @param string|null $property
-     * @param object|null $query
-     * @param object[]    $choices
+     * @param object[] $choices
      *
-     * @phpstan-param class-string $class
+     * @phpstan-param class-string|null $class
      */
     public function __construct(
         ModelManagerInterface $modelManager,
-        $class,
-        $property = null,
-        $query = null,
-        $choices = [],
-        ?PropertyAccessorInterface $propertyAccessor = null
+        PropertyAccessorInterface $propertyAccessor,
+        ?string $class = null,
+        ?string $property = null,
+        ?object $query = null,
+        array $choices = []
     ) {
         $this->modelManager = $modelManager;
         $this->class = $class;
@@ -94,32 +84,21 @@ final class ModelChoiceLoader implements ChoiceLoaderInterface
 
         if ($query) {
             if (!$this->modelManager->supportsQuery($query)) {
-                // NEXT_MAJOR: Remove the deprecation and uncomment the exception.
-                @trigger_error(
-                    'Passing a query which is not supported by the model manager is deprecated since'
-                    .' sonata-project/admin-bundle 3.76 and will throw an exception in version 4.0.',
-                    E_USER_DEPRECATED
-                );
-                // throw new \InvalidArgumentException('The model manager does not support the query.');
+                throw new \InvalidArgumentException('The model manager does not support the query.');
             }
 
             $this->query = $query;
         }
 
-        // The property option defines, which property (path) is used for
-        // displaying entities as strings
-        if ($property) {
-            $this->propertyPath = new PropertyPath($property);
-            $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
-        }
+        $this->propertyAccessor = $propertyAccessor;
     }
 
-    public function loadChoiceList($value = null)
+    public function loadChoiceList($value = null): ChoiceListInterface
     {
         if (!$this->choiceList) {
             if ($this->query) {
                 $entities = $this->modelManager->executeQuery($this->query);
-            } elseif (\is_array($this->choices) && \count($this->choices) > 0) {
+            } elseif (\count($this->choices) > 0) {
                 $entities = $this->choices;
             } else {
                 $entities = $this->modelManager->findBy($this->class);
@@ -127,9 +106,9 @@ final class ModelChoiceLoader implements ChoiceLoaderInterface
 
             $choices = [];
             foreach ($entities as $model) {
-                if ($this->propertyPath) {
+                if (null !== $this->property) {
                     // If the property option was given, use it
-                    $valueObject = $this->propertyAccessor->getValue($model, $this->propertyPath);
+                    $valueObject = $this->propertyAccessor->getValue($model, $this->property);
                 } else {
                     // Otherwise expect a __toString() method in the entity
                     try {
@@ -169,22 +148,20 @@ final class ModelChoiceLoader implements ChoiceLoaderInterface
         return $this->choiceList;
     }
 
-    public function loadChoicesForValues(array $values, $value = null)
+    public function loadChoicesForValues(array $values, $value = null): array
     {
         return $this->loadChoiceList($value)->getChoicesForValues($values);
     }
 
-    public function loadValuesForChoices(array $choices, $value = null)
+    public function loadValuesForChoices(array $choices, $value = null): array
     {
         return $this->loadChoiceList($value)->getValuesForChoices($choices);
     }
 
     /**
-     * @param object $model
-     *
      * @return mixed[]
      */
-    private function getIdentifierValues($model): array
+    private function getIdentifierValues(object $model): array
     {
         try {
             return $this->modelManager->getIdentifierValues($model);

--- a/src/Form/ChoiceList/ModelChoiceLoader.php
+++ b/src/Form/ChoiceList/ModelChoiceLoader.php
@@ -67,7 +67,7 @@ final class ModelChoiceLoader implements ChoiceLoaderInterface
     /**
      * @param object[] $choices
      *
-     * @phpstan-param class-string|null $class
+     * @phpstan-param class-string $class
      */
     public function __construct(
         ModelManagerInterface $modelManager,
@@ -78,6 +78,7 @@ final class ModelChoiceLoader implements ChoiceLoaderInterface
         array $choices = []
     ) {
         $this->modelManager = $modelManager;
+        $this->propertyAccessor = $propertyAccessor;
         $this->class = $class;
         $this->property = $property;
         $this->choices = $choices;
@@ -89,8 +90,6 @@ final class ModelChoiceLoader implements ChoiceLoaderInterface
 
             $this->query = $query;
         }
-
-        $this->propertyAccessor = $propertyAccessor;
     }
 
     public function loadChoiceList($value = null): ChoiceListInterface

--- a/src/Form/ChoiceList/ModelChoiceLoader.php
+++ b/src/Form/ChoiceList/ModelChoiceLoader.php
@@ -55,7 +55,7 @@ final class ModelChoiceLoader implements ChoiceLoaderInterface
     private $query;
 
     /**
-     * @var object[]|null
+     * @var object[]
      */
     private $choices;
 

--- a/src/Form/ChoiceList/ModelChoiceLoader.php
+++ b/src/Form/ChoiceList/ModelChoiceLoader.php
@@ -38,9 +38,9 @@ final class ModelChoiceLoader implements ChoiceLoaderInterface
     private $propertyAccessor;
 
     /**
-     * @var string|null
+     * @var string
      *
-     * @phpstan-var class-string|null
+     * @phpstan-var class-string
      */
     private $class;
 
@@ -72,7 +72,7 @@ final class ModelChoiceLoader implements ChoiceLoaderInterface
     public function __construct(
         ModelManagerInterface $modelManager,
         PropertyAccessorInterface $propertyAccessor,
-        ?string $class = null,
+        string $class,
         ?string $property = null,
         ?object $query = null,
         array $choices = []

--- a/src/Form/DataTransformer/ArrayToModelTransformer.php
+++ b/src/Form/DataTransformer/ArrayToModelTransformer.php
@@ -36,11 +36,9 @@ final class ArrayToModelTransformer implements DataTransformerInterface
     private $className;
 
     /**
-     * @param string $className
-     *
      * @phpstan-param class-string<T> $className
      */
-    public function __construct(ModelManagerInterface $modelManager, $className)
+    public function __construct(ModelManagerInterface $modelManager, string $className)
     {
         $this->modelManager = $modelManager;
         $this->className = $className;
@@ -49,13 +47,11 @@ final class ArrayToModelTransformer implements DataTransformerInterface
     /**
      * @param object|array<string, mixed>|null $value
      *
-     * @return object
-     *
      * @phpstan-param T|array<string, mixed>|null $value
      *
      * @phpstan-return T
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): object
     {
         // when the object is created the form return an array
         // one the object is persisted, the edit $array is the user instance
@@ -63,10 +59,8 @@ final class ArrayToModelTransformer implements DataTransformerInterface
             return $value;
         }
 
-        $instance = new $this->className();
-
         if (!\is_array($value)) {
-            return $instance;
+            return new $this->className();
         }
 
         return $this->modelManager->modelReverseTransform($this->className, $value);

--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -56,20 +56,15 @@ final class ModelToIdPropertyTransformer implements DataTransformerInterface
     private $toStringCallback;
 
     /**
-     * @param string        $className
-     * @param string        $property
-     * @param bool          $multiple
-     * @param callable|null $toStringCallback
-     *
      * @phpstan-param class-string<T> $className
      * @phpstan-param null|callable(object, string): string $toStringCallback
      */
     public function __construct(
         ModelManagerInterface $modelManager,
-        $className,
-        $property,
-        $multiple = false,
-        $toStringCallback = null
+        string $className,
+        string $property,
+        bool $multiple = false,
+        ?callable $toStringCallback = null
     ) {
         $this->modelManager = $modelManager;
         $this->className = $className;
@@ -80,6 +75,8 @@ final class ModelToIdPropertyTransformer implements DataTransformerInterface
 
     /**
      * @param mixed $value
+     *
+     * @throws \UnexpectedValueException
      *
      * @return Collection<int|string, object>|object|null
      *
@@ -123,6 +120,8 @@ final class ModelToIdPropertyTransformer implements DataTransformerInterface
 
     /**
      * @param object|object[]|null $value
+     *
+     * @throws \InvalidArgumentException
      *
      * @return array<string|int, string>
      *
@@ -170,7 +169,7 @@ final class ModelToIdPropertyTransformer implements DataTransformerInterface
             }
         }
 
-        if (empty($this->property)) {
+        if ('' === $this->property) {
             throw new \RuntimeException('Please define "property" parameter.');
         }
 
@@ -178,12 +177,6 @@ final class ModelToIdPropertyTransformer implements DataTransformerInterface
             $id = current($this->modelManager->getIdentifierValues($model));
 
             if (null !== $this->toStringCallback) {
-                if (!\is_callable($this->toStringCallback)) {
-                    throw new \RuntimeException(
-                        'Callback in "to_string_callback" option doesn`t contain callable function.'
-                    );
-                }
-
                 $label = ($this->toStringCallback)($model, $this->property);
             } elseif (method_exists($model, '__toString')) {
                 $label = (string) $model;

--- a/src/Form/DataTransformer/ModelToIdTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdTransformer.php
@@ -36,11 +36,9 @@ final class ModelToIdTransformer implements DataTransformerInterface
     private $className;
 
     /**
-     * @param string $className
-     *
      * @phpstan-param class-string<T> $className
      */
-    public function __construct(ModelManagerInterface $modelManager, $className)
+    public function __construct(ModelManagerInterface $modelManager, string $className)
     {
         $this->modelManager = $modelManager;
         $this->className = $className;
@@ -49,11 +47,9 @@ final class ModelToIdTransformer implements DataTransformerInterface
     /**
      * @param mixed $value
      *
-     * @return object|null
-     *
      * @phpstan-return T|null
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): ?object
     {
         if (empty($value) && !\in_array($value, ['0', 0], true)) {
             return null;
@@ -65,11 +61,9 @@ final class ModelToIdTransformer implements DataTransformerInterface
     /**
      * @param object|null $value
      *
-     * @return string|null
-     *
      * @phpstan-param T|null $value
      */
-    public function transform($value)
+    public function transform($value): ?string
     {
         if (empty($value)) {
             return null;

--- a/src/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/src/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -65,8 +65,6 @@ final class ModelsToArrayTransformer implements DataTransformerInterface
 
         $array = [];
         foreach ($value as $model) {
-            \assert($model instanceof $this->class);
-
             $array[] = implode(AdapterInterface::ID_SEPARATOR, $this->getIdentifierValues($model));
         }
 

--- a/src/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/src/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -57,7 +57,7 @@ final class ModelsToArrayTransformer implements DataTransformerInterface
      *
      * @phpstan-param T[]|null $value
      */
-    public function transform($value)
+    public function transform($value): array
     {
         if (null === $value) {
             return [];
@@ -65,15 +65,17 @@ final class ModelsToArrayTransformer implements DataTransformerInterface
 
         $array = [];
         foreach ($value as $model) {
-            $id = implode(AdapterInterface::ID_SEPARATOR, $this->getIdentifierValues($model));
+            \assert($model instanceof $this->class);
 
-            $array[] = $id;
+            $array[] = implode(AdapterInterface::ID_SEPARATOR, $this->getIdentifierValues($model));
         }
 
         return $array;
     }
 
     /**
+     * @throws UnexpectedTypeException
+     *
      * @return Collection<int|string, object>|null
      *
      * @phpstan-return Collection<array-key, T>|null
@@ -112,13 +114,11 @@ final class ModelsToArrayTransformer implements DataTransformerInterface
     }
 
     /**
-     * @param object $model
-     *
      * @return mixed[]
      *
      * @phpstan-param T $model
      */
-    private function getIdentifierValues($model): array
+    private function getIdentifierValues(object $model): array
     {
         try {
             return $this->modelManager->getIdentifierValues($model);

--- a/src/Form/EventListener/MergeCollectionListener.php
+++ b/src/Form/EventListener/MergeCollectionListener.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Form\EventListener;
 
 use Doctrine\Common\Collections\Collection;
-use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -24,28 +23,7 @@ use Symfony\Component\Form\FormEvents;
  */
 final class MergeCollectionListener implements EventSubscriberInterface
 {
-    /**
-     * @var ModelManagerInterface|null
-     */
-    private $modelManager;
-
-    /**
-     * NEXT_MAJOR: Remove this constructor and the modelManager property.
-     */
-    public function __construct(?ModelManagerInterface $modelManager = null)
-    {
-        if (null !== $modelManager) {
-            @trigger_error(sprintf(
-                'Passing argument 1 to %s() is deprecated since sonata-project/admin-bundle 3.75'
-                .' and will be ignored in version 4.0.',
-                __METHOD__
-            ), E_USER_DEPRECATED);
-        }
-
-        $this->modelManager = $modelManager;
-    }
-
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::SUBMIT => ['onBind', 10],

--- a/src/Form/Extension/ChoiceTypeExtension.php
+++ b/src/Form/Extension/ChoiceTypeExtension.php
@@ -41,16 +41,6 @@ final class ChoiceTypeExtension extends AbstractTypeExtension
     }
 
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
-     */
-    public function getExtendedType()
-    {
-        return ChoiceType::class;
-    }
-
-    /**
      * @return string[]
      *
      * @phpstan-return class-string<FormTypeInterface>[]

--- a/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -39,8 +39,6 @@ final class FormTypeFieldExtension extends AbstractTypeExtension
     private $options = [];
 
     /**
-     * FormTypeFieldExtension constructor.
-     *
      * @param array<string, string> $defaultClasses
      * @param array<string, mixed>  $options
      */
@@ -161,16 +159,6 @@ final class FormTypeFieldExtension extends AbstractTypeExtension
     }
 
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
-     */
-    public function getExtendedType()
-    {
-        return FormType::class;
-    }
-
-    /**
      * @return string[]
      *
      * @phpstan-return class-string<FormTypeInterface>[]
@@ -196,15 +184,13 @@ final class FormTypeFieldExtension extends AbstractTypeExtension
      * return the value related to FieldDescription, if the associated object does no
      * exists => a temporary one is created.
      *
-     * @param object|null $object
-     *
      * @return mixed
      */
-    public function getValueFromFieldDescription($object, FieldDescriptionInterface $fieldDescription)
+    public function getValueFromFieldDescription(?object $object, FieldDescriptionInterface $fieldDescription)
     {
         $value = null;
 
-        if (!$object) {
+        if (null === $object) {
             return null;
         }
 

--- a/src/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
@@ -48,16 +48,6 @@ final class MopaCompatibilityTypeFieldExtension extends AbstractTypeExtension
     }
 
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
-     */
-    public function getExtendedType()
-    {
-        return FormType::class;
-    }
-
-    /**
      * @return string[]
      *
      * @phpstan-return class-string<FormTypeInterface>[]

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -181,8 +181,6 @@ class FormMapper extends BaseGroupedMapper
     }
 
     /**
-     * Removes a group.
-     *
      * @param string $group          The group to delete
      * @param string $tab            The tab the group belongs to, defaults to 'default'
      * @param bool   $deleteEmptyTab Whether or not the Tab should be deleted, when the deleted group leaves the tab empty after deletion

--- a/src/Form/Type/AclMatrixType.php
+++ b/src/Form/Type/AclMatrixType.php
@@ -52,7 +52,7 @@ final class AclMatrixType extends AbstractType
         $resolver->setAllowedTypes('acl_value', ['string', UserInterface::class]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_acl_matrix';
     }

--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -131,7 +131,7 @@ final class AdminType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_admin';
     }

--- a/src/Form/Type/ChoiceFieldMaskType.php
+++ b/src/Form/Type/ChoiceFieldMaskType.php
@@ -25,6 +25,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class ChoiceFieldMaskType extends AbstractType
 {
+    /**
+     * @param mixed[] $options
+     */
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $sanitizedMap = [];
@@ -59,16 +62,14 @@ final class ChoiceFieldMaskType extends AbstractType
     }
 
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
+     * @phpstan-return class-string<FormTypeInterface>|null
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_choice_field_mask';
     }

--- a/src/Form/Type/ChoiceFieldMaskType.php
+++ b/src/Form/Type/ChoiceFieldMaskType.php
@@ -26,7 +26,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class ChoiceFieldMaskType extends AbstractType
 {
     /**
-     * @param mixed[] $options
+     * @param array<string, mixed> $options
      */
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {

--- a/src/Form/Type/ChoiceFieldMaskType.php
+++ b/src/Form/Type/ChoiceFieldMaskType.php
@@ -62,9 +62,9 @@ final class ChoiceFieldMaskType extends AbstractType
     }
 
     /**
-     * @phpstan-return class-string<FormTypeInterface>|null
+     * @phpstan-return class-string<FormTypeInterface>
      */
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/src/Form/Type/CollectionType.php
+++ b/src/Form/Type/CollectionType.php
@@ -26,9 +26,9 @@ use Symfony\Component\Form\FormTypeInterface;
 final class CollectionType extends AbstractType
 {
     /**
-     * @phpstan-return class-string<FormTypeInterface>|null
+     * @phpstan-return class-string<FormTypeInterface>
      */
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return SymfonyCollectionType::class;
     }

--- a/src/Form/Type/CollectionType.php
+++ b/src/Form/Type/CollectionType.php
@@ -26,16 +26,14 @@ use Symfony\Component\Form\FormTypeInterface;
 final class CollectionType extends AbstractType
 {
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
+     * @phpstan-return class-string<FormTypeInterface>|null
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return SymfonyCollectionType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_native_collection';
     }

--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class ChoiceType extends AbstractType
 {
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_filter_choice';
     }

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class DateRangeType extends AbstractType
 {
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_filter_date_range';
     }

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class DateTimeRangeType extends AbstractType
 {
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_filter_datetime_range';
     }

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class DateTimeType extends AbstractType
 {
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_filter_datetime';
     }

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class DateType extends AbstractType
 {
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_filter_date';
     }

--- a/src/Form/Type/Filter/DefaultType.php
+++ b/src/Form/Type/Filter/DefaultType.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class DefaultType extends AbstractType
 {
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_filter_default';
     }

--- a/src/Form/Type/Filter/NumberType.php
+++ b/src/Form/Type/Filter/NumberType.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class NumberType extends AbstractType
 {
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_filter_number';
     }

--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -57,6 +57,9 @@ final class ModelAutocompleteType extends AbstractType
         }
     }
 
+    /**
+     * @param mixed[] $options
+     */
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         foreach ([
@@ -96,7 +99,7 @@ final class ModelAutocompleteType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $compound = static function (Options $options) {
+        $compound = static function (Options $options): bool {
             return $options['multiple'];
         };
 
@@ -150,7 +153,7 @@ final class ModelAutocompleteType extends AbstractType
         $resolver->setRequired(['property']);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_model_autocomplete';
     }

--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -58,7 +58,7 @@ final class ModelAutocompleteType extends AbstractType
     }
 
     /**
-     * @param mixed[] $options
+     * @param array<string, mixed> $options
      */
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {

--- a/src/Form/Type/ModelHiddenType.php
+++ b/src/Form/Type/ModelHiddenType.php
@@ -49,9 +49,9 @@ final class ModelHiddenType extends AbstractType
     }
 
     /**
-     * @phpstan-return class-string<FormTypeInterface>|null
+     * @phpstan-return class-string<FormTypeInterface>
      */
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return HiddenType::class;
     }

--- a/src/Form/Type/ModelHiddenType.php
+++ b/src/Form/Type/ModelHiddenType.php
@@ -49,16 +49,14 @@ final class ModelHiddenType extends AbstractType
     }
 
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
+     * @phpstan-return class-string<FormTypeInterface>|null
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return HiddenType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_model_hidden';
     }

--- a/src/Form/Type/ModelListType.php
+++ b/src/Form/Type/ModelListType.php
@@ -84,9 +84,9 @@ final class ModelListType extends AbstractType
     }
 
     /**
-     * @phpstan-return class-string<FormTypeInterface>|null
+     * @phpstan-return class-string<FormTypeInterface>
      */
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return TextType::class;
     }

--- a/src/Form/Type/ModelListType.php
+++ b/src/Form/Type/ModelListType.php
@@ -54,6 +54,9 @@ final class ModelListType extends AbstractType
             ->addViewTransformer(new ModelToIdTransformer($options['model_manager'], $options['class']));
     }
 
+    /**
+     * @param mixed[] $options
+     */
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         if (isset($view->vars['sonata_admin'])) {
@@ -81,16 +84,14 @@ final class ModelListType extends AbstractType
     }
 
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
+     * @phpstan-return class-string<FormTypeInterface>|null
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return TextType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_model_list';
     }

--- a/src/Form/Type/ModelListType.php
+++ b/src/Form/Type/ModelListType.php
@@ -55,7 +55,7 @@ final class ModelListType extends AbstractType
     }
 
     /**
-     * @param mixed[] $options
+     * @param array<string, mixed> $options
      */
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {

--- a/src/Form/Type/ModelReferenceType.php
+++ b/src/Form/Type/ModelReferenceType.php
@@ -43,9 +43,9 @@ final class ModelReferenceType extends AbstractType
     }
 
     /**
-     * @phpstan-return class-string<FormTypeInterface>|null
+     * @phpstan-return class-string<FormTypeInterface>
      */
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return TextType::class;
     }

--- a/src/Form/Type/ModelReferenceType.php
+++ b/src/Form/Type/ModelReferenceType.php
@@ -43,16 +43,14 @@ final class ModelReferenceType extends AbstractType
     }
 
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
+     * @phpstan-return class-string<FormTypeInterface>|null
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return TextType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_model_reference';
     }

--- a/src/Form/Type/ModelType.php
+++ b/src/Form/Type/ModelType.php
@@ -132,9 +132,9 @@ final class ModelType extends AbstractType
     }
 
     /**
-     * @phpstan-return class-string<FormTypeInterface>|null
+     * @phpstan-return class-string<FormTypeInterface>
      */
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/src/Form/Type/ModelType.php
+++ b/src/Form/Type/ModelType.php
@@ -65,7 +65,7 @@ final class ModelType extends AbstractType
     }
 
     /**
-     * @param mixed[] $options
+     * @param array<string, mixed> $options
      */
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {

--- a/src/Form/Type/ModelType.php
+++ b/src/Form/Type/ModelType.php
@@ -79,24 +79,20 @@ final class ModelType extends AbstractType
     {
         $options = [];
 
-        $options['choice_loader'] =
-            /**
-             * @phpstan-return ModelChoiceLoader|mixed[]
-             */
-            function (Options $options, ?ChoiceListInterface $previousValue) {
-                if ($previousValue && \count($choices = $previousValue->getChoices())) {
-                    return $choices;
-                }
+        $options['choice_loader'] = function (Options $options, ?ChoiceListInterface $previousValue) {
+            if ($previousValue && \count($choices = $previousValue->getChoices())) {
+                return $choices;
+            }
 
-                return new ModelChoiceLoader(
-                    $options['model_manager'],
-                    $this->propertyAccessor,
-                    $options['class'],
-                    $options['property'],
-                    $options['query'],
-                    $options['choices'],
-                );
-            };
+            return new ModelChoiceLoader(
+                $options['model_manager'],
+                $this->propertyAccessor,
+                $options['class'],
+                $options['property'],
+                $options['query'],
+                $options['choices'],
+            );
+        };
 
         $resolver->setDefaults(array_merge($options, [
             'compound' => static function (Options $options) {

--- a/src/Form/Type/Operator/ContainsOperatorType.php
+++ b/src/Form/Type/Operator/ContainsOperatorType.php
@@ -37,9 +37,9 @@ final class ContainsOperatorType extends AbstractType
     }
 
     /**
-     * @phpstan-return class-string<FormTypeInterface>|null
+     * @phpstan-return class-string<FormTypeInterface>
      */
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return FormChoiceType::class;
     }

--- a/src/Form/Type/Operator/ContainsOperatorType.php
+++ b/src/Form/Type/Operator/ContainsOperatorType.php
@@ -24,10 +24,7 @@ final class ContainsOperatorType extends AbstractType
     public const TYPE_NOT_CONTAINS = 2;
     public const TYPE_EQUAL = 3;
 
-    /**
-     * @return void
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choice_translation_domain' => 'SonataAdminBundle',
@@ -40,16 +37,14 @@ final class ContainsOperatorType extends AbstractType
     }
 
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
+     * @phpstan-return class-string<FormTypeInterface>|null
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return FormChoiceType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_operator_contains';
     }

--- a/src/Form/Type/Operator/DateOperatorType.php
+++ b/src/Form/Type/Operator/DateOperatorType.php
@@ -28,10 +28,7 @@ final class DateOperatorType extends AbstractType
     public const TYPE_NULL = 6;
     public const TYPE_NOT_NULL = 7;
 
-    /**
-     * @return void
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choice_translation_domain' => 'SonataAdminBundle',
@@ -48,16 +45,14 @@ final class DateOperatorType extends AbstractType
     }
 
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
+     * @phpstan-return class-string<FormTypeInterface>|null
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return FormChoiceType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_operator_date';
     }

--- a/src/Form/Type/Operator/DateOperatorType.php
+++ b/src/Form/Type/Operator/DateOperatorType.php
@@ -45,9 +45,9 @@ final class DateOperatorType extends AbstractType
     }
 
     /**
-     * @phpstan-return class-string<FormTypeInterface>|null
+     * @phpstan-return class-string<FormTypeInterface>
      */
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return FormChoiceType::class;
     }

--- a/src/Form/Type/Operator/DateRangeOperatorType.php
+++ b/src/Form/Type/Operator/DateRangeOperatorType.php
@@ -35,9 +35,9 @@ final class DateRangeOperatorType extends AbstractType
     }
 
     /**
-     * @phpstan-return class-string<FormTypeInterface>|null
+     * @phpstan-return class-string<FormTypeInterface>
      */
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return FormChoiceType::class;
     }

--- a/src/Form/Type/Operator/DateRangeOperatorType.php
+++ b/src/Form/Type/Operator/DateRangeOperatorType.php
@@ -23,10 +23,7 @@ final class DateRangeOperatorType extends AbstractType
     public const TYPE_BETWEEN = 1;
     public const TYPE_NOT_BETWEEN = 2;
 
-    /**
-     * @return void
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choice_translation_domain' => 'SonataAdminBundle',
@@ -38,16 +35,14 @@ final class DateRangeOperatorType extends AbstractType
     }
 
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
+     * @phpstan-return class-string<FormTypeInterface>|null
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return FormChoiceType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_operator_date_range';
     }

--- a/src/Form/Type/Operator/EqualOperatorType.php
+++ b/src/Form/Type/Operator/EqualOperatorType.php
@@ -23,10 +23,7 @@ final class EqualOperatorType extends AbstractType
     public const TYPE_EQUAL = 1;
     public const TYPE_NOT_EQUAL = 2;
 
-    /**
-     * @return void
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choice_translation_domain' => 'SonataAdminBundle',
@@ -38,16 +35,14 @@ final class EqualOperatorType extends AbstractType
     }
 
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
+     * @phpstan-return class-string<FormTypeInterface>|null
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return FormChoiceType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_operator_equal';
     }

--- a/src/Form/Type/Operator/EqualOperatorType.php
+++ b/src/Form/Type/Operator/EqualOperatorType.php
@@ -35,9 +35,9 @@ final class EqualOperatorType extends AbstractType
     }
 
     /**
-     * @phpstan-return class-string<FormTypeInterface>|null
+     * @phpstan-return class-string<FormTypeInterface>
      */
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return FormChoiceType::class;
     }

--- a/src/Form/Type/Operator/NumberOperatorType.php
+++ b/src/Form/Type/Operator/NumberOperatorType.php
@@ -26,12 +26,9 @@ final class NumberOperatorType extends AbstractType
     public const TYPE_LESS_EQUAL = 4;
     public const TYPE_LESS_THAN = 5;
 
-    /**
-     * @return void
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setDefaults($defaultOptions = [
+        $resolver->setDefaults([
             'choice_translation_domain' => 'SonataAdminBundle',
             'choices' => [
                 'label_type_equal' => self::TYPE_EQUAL,
@@ -44,16 +41,14 @@ final class NumberOperatorType extends AbstractType
     }
 
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
+     * @phpstan-return class-string<FormTypeInterface>|null
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return FormChoiceType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_operator_number';
     }

--- a/src/Form/Type/Operator/NumberOperatorType.php
+++ b/src/Form/Type/Operator/NumberOperatorType.php
@@ -41,9 +41,9 @@ final class NumberOperatorType extends AbstractType
     }
 
     /**
-     * @phpstan-return class-string<FormTypeInterface>|null
+     * @phpstan-return class-string<FormTypeInterface>
      */
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return FormChoiceType::class;
     }

--- a/src/Form/Type/Operator/StringOperatorType.php
+++ b/src/Form/Type/Operator/StringOperatorType.php
@@ -26,10 +26,7 @@ final class StringOperatorType extends AbstractType
     public const TYPE_STARTS_WITH = 4;
     public const TYPE_ENDS_WITH = 5;
 
-    /**
-     * @return void
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choice_translation_domain' => 'SonataAdminBundle',
@@ -44,16 +41,14 @@ final class StringOperatorType extends AbstractType
     }
 
     /**
-     * @return string
-     *
-     * @phpstan-return class-string<FormTypeInterface>
+     * @phpstan-return class-string<FormTypeInterface>|null
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return FormChoiceType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_operator_string';
     }

--- a/src/Form/Type/Operator/StringOperatorType.php
+++ b/src/Form/Type/Operator/StringOperatorType.php
@@ -41,9 +41,9 @@ final class StringOperatorType extends AbstractType
     }
 
     /**
-     * @phpstan-return class-string<FormTypeInterface>|null
+     * @phpstan-return class-string<FormTypeInterface>
      */
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return FormChoiceType::class;
     }

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -268,8 +268,6 @@ abstract class BaseGroupedMapper extends BaseMapper
     abstract protected function getName(): string;
 
     /**
-     * Add the field name to the current group.
-     *
      * @return array<string, mixed>
      */
     protected function addFieldToCurrentGroup(string $fieldName): array

--- a/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
+++ b/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
@@ -41,7 +41,7 @@ class ModelChoiceLoaderTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The model manager does not support the query.');
 
-        new ModelChoiceLoader($this->modelManager, $this->propertyAccessor, null, null, new \stdClass());
+        new ModelChoiceLoader($this->modelManager, $this->propertyAccessor, \stdClass::class, null, new \stdClass());
     }
 
     public function testLoadFromEntityWithSamePropertyValues(): void

--- a/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
+++ b/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class ModelChoiceLoaderTest extends TestCase
 {
@@ -25,24 +26,22 @@ class ModelChoiceLoaderTest extends TestCase
 
     private $modelManager;
 
+    private $propertyAccessor;
+
     protected function setUp(): void
     {
         $this->modelManager = $this->createMock(ModelManagerInterface::class);
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
     }
 
-    /**
-     * NEXT_MAJOR: Expect exception instead.
-     *
-     * @group legacy
-     *
-     * @doesNotPerformAssertions
-     */
     public function testConstructWithUnsupportedQuery(): void
     {
         $this->modelManager->method('supportsQuery')->willReturn(false);
 
-        $this->expectDeprecation('Passing a query which is not supported by the model manager is deprecated since sonata-project/admin-bundle 3.76 and will throw an exception in version 4.0.');
-        new ModelChoiceLoader($this->modelManager, \stdClass::class, null, new \stdClass());
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The model manager does not support the query.');
+
+        new ModelChoiceLoader($this->modelManager, $this->propertyAccessor, null, null, new \stdClass());
     }
 
     public function testLoadFromEntityWithSamePropertyValues(): void
@@ -67,6 +66,7 @@ class ModelChoiceLoaderTest extends TestCase
 
         $modelChoiceLoader = new ModelChoiceLoader(
             $this->modelManager,
+            $this->propertyAccessor,
             \Sonata\AdminBundle\Tests\Fixtures\Entity\Foo::class,
             'baz'
         );

--- a/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
@@ -184,24 +184,6 @@ class ModelToIdPropertyTransformerTest extends TestCase
         $this->assertSame([123, '_labels' => ['bazz']], $transformer->transform($model));
     }
 
-    public function testTransformToStringCallbackException(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Callback in "to_string_callback" option doesn`t contain callable function.');
-
-        $model = new Foo();
-        $model->setBar('example');
-        $model->setBaz('bazz');
-
-        $this->modelManager->expects($this->once())
-            ->method('getIdentifierValues')
-            ->willReturn([123]);
-
-        $transformer = new ModelToIdPropertyTransformer($this->modelManager, Foo::class, 'bar', false, '987654');
-
-        $transformer->transform($model);
-    }
-
     public function testTransformMultiple(): void
     {
         $entity1 = new Foo();

--- a/tests/Form/DataTransformer/ModelToIdTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelToIdTransformerTest.php
@@ -35,8 +35,6 @@ class ModelToIdTransformerTest extends TestCase
                 ->method('find')
                 ->willReturn(new \stdClass());
 
-        $this->assertFalse(\in_array(false, ['0', 0], true));
-
         // we pass 0 as integer
         $this->assertNotNull($transformer->reverseTransform(0));
 

--- a/tests/Form/Extension/ChoiceTypeExtensionTest.php
+++ b/tests/Form/Extension/ChoiceTypeExtensionTest.php
@@ -31,13 +31,6 @@ class ChoiceTypeExtensionTest extends TestCase
 
     public function testExtendedType(): void
     {
-        $extension = new ChoiceTypeExtension();
-
-        $this->assertSame(
-            ChoiceType::class,
-            $extension->getExtendedType()
-        );
-
         $this->assertSame(
             [ChoiceType::class],
             ChoiceTypeExtension::getExtendedTypes()

--- a/tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
+++ b/tests/Form/Extension/Field/Type/FormTypeFieldExtensionTest.php
@@ -27,9 +27,6 @@ class FormTypeFieldExtensionTest extends TestCase
 {
     public function testExtendedType(): void
     {
-        $extension = new FormTypeFieldExtension([], []);
-
-        $this->assertSame(FormType::class, $extension->getExtendedType());
         $this->assertSame([FormType::class], FormTypeFieldExtension::getExtendedTypes());
     }
 

--- a/tests/Form/Type/ModelTypeTest.php
+++ b/tests/Form/Type/ModelTypeTest.php
@@ -39,14 +39,14 @@ class ModelTypeTest extends TypeTestCase
 
         $this->type->configureOptions($optionResolver);
 
-        $options = $optionResolver->resolve(['model_manager' => $modelManager, 'choices' => []]);
+        $options = $optionResolver->resolve(['model_manager' => $modelManager, 'class' => \stdClass::class, 'choices' => []]);
 
         $this->assertFalse($options['compound']);
         $this->assertSame('choice', $options['template']);
         $this->assertFalse($options['multiple']);
         $this->assertFalse($options['expanded']);
         $this->assertInstanceOf(ModelManagerInterface::class, $options['model_manager']);
-        $this->assertNull($options['class']);
+        $this->assertSame(\stdClass::class, $options['class']);
         $this->assertNull($options['property']);
         $this->assertNull($options['query']);
         $this->assertCount(0, $options['choices']);
@@ -68,14 +68,14 @@ class ModelTypeTest extends TypeTestCase
 
         $this->type->configureOptions($optionResolver);
 
-        $options = $optionResolver->resolve(['model_manager' => $modelManager, 'choices' => [], 'multiple' => $multiple, 'expanded' => $expanded]);
+        $options = $optionResolver->resolve(['model_manager' => $modelManager,'class' => \stdClass::class, 'choices' => [], 'multiple' => $multiple, 'expanded' => $expanded]);
 
         $this->assertSame($expectedCompound, $options['compound']);
         $this->assertSame('choice', $options['template']);
         $this->assertSame($multiple, $options['multiple']);
         $this->assertSame($expanded, $options['expanded']);
         $this->assertInstanceOf(ModelManagerInterface::class, $options['model_manager']);
-        $this->assertNull($options['class']);
+        $this->assertSame(\stdClass::class, $options['class']);
         $this->assertNull($options['property']);
         $this->assertNull($options['query']);
         $this->assertCount(0, $options['choices']);

--- a/tests/Form/Type/ModelTypeTest.php
+++ b/tests/Form/Type/ModelTypeTest.php
@@ -68,7 +68,7 @@ class ModelTypeTest extends TypeTestCase
 
         $this->type->configureOptions($optionResolver);
 
-        $options = $optionResolver->resolve(['model_manager' => $modelManager,'class' => \stdClass::class, 'choices' => [], 'multiple' => $multiple, 'expanded' => $expanded]);
+        $options = $optionResolver->resolve(['model_manager' => $modelManager, 'class' => \stdClass::class, 'choices' => [], 'multiple' => $multiple, 'expanded' => $expanded]);
 
         $this->assertSame($expectedCompound, $options['compound']);
         $this->assertSame('choice', $options['template']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Narrow the API for classes declared under the `Sonata\AdminBundle\Form\` namespace.
- Narrow the API for classes declared under the `Sonata\AdminBundle\Mapper\` namespace.
- Changed the order of `ModelChoiceLoder` construct arguments
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

I have applied PHPStan level 8 and Psalm level 2 when doing it and all of the errors related to the typehints are done.
