### PR TITLE
Add AbstractAdmin::configureExportFields extension point

### DIFF
--- a/docs/reference/action_export.rst
+++ b/docs/reference/action_export.rst
@@ -29,9 +29,9 @@ Picking which fields to export
 By default, all fields are exported. More accurately, it depends on the
 persistence backend you are using, but for instance, the doctrine ORM backend
 exports all fields (associations are not exported). If you want to change this
-behavior for a specific admin, you can override the ``getExportFields()`` method::
+behavior for a specific admin, you can override the ``configureExportFields()`` method::
 
-    public function getExportFields()
+    protected function configureExportFields(): array
     {
         return ['givenName', 'familyName', 'contact.phone', 'getAddress'];
     }

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -641,11 +641,13 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     }
 
     /**
+     * @final since sonata-project/admin-bundle 3.x
+     *
      * @return array
      */
     public function getExportFields()
     {
-        $fields = $this->getModelManager()->getExportFields($this->getClass());
+        $fields = $this->configureExportFields();
 
         foreach ($this->getExtensions() as $extension) {
             if (method_exists($extension, 'configureExportFields')) {
@@ -3206,6 +3208,14 @@ EOT;
         }
 
         return $this->hasAccess($action, $object);
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function configureExportFields(): array
+    {
+        return $this->getModelManager()->getExportFields($this->getClass());
     }
 
     protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

All extension points are protected and start with `configure*`. This PRs adds a new one for export fields, so you can define custom fields and can use admin extensions.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add `AbstractAdmin::configureExportFields` extension point
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
