### PR TITLE
Fix ProxyQueryInterface return typehint

### DIFF
--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -46,11 +46,14 @@ interface ProxyQueryInterface
 
     public function getSortOrder(): string;
 
-    public function getSingleScalarResult(): ?int;
+    /**
+     * @return mixed
+     */
+    public function getSingleScalarResult();
 
     public function setFirstResult(?int $firstResult): self;
 
-    public function getFirstResult(): ?object;
+    public function getFirstResult(): ?int;
 
     public function setMaxResults(?int $maxResults): self;
 

--- a/tests/App/Datagrid/ProxyQuery.php
+++ b/tests/App/Datagrid/ProxyQuery.php
@@ -23,10 +23,12 @@ final class ProxyQuery implements ProxyQueryInterface
 
     public function execute(array $params = [], ?int $hydrationMode = null)
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function setSortBy(array $parentAssociationMappings, array $fieldMapping): void
+    public function setSortBy(array $parentAssociationMappings, array $fieldMapping): ProxyQueryInterface
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
     public function getSortBy(): string
@@ -34,8 +36,9 @@ final class ProxyQuery implements ProxyQueryInterface
         return 'e.id';
     }
 
-    public function setSortOrder(string $sortOrder): void
+    public function setSortOrder(string $sortOrder): ProxyQueryInterface
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
     public function getSortOrder(): string
@@ -43,22 +46,24 @@ final class ProxyQuery implements ProxyQueryInterface
         return 'ASC';
     }
 
-    public function getSingleScalarResult(): ?int
+    public function getSingleScalarResult()
     {
         return 0;
     }
 
-    public function setFirstResult(?int $firstResult): void
-    {
-    }
-
-    public function getFirstResult(): ?object
+    public function setFirstResult(?int $firstResult): ProxyQueryInterface
     {
         throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function setMaxResults(?int $maxResults): void
+    public function getFirstResult(): ?int
     {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+
+    public function setMaxResults(?int $maxResults): ProxyQueryInterface
+    {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
     public function getMaxResults(): ?int


### PR DESCRIPTION
This was introduced by https://github.com/sonata-project/SonataAdminBundle/pull/6257/files

getSingleScalarResult can return anything (int, bool, string, DateTime, ...).

I also think we should deprecate this method in 3.x and remove it in 4.0, because we don't use it in the project so there is no need to require it in the interface. WDYT @sonata-project/contributors ?