### PR TITLE
Add Field description collection interface

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -427,12 +427,12 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     /**
      * The list collection.
      *
-     * @var FieldDescriptionCollection|null
+     * @var FieldDescriptionCollectionInterface|null
      */
     private $list;
 
     /**
-     * @var FieldDescriptionCollection|null
+     * @var FieldDescriptionCollectionInterface|null
      */
     private $show;
 
@@ -1162,7 +1162,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return $this->form;
     }
 
-    public function getList(): ?FieldDescriptionCollection
+    public function getList(): ?FieldDescriptionCollectionInterface
     {
         $this->buildList();
 
@@ -2023,7 +2023,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return $this->validator;
     }
 
-    public function getShow(): ?FieldDescriptionCollection
+    public function getShow(): ?FieldDescriptionCollectionInterface
     {
         $this->buildShow();
 

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -186,11 +186,11 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     public function getValidator(): ?ValidatorInterface;
 
-    public function getShow(): ?FieldDescriptionCollection;
+    public function getShow(): ?FieldDescriptionCollectionInterface;
 
     public function setFormTheme(array $formTheme): void;
 
-    public function getList(): ?FieldDescriptionCollection;
+    public function getList(): ?FieldDescriptionCollectionInterface;
 
     /**
      * @return string[]

--- a/src/Admin/FieldDescriptionCollection.php
+++ b/src/Admin/FieldDescriptionCollection.php
@@ -16,7 +16,7 @@ namespace Sonata\AdminBundle\Admin;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-final class FieldDescriptionCollection implements \ArrayAccess, \Countable
+final class FieldDescriptionCollection implements FieldDescriptionCollectionInterface
 {
     /**
      * @var FieldDescriptionInterface[]

--- a/src/Admin/FieldDescriptionCollectionInterface.php
+++ b/src/Admin/FieldDescriptionCollectionInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Admin;
+
+interface FieldDescriptionCollectionInterface extends \ArrayAccess, \Countable
+{
+    public function add(FieldDescriptionInterface $fieldDescription): void;
+
+    /**
+     * @return array<string, FieldDescriptionInterface>
+     */
+    public function getElements(): array;
+
+    public function has(string $name): bool;
+
+    /**
+     * @throws \InvalidArgumentException if the element is not found
+     */
+    public function get(string $name): FieldDescriptionInterface;
+
+    public function remove(string $name): void;
+
+    /**
+     * @param array<string> $keys
+     */
+    public function reorder(array $keys): void;
+}

--- a/src/Builder/ListBuilderInterface.php
+++ b/src/Builder/ListBuilderInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Builder;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollectionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 
 /**
@@ -22,12 +22,12 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
  */
 interface ListBuilderInterface extends BuilderInterface
 {
-    public function getBaseList(array $options = []): FieldDescriptionCollection;
+    public function getBaseList(array $options = []): FieldDescriptionCollectionInterface;
 
     public function buildField(?string $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin): void;
 
     public function addField(
-        FieldDescriptionCollection $list,
+        FieldDescriptionCollectionInterface $list,
         ?string $type,
         FieldDescriptionInterface $fieldDescription,
         AdminInterface $admin

--- a/src/Builder/ShowBuilderInterface.php
+++ b/src/Builder/ShowBuilderInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Builder;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollectionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 
 /**
@@ -22,10 +22,10 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
  */
 interface ShowBuilderInterface extends BuilderInterface
 {
-    public function getBaseList(array $options = []): FieldDescriptionCollection;
+    public function getBaseList(array $options = []): FieldDescriptionCollectionInterface;
 
     public function addField(
-        FieldDescriptionCollection $list,
+        FieldDescriptionCollectionInterface $list,
         ?string $type,
         FieldDescriptionInterface $fieldDescription,
         AdminInterface $admin

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -17,7 +17,7 @@ use Doctrine\Inflector\InflectorFactory;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollectionInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Exception\LockException;
 use Sonata\AdminBundle\Exception\ModelManagerException;
@@ -602,7 +602,7 @@ class CRUDController extends Controller
         $this->admin->setSubject($object);
 
         $fields = $this->admin->getShow();
-        \assert($fields instanceof FieldDescriptionCollection);
+        \assert($fields instanceof FieldDescriptionCollectionInterface);
 
         $template = $this->templateRegistry->getTemplate('show');
 

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Datagrid;
 
-use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollectionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Component\Form\CallbackTransformer;
@@ -41,7 +41,7 @@ final class Datagrid implements DatagridInterface
     private $values = [];
 
     /**
-     * @var FieldDescriptionCollection
+     * @var FieldDescriptionCollectionInterface
      */
     private $columns;
 
@@ -82,7 +82,7 @@ final class Datagrid implements DatagridInterface
      */
     public function __construct(
         ProxyQueryInterface $query,
-        FieldDescriptionCollection $columns,
+        FieldDescriptionCollectionInterface $columns,
         PagerInterface $pager,
         FormBuilderInterface $formBuilder,
         array $values = []
@@ -272,7 +272,7 @@ final class Datagrid implements DatagridInterface
         return false;
     }
 
-    public function getColumns(): FieldDescriptionCollection
+    public function getColumns(): FieldDescriptionCollectionInterface
     {
         return $this->columns;
     }

--- a/src/Datagrid/DatagridInterface.php
+++ b/src/Datagrid/DatagridInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Datagrid;
 
-use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollectionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Component\Form\FormInterface;
@@ -53,7 +53,7 @@ interface DatagridInterface
      */
     public function getValues(): array;
 
-    public function getColumns(): FieldDescriptionCollection;
+    public function getColumns(): FieldDescriptionCollectionInterface;
 
     /**
      * @param mixed $value

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Datagrid;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollectionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
 use Sonata\AdminBundle\Mapper\BaseMapper;
@@ -33,7 +33,7 @@ class ListMapper extends BaseMapper
     public const TYPE_SELECT = 'select';
 
     /**
-     * @var FieldDescriptionCollection
+     * @var FieldDescriptionCollectionInterface
      */
     protected $list;
 
@@ -44,7 +44,7 @@ class ListMapper extends BaseMapper
 
     public function __construct(
         ListBuilderInterface $listBuilder,
-        FieldDescriptionCollection $list,
+        FieldDescriptionCollectionInterface $list,
         AdminInterface $admin
     ) {
         parent::__construct($listBuilder, $admin);

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Show;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollectionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
@@ -37,7 +37,7 @@ class ShowMapper extends BaseGroupedMapper
 
     public function __construct(
         ShowBuilderInterface $showBuilder,
-        FieldDescriptionCollection $list,
+        FieldDescriptionCollectionInterface $list,
         AdminInterface $admin
     ) {
         parent::__construct($showBuilder, $admin);

--- a/tests/App/Builder/ListBuilder.php
+++ b/tests/App/Builder/ListBuilder.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Tests\App\Builder;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollectionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
 
@@ -24,7 +25,7 @@ final class ListBuilder implements ListBuilderInterface
     {
     }
 
-    public function getBaseList(array $options = []): FieldDescriptionCollection
+    public function getBaseList(array $options = []): FieldDescriptionCollectionInterface
     {
         return new FieldDescriptionCollection();
     }
@@ -33,7 +34,7 @@ final class ListBuilder implements ListBuilderInterface
     {
     }
 
-    public function addField(FieldDescriptionCollection $list, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin): void
+    public function addField(FieldDescriptionCollectionInterface $list, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin): void
     {
         $fieldDescription->setType($type);
         $admin->addListFieldDescription($fieldDescription->getName(), $fieldDescription);

--- a/tests/App/Builder/ShowBuilder.php
+++ b/tests/App/Builder/ShowBuilder.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Tests\App\Builder;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollectionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 
@@ -24,12 +25,12 @@ final class ShowBuilder implements ShowBuilderInterface
     {
     }
 
-    public function getBaseList(array $options = []): FieldDescriptionCollection
+    public function getBaseList(array $options = []): FieldDescriptionCollectionInterface
     {
         return new FieldDescriptionCollection();
     }
 
-    public function addField(FieldDescriptionCollection $list, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin): void
+    public function addField(FieldDescriptionCollectionInterface $list, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin): void
     {
         $fieldDescription->setType($type);
         $fieldDescription->setAdmin($admin);

--- a/tests/App/Datagrid/Datagrid.php
+++ b/tests/App/Datagrid/Datagrid.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\App\Datagrid;
 
-use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollectionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
@@ -78,7 +78,7 @@ final class Datagrid implements DatagridInterface
         return [];
     }
 
-    public function getColumns(): FieldDescriptionCollection
+    public function getColumns(): FieldDescriptionCollectionInterface
     {
         throw new \BadMethodCallException('Not implemented.');
     }

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -754,7 +754,7 @@ class CRUDControllerTest extends TestCase
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('show', $this->parameters['action']);
-        $this->assertInstanceOf(FieldDescriptionCollection::class, $this->parameters['elements']);
+        $this->assertSame($show, $this->parameters['elements']);
         $this->assertSame($object, $this->parameters['object']);
 
         $this->assertSame([], $this->session->getFlashBag()->all());

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Tests\Datagrid;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollectionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
@@ -47,7 +48,7 @@ class DatagridTest extends TestCase
     private $query;
 
     /**
-     * @var FieldDescriptionCollection
+     * @var FieldDescriptionCollectionInterface
      */
     private $columns;
 

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollectionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -37,7 +38,7 @@ class ListMapperTest extends TestCase
     private $listMapper;
 
     /**
-     * @var FieldDescriptionCollection
+     * @var FieldDescriptionCollectionInterface
      */
     private $fieldDescriptionCollection;
 

--- a/tests/Show/ShowMapperTest.php
+++ b/tests/Show/ShowMapperTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollectionInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
@@ -51,7 +52,7 @@ class ShowMapperTest extends TestCase
     private $showBuilder;
 
     /**
-     * @var FieldDescriptionCollection
+     * @var FieldDescriptionCollectionInterface
      */
     private $fieldDescriptionCollection;
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because the Interface is not useful without the param/return type change, which are BC-break.

When trying to use the master branch, I got an error: https://travis-ci.org/github/sonata-project/SonataDoctrineORMAdminBundle/jobs/720007568

I can fix it by using `new FieldDescriptionCollection()` instead.
But I wanted to ask you @sonata-project/contributors WDYT about this situation.

Should we create an Interface as I did in this PR or not ?
- In a similar way, we did introduce a `RouteCollectionInterface`.
- In other hands, a lot of our existing classes (which are final) does not have an interface. So why my class and not another ? If we add `final` to a class, should we create an interface ?

## Changelog

Will be added if the PR is accepted.