### PR TITLE
Prevent addFormFieldDescription if field role no granted

### DIFF
--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -67,6 +67,10 @@ class FormMapper extends BaseGroupedMapper
             return $this;
         }
 
+        if (isset($fieldDescriptionOptions['role']) && !$this->admin->isGranted($fieldDescriptionOptions['role'])) {
+            return $this;
+        }
+
         if ($name instanceof FormBuilderInterface) {
             $fieldName = $name->getName();
         } else {
@@ -153,10 +157,7 @@ class FormMapper extends BaseGroupedMapper
         }
 
         $this->admin->addFormFieldDescription($fieldName, $fieldDescription);
-
-        if (!isset($fieldDescriptionOptions['role']) || $this->admin->isGranted($fieldDescriptionOptions['role'])) {
-            $this->formBuilder->add($name, $type, $options);
-        }
+        $this->formBuilder->add($name, $type, $options);
 
         return $this;
     }

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -527,6 +527,7 @@ class FormMapperTest extends TestCase
         $this->formMapper->add('bar', 'bar');
 
         $this->assertTrue($this->formMapper->has('bar'));
+        $this->assertTrue($this->admin->hasFormFieldDescription('bar'));
 
         $this->formMapper->add('quux', 'bar', [], ['role' => 'ROLE_QUX']);
 
@@ -541,9 +542,15 @@ class FormMapperTest extends TestCase
             ->end();
 
         $this->assertArrayHasKey('qux', $this->admin->getFormGroups());
+
         $this->assertTrue($this->formMapper->has('foobar'));
+        $this->assertTrue($this->admin->hasFormFieldDescription('foobar'));
+
         $this->assertFalse($this->formMapper->has('foo'));
+        $this->assertFalse($this->admin->hasFormFieldDescription('foo'));
+
         $this->assertTrue($this->formMapper->has('baz'));
+        $this->assertTrue($this->admin->hasFormFieldDescription('baz'));
     }
 
     private function getFieldDescriptionMock(


### PR DESCRIPTION
## Subject

I am targeting this branch, because im think that no needed handle field if role no granted.

Closes #6338.

## Changelog


<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
-  Prevent `addFormFieldDescription` if field role no granted
```

## To do

- [x] Update the tests;