### PR TITLE
Deprecate ModelManagerInterface collection-related methods

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,15 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated `Sonata\AdminBundle\Model\ModelManagerInterface` collection-related methods.
+
+Use:
+- `new \Doctrine\Common\Collections\ArrayCollection()` instead of `getModelCollectionInstance($class)`
+- `$collection->removeElement($element)` instead of `collectionRemoveElement($collection, $element)`
+- `$collection->add($element)` instead of `collectionAddElement($collection, $element)`
+- `$collection->contains($element)` instead of `collectionHasElement($collection, $element)`
+- `$collection->clear()` instead of `collectionClear($collection)`
+
 UPGRADE FROM 3.73 to 3.74
 =========================
 

--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Form\DataTransformer;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Util\ClassUtils;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\DataTransformerInterface;
@@ -73,7 +74,7 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
 
     public function reverseTransform($value)
     {
-        $collection = $this->modelManager->getModelCollectionInstance($this->className);
+        $collection = new ArrayCollection();
 
         if (empty($value)) {
             if ($this->multiple) {

--- a/src/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/src/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Form\DataTransformer;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Util\ClassUtils;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
@@ -146,7 +147,7 @@ class ModelsToArrayTransformer implements DataTransformerInterface
             throw new UnexpectedTypeException($keys, 'array');
         }
 
-        $collection = $this->modelManager->getModelCollectionInstance($this->class);
+        $collection = new ArrayCollection();
         $notFound = [];
 
         // optimize this into a SELECT WHERE IN query

--- a/src/Form/EventListener/MergeCollectionListener.php
+++ b/src/Form/EventListener/MergeCollectionListener.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Form\EventListener;
 
+use Doctrine\Common\Collections\Collection;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvent;
@@ -26,12 +27,23 @@ use Symfony\Component\Form\FormEvents;
 class MergeCollectionListener implements EventSubscriberInterface
 {
     /**
-     * @var ModelManagerInterface
+     * @var ModelManagerInterface|null
      */
     protected $modelManager;
 
-    public function __construct(ModelManagerInterface $modelManager)
+    /**
+     * NEXT_MAJOR: Remove this constructor and the modelManager property.
+     */
+    public function __construct(?ModelManagerInterface $modelManager = null)
     {
+        if (null !== $modelManager) {
+            @trigger_error(sprintf(
+                'Passing argument 1 to %s() is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will be ignored in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         $this->modelManager = $modelManager;
     }
 
@@ -45,7 +57,10 @@ class MergeCollectionListener implements EventSubscriberInterface
     public function onBind(FormEvent $event)
     {
         $collection = $event->getForm()->getData();
+        \assert(null === $collection || $collection instanceof Collection);
+
         $data = $event->getData();
+        \assert($data instanceof Collection);
 
         // looks like there is no way to remove other listeners
         $event->stopPropagation();
@@ -53,19 +68,19 @@ class MergeCollectionListener implements EventSubscriberInterface
         if (!$collection) {
             $collection = $data;
         } elseif (0 === \count($data)) {
-            $this->modelManager->collectionClear($collection);
+            $collection->clear();
         } else {
             // merge $data into $collection
             foreach ($collection as $model) {
-                if (!$this->modelManager->collectionHasElement($data, $model)) {
-                    $this->modelManager->collectionRemoveElement($collection, $model);
+                if (!$data->contains($model)) {
+                    $collection->removeElement($model);
                 } else {
-                    $this->modelManager->collectionRemoveElement($data, $model);
+                    $data->removeElement($model);
                 }
             }
 
             foreach ($data as $model) {
-                $this->modelManager->collectionAddElement($collection, $model);
+                $collection->add($model);
             }
         }
 

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -169,6 +169,10 @@ interface ModelManagerInterface extends DatagridManagerInterface
     public function getModelInstance($class);
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x. To be removed in 4.0. Use doctrine/collections instead.
+     *
      * @param string $class
      *
      * @return array|\ArrayAccess
@@ -176,6 +180,10 @@ interface ModelManagerInterface extends DatagridManagerInterface
     public function getModelCollectionInstance($class);
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x. To be removed in 4.0. Use doctrine/collections instead.
+     *
      * Removes an element from the collection.
      *
      * @param array  $collection
@@ -184,6 +192,10 @@ interface ModelManagerInterface extends DatagridManagerInterface
     public function collectionRemoveElement(&$collection, &$element);
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x. To be removed in 4.0. Use doctrine/collections instead.
+     *
      * Add an element from the collection.
      *
      * @param array  $collection
@@ -192,6 +204,10 @@ interface ModelManagerInterface extends DatagridManagerInterface
     public function collectionAddElement(&$collection, &$element);
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x. To be removed in 4.0. Use doctrine/collections instead.
+     *
      * Check if the element exists in the collection.
      *
      * @param array  $collection
@@ -202,6 +218,10 @@ interface ModelManagerInterface extends DatagridManagerInterface
     public function collectionHasElement(&$collection, &$element);
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x. To be removed in 4.0. Use doctrine/collections instead.
+     *
      * Clear the collection.
      *
      * @param array $collection

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -124,23 +124,38 @@ final class ModelManager implements ModelManagerInterface
         }
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getModelCollectionInstance($class)
     {
         return [];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function collectionRemoveElement(&$collection, &$element): void
     {
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function collectionAddElement(&$collection, &$element): void
     {
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function collectionHasElement(&$collection, &$element): void
     {
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function collectionClear(&$collection): void
     {
     }


### PR DESCRIPTION
## Subject
 
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6024.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `Sonata\AdminBundle\Model\ModelManagerInterface` collection-related methods.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
