### PR TITLE
Fix help deprecation

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -40,8 +40,14 @@ You MUST use Symfony's [`help`](https://symfony.com/doc/4.4/reference/forms/type
 Before:
 ```php
 $formMapper
-    ->add('field', null, [
+    ->add('field', null, [], [
         'help' => 'Help text <small>Please!</small>',
+    ])
+    ->add('field2')
+    ->addHelp('field2', 'This field is required.')
+    ->add('field3')
+    ->setHelps([
+        'field3' => 'Great day to great work!',
     ]);
 ```
 
@@ -51,6 +57,12 @@ $formMapper
     ->add('field', null, [
         'help' => 'Help text <small>Please!</small>',
         'help_html' => true,
+    ])
+    ->add('field2', null, [
+        'help' => 'This field is required.'
+    ])
+    ->add('field3', null, [
+        'help' => 'Great day to great work!'
     ]);
 ```
 

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -475,13 +475,22 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         $this->help = $help;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0. Use Symfony Form "help" option instead.
+     *
+     * @return string
+     */
     public function getHelp()
     {
-        @trigger_error(sprintf(
-            'The "%s()" method is deprecated since sonata-project/admin-bundle 3.74 and will be removed in version 4.0.'
-            .' Use Symfony Form "help" option instead.',
-            __METHOD__
-        ), E_USER_DEPRECATED);
+        if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'The "%s()" method is deprecated since sonata-project/admin-bundle 3.74 and will be removed in version 4.0.'
+                .' Use Symfony Form "help" option instead.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
 
         return $this->help;
     }

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -137,10 +137,10 @@ class FormMapper extends BaseGroupedMapper
             }
 
             // NEXT_MAJOR: Remove this block.
-            if (isset($options['help'])) {
+            if (isset($options['help']) && !isset($options['help_html'])) {
                 $containsHtml = $options['help'] !== strip_tags($options['help']);
 
-                if (!isset($options['help_html']) && $containsHtml) {
+                if ($containsHtml) {
                     @trigger_error(
                         'Using HTML syntax within the "help" option and not setting the "help_html" option to "true" is deprecated'
                         .' since sonata-project/admin-bundle 3.74 and it will not work in version 4.0.',

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -153,13 +153,13 @@ file that was distributed with this source code.
         {% endif %}
 
         <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-            {% if translation_domain is same as(false) %}
+            {%- if translation_domain is same as(false) -%}
                 {{- label -}}
-            {% elseif not sonata_admin.admin %}
+            {%- elseif not sonata_admin.admin -%}
                 {{- label|trans(label_translation_parameters, translation_domain) -}}
-            {% else %}
-                {{ label|trans(label_translation_parameters, sonata_admin.field_description.translationDomain ?: admin.translationDomain) }}
-            {% endif %}
+            {%- else -%}
+                {{- label|trans(label_translation_parameters, sonata_admin.field_description.translationDomain ?: admin.translationDomain) -}}
+            {%- endif -%}
         </label>
     {% endif %}
 {% endapply %}

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -33,11 +33,13 @@ file that was distributed with this source code.
 {% endapply %}
 {% endblock %}
 
-{% block form_help %}
-    {% apply spaceless %}
-        <span class="help-block sonata-ba-field-widget-help sonata-ba-field-help">{{ parent() }}</span>
-    {% endapply %}
-{% endblock %}
+{% block form_help -%}
+    {% if help is not empty %}
+        {# NEXT_MAJOR: Remove class sonata-ba-field-widget-help #}
+        {% set help_attr = help_attr|merge({class: (help_attr.class|default('') ~ ' help-block sonata-ba-field-widget-help sonata-ba-field-help')}) %}
+        {{ parent() }}
+    {% endif %}
+{%- endblock form_help %}
 
 {% block form_widget -%}
     {{ parent() }}
@@ -401,8 +403,7 @@ file that was distributed with this source code.
             {% endif %}
 
             {# NEXT_MAJOR: Remove this block #}
-            {% if sonata_admin is defined and sonata_admin_enabled and sonata_admin.field_description.help|default(false) %}
-                {% deprecated 'The "help" option is deprecated in field description since sonata-project/admin-bundle 3.74, to be removed in 4.0. Use Symfony Form "help" option instead.' %}
+            {% if sonata_admin is defined and sonata_admin_enabled and sonata_admin.field_description.getHelp('sonata_deprecation_mute')|default(false) %}
                 <span class="help-block sonata-ba-field-help">{{ sonata_admin.field_description.help|trans(help_translation_parameters, sonata_admin.field_description.translationDomain ?: admin.translationDomain)|raw }}</span>
             {% endif %}
 

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -52,7 +52,7 @@ final class CRUDControllerTest extends WebTestCase
         );
         $this->assertCount(
             1,
-            $crawler->filter('.sonata-ba-field-help:contains("Help me!")')
+            $crawler->filter('p.help-block.sonata-ba-field-help:contains("Help me!")')
         );
     }
 


### PR DESCRIPTION
##  Too many deprecation notices

I am targeting this branch, because receive too many deprecation notices and in upgrades was not actual instructions.

Closes #6319.
Addition for #6215.

## Changelog


```markdown
### Fixed
- Remove unnecessary span wrapper for field help. Merge styles with paragraph.
- Prevent too many deprecation notices.
```