### PR TITLE
allow symfony/http-foundation and symfony/validator 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "symfony/expression-language": "^4.4 || ^5.1",
         "symfony/form": "^4.4",
         "symfony/framework-bundle": "^4.4",
-        "symfony/http-foundation": "^4.4",
+        "symfony/http-foundation": "^4.4 || ^5.1",
         "symfony/http-kernel": "^4.4",
         "symfony/options-resolver": "^4.4 || ^5.1",
         "symfony/property-access": "^4.4 || ^5.1",
@@ -57,7 +57,7 @@
         "symfony/translation": "^4.4",
         "symfony/twig-bridge": "^4.4",
         "symfony/twig-bundle": "^4.4",
-        "symfony/validator": "^4.4",
+        "symfony/validator": "^4.4 || ^5.1",
         "twig/string-extra": "^3.0",
         "twig/twig": "^2.12.1 || ^3.0"
     },

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -142,7 +142,7 @@ final class RetrieveAutocompleteItemsAction
         }
 
         $datagrid->setValue('_per_page', null, $itemsPerPage);
-        $datagrid->setValue('_page', null, $request->query->get($reqParamPageNumber, 1));
+        $datagrid->setValue('_page', null, $request->query->get($reqParamPageNumber, '1'));
         $datagrid->buildPager();
 
         $pager = $datagrid->getPager();

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -47,6 +47,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\InputBag;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface as RoutingUrlGeneratorInterface;
@@ -812,7 +814,14 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
         // build the values array
         if ($this->hasRequest()) {
-            $filters = $this->request->query->get('filter', []);
+            /** @var InputBag|ParameterBag $bag */
+            $bag = $this->request->query;
+            if ($bag instanceof InputBag) {
+                // symfony 5.1+
+                $filters = $bag->all('filter');
+            } else {
+                $filters = $bag->get('filter', []);
+            }
             if (isset($filters['_page'])) {
                 $filters['_page'] = (int) $filters['_page'];
             }

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -32,6 +32,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -429,7 +430,13 @@ class CRUDController implements ContainerAwareInterface
             $forwardedRequest->request->replace(array_merge($forwardedRequest->request->all(), $data));
         } else {
             $action = $forwardedRequest->request->get('action');
-            $idx = $request->request->get('idx', []);
+            $bag = $request->request;
+            if ($bag instanceof InputBag) {
+                // symfony 5.1+
+                $idx = $bag->all('idx');
+            } else {
+                $idx = $bag->get('idx', []);
+            }
             $allElements = $forwardedRequest->request->getBoolean('all_elements');
 
             $forwardedRequest->request->set('idx', $idx);

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -34,6 +34,7 @@ use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -430,6 +431,7 @@ class CRUDController implements ContainerAwareInterface
             $forwardedRequest->request->replace(array_merge($forwardedRequest->request->all(), $data));
         } else {
             $action = $forwardedRequest->request->get('action');
+            /** @var InputBag|ParameterBag $bag */
             $bag = $request->request;
             if ($bag instanceof InputBag) {
                 // symfony 5.1+

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1594,6 +1594,7 @@ class AdminTest extends TestCase
 
         $postAdmin = $this->getMockBuilder(PostAdmin::class)->disableOriginalConstructor()->getMock();
         $postAdmin->method('getObject')->willReturn($post);
+        $postAdmin->method('getIdParameter')->willReturn('parent_id');
 
         $formBuilder = $this->createStub(FormBuilderInterface::class);
         $formBuilder->method('getForm')->willReturn(null);
@@ -1629,6 +1630,7 @@ class AdminTest extends TestCase
 
         $postAdmin = $this->getMockBuilder(PostAdmin::class)->disableOriginalConstructor()->getMock();
         $postAdmin->method('getObject')->willReturn($post);
+        $postAdmin->method('getIdParameter')->willReturn('parent_id');
 
         $formBuilder = $this->createStub(FormBuilderInterface::class);
         $formBuilder->method('getForm')->willReturn(null);
@@ -1666,6 +1668,7 @@ class AdminTest extends TestCase
 
         $postAdmin = $this->getMockBuilder(PostAdmin::class)->disableOriginalConstructor()->getMock();
         $postAdmin->method('getObject')->willReturn($post);
+        $postAdmin->method('getIdParameter')->willReturn('parent_id');
 
         $formBuilder = $this->createStub(FormBuilderInterface::class);
         $formBuilder->method('getForm')->willReturn(null);

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -974,6 +974,7 @@ class CRUDControllerTest extends TestCase
         $object2 = new \stdClass();
 
         $admin = $this->createMock(PostAdmin::class);
+        $admin->method('getIdParameter')->willReturn('parent_id');
 
         $admin->expects($this->once())
             ->method('getObject')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I propose to allow symfony/http-foundation and symfony/validator 5.1. 

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because its BC and would be nice to have 3.x fully support symfony 5.1 soon.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- support for symfony/http-foundation and symfony/validator 5.1
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
