### PR TITLE
Add support for symfony/form 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "symfony/event-dispatcher": "^4.4",
         "symfony/event-dispatcher-contracts": "^1.1 || ^2.0",
         "symfony/expression-language": "^4.4 || ^5.1",
-        "symfony/form": "^4.4.12",
+        "symfony/form": "^4.4.12 || ^5.1",
         "symfony/framework-bundle": "^4.4",
         "symfony/http-foundation": "^4.4 || ^5.1",
         "symfony/http-kernel": "^4.4",

--- a/src/Form/Extension/ChoiceTypeExtension.php
+++ b/src/Form/Extension/ChoiceTypeExtension.php
@@ -55,7 +55,7 @@ final class ChoiceTypeExtension extends AbstractTypeExtension
      *
      * @phpstan-return class-string<FormTypeInterface>[]
      */
-    public static function getExtendedTypes()
+    public static function getExtendedTypes(): iterable
     {
         return [ChoiceType::class];
     }

--- a/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -175,7 +175,7 @@ final class FormTypeFieldExtension extends AbstractTypeExtension
      *
      * @phpstan-return class-string<FormTypeInterface>[]
      */
-    public static function getExtendedTypes()
+    public static function getExtendedTypes(): iterable
     {
         return [FormType::class];
     }

--- a/src/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/MopaCompatibilityTypeFieldExtension.php
@@ -62,7 +62,7 @@ final class MopaCompatibilityTypeFieldExtension extends AbstractTypeExtension
      *
      * @phpstan-return class-string<FormTypeInterface>[]
      */
-    public static function getExtendedTypes()
+    public static function getExtendedTypes(): iterable
     {
         return [FormType::class];
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

~Splitting https://github.com/sonata-project/SonataAdminBundle/pull/6263 in small chunks. In this case adding support for symfony/form 5.1.~

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because ~it would be nice to have Symfony 5 support in 3.x~ it is BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for `symfony/form` 5.1.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
