### PR TITLE
allow symfony/console ^5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "sonata-project/twig-extensions": "^1.3",
         "symfony/asset": "^4.4 || ^5.1",
         "symfony/config": "^4.4",
-        "symfony/console": "^4.4",
+        "symfony/console": "^4.4 || ^5.1",
         "symfony/dependency-injection": "^4.4.8",
         "symfony/doctrine-bridge": "^4.4",
         "symfony/event-dispatcher": "^4.4",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Allow using `symfony/console ^5.1` as it should be fully compatible.

The only relevant BC break was fixed already:
> Removed support for returning null from Command::execute(), return 0 instead

See https://github.com/symfony/symfony/blob/master/UPGRADE-5.0.md#console



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for `symfony/console ^5.1`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
