### PR TITLE
Add more type hints

### DIFF
--- a/.phpstan/phpstan-baseline.neon
+++ b/.phpstan/phpstan-baseline.neon
@@ -8,7 +8,7 @@ parameters:
 
         -
             # will be fixed in v4. Code is marked as deprecated
-            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AbstractAdmin\\:\\:getActiveSubClass\\(\\) should return string but returns null\\.$#"
+            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AbstractAdmin\\:\\:getActiveSubClass\\(\\) should return class-string but returns null\\.$#"
             count: 1
             path: ../src/Admin/AbstractAdmin.php
 
@@ -147,13 +147,13 @@ parameters:
 
         -
             # will be fixed in v4. Currently BC break
-            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AdminInterface\\:\\:getFormGroups\\(\\) invoked with 1 parameter, 0 required\\.$#"
+            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AdminInterface\\<object\\>\\:\\:getFormGroups\\(\\) invoked with 1 parameter, 0 required\\.$#"
             count: 1
             path: ../src/Form/FormMapper.php
 
         -
             # will be fixed in v4. Currently BC break
-            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AdminInterface\\:\\:getFormTabs\\(\\) invoked with 1 parameter, 0 required\\.$#"
+            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AdminInterface\\<object\\>\\:\\:getFormTabs\\(\\) invoked with 1 parameter, 0 required\\.$#"
             count: 1
             path: ../src/Form/FormMapper.php
 
@@ -177,13 +177,13 @@ parameters:
 
         -
             # will be fixed in v4. Currently BC break
-            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AdminInterface\\:\\:getShowGroups\\(\\) invoked with 1 parameter, 0 required\\.$#"
+            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AdminInterface\\<object\\>\\:\\:getShowGroups\\(\\) invoked with 1 parameter, 0 required\\.$#"
             count: 1
             path: ../src/Show/ShowMapper.php
 
         -
             # will be fixed in v4. Currently BC break
-            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AdminInterface\\:\\:getShowTabs\\(\\) invoked with 1 parameter, 0 required\\.$#"
+            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AdminInterface\\<object\\>\\:\\:getShowTabs\\(\\) invoked with 1 parameter, 0 required\\.$#"
             count: 1
             path: ../src/Show/ShowMapper.php
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -60,6 +60,9 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @phpstan-template T of object
+ * @phpstan-implements AdminInterface<T>
  */
 abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, AdminTreeInterface
 {
@@ -234,13 +237,15 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      * The subject only set in edit/update/create mode.
      *
      * @var object|null
+     *
+     * @phpstan-var T|null
      */
     protected $subject;
 
     /**
      * Define a Collection of child admin, ie /admin/order/{id}/order-element/{childId}.
      *
-     * @var array
+     * @var array<string, AdminInterface>
      */
     protected $children = [];
 
@@ -453,10 +458,13 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     /**
      * Roles and permissions per role.
      *
-     * @var array 'role' => ['permission', 'permission']
+     * @var array<string, string[]> 'role' => ['permission', 'permission']
      */
     protected $securityInformation = [];
 
+    /**
+     * @var array<string, bool>
+     */
     protected $cacheIsGranted = [];
 
     /**
@@ -466,6 +474,9 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      */
     protected $searchResultActions = ['edit', 'show'];
 
+    /**
+     * @var array<string, array<string, string>>
+     */
     protected $listModes = [
         'list' => [
             'class' => 'fa fa-list fa-fw',
@@ -491,6 +502,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      * The class name managed by the admin class.
      *
      * @var string
+     *
+     * @phpstan-var class-string<T>
      */
     private $class;
 
@@ -597,6 +610,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      * @param string      $code
      * @param string      $class
      * @param string|null $baseControllerName
+     *
+     * @phpstan-param class-string<T> $class
      */
     public function __construct($code, $class, $baseControllerName = null)
     {
@@ -775,6 +790,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     /**
      * @param object $object
+     *
+     * @phpstan-param T $object
      */
     public function preValidate($object)
     {
@@ -2845,7 +2862,7 @@ EOT;
         }
 
         if (method_exists($object, '__toString') && null !== $object->__toString()) {
-            return (string) $object;
+            return $object->__toString();
         }
 
         return sprintf('%s:%s', ClassUtils::getClass($object), spl_object_hash($object));
@@ -2997,10 +3014,12 @@ EOT;
     /**
      * Hook to handle access authorization, without throw Exception.
      *
-     * @param string $action
-     * @param object $object
+     * @param string      $action
+     * @param object|null $object
      *
      * @return bool
+     *
+     * @phpstan-param T|null $object
      */
     public function hasAccess($action, $object = null)
     {
@@ -3028,6 +3047,8 @@ EOT;
      * @param object|null $object
      *
      * @return array
+     *
+     * @phpstan-param T|null $object
      */
     public function configureActionButtons($action, $object = null)
     {
@@ -3105,10 +3126,12 @@ EOT;
     }
 
     /**
-     * @param string $action
-     * @param object $object
+     * @param string      $action
+     * @param object|null $object
      *
      * @return array
+     *
+     * @phpstan-param T|null $object
      */
     public function getActionButtons($action, $object = null)
     {
@@ -3174,6 +3197,8 @@ EOT;
 
     /**
      * @param object $object
+     *
+     * @phpstan-param T $object
      */
     final public function getSearchResultLink($object)
     {
@@ -3219,6 +3244,8 @@ EOT;
      * @param object $object
      *
      * @return bool
+     *
+     * @phpstan-param T $object
      */
     public function canAccessObject($action, $object)
     {
@@ -3447,6 +3474,8 @@ EOT;
      * @param string $name The name of the sub class
      *
      * @return string the subclass
+     *
+     * @phpstan-return class-string<T>
      */
     protected function getSubClass($name)
     {
@@ -3568,6 +3597,8 @@ EOT;
 
     /**
      * Set the parent object, if any, to the provided object.
+     *
+     * @phpstan-param T $object
      */
     final protected function appendParentObject(object $object): void
     {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2413,7 +2413,10 @@ EOT;
     public function getCurrentChildAdmin()
     {
         foreach ($this->children as $children) {
-            if ($children->isCurrentChild()) {
+            // NEXT_MAJOR: Remove method_exists check and delete elseif case
+            if (method_exists($children, 'isCurrentChild') && $children->isCurrentChild()) {
+                return $children;
+            } elseif ($children->getCurrentChild()) {
                 return $children;
             }
         }

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -119,11 +119,11 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     }
 
     /**
-     * @param array  $list
-     * @param string $action
-     * @param object $object
+     * @param array<string, mixed> $list
+     * @param string               $action
+     * @param object               $object
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function configureActionButtons(AdminInterface $admin, $list, $action, $object)
     {

--- a/src/Admin/AccessRegistryInterface.php
+++ b/src/Admin/AccessRegistryInterface.php
@@ -19,6 +19,8 @@ namespace Sonata\AdminBundle\Admin;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @method bool hasAccess(string $action, ?object $object = null)
+ *
+ * @phpstan-template T of object
  */
 interface AccessRegistryInterface
 {
@@ -34,6 +36,8 @@ interface AccessRegistryInterface
      *
      * @param string $action
      * @param object $object
+     *
+     * @phpstan-param T|null $object
      */
     public function checkAccess($action, $object = null);
 

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -34,14 +34,29 @@ use Sonata\Form\Validator\ErrorElement;
  */
 interface AdminExtensionInterface
 {
+    /**
+     * @return void
+     */
     public function configureFormFields(FormMapper $formMapper);
 
+    /**
+     * @return void
+     */
     public function configureListFields(ListMapper $listMapper);
 
+    /**
+     * @return void
+     */
     public function configureDatagridFilters(DatagridMapper $datagridMapper);
 
+    /**
+     * @return void
+     */
     public function configureShowFields(ShowMapper $showMapper);
 
+    /**
+     * @return void
+     */
     public function configureRoutes(AdminInterface $admin, RouteCollection $collection);
 
     /**
@@ -50,6 +65,8 @@ interface AdminExtensionInterface
      * NEXT_MAJOR: remove this method.
      *
      * @param string $action
+     *
+     * @return void
      *
      * @deprecated
      */
@@ -64,6 +81,8 @@ interface AdminExtensionInterface
      * Builds the tab menu.
      *
      * @param string $action
+     *
+     * @return void
      */
     public function configureTabMenu(
         AdminInterface $admin,
@@ -74,11 +93,15 @@ interface AdminExtensionInterface
 
     /**
      * @param object $object
+     *
+     * @return void
      */
     public function validate(AdminInterface $admin, ErrorElement $errorElement, $object);
 
     /**
      * @param string $context
+     *
+     * @return void
      */
     public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list');
 
@@ -86,6 +109,8 @@ interface AdminExtensionInterface
      * Get a chance to modify a newly created instance.
      *
      * @param object $object
+     *
+     * @return void
      */
     public function alterNewInstance(AdminInterface $admin, $object);
 
@@ -93,6 +118,8 @@ interface AdminExtensionInterface
      * Get a chance to modify object instance.
      *
      * @param object $object
+     *
+     * @return void
      */
     public function alterObject(AdminInterface $admin, $object);
 

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -64,9 +64,17 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @method void                            reorderFormGroup(string $group, array $keys)
  * @method void                            defineFormBuilder(FormBuilderInterface $formBuilder)
  * @method string                          getPagerType()
+ *
+ * @phpstan-template T of object
+ * @phpstan-extends AccessRegistryInterface<T>
+ * @phpstan-extends UrlGeneratorInterface<T>
+ * @phpstan-extends LifecycleHookProviderInterface<T>
  */
 interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface
 {
+    /**
+     * @return void
+     */
     public function setMenuFactory(MenuFactoryInterface $menuFactory);
 
     /**
@@ -74,8 +82,14 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function getMenuFactory();
 
+    /**
+     * @return void
+     */
     public function setFormContractor(FormContractorInterface $formContractor);
 
+    /**
+     * @return void
+     */
     public function setListBuilder(ListBuilderInterface $listBuilder);
 
     /**
@@ -83,6 +97,9 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function getListBuilder();
 
+    /**
+     * @return void
+     */
     public function setDatagridBuilder(DatagridBuilderInterface $datagridBuilder);
 
     /**
@@ -90,6 +107,9 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function getDatagridBuilder();
 
+    /**
+     * @return void
+     */
     public function setTranslator(TranslatorInterface $translator);
 
     /**
@@ -97,8 +117,14 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function getTranslator();
 
+    /**
+     * @return void
+     */
     public function setRequest(Request $request);
 
+    /**
+     * @return void
+     */
     public function setConfigurationPool(Pool $pool);
 
     /**
@@ -108,9 +134,14 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * - class name if not.
      *
      * @return string
+     *
+     * @phpstan-return class-string<T>
      */
     public function getClass();
 
+    /**
+     * @return void
+     */
     public function attachAdminClass(FieldDescriptionInterface $fieldDescription);
 
     // NEXT_MAJOR: uncomment this method in 4.0
@@ -125,6 +156,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * Set base controller name.
      *
      * @param string $baseControllerName
+     *
+     * @return void
      */
     public function setBaseControllerName($baseControllerName);
 
@@ -195,10 +228,13 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * - one permission that has the same name as the role for the role handler
      * This should be used by experimented users.
      *
-     * @return array 'role' => ['permission', 'permission']
+     * @return array<string, string[]> 'role' => ['permission', 'permission']
      */
     public function getSecurityInformation();
 
+    /**
+     * @return void
+     */
     public function setParentFieldDescription(FieldDescriptionInterface $parentFieldDescription);
 
     /**
@@ -261,6 +297,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @param object|null  $object
      *
      * @return bool
+     *
+     * @phpstan-param T|null $object
      */
     public function isGranted($name, $object = null);
 
@@ -268,6 +306,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @param object $model
      *
      * @return string a string representation of the identifiers for this instance
+     *
+     * @phpstan-param T $model
      */
     public function getNormalizedIdentifier($model);
 
@@ -277,11 +317,15 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @param object $model
      *
      * @return mixed
+     *
+     * @phpstan-param T $model
      */
     public function id($model);
 
     /**
      * @param ValidatorInterface $validator
+     *
+     * @return void
      */
     public function setValidator($validator);
 
@@ -298,6 +342,9 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 //    NEXT_MAJOR: uncomment this method in 4.0
 //    public function getList(): ?FieldDescriptionCollection;
 
+    /**
+     * @return void
+     */
     public function setFormTheme(array $formTheme);
 
     /**
@@ -305,6 +352,11 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function getFormTheme();
 
+    /**
+     * @param string[] $filterTheme
+     *
+     * @return void
+     */
     public function setFilterTheme(array $filterTheme);
 
     /**
@@ -312,6 +364,9 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function getFilterTheme();
 
+    /**
+     * @return void
+     */
     public function addExtension(AdminExtensionInterface $extension);
 
     /**
@@ -321,6 +376,9 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function getExtensions();
 
+    /**
+     * @return void
+     */
     public function setRouteBuilder(RouteBuilderInterface $routeBuilder);
 
     /**
@@ -332,9 +390,14 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @param object $object
      *
      * @return string
+     *
+     * @phpstan-param T $object
      */
     public function toString($object);
 
+    /**
+     * @return void
+     */
     public function setLabelTranslatorStrategy(LabelTranslatorStrategyInterface $labelTranslatorStrategy);
 
     /**
@@ -353,11 +416,15 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * @return object a new object instance
+     *
+     * @phpstan-return T
      */
     public function getNewInstance();
 
     /**
      * @param string $uniqId
+     *
+     * @return void
      */
     public function setUniqid($uniqId);
 
@@ -372,11 +439,17 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @param mixed $id
      *
      * @return object|null
+     *
+     * @phpstan-return T|null
      */
     public function getObject($id);
 
     /**
      * @param object|null $subject
+     *
+     * @return void
+     *
+     * @phpstan-param T|null $subject
      */
     public function setSubject($subject);
 
@@ -384,6 +457,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * NEXT MAJOR: return object.
      *
      * @return object|null
+     *
+     * @phpstan-return T|null
      */
     public function getSubject();
 
@@ -432,6 +507,9 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function getDataSourceIterator();
 
+    /**
+     * @return void
+     */
     public function configure();
 
     /**
@@ -461,8 +539,12 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      *
      * @param object $object
      *
+     * @return void
+     *
      * @deprecated this feature cannot be stable, use a custom validator,
      *             the feature will be removed with Symfony 2.2
+     *
+     * @phpstan-param T $object
      */
     public function validate(ErrorElement $errorElement, $object);
 
@@ -477,6 +559,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * Add object security, fe. make the current user owner of the object.
      *
      * @param object $object
+     *
+     * @phpstan-param T $object
      */
     public function createObjectSecurity($object);
 
@@ -485,6 +569,9 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      */
     public function getParent();
 
+    /**
+     * @return void
+     */
     public function setParent(self $admin);
 
     /**
@@ -509,6 +596,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * Set the translation domain.
      *
      * @param string $translationDomain the translation domain
+     *
+     * @return void
      */
     public function setTranslationDomain($translationDomain);
 
@@ -530,27 +619,45 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * Set the form groups.
+     *
+     * @param array<string, mixed> $formGroups
      */
     public function setFormGroups(array $formGroups);
 
     /**
      * NEXT_MAJOR: must return only `array<string, mixed>`.
+     *
+     * @return array<string, mixed>|false
      */
     public function getFormTabs();
 
+    /**
+     * @param array<string, mixed> $formTabs
+     *
+     * @return void
+     */
     public function setFormTabs(array $formTabs);
 
     /**
      * NEXT_MAJOR: must return only `array<string, mixed>`.
+     *
+     * @return array<string, mixed>|false
      */
     public function getShowTabs();
 
+    /**
+     * @param array<string, mixed> $showTabs
+     *
+     * @return void
+     */
     public function setShowTabs(array $showTabs);
 
     /**
      * Remove a form group field.
      *
      * @param string $key
+     *
+     * @return void
      */
     public function removeFieldFromFormGroup($key);
 
@@ -565,13 +672,20 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * Set the show groups.
+     *
+     * @param array<string, mixed> $showGroups
+     *
+     * @return void
      */
     public function setShowGroups(array $showGroups);
 
     /**
      * Reorder items in showGroup.
      *
-     * @param string $group
+     * @param string   $group
+     * @param string[] $keys
+     *
+     * @return void
      */
     public function reorderShowGroup($group, array $keys);
 
@@ -590,6 +704,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * Remove a FieldDescription.
      *
      * @param string $name
+     *
+     * @return void
      */
     public function removeFormFieldDescription($name);
 
@@ -602,6 +718,12 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * Sets the list of supported sub classes.
+     *
+     * @param string[] $subClasses
+     *
+     * @return void
+     *
+     * @phpstan-param array<class-string<T>> $subClasses
      */
     public function setSubClasses(array $subClasses);
 
@@ -611,6 +733,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @param string $name The name of the sub class
      *
      * @return bool
+     *
+     * @phpstan-param class-string $name
      */
     public function hasSubClass($name);
 
@@ -625,6 +749,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * Returns the currently active sub class.
      *
      * @return string the active sub class
+     *
+     * @phpstan-return class-string
      */
     public function getActiveSubClass();
 
@@ -662,7 +788,7 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      *
      * @param string $action
      *
-     * @return iterable
+     * @return ItemInterface[]
      */
     public function getBreadcrumbs($action);
 
@@ -670,6 +796,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * Set the current child status.
      *
      * @param bool $currentChild
+     *
+     * @return void
      */
     public function setCurrentChild($currentChild);
 
@@ -697,6 +825,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @param object $object
      *
      * @return MetadataInterface
+     *
+     * @phpstan-param T $object
      */
     public function getObjectMetadata($object);
 
@@ -719,6 +849,8 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
 
     /**
      * @param string $mode
+     *
+     * @return void
      */
     public function setListMode($mode);
 

--- a/src/Admin/BreadcrumbsBuilder.php
+++ b/src/Admin/BreadcrumbsBuilder.php
@@ -145,11 +145,11 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
      * Creates a new menu item from a simple name. The name is normalized and
      * translated with the specified translation domain.
      *
-     * @param AdminInterface $admin             used for translation
-     * @param ItemInterface  $menu              will be modified and returned
-     * @param string         $name              the source of the final label
-     * @param string         $translationDomain for label translation
-     * @param array          $options           menu item options
+     * @param AdminInterface       $admin             used for translation
+     * @param ItemInterface        $menu              will be modified and returned
+     * @param string               $name              the source of the final label
+     * @param string               $translationDomain for label translation
+     * @param array<string, mixed> $options           menu item options
      */
     private function createMenuItem(
         AdminInterface $admin,

--- a/src/Admin/BreadcrumbsBuilderInterface.php
+++ b/src/Admin/BreadcrumbsBuilderInterface.php
@@ -30,7 +30,7 @@ interface BreadcrumbsBuilderInterface
      * @param string $action the name of the action we want to get a
      *                       breadcrumbs for
      *
-     * @return iterable the breadcrumbs
+     * @return ItemInterface[] the breadcrumbs
      */
     public function getBreadcrumbs(AdminInterface $admin, $action);
 

--- a/src/Admin/FieldDescriptionRegistryInterface.php
+++ b/src/Admin/FieldDescriptionRegistryInterface.php
@@ -70,6 +70,8 @@ interface FieldDescriptionRegistryInterface
      * Adds a FieldDescription.
      *
      * @param string $name
+     *
+     * @return void
      */
     public function addShowFieldDescription($name, FieldDescriptionInterface $fieldDescription);
 
@@ -77,6 +79,8 @@ interface FieldDescriptionRegistryInterface
      * Removes a ShowFieldDescription.
      *
      * @param string $name
+     *
+     * @return void
      */
     public function removeShowFieldDescription($name);
 
@@ -93,6 +97,8 @@ interface FieldDescriptionRegistryInterface
      * Adds a list FieldDescription.
      *
      * @param string $name
+     *
+     * @return void
      */
     public function addListFieldDescription($name, FieldDescriptionInterface $fieldDescription);
 
@@ -100,6 +106,8 @@ interface FieldDescriptionRegistryInterface
      * Removes a list FieldDescription.
      *
      * @param string $name
+     *
+     * @return void
      */
     public function removeListFieldDescription($name);
 
@@ -135,6 +143,8 @@ interface FieldDescriptionRegistryInterface
      * Adds a filter FieldDescription.
      *
      * @param string $name
+     *
+     * @return void
      */
     public function addFilterFieldDescription($name, FieldDescriptionInterface $fieldDescription);
 
@@ -142,6 +152,8 @@ interface FieldDescriptionRegistryInterface
      * Removes a filter FieldDescription.
      *
      * @param string $name
+     *
+     * @return void
      */
     public function removeFilterFieldDescription($name);
 

--- a/src/Admin/LifecycleHookProviderInterface.php
+++ b/src/Admin/LifecycleHookProviderInterface.php
@@ -20,6 +20,8 @@ namespace Sonata\AdminBundle\Admin;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @method void preValidate($object)
+ *
+ * @phpstan-template T of object
  */
 interface LifecycleHookProviderInterface
 {
@@ -29,6 +31,8 @@ interface LifecycleHookProviderInterface
      * @param object $object
      *
      * @return object
+     *
+     * @phpstan-param T $object
      */
     public function update($object);
 
@@ -38,6 +42,8 @@ interface LifecycleHookProviderInterface
      * @param object $object
      *
      * @return object
+     *
+     * @phpstan-param T $object
      */
     public function create($object);
 
@@ -45,6 +51,8 @@ interface LifecycleHookProviderInterface
      * This method should call preRemove, do the removal, and call postRemove.
      *
      * @param object $object
+     *
+     * @phpstan-param T $object
      */
     public function delete($object);
 
@@ -56,31 +64,43 @@ interface LifecycleHookProviderInterface
 
     /**
      * @param object $object
+     *
+     * @phpstan-param T $object
      */
     public function preUpdate($object);
 
     /**
      * @param object $object
+     *
+     * @phpstan-param T $object
      */
     public function postUpdate($object);
 
     /**
      * @param object $object
+     *
+     * @phpstan-param T $object
      */
     public function prePersist($object);
 
     /**
      * @param object $object
+     *
+     * @phpstan-param T $object
      */
     public function postPersist($object);
 
     /**
      * @param object $object
+     *
+     * @phpstan-param T $object
      */
     public function preRemove($object);
 
     /**
      * @param object $object
+     *
+     * @phpstan-param T $object
      */
     public function postRemove($object);
 }

--- a/src/Admin/ParentAdminInterface.php
+++ b/src/Admin/ParentAdminInterface.php
@@ -39,7 +39,7 @@ interface ParentAdminInterface
     /**
      * Returns an collection of admin children.
      *
-     * @return array list of Admin children
+     * @return array<string, AdminInterface> list of Admin children
      */
     public function getChildren();
 

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -42,7 +42,9 @@ class Pool
     protected $adminGroups = [];
 
     /**
-     * @var array
+     * @var array<string, string[]>
+     *
+     * @phpstan-var array<class-string, string[]>
      */
     protected $adminClasses = [];
 
@@ -197,6 +199,10 @@ class Pool
      * @param string $class
      *
      * @return AdminInterface|null
+     *
+     * @phpstan-template T of object
+     * @phpstan-param class-string<T> $class
+     * @phpstan-return AdminInterface<T>|null
      */
     public function getAdminByClass($class)
     {
@@ -236,6 +242,8 @@ class Pool
      * @param string $class
      *
      * @return bool
+     *
+     * @phpstan-param class-string $class
      */
     public function hasAdminByClass($class)
     {
@@ -387,6 +395,9 @@ class Pool
         return $this->container;
     }
 
+    /**
+     * @return void
+     */
     public function setAdminGroups(array $adminGroups)
     {
         $this->adminGroups = $adminGroups;
@@ -400,6 +411,9 @@ class Pool
         return $this->adminGroups;
     }
 
+    /**
+     * @return void
+     */
     public function setAdminServiceIds(array $adminServiceIds)
     {
         $this->adminServiceIds = $adminServiceIds;
@@ -413,26 +427,37 @@ class Pool
         return $this->adminServiceIds;
     }
 
+    /**
+     * @param array<string, string[]> $adminClasses
+     *
+     * @phpstan-param array<class-string, string[]> $adminClasses
+     *
+     * @return void
+     */
     public function setAdminClasses(array $adminClasses)
     {
         $this->adminClasses = $adminClasses;
     }
 
     /**
-     * @return array
+     * @return array<string, string[]>
+     *
+     * @phpstan-return array<class-string, string[]>
      */
     public function getAdminClasses()
     {
         return $this->adminClasses;
     }
 
-    final public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry)
+    final public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void
     {
         $this->templateRegistry = $templateRegistry;
     }
 
     /**
      * @deprecated since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
+     *
+     * @return void
      */
     public function setTemplates(array $templates)
     {

--- a/src/Admin/UrlGeneratorInterface.php
+++ b/src/Admin/UrlGeneratorInterface.php
@@ -21,6 +21,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface as RoutingUrlGener
  * Contains url generation logic related to an admin.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @phpstan-template T of object
  */
 interface UrlGeneratorInterface
 {
@@ -49,6 +51,8 @@ interface UrlGeneratorInterface
      * @param int                  $referenceType
      *
      * @return string return a complete url
+     *
+     * @phpstan-param T $object
      */
     public function generateObjectUrl(
         $name,
@@ -83,6 +87,8 @@ interface UrlGeneratorInterface
      * @param object $model
      *
      * @return string a string representation of the id that is safe to use in a url
+     *
+     * @phpstan-param T $model
      */
     public function getUrlSafeIdentifier($model);
 }

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -55,7 +55,7 @@ class ListMapper extends BaseMapper
      * @param string      $name
      * @param string|null $type
      *
-     * @return $this
+     * @return static
      */
     public function addIdentifier($name, $type = null, array $fieldDescriptionOptions = [])
     {
@@ -79,7 +79,7 @@ class ListMapper extends BaseMapper
      *
      * @throws \LogicException
      *
-     * @return $this
+     * @return static
      */
     public function add($name, $type = null, array $fieldDescriptionOptions = [])
     {

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -570,6 +570,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
 
     /**
      * @param int $nb
+     *
+     * @return void
      */
     protected function setNbResults($nb)
     {
@@ -578,6 +580,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
 
     /**
      * @param int $page
+     *
+     * @return void
      */
     protected function setLastPage($page)
     {
@@ -600,6 +604,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
 
     /**
      * Loads data into properties used for iteration.
+     *
+     * @return void
      */
     protected function initializeIterator()
     {
@@ -609,6 +615,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
 
     /**
      * Empties properties used for iteration.
+     *
+     * @return void
      */
     protected function resetIterator()
     {

--- a/src/Filter/Persister/FilterPersisterInterface.php
+++ b/src/Filter/Persister/FilterPersisterInterface.php
@@ -26,24 +26,26 @@ interface FilterPersisterInterface
      *
      * @param string $adminCode The admin code
      *
-     * @return array The persisted filters
+     * @return array<string, mixed> The persisted filters
      */
     public function get($adminCode);
 
     /**
      * Set persisted filters for given admin.
      *
-     * @param string $adminCode The admin code
-     * @param array  $filters   The filters to persist. Structure :
-     *                          {string filter field} => array(
-     *                          "type" => {int filter type},
-     *                          "value" => {mixed filter value},
-     *                          ),
-     *                          ...,
-     *                          "_page" => {int page num},
-     *                          "_sort_by" => {string sort property},
-     *                          "_sort_order" => {string sort order (ASC|DESC)},
-     *                          "_per_page" => {int count rows per page}
+     * @param string               $adminCode The admin code
+     * @param array<string, mixed> $filters   The filters to persist. Structure :
+     *                                        {string filter field} => array(
+     *                                        "type" => {int filter type},
+     *                                        "value" => {mixed filter value},
+     *                                        ),
+     *                                        ...,
+     *                                        "_page" => {int page num},
+     *                                        "_sort_by" => {string sort property},
+     *                                        "_sort_order" => {string sort order (ASC|DESC)},
+     *                                        "_per_page" => {int count rows per page}
+     *
+     * @return void
      */
     public function set($adminCode, array $filters);
 
@@ -51,6 +53,8 @@ interface FilterPersisterInterface
      * Reset persisted filters for given admin.
      *
      * @param string $adminCode The admin code
+     *
+     * @return void
      */
     public function reset($adminCode);
 }

--- a/src/Form/ChoiceList/ModelChoiceLoader.php
+++ b/src/Form/ChoiceList/ModelChoiceLoader.php
@@ -17,6 +17,7 @@ use Doctrine\Common\Util\ClassUtils;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\Doctrine\Adapter\AdapterInterface;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\Exception\RuntimeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -33,19 +34,30 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
     public $identifier;
 
     /**
-     * @var \Sonata\AdminBundle\Model\ModelManagerInterface
+     * @var ModelManagerInterface
      */
     private $modelManager;
 
     /**
      * @var string
+     *
+     * @phpstan-var class-string
      */
     private $class;
 
+    /**
+     * @var string|null
+     */
     private $property;
 
+    /**
+     * @var object|null
+     */
     private $query;
 
+    /**
+     * @var object[]
+     */
     private $choices;
 
     /**
@@ -58,13 +70,18 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
      */
     private $propertyAccessor;
 
+    /**
+     * @var ChoiceListInterface|null
+     */
     private $choiceList;
 
     /**
      * @param string      $class
      * @param string|null $property
-     * @param mixed|null  $query
-     * @param array       $choices
+     * @param object|null $query
+     * @param object[]    $choices
+     *
+     * @phpstan-param class-string $class
      */
     public function __construct(
         ModelManagerInterface $modelManager,
@@ -157,6 +174,8 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
 
     /**
      * @param object $model
+     *
+     * @return mixed[]
      */
     private function getIdentifierValues($model): array
     {

--- a/src/Form/Extension/ChoiceTypeExtension.php
+++ b/src/Form/Extension/ChoiceTypeExtension.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Form\Extension;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -26,6 +27,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ChoiceTypeExtension extends AbstractTypeExtension
 {
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $optionalOptions = ['sortable'];
@@ -33,16 +37,29 @@ class ChoiceTypeExtension extends AbstractTypeExtension
         $resolver->setDefined($optionalOptions);
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['sortable'] = \array_key_exists('sortable', $options) && $options['sortable'];
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getExtendedType()
     {
         return ChoiceType::class;
     }
 
+    /**
+     * @return string[]
+     *
+     * @phpstan-return class-string<FormTypeInterface>[]
+     */
     public static function getExtendedTypes()
     {
         return [ChoiceType::class];

--- a/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -30,21 +31,30 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class FormTypeFieldExtension extends AbstractTypeExtension
 {
     /**
-     * @var array
+     * @var array<string, string>
      */
     protected $defaultClasses = [];
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected $options = [];
 
+    /**
+     * FormTypeFieldExtension constructor.
+     *
+     * @param array<string, string> $defaultClasses
+     * @param array<string, mixed>  $options
+     */
     public function __construct(array $defaultClasses, array $options)
     {
         $this->defaultClasses = $defaultClasses;
         $this->options = $options;
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $sonataAdmin = [
@@ -79,6 +89,9 @@ class FormTypeFieldExtension extends AbstractTypeExtension
         $builder->setAttribute('sonata_admin', $sonataAdmin);
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $sonataAdmin = $form->getConfig()->getAttribute('sonata_admin');
@@ -157,16 +170,29 @@ class FormTypeFieldExtension extends AbstractTypeExtension
         $view->vars['sonata_admin'] = $sonataAdmin;
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getExtendedType()
     {
         return FormType::class;
     }
 
+    /**
+     * @return string[]
+     *
+     * @phpstan-return class-string<FormTypeInterface>[]
+     */
     public static function getExtendedTypes()
     {
         return [FormType::class];
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver

--- a/src/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Form\Extension\Field\Type;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,6 +30,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class MopaCompatibilityTypeFieldExtension extends AbstractTypeExtension
 {
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -38,6 +42,9 @@ class MopaCompatibilityTypeFieldExtension extends AbstractTypeExtension
         ]);
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['horizontal_label_class'] = $options['horizontal_label_class'];
@@ -45,11 +52,21 @@ class MopaCompatibilityTypeFieldExtension extends AbstractTypeExtension
         $view->vars['horizontal_input_wrapper_class'] = $options['horizontal_input_wrapper_class'];
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getExtendedType()
     {
         return FormType::class;
     }
 
+    /**
+     * @return string[]
+     *
+     * @phpstan-return class-string<FormTypeInterface>[]
+     */
     public static function getExtendedTypes()
     {
         return [FormType::class];

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -58,8 +58,10 @@ class FormMapper extends BaseGroupedMapper
     /**
      * @param FormBuilderInterface|string $name
      * @param string|null                 $type
+     * @param array<string, mixed>        $options
+     * @param array<string, mixed>        $fieldDescriptionOptions
      *
-     * @return $this
+     * @return static
      */
     public function add($name, $type = null, array $options = [], array $fieldDescriptionOptions = [])
     {
@@ -175,6 +177,9 @@ class FormMapper extends BaseGroupedMapper
         return $this->formBuilder->has($key);
     }
 
+    /**
+     * @return string[]
+     */
     final public function keys()
     {
         return array_keys($this->formBuilder->all());
@@ -197,7 +202,7 @@ class FormMapper extends BaseGroupedMapper
      * @param string $tab            The tab the group belongs to, defaults to 'default'
      * @param bool   $deleteEmptyTab Whether or not the Tab should be deleted, when the deleted group leaves the tab empty after deletion
      *
-     * @return $this
+     * @return static
      */
     public function removeGroup($group, $tab = 'default', $deleteEmptyTab = false)
     {
@@ -240,8 +245,9 @@ class FormMapper extends BaseGroupedMapper
     }
 
     /**
-     * @param string $name
-     * @param mixed  $type
+     * @param string               $name
+     * @param mixed                $type
+     * @param array<string, mixed> $options
      *
      * @return FormBuilderInterface
      */

--- a/src/Form/Type/AclMatrixType.php
+++ b/src/Form/Type/AclMatrixType.php
@@ -30,6 +30,9 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 class AclMatrixType extends AbstractType
 {
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $aclValueType = $options['acl_value'] instanceof UserInterface ? 'user' : 'role';
@@ -44,6 +47,9 @@ class AclMatrixType extends AbstractType
         }
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setRequired(['permissions', 'acl_value']);
@@ -54,7 +60,7 @@ class AclMatrixType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {

--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -58,6 +58,9 @@ class AdminType extends AbstractType
         $this->adminHelper = $adminHelper;
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $admin = clone $this->getAdmin($options);
@@ -122,6 +125,9 @@ class AdminType extends AbstractType
         $builder->addModelTransformer(new ArrayToModelTransformer($admin->getModelManager(), $admin->getClass()));
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['btn_add'] = $options['btn_add'];
@@ -130,6 +136,9 @@ class AdminType extends AbstractType
         $view->vars['btn_catalogue'] = $options['btn_catalogue'];
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -154,7 +163,7 @@ class AdminType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {
@@ -167,6 +176,8 @@ class AdminType extends AbstractType
     }
 
     /**
+     * @param array<string, mixed> $options
+     *
      * @throws \RuntimeException
      *
      * @return FieldDescriptionInterface
@@ -181,6 +192,8 @@ class AdminType extends AbstractType
     }
 
     /**
+     * @param array<string, mixed> $options
+     *
      * @return AdminInterface
      */
     protected function getAdmin(array $options)

--- a/src/Form/Type/ChoiceFieldMaskType.php
+++ b/src/Form/Type/ChoiceFieldMaskType.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -48,6 +49,9 @@ class ChoiceFieldMaskType extends AbstractType
         parent::buildView($view, $form, $options);
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
@@ -59,6 +63,11 @@ class ChoiceFieldMaskType extends AbstractType
         $resolver->setAllowedTypes('map', 'array');
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getParent()
     {
         return ChoiceType::class;
@@ -67,7 +76,7 @@ class ChoiceFieldMaskType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {

--- a/src/Form/Type/CollectionType.php
+++ b/src/Form/Type/CollectionType.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType as SymfonyCollectionType;
+use Symfony\Component\Form\FormTypeInterface;
 
 /**
  * This type wrap native `collection` form type and render `add` and `delete`
@@ -26,6 +27,11 @@ use Symfony\Component\Form\Extension\Core\Type\CollectionType as SymfonyCollecti
  */
 class CollectionType extends AbstractType
 {
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getParent()
     {
         return SymfonyCollectionType::class;
@@ -34,7 +40,7 @@ class CollectionType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {

--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -59,7 +59,7 @@ class ChoiceType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {
@@ -71,6 +71,9 @@ class ChoiceType extends AbstractType
         return 'sonata_type_filter_choice';
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -79,6 +82,9 @@ class ChoiceType extends AbstractType
         ;
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -54,7 +54,7 @@ class DateRangeType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {
@@ -66,6 +66,9 @@ class DateRangeType extends AbstractType
         return 'sonata_type_filter_date_range';
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -74,6 +77,9 @@ class DateRangeType extends AbstractType
         ;
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -54,7 +54,7 @@ class DateTimeRangeType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {
@@ -66,6 +66,9 @@ class DateTimeRangeType extends AbstractType
         return 'sonata_type_filter_datetime_range';
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -74,6 +77,9 @@ class DateTimeRangeType extends AbstractType
         ;
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -79,7 +79,7 @@ class DateTimeType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {
@@ -91,6 +91,9 @@ class DateTimeType extends AbstractType
         return 'sonata_type_filter_datetime';
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -99,6 +102,9 @@ class DateTimeType extends AbstractType
         ;
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -79,7 +79,7 @@ class DateType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {
@@ -91,6 +91,9 @@ class DateType extends AbstractType
         return 'sonata_type_filter_date';
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -99,6 +102,9 @@ class DateType extends AbstractType
         ;
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([

--- a/src/Form/Type/Filter/DefaultType.php
+++ b/src/Form/Type/Filter/DefaultType.php
@@ -29,7 +29,7 @@ class DefaultType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {
@@ -41,6 +41,9 @@ class DefaultType extends AbstractType
         return 'sonata_type_filter_default';
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -49,6 +52,9 @@ class DefaultType extends AbstractType
         ;
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([

--- a/src/Form/Type/Filter/NumberType.php
+++ b/src/Form/Type/Filter/NumberType.php
@@ -69,7 +69,7 @@ class NumberType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {
@@ -81,6 +81,9 @@ class NumberType extends AbstractType
         return 'sonata_type_filter_number';
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -89,6 +92,9 @@ class NumberType extends AbstractType
         ;
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([

--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -33,6 +33,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ModelAutocompleteType extends AbstractType
 {
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->addViewTransformer(new ModelToIdPropertyTransformer($options['model_manager'], $options['class'], $options['property'], $options['multiple'], $options['to_string_callback']), true);
@@ -93,6 +96,9 @@ class ModelAutocompleteType extends AbstractType
         }
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $compound = static function (Options $options) {
@@ -158,7 +164,7 @@ class ModelAutocompleteType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {

--- a/src/Form/Type/ModelHiddenType.php
+++ b/src/Form/Type/ModelHiddenType.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -28,6 +29,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ModelHiddenType extends AbstractType
 {
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -35,6 +39,9 @@ class ModelHiddenType extends AbstractType
         ;
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -46,6 +53,11 @@ class ModelHiddenType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getParent()
     {
         return HiddenType::class;
@@ -54,7 +66,7 @@ class ModelHiddenType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {

--- a/src/Form/Type/ModelListType.php
+++ b/src/Form/Type/ModelListType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -45,6 +46,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ModelListType extends AbstractType
 {
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -65,6 +69,9 @@ class ModelListType extends AbstractType
         $view->vars['btn_catalogue'] = $options['btn_catalogue'];
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -78,6 +85,11 @@ class ModelListType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getParent()
     {
         return TextType::class;
@@ -86,7 +98,7 @@ class ModelListType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {

--- a/src/Form/Type/ModelReferenceType.php
+++ b/src/Form/Type/ModelReferenceType.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -26,11 +27,17 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ModelReferenceType extends AbstractType
 {
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->addModelTransformer(new ModelToIdTransformer($options['model_manager'], $options['class']));
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -40,6 +47,11 @@ class ModelReferenceType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getParent()
     {
         return TextType::class;
@@ -48,7 +60,7 @@ class ModelReferenceType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {

--- a/src/Form/Type/ModelType.php
+++ b/src/Form/Type/ModelType.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -45,6 +46,9 @@ class ModelType extends AbstractType
         $this->propertyAccessor = $propertyAccessor;
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if ($options['multiple']) {
@@ -71,6 +75,9 @@ class ModelType extends AbstractType
         $view->vars['btn_catalogue'] = $options['btn_catalogue'];
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $options = [];
@@ -127,6 +134,11 @@ class ModelType extends AbstractType
         ]));
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getParent()
     {
         return ChoiceType::class;
@@ -135,7 +147,7 @@ class ModelType extends AbstractType
     /**
      * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
      *
-     * {@inheritdoc}
+     * @return string
      */
     public function getName()
     {

--- a/src/Form/Type/Operator/ContainsOperatorType.php
+++ b/src/Form/Type/Operator/ContainsOperatorType.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Form\Type\Operator;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class ContainsOperatorType extends AbstractType
@@ -23,6 +24,9 @@ final class ContainsOperatorType extends AbstractType
     public const TYPE_NOT_CONTAINS = 2;
     public const TYPE_EQUAL = 3;
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -35,6 +39,11 @@ final class ContainsOperatorType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getParent()
     {
         return FormChoiceType::class;

--- a/src/Form/Type/Operator/DateOperatorType.php
+++ b/src/Form/Type/Operator/DateOperatorType.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Form\Type\Operator;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class DateOperatorType extends AbstractType
@@ -27,6 +28,9 @@ final class DateOperatorType extends AbstractType
     public const TYPE_NULL = 6;
     public const TYPE_NOT_NULL = 7;
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -43,6 +47,11 @@ final class DateOperatorType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getParent()
     {
         return FormChoiceType::class;

--- a/src/Form/Type/Operator/DateRangeOperatorType.php
+++ b/src/Form/Type/Operator/DateRangeOperatorType.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Form\Type\Operator;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class DateRangeOperatorType extends AbstractType
@@ -22,6 +23,9 @@ final class DateRangeOperatorType extends AbstractType
     public const TYPE_BETWEEN = 1;
     public const TYPE_NOT_BETWEEN = 2;
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -33,6 +37,11 @@ final class DateRangeOperatorType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getParent()
     {
         return FormChoiceType::class;

--- a/src/Form/Type/Operator/EqualOperatorType.php
+++ b/src/Form/Type/Operator/EqualOperatorType.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Form\Type\Operator;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class EqualOperatorType extends AbstractType
@@ -31,6 +32,9 @@ final class EqualOperatorType extends AbstractType
     public const TYPE_EQUAL = 1;
     public const TYPE_NOT_EQUAL = 2;
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -42,6 +46,11 @@ final class EqualOperatorType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getParent()
     {
         return FormChoiceType::class;

--- a/src/Form/Type/Operator/NumberOperatorType.php
+++ b/src/Form/Type/Operator/NumberOperatorType.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Form\Type\Operator;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class NumberOperatorType extends AbstractType
@@ -25,6 +26,9 @@ final class NumberOperatorType extends AbstractType
     public const TYPE_LESS_EQUAL = 4;
     public const TYPE_LESS_THAN = 5;
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults($defaultOptions = [
@@ -39,6 +43,11 @@ final class NumberOperatorType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getParent()
     {
         return FormChoiceType::class;

--- a/src/Form/Type/Operator/StringOperatorType.php
+++ b/src/Form/Type/Operator/StringOperatorType.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Form\Type\Operator;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class StringOperatorType extends AbstractType
@@ -25,6 +26,9 @@ final class StringOperatorType extends AbstractType
     public const TYPE_STARTS_WITH = 4;
     public const TYPE_ENDS_WITH = 5;
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -39,6 +43,11 @@ final class StringOperatorType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     *
+     * @phpstan-return class-string<FormTypeInterface>
+     */
     public function getParent()
     {
         return FormChoiceType::class;

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -40,11 +40,12 @@ abstract class BaseGroupedMapper extends BaseMapper
     /**
      * Add new group or tab (if parameter "tab=true" is available in options).
      *
-     * @param string $name
+     * @param string               $name
+     * @param array<string, mixed> $options
      *
      * @throws \LogicException
      *
-     * @return $this
+     * @return static
      */
     public function with($name, array $options = [])
     {
@@ -176,7 +177,7 @@ abstract class BaseGroupedMapper extends BaseMapper
      *
      * @param bool $bool
      *
-     * @return $this
+     * @return static
      */
     public function ifTrue($bool)
     {
@@ -190,7 +191,7 @@ abstract class BaseGroupedMapper extends BaseMapper
      *
      * @param bool $bool
      *
-     * @return $this
+     * @return static
      */
     public function ifFalse($bool)
     {
@@ -202,7 +203,7 @@ abstract class BaseGroupedMapper extends BaseMapper
     /**
      * @throws \LogicException
      *
-     * @return $this
+     * @return static
      */
     public function ifEnd()
     {
@@ -218,9 +219,10 @@ abstract class BaseGroupedMapper extends BaseMapper
     /**
      * Add new tab.
      *
-     * @param string $name
+     * @param string               $name
+     * @param array<string, mixed> $options
      *
-     * @return $this
+     * @return static
      */
     public function tab($name, array $options = [])
     {
@@ -232,7 +234,7 @@ abstract class BaseGroupedMapper extends BaseMapper
      *
      * @throws \LogicException
      *
-     * @return $this
+     * @return static
      */
     public function end()
     {
@@ -262,17 +264,23 @@ abstract class BaseGroupedMapper extends BaseMapper
     }
 
     /**
-     * @return array
+     * @return array<string, array<string, mixed>>
      */
     abstract protected function getGroups();
 
     /**
-     * @return array
+     * @return array<string, array<string, mixed>>
      */
     abstract protected function getTabs();
 
+    /**
+     * @param array<string, array<string, mixed>> $groups
+     */
     abstract protected function setGroups(array $groups);
 
+    /**
+     * @param array<string, array<string, mixed>> $tabs
+     */
     abstract protected function setTabs(array $tabs);
 
     /**
@@ -294,6 +302,8 @@ abstract class BaseGroupedMapper extends BaseMapper
      * Add the field name to the current group.
      *
      * @param string $fieldName
+     *
+     * @return array<string, mixed>
      */
     protected function addFieldToCurrentGroup($fieldName)
     {

--- a/src/Mapper/BaseMapper.php
+++ b/src/Mapper/BaseMapper.php
@@ -64,7 +64,7 @@ abstract class BaseMapper
     /**
      * @param string $key
      *
-     * @return $this
+     * @return static
      */
     abstract public function remove($key);
 
@@ -79,7 +79,7 @@ abstract class BaseMapper
     /**
      * @param array $keys field names
      *
-     * @return $this
+     * @return static
      */
     abstract public function reorder(array $keys);
 }

--- a/src/Menu/Matcher/Voter/AdminVoter.php
+++ b/src/Menu/Matcher/Voter/AdminVoter.php
@@ -46,7 +46,7 @@ class AdminVoter implements VoterInterface
     /**
      * @deprecated since sonata-project/admin-bundle 3.31. Pass a RequestStack to the constructor instead.
      *
-     * @return $this
+     * @return static
      */
     public function setRequest($request)
     {

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -61,7 +61,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return object[] all objects matching the criteria
      *
-     * @phpstan-template T
+     * @phpstan-template T of object
      * @phpstan-param class-string<T> $class
      * @phpstan-return T[]
      */
@@ -73,7 +73,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return object|null an object matching the criteria or null if none match
      *
-     * @phpstan-template T
+     * @phpstan-template T of object
      * @phpstan-param class-string<T> $class
      * @phpstan-return T|null
      */
@@ -85,7 +85,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return object|null the object with id or null if not found
      *
-     * @phpstan-template T
+     * @phpstan-template T of object
      * @phpstan-param class-string<T> $class
      * @phpstan-return T|null
      */
@@ -192,7 +192,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return object
      *
-     * @phpstan-template T
+     * @phpstan-template T of object
      * @phpstan-param class-string<T> $class
      * @phpstan-return T
      */
@@ -275,7 +275,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return object
      *
-     * @phpstan-template T
+     * @phpstan-template T of object
      * @phpstan-param class-string<T> $class
      * @phpstan-return T
      */
@@ -287,14 +287,14 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return object
      *
-     * @phpstan-template T
+     * @phpstan-template T of object
      * @phpstan-param class-string<T> $class
      * @phpstan-return T
      */
     public function modelTransform($class, $instance);
 
     /**
-     * @param mixed $query
+     * @param object $query
      */
     public function executeQuery($query);
 

--- a/src/Security/Handler/AclSecurityHandler.php
+++ b/src/Security/Handler/AclSecurityHandler.php
@@ -187,13 +187,6 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
         return $acls;
     }
 
-    /**
-     * NEXT_MAJOR: change signature to `addObjectOwner(MutableAclInterface $acl, ?UserSecurityIdentity $securityIdentity = null): void`.
-     *
-     * @param MutableAclInterface $acl
-     *
-     * @return void
-     */
     public function addObjectOwner(AclInterface $acl, ?UserSecurityIdentity $securityIdentity = null)
     {
         // NEXT_MAJOR: remove `if` condition
@@ -210,15 +203,6 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
         }
     }
 
-    /**
-     * Add the object class ACE's to the object ACL.
-     *
-     * NEXT_MAJOR: change signature to `addObjectClassAces(MutableAclInterface $acl, array $roleInformation = []): void`.
-     *
-     * @param MutableAclInterface $acl
-     *
-     * @return void
-     */
     public function addObjectClassAces(AclInterface $acl, array $roleInformation = [])
     {
         // NEXT_MAJOR: remove `assert` statement
@@ -251,23 +235,11 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
         }
     }
 
-    /**
-     * NEXT_MAJOR: change signature to `createAcl(ObjectIdentityInterface $objectIdentity): MutableAclInterface`.
-     *
-     * @return MutableAclInterface
-     */
     public function createAcl(ObjectIdentityInterface $objectIdentity)
     {
         return $this->aclProvider->createAcl($objectIdentity);
     }
 
-    /**
-     * NEXT_MAJOR: change signature to `updateAcl(MutableAclInterface $acl): void`.
-     *
-     * @param MutableAclInterface $acl
-     *
-     * @@return void
-     */
     public function updateAcl(AclInterface $acl)
     {
         // NEXT_MAJOR: remove `assert` statement
@@ -280,13 +252,6 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
         $this->aclProvider->deleteAcl($objectIdentity);
     }
 
-    /**
-     * NEXT_MAJOR: change signature to `findClassAceIndexByRole(MutableAclInterface $acl, string $role): int|string|false`.
-     *
-     * @param MutableAclInterface $acl
-     *
-     * @return array-key|false
-     */
     public function findClassAceIndexByRole(AclInterface $acl, $role)
     {
         foreach ($acl->getClassAces() as $index => $entry) {
@@ -298,13 +263,6 @@ class AclSecurityHandler implements AclSecurityHandlerInterface
         return false;
     }
 
-    /**
-     * NEXT_MAJOR: change signature to `findClassAceIndexByUsername(MutableAclInterface $acl, string $username): int|string|false`.
-     *
-     * @param MutableAclInterface $acl
-     *
-     * @return array-key|false
-     */
     public function findClassAceIndexByUsername(AclInterface $acl, $username)
     {
         foreach ($acl->getClassAces() as $index => $entry) {

--- a/src/Security/Handler/AclSecurityHandlerInterface.php
+++ b/src/Security/Handler/AclSecurityHandlerInterface.php
@@ -25,6 +25,8 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
 {
     /**
      * Set the permissions not related to an object instance and also to be available when objects do not exist.
+     *
+     * @return void
      */
     public function setAdminPermissions(array $permissions);
 
@@ -37,6 +39,8 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
 
     /**
      * Set the permissions related to an object instance.
+     *
+     * @return void
      */
     public function setObjectPermissions(array $permissions);
 
@@ -110,6 +114,8 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
 
     /**
      * Delete the ACL.
+     *
+     * @return void
      */
     public function deleteAcl(ObjectIdentityInterface $objectIdentity);
 

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -50,7 +50,7 @@ class ShowMapper extends BaseGroupedMapper
      *
      * @throws \LogicException
      *
-     * @return $this
+     * @return static
      */
     public function add($name, $type = null, array $fieldDescriptionOptions = [])
     {
@@ -126,7 +126,7 @@ class ShowMapper extends BaseGroupedMapper
      * @param bool   $deleteEmptyTab Whether or not the parent Tab should be deleted too,
      *                               when the deleted group leaves the tab empty after deletion
      *
-     * @return $this
+     * @return static
      */
     public function removeGroup($group, $tab = 'default', $deleteEmptyTab = false)
     {

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -19,13 +19,15 @@ namespace Sonata\AdminBundle\Templating;
 interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
 {
     /**
-     * @param array $templates 'name' => 'file_path.html.twig'
+     * @param array<string, string> $templates 'name' => 'file_path.html.twig'
      */
     public function setTemplates(array $templates);
 
     /**
      * @param string $name
      * @param string $template
+     *
+     * @return void
      */
     public function setTemplate($name, $template);
 }

--- a/src/Templating/TemplateRegistry.php
+++ b/src/Templating/TemplateRegistry.php
@@ -65,7 +65,7 @@ final class TemplateRegistry implements MutableTemplateRegistryInterface
     public const TYPE_ONE_TO_ONE = 'one_to_one';
 
     /**
-     * @var string[]
+     * @var array<string, string>
      */
     private $templates = [];
 
@@ -77,17 +77,11 @@ final class TemplateRegistry implements MutableTemplateRegistryInterface
         $this->templates = $templates;
     }
 
-    /**
-     * @return string[]
-     */
     public function getTemplates(): array
     {
         return $this->templates;
     }
 
-    /**
-     * @param string[] $templates
-     */
     public function setTemplates(array $templates)
     {
         $this->templates = $templates;

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -21,7 +21,7 @@ namespace Sonata\AdminBundle\Templating;
 interface TemplateRegistryInterface
 {
     /**
-     * @return array 'name' => 'file_path.html.twig'
+     * @return array<string, string> 'name' => 'file_path.html.twig'
      */
     public function getTemplates();
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -2669,6 +2669,11 @@ class AdminTest extends TestCase
         $this->assertSame(2, $commentVoteAdmin->getChildDepth());
     }
 
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation The Sonata\AdminBundle\Admin\AbstractAdmin::getCurrentChild() method is deprecated since version 3.65 and will be removed in 4.0. Use Sonata\AdminBundle\Admin\AbstractAdmin::isCurrentChild() instead.
+     */
     public function testGetCurrentLeafChildAdmin(): void
     {
         $postAdmin = new PostAdmin(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is a follow up of #6351 to add more type hints.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added generic type hints to (nearly) all admin interfaces

### Fix
-  Fix calling undefined `AdminInterface::isCurrentChild` 
```
