### PR TITLE
Deprecate getSingleScalarResult method

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,10 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+## Deprecated `Sonata\AdminBundle\Datagrid\ProxyQueryInterface::getSingleScalarResult`
+
+Use `Sonata\AdminBundle\Datagrid\ProxyQueryInterface::execute` instead.
+
 ## The following templates have been deprecated
 
  - `src/Resources/views/CRUD/base_filter_field.html.twig`

--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -61,6 +61,10 @@ interface ProxyQueryInterface
     public function getSortOrder();
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     *
      * @return mixed
      */
     public function getSingleScalarResult();

--- a/tests/App/Datagrid/ProxyQuery.php
+++ b/tests/App/Datagrid/ProxyQuery.php
@@ -23,55 +23,64 @@ final class ProxyQuery implements ProxyQueryInterface
 
     public function execute(array $params = [], $hydrationMode = null)
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function setSortBy($parentAssociationMappings, $fieldMapping): void
+    public function setSortBy($parentAssociationMappings, $fieldMapping): ProxyQueryInterface
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function getSortBy()
+    public function getSortBy(): string
     {
         return 'e.id';
     }
 
-    public function setSortOrder($sortOrder): void
+    public function setSortOrder($sortOrder): ProxyQueryInterface
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function getSortOrder()
+    public function getSortOrder(): string
     {
         return 'ASC';
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getSingleScalarResult()
     {
         return 0;
     }
 
-    public function setFirstResult($firstResult): void
-    {
-    }
-
-    public function getFirstResult()
+    public function setFirstResult($firstResult): ProxyQueryInterface
     {
         throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function setMaxResults($maxResults): void
+    public function getFirstResult(): ?int
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function getMaxResults()
+    public function setMaxResults($maxResults): ProxyQueryInterface
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+
+    public function getMaxResults(): ?int
     {
         return 1;
     }
 
-    public function getUniqueParameterId()
+    public function getUniqueParameterId(): int
     {
         return 1;
     }
 
-    public function entityJoin(array $associationMappings): void
+    public function entityJoin(array $associationMappings): array
     {
+        throw new \BadMethodCallException('Not implemented.');
     }
 }


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

This method is not used by SonataAdmin, so I see no reason to require his implementation in the interface.
And I feel like it's too much doctrine-oriented. 

## Changelog

```markdown
### Deprecated
- Deprecated `Sonata\AdminBundle\Datagrid\ProxyQueryInterface::getSingleScalarResult`
```