### PR TITLE
Deprecate Pool param for SearchHandler

### DIFF
--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -81,7 +81,6 @@
             <deprecated>The service "%service_id%" is deprecated in favor of the "sonata.exporter.exporter" service since version 3.14 and will be removed in 4.0.</deprecated>
         </service>
         <service id="sonata.admin.search.handler" class="Sonata\AdminBundle\Search\SearchHandler" public="true">
-            <argument type="service" id="sonata.admin.pool"/>
             <argument>%sonata.admin.configuration.global_search.case_sensitive%</argument>
         </service>
         <service id="Sonata\AdminBundle\Search\SearchHandler" alias="sonata.admin.search.handler"/>

--- a/src/Search/SearchHandler.php
+++ b/src/Search/SearchHandler.php
@@ -26,7 +26,7 @@ use Sonata\AdminBundle\Filter\FilterInterface;
 class SearchHandler
 {
     /**
-     * @var Pool
+     * @var Pool|null
      */
     protected $pool;
 
@@ -36,14 +36,26 @@ class SearchHandler
     private $caseSensitive;
 
     /**
-     * NEXT_MAJOR: remove default true value for $caseSensitive and add bool type hint.
+     * NEXT_MAJOR: Change signature to __construct(bool $caseSensitive) and remove pool property.
      *
-     * @param bool $caseSensitive
+     * @param Pool|bool $deprecatedPoolOrCaseSensitive
+     * @param bool      $caseSensitive
      */
-    public function __construct(Pool $pool, $caseSensitive = true)
+    public function __construct($deprecatedPoolOrCaseSensitive, $caseSensitive = true)
     {
-        $this->pool = $pool;
-        $this->caseSensitive = $caseSensitive;
+        if ($deprecatedPoolOrCaseSensitive instanceof Pool) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/admin-bundle 3.x.'
+                .' It will accept only bool in version 4.0.',
+                Pool::class,
+                __METHOD__
+            ), E_USER_DEPRECATED);
+
+            $this->pool = $deprecatedPoolOrCaseSensitive;
+            $this->caseSensitive = $caseSensitive;
+        } else {
+            $this->caseSensitive = $deprecatedPoolOrCaseSensitive;
+        }
     }
 
     /**

--- a/tests/Search/SearchHandlerTest.php
+++ b/tests/Search/SearchHandlerTest.php
@@ -15,30 +15,13 @@ namespace Sonata\AdminBundle\Tests\Search;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Sonata\AdminBundle\Search\SearchHandler;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class SearchHandlerTest extends TestCase
 {
-    public function getPool(?AdminInterface $admin = null): Pool
-    {
-        $container = $this->getMockForAbstractClass(ContainerInterface::class);
-        $container->method('get')->willReturnCallback(static function (string $id) use ($admin): AdminInterface {
-            if ('fake' === $id) {
-                throw new ServiceNotFoundException('Fake service does not exist');
-            }
-
-            return $admin;
-        });
-
-        return new Pool($container, 'title', 'logo', ['asd']);
-    }
-
     public function testBuildPagerWithNoGlobalSearchField(): void
     {
         $filter = $this->getMockForAbstractClass(FilterInterface::class);
@@ -51,16 +34,14 @@ class SearchHandlerTest extends TestCase
         $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->once())->method('getDatagrid')->willReturn($datagrid);
 
-        $handler = new SearchHandler($this->getPool($admin));
+        $handler = new SearchHandler(true);
         $this->assertFalse($handler->search($admin, 'myservice'));
     }
 
     /**
-     * @test
-     *
      * @dataProvider buildPagerWithGlobalSearchFieldProvider
      */
-    public function buildPagerWithGlobalSearchField(bool $caseSensitive): void
+    public function testBuildPagerWithGlobalSearchField(bool $caseSensitive): void
     {
         $filter = $this->getMockForAbstractClass(FilterInterface::class);
         $filter->expects($this->once())->method('getOption')->willReturn(true);
@@ -78,7 +59,7 @@ class SearchHandlerTest extends TestCase
         $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->expects($this->once())->method('getDatagrid')->willReturn($datagrid);
 
-        $handler = new SearchHandler($this->getPool($admin), $caseSensitive);
+        $handler = new SearchHandler($caseSensitive);
         $this->assertInstanceOf(PagerInterface::class, $handler->search($admin, 'myservice'));
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.



See https://github.com/sonata-project/SonataAdminBundle/pull/6307#issuecomment-678620825

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Passing a Pool to SearchHandler class
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
