### PR TITLE
Fix allowing valid action names in `CRUDController::batchAction()`

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -428,7 +428,7 @@ class CRUDController implements ContainerAwareInterface
             $allElements = (bool) $data['all_elements'];
             $forwardedRequest->request->replace(array_merge($forwardedRequest->request->all(), $data));
         } else {
-            $action = $forwardedRequest->request->getAlnum('action');
+            $action = $forwardedRequest->request->get('action');
             $idx = $request->request->get('idx', []);
             $allElements = $forwardedRequest->request->getBoolean('all_elements');
 

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3398,11 +3398,6 @@ class CRUDControllerTest extends TestCase
      */
     public function testBatchActionMethodNotExist(): void
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
-            'A `Sonata\AdminBundle\Controller\CRUDController::batchActionFoo` method must be callable'
-        );
-
         $batchActions = ['foo' => ['label' => 'Foo Bar', 'ask_confirmation' => false]];
 
         $this->admin->expects($this->once())
@@ -3417,6 +3412,11 @@ class CRUDControllerTest extends TestCase
         $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('data', json_encode(['action' => 'foo', 'idx' => ['123', '456'], 'all_elements' => false]));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'A `Sonata\AdminBundle\Controller\CRUDController::batchActionFoo` method must be callable'
+        );
 
         $this->controller->batchAction();
     }
@@ -3597,13 +3597,15 @@ class CRUDControllerTest extends TestCase
      * NEXT_MAJOR: Remove this legacy group.
      *
      * @group legacy
+     *
+     * @dataProvider provideActionNames
      */
-    public function testBatchActionNonRelevantAction(): void
+    public function testBatchActionNonRelevantAction(string $actionName): void
     {
         $controller = new BatchAdminController();
         $controller->setContainer($this->container);
 
-        $batchActions = ['foo' => ['label' => 'Foo Bar', 'ask_confirmation' => false]];
+        $batchActions = [$actionName => ['label' => 'Foo Bar', 'ask_confirmation' => false]];
 
         $this->admin->expects($this->once())
             ->method('getBatchActions')
@@ -3618,7 +3620,7 @@ class CRUDControllerTest extends TestCase
         $this->expectTranslate('flash_batch_empty', [], 'SonataAdminBundle');
 
         $this->request->setMethod(Request::METHOD_POST);
-        $this->request->request->set('action', 'foo');
+        $this->request->request->set('action', $actionName);
         $this->request->request->set('idx', ['789']);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
@@ -3630,6 +3632,14 @@ class CRUDControllerTest extends TestCase
         $this->assertInstanceOf(RedirectResponse::class, $result);
         $this->assertSame(['flash_batch_empty'], $this->session->getFlashBag()->get('sonata_flash_info'));
         $this->assertSame('list', $result->getTargetUrl());
+    }
+
+    public function provideActionNames(): iterable
+    {
+        yield ['foo'];
+        yield ['foo_bar'];
+        yield ['foo-bar'];
+        yield ['foobar'];
     }
 
     public function testBatchActionWithCustomConfirmationTemplate(): void

--- a/tests/Fixtures/Controller/BatchAdminController.php
+++ b/tests/Fixtures/Controller/BatchAdminController.php
@@ -55,4 +55,8 @@ class BatchAdminController extends CRUDController
 
         return false;
     }
+
+    public function batchActionFooBarIsRelevant(array $idx, $allElements)
+    {
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix allowing valid action names in `CRUDController::batchAction()`.

Currently, actions like "do-something" or "do_something" are being interpreted as "dosomething", leading to a `\RuntimeException` exception:
```php
// App/Admin/MyAdmin.php

public function getBatchActions()
{
    $actions = parent::getBatchActions();

    $actions['do_something'] = [
        'label' => 'bulk_action.do_something',
        'ask_confirmation' => true,
    ];

    return $actions;
}
```
```
The `dosomething` batch action is not defined
```

See https://github.com/sonata-project/SonataAdminBundle/pull/6251#discussion_r465252211.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Issue introduced at #6251.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed allowing valid action names in `CRUDController::batchAction()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do

- [x] Add tests.