### PR TITLE
Replace multiple DB transactions with a single one

### DIFF
--- a/src/Util/TraversableToCollection.php
+++ b/src/Util/TraversableToCollection.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Util;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+final class TraversableToCollection
+{
+    /**
+     * @param mixed $value
+     *
+     * @throws \TypeError
+     *
+     * @return Collection<int|string, mixed>
+     *
+     * @phpstan-return Collection<array-key, mixed>
+     */
+    public static function transform($value): Collection
+    {
+        if ($value instanceof Collection) {
+            return $value;
+        }
+
+        if ($value instanceof \Traversable) {
+            return new ArrayCollection(iterator_to_array($value));
+        }
+
+        if (\is_array($value)) {
+            return new ArrayCollection($value);
+        }
+
+        throw new \TypeError(sprintf(
+            'Argument 1 passed to "%s()" must be of type "%s" or "%s", %s given.',
+            __METHOD__,
+            \Traversable::class,
+            'array',
+            \is_object($value) ? 'instance of "'.\get_class($value).'"' : '"'.\gettype($value).'"'
+        ));
+    }
+}

--- a/tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -13,11 +13,15 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
 
+use Doctrine\Common\Collections\Collection;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
 use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 class ModelsToArrayTransformerTest extends TestCase
 {
@@ -43,5 +47,88 @@ class ModelsToArrayTransformerTest extends TestCase
         );
 
         $this->assertInstanceOf(ModelsToArrayTransformer::class, $transformer);
+    }
+
+    /**
+     * @dataProvider reverseTransformProvider
+     */
+    public function testReverseTransform(?array $value): void
+    {
+        $modelManager = $this->createStub(ModelManagerInterface::class);
+
+        if (null !== $value) {
+            $proxyQuery = $this->createStub(ProxyQueryInterface::class);
+            $modelManager
+                ->method('createQuery')
+                ->with($this->equalTo(Foo::class))
+                ->willReturn($proxyQuery);
+            $modelManager
+                ->method('executeQuery')
+                ->with($this->equalTo($proxyQuery))
+                ->willReturn($value);
+        }
+
+        $transformer = new ModelsToArrayTransformer(
+            $modelManager,
+            Foo::class
+        );
+
+        $result = $transformer->reverseTransform($value);
+
+        if (null === $value) {
+            $this->assertNull($result);
+        } else {
+            $this->assertInstanceOf(Collection::class, $result);
+            $this->assertCount(\count($value), $result);
+        }
+    }
+
+    public function reverseTransformProvider(): iterable
+    {
+        yield [['a']];
+        yield [['a', 'b', 3]];
+        yield [null];
+    }
+
+    public function testReverseTransformUnexpectedType(): void
+    {
+        $value = 'unexpected';
+        $modelManager = $this->createStub(ModelManagerInterface::class);
+
+        $transformer = new ModelsToArrayTransformer(
+            $modelManager,
+            Foo::class
+        );
+
+        $this->expectException(UnexpectedTypeException::class);
+        $this->expectExceptionMessage('Expected argument of type "array", "string" given');
+
+        $transformer->reverseTransform($value);
+    }
+
+    public function testReverseTransformFailed(): void
+    {
+        $value = ['a', 'b'];
+        $reverseTransformCollection = ['a'];
+        $modelManager = $this->createStub(ModelManagerInterface::class);
+        $proxyQuery = $this->createStub(ProxyQueryInterface::class);
+        $modelManager
+            ->method('createQuery')
+            ->with($this->equalTo(Foo::class))
+            ->willReturn($proxyQuery);
+        $modelManager
+            ->method('executeQuery')
+            ->with($this->equalTo($proxyQuery))
+            ->willReturn($reverseTransformCollection);
+
+        $transformer = new ModelsToArrayTransformer(
+            $modelManager,
+            Foo::class
+        );
+
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('1 keys could not be found in the provided values: "a", "b".');
+
+        $transformer->reverseTransform($value);
     }
 }

--- a/tests/Util/TraversableToCollectionTest.php
+++ b/tests/Util/TraversableToCollectionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Util;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Util\TraversableToCollection;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class TraversableToCollectionTest extends TestCase
+{
+    /**
+     * @dataProvider provideTraversableValues
+     */
+    public function testTransform(int $expectedCount, $value): void
+    {
+        $collection = TraversableToCollection::transform($value);
+
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertCount($expectedCount, $collection);
+    }
+
+    public function provideTraversableValues(): iterable
+    {
+        yield [0, []];
+        yield [1, [null]];
+        yield [1, [0]];
+        yield [1, ['a']];
+        yield [3, ['a', 'b', 'other_offset' => 'c']];
+        yield [2, (static function () { yield from ['d', 'e']; })()];
+        yield [4, new ArrayCollection(['f', 'g', 'h', 'i'])];
+    }
+
+    /**
+     * @dataProvider provideInvalidValues
+     */
+    public function testFailedTransform(string $invalidType, $value): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage(sprintf(
+            'Argument 1 passed to "Sonata\AdminBundle\Util\TraversableToCollection::transform()" must be of type "Traversable" or "array", %s given.',
+            $invalidType
+        ));
+
+        TraversableToCollection::transform($value);
+    }
+
+    public function provideInvalidValues(): iterable
+    {
+        yield ['"NULL"', null];
+        yield ['"integer"', 0];
+        yield ['"integer"', 1];
+        yield ['"string"', 'a'];
+        yield ['instance of "stdClass"', new \stdClass()];
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Replace multiple DB transactions with a single one.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6280.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed multiple calls to `ModelManagerInterface::find()` with `ModelManagerInterface::findBy()` in order to avoid multiple transactions.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
