### PR TITLE
allow symfony/translation ^5.1 as its fully compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "symfony/security-core": "^4.4",
         "symfony/security-csrf": "^4.4 || ^5.1",
         "symfony/string": "^5.1",
-        "symfony/translation": "^4.4",
+        "symfony/translation": "^4.4 || ^5.1",
         "symfony/twig-bridge": "^4.4",
         "symfony/twig-bundle": "^4.4",
         "symfony/validator": "^4.4 || ^5.1",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Actually all references to the deprecated translator interface and `transChoice` have been removed already on master. So its fully compatible with `symfony/translation` 5.1 :blush: 

Cannot see any other issues here: https://github.com/symfony/symfony/blob/master/UPGRADE-5.0.md#translation

Replaces https://github.com/sonata-project/SonataAdminBundle/pull/6342

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for `symfony/translation ^5.1`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
