### PR TITLE
Fix proxy query return typehint 

### DIFF
--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -40,11 +40,11 @@ interface ProxyQueryInterface
      */
     public function setSortBy(array $parentAssociationMappings, array $fieldMapping): self;
 
-    public function getSortBy(): string;
+    public function getSortBy(): ?string;
 
     public function setSortOrder(string $sortOrder): self;
 
-    public function getSortOrder(): string;
+    public function getSortOrder(): ?string;
 
     /**
      * @return mixed
@@ -62,6 +62,8 @@ interface ProxyQueryInterface
     public function getUniqueParameterId(): int;
 
     /**
+     * Join entities from the given association mappings and return the last alias created.
+     *
      * @param mixed[] $associationMappings
      */
     public function entityJoin(array $associationMappings): string;

--- a/tests/App/Datagrid/ProxyQuery.php
+++ b/tests/App/Datagrid/ProxyQuery.php
@@ -31,7 +31,7 @@ final class ProxyQuery implements ProxyQueryInterface
         throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function getSortBy(): string
+    public function getSortBy(): ?string
     {
         return 'e.id';
     }
@@ -41,7 +41,7 @@ final class ProxyQuery implements ProxyQueryInterface
         throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function getSortOrder(): string
+    public function getSortOrder(): ?string
     {
         return 'ASC';
     }


### PR DESCRIPTION
Following https://github.com/sonata-project/SonataAdminBundle/pull/6290

During my work on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1073, I got errors because `null` is not allowed. But if the value is not set, it's `null`.

There is no need for a changelog since it's on master branch, and related to https://github.com/sonata-project/SonataAdminBundle/pull/6257/files