### PR TITLE
Restrict param type of AdminInterface identifiers methods

### DIFF
--- a/src/Action/AppendFormFieldElementAction.php
+++ b/src/Action/AppendFormFieldElementAction.php
@@ -63,12 +63,12 @@ final class AppendFormFieldElementAction
             $admin->setUniqid($uniqid);
         }
 
-        $subject = $admin->getObject($objectId);
-        if ($objectId && !$subject) {
-            throw new NotFoundHttpException(sprintf('Could not find subject for id "%s"', $objectId));
-        }
-
-        if (!$subject) {
+        if ($objectId) {
+            $subject = $admin->getObject($objectId);
+            if (!$subject) {
+                throw new NotFoundHttpException(sprintf('Could not find subject for id "%s"', $objectId));
+            }
+        } else {
             $subject = $admin->getNewInstance();
         }
 

--- a/src/Action/GetShortObjectDescriptionAction.php
+++ b/src/Action/GetShortObjectDescriptionAction.php
@@ -60,14 +60,20 @@ final class GetShortObjectDescriptionAction
             $admin->setUniqid($uniqid);
         }
 
-        if (!$objectId) {
-            $objectId = null;
-        }
-
         $object = $admin->getObject($objectId);
 
-        if (!$object && 'html' === $request->get('_format')) {
-            return new Response();
+        if (!$object) {
+            // NEXT_MAJOR: Remove the deprecation and uncomment the exception.
+            @trigger_error(sprintf(
+                'Trying to get a short object description for a non found object is deprecated'
+                .' since sonata-project/admin-bundle 3.x and will be throw a 404 in version 4.0.'
+            ), E_USER_DEPRECATED);
+            //throw new NotFoundHttpException(sprintf('Could not find subject for id "%s"', $objectId));
+
+            // NEXT_MAJOR: Remove this.
+            if ('html' === $request->get('_format')) {
+                return new Response();
+            }
         }
 
         if ('json' === $request->get('_format')) {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1478,6 +1478,10 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     public function getObject($id)
     {
+        if (null === $id) {
+            return null;
+        }
+
         $object = $this->getModelManager()->find($this->getClass(), $id);
         foreach ($this->getExtensions() as $extension) {
             $extension->alterObject($this, $object);
@@ -2825,7 +2829,15 @@ EOT;
 
     public function toString($object)
     {
+        // NEXT_MAJOR: Remove this check and use object as param typehint.
         if (!\is_object($object)) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 for %s() is deprecated since sonata-project/admin-bundle 3.x.'
+                .' Only object will be allowed in version 4.0.',
+                \gettype($object),
+                __METHOD__
+            ), E_USER_DEPRECATED);
+
             return '';
         }
 

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -265,7 +265,7 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
     public function isGranted($name, $object = null);
 
     /**
-     * @param mixed $model
+     * @param object $model
      *
      * @return string a string representation of the identifiers for this instance
      */

--- a/src/Admin/UrlGeneratorInterface.php
+++ b/src/Admin/UrlGeneratorInterface.php
@@ -80,7 +80,7 @@ interface UrlGeneratorInterface
     public function generateMenuUrl($name, array $parameters = [], $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH);
 
     /**
-     * @param mixed $model
+     * @param object $model
      *
      * @return string a string representation of the id that is safe to use in a url
      */

--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -19,7 +19,7 @@ file that was distributed with this source code.
     <div id="field_container_{{ id }}" class="field-container">
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" class="field-short-description">
-                {% if sonata_admin.admin.id(sonata_admin.value) %}
+                {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
                     {{ render(path('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),

--- a/tests/Action/GetShortObjectDescriptionActionTest.php
+++ b/tests/Action/GetShortObjectDescriptionActionTest.php
@@ -77,6 +77,12 @@ final class GetShortObjectDescriptionActionTest extends TestCase
         ($this->action)($request);
     }
 
+    /**
+     * NEXT_MAJOR: Expect a NotFoundHttpException instead.
+     *
+     * @group legacy
+     * @expectedDeprecation Trying to get a short object description for a non found object is deprecated since sonata-project/admin-bundle 3.x and will be throw a 404 in version 4.0.
+     */
     public function testGetShortObjectDescriptionActionObjectDoesNotExist(): void
     {
         $this->expectException(\RuntimeException::class);
@@ -94,17 +100,22 @@ final class GetShortObjectDescriptionActionTest extends TestCase
         ($this->action)($request);
     }
 
+    /**
+     * NEXT_MAJOR: Expect a NotFoundHttpException instead.
+     *
+     * @group legacy
+     * @expectedDeprecation Trying to get a short object description for a non found object is deprecated since sonata-project/admin-bundle 3.x and will be throw a 404 in version 4.0.
+     */
     public function testGetShortObjectDescriptionActionEmptyObjectId(): void
     {
         $request = new Request([
             'code' => 'sonata.post.admin',
-            'objectId' => '',
             'uniqid' => 'asdasd123',
             '_format' => 'html',
         ]);
 
         $this->admin->setUniqid('asdasd123')->shouldBeCalled();
-        $this->admin->getObject(null)->willReturn(false);
+        $this->admin->getObject(null)->willReturn(null);
 
         $this->assertInstanceOf(Response::class, ($this->action)($request));
     }
@@ -129,19 +140,24 @@ final class GetShortObjectDescriptionActionTest extends TestCase
         $this->assertSame('renderedTemplate', $response->getContent());
     }
 
+    /**
+     * NEXT_MAJOR: Expect a NotFoundHttpException instead.
+     *
+     * @group legacy
+     * @expectedDeprecation Trying to get a short object description for a non found object is deprecated since sonata-project/admin-bundle 3.x and will be throw a 404 in version 4.0.
+     */
     public function testGetShortObjectDescriptionActionEmptyObjectIdAsJson(): void
     {
         $request = new Request([
             'code' => 'sonata.post.admin',
-            'objectId' => '',
             'uniqid' => 'asdasd123',
             '_format' => 'json',
         ]);
 
         $this->admin->setUniqid('asdasd123')->shouldBeCalled();
-        $this->admin->getObject(null)->willReturn(false);
-        $this->admin->id(false)->willReturn('');
-        $this->admin->toString(false)->willReturn('');
+        $this->admin->getObject(null)->willReturn(null);
+        $this->admin->id(null)->willReturn('');
+        $this->admin->toString(null)->willReturn('');
 
         $response = ($this->action)($request);
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -710,6 +710,18 @@ class AdminTest extends TestCase
         $this->assertNotEmpty($admin->toString($s));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     * @expectedDeprecation Passing boolean as argument 1 for Sonata\AdminBundle\Admin\AbstractAdmin::toString() is deprecated since sonata-project/admin-bundle 3.x. Only object will be allowed in version 4.0.
+     */
+    public function testToStringForNonObject(): void
+    {
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
+        $this->assertSame('', $admin->toString(false));
+    }
+
     public function testIsAclEnabled(): void
     {
         $postAdmin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -693,8 +693,6 @@ class AdminTest extends TestCase
 
         $s = new FooToString();
         $this->assertSame('salut', $admin->toString($s));
-
-        $this->assertSame('', $admin->toString(false));
     }
 
     public function testToStringNull(): void

--- a/tests/App/Datagrid/Pager.php
+++ b/tests/App/Datagrid/Pager.php
@@ -62,4 +62,19 @@ final class Pager implements PagerInterface
     {
         return 1;
     }
+
+    public function getPage()
+    {
+        return 1;
+    }
+
+    public function isLastPage()
+    {
+        return true;
+    }
+
+    public function getNbResults()
+    {
+        return \count($this->getResults());
+    }
 }

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -143,7 +143,6 @@ class HelperControllerTest extends TestCase
     {
         $request = new Request([
             'code' => 'sonata.post.admin',
-            'objectId' => '',
             'uniqid' => 'asdasd123',
             '_format' => 'html',
         ]);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because BC.

I'm introducing deprecation related to this PR: https://github.com/sonata-project/SonataAdminBundle/pull/6304

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Passing another type than `object` to `AbstractAdmin::toString`
- Passing `null` to `AbstractAdmin::getUrlSafeIdentifier`, `AbstractAdmin::getNormalizedIdentifier`, `AbstractAdmin::getId`
- Using `GetShortObjectDescriptionAction` with an empty objectId. 
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
