### PR TITLE
Add missed PHPDoc blocks to AbstractAdmin and related interfaces

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -455,6 +455,9 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      */
     protected $securityInformation = [];
 
+    /**
+     * @var array
+     */
     protected $cacheIsGranted = [];
 
     /**
@@ -464,6 +467,9 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      */
     protected $searchResultActions = ['edit', 'show'];
 
+    /**
+     * @var array<string, array<string, mixed>>
+     */
     protected $listModes = [
         'list' => [
             'class' => 'fa fa-list fa-fw',
@@ -3263,22 +3269,47 @@ EOT;
         return $defaultFilterValues;
     }
 
+    /**
+     * Configure fields for form view.
+     *
+     * @param FormMapper $form Object for simulating Form API
+     */
     protected function configureFormFields(FormMapper $form)
     {
     }
 
+    /**
+     * Configure fields for list view.
+     *
+     * @param ListMapper $list Object for simulating Form API
+     */
     protected function configureListFields(ListMapper $list)
     {
     }
 
+    /**
+     * Configure fields for datagrid filters.
+     *
+     * @param DatagridMapper $filter Object for simulating Form API
+     */
     protected function configureDatagridFilters(DatagridMapper $filter)
     {
     }
 
+    /**
+     * Configure fields for show view.
+     *
+     * @param ShowMapper $show Object for simulating Form API
+     */
     protected function configureShowFields(ShowMapper $show)
     {
     }
 
+    /**
+     * Configure routes collection.
+     *
+     * @param RouteCollection $collection Collection of admin routes
+     */
     protected function configureRoutes(RouteCollection $collection)
     {
     }

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -432,6 +432,9 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function getDataSourceIterator();
 
+    /**
+     * Additional admin configuration.
+     */
     public function configure();
 
     /**


### PR DESCRIPTION
Classes and interfaces:
- AbstractAdmin
- AdminInterface
- UrlGeneratorInterface

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because I want to get more well-documented code. It's good practice to document code.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

