### PR TITLE
Remove oppressive language

### DIFF
--- a/docs/reference/routing.rst
+++ b/docs/reference/routing.rst
@@ -281,7 +281,7 @@ Any single registered route can be removed by name::
 Removing all routes except named ones
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you want to disable all default Sonata routes except few whitelisted ones, you can use
+If you want to disable all default Sonata routes except few allowed ones, you can use
 the ``clearExcept()`` method. This method accepts an array of routes you want to keep active::
 
     // src/Admin/MediaAdmin.php


### PR DESCRIPTION
## Subject

This removes oppressive language from the code.

There is a default permission of `MASTER` which may want to be considered for changing, but this would be a BC break and may be something people are comfortable keeping given the context it is used in.

I am targeting this branch, because the change is back-compatible.

Closes #6185.