### PR TITLE
Prevent error "Notice: Undefined index: idx" if there are no list items are selected.

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -429,6 +429,10 @@ class CRUDController implements ContainerAwareInterface
             $action = $request->request->getAlnum('action');
             $idx = $request->request->get('idx', []);
             $allElements = $request->request->getBoolean('all_elements');
+
+            $request->request->set('idx', $idx);
+            $request->request->set('all_elements', $allElements);
+
             $data = $request->request->all();
 
             unset($data['_sonata_csrf_token']);


### PR DESCRIPTION
## Prevent error "Notice: Undefined index: idx" if there are no list items are selected.

I am targeting this branch, because 3.x and the master branch are containing this problem.

## Changelog

```markdown
### Fixed
- "Notice: Undefined index: idx" if there are no list items are selected.
```
