### PR TITLE
Added option to load different Admin LTE skins

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -77,6 +77,7 @@ Full Configuration Options
                 sort_admins: false
                 confirm_exit: true
                 js_debug: false
+                skin: 'skin-black'
                 use_select2: true
                 use_icheck: true
                 use_bootlint: false
@@ -181,7 +182,6 @@ Full Configuration Options
                     - bundles/sonatacore/vendor/components-font-awesome/css/font-awesome.min.css
                     - bundles/sonatacore/vendor/ionicons/css/ionicons.min.css
                     - bundles/sonataadmin/vendor/admin-lte/dist/css/AdminLTE.min.css
-                    - bundles/sonataadmin/vendor/admin-lte/dist/css/skins/skin-black.min.css
                     - bundles/sonataadmin/vendor/iCheck/skins/square/blue.css
                     - bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css
                     - bundles/sonataadmin/vendor/jqueryui/themes/base/jquery-ui.css

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -134,6 +134,23 @@ CASESENSITIVE;
                         ->booleanNode('sort_admins')->defaultFalse()->info('Auto order groups and admins by label or id')->end()
                         ->booleanNode('confirm_exit')->defaultTrue()->end()
                         ->booleanNode('js_debug')->defaultFalse()->end()
+                        ->enumNode('skin')
+                            ->defaultValue('skin-black')
+                            ->values([
+                                'skin-black',
+                                'skin-black-light',
+                                'skin-blue',
+                                'skin-blue-light',
+                                'skin-green',
+                                'skin-green-light',
+                                'skin-purple',
+                                'skin-purple-light',
+                                'skin-red',
+                                'skin-red-light',
+                                'skin-yellow',
+                                'skin-yellow-light',
+                            ])
+                        ->end()
                         ->booleanNode('use_select2')->defaultTrue()->end()
                         ->booleanNode('use_icheck')->defaultTrue()->end()
                         ->booleanNode('use_bootlint')->defaultFalse()->end()
@@ -406,7 +423,6 @@ CASESENSITIVE;
                                 'bundles/sonatacore/vendor/components-font-awesome/css/font-awesome.min.css',
                                 'bundles/sonatacore/vendor/ionicons/css/ionicons.min.css',
                                 'bundles/sonataadmin/vendor/admin-lte/dist/css/AdminLTE.min.css',
-                                'bundles/sonataadmin/vendor/admin-lte/dist/css/skins/skin-black.min.css',
                                 'bundles/sonataadmin/vendor/iCheck/skins/square/blue.css',
 
                                 'bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css',

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -226,6 +226,11 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
 
     private function buildStylesheets(array $config): array
     {
+        $config['assets']['stylesheets'][] = sprintf(
+            'bundles/sonataadmin/vendor/admin-lte/dist/css/skins/%s.min.css',
+            $config['options']['skin']
+        );
+
         return $this->mergeArray(
             $config['assets']['stylesheets'],
             $config['assets']['extra_stylesheets'],

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -21,6 +21,7 @@ file that was distributed with this source code.
 {% set _actions = block('actions') is defined ? block('actions')|trim : null %}
 {% set _navbar_title = block('navbar_title') is defined ? block('navbar_title')|trim : null %}
 {% set _list_filters_actions = block('list_filters_actions') is defined ? block('list_filters_actions')|trim : null -%}
+{% set _skin = sonata_admin.adminPool.getOption('skin') %}
 {% set _use_select2 = sonata_admin.adminPool.getOption('use_select2') %}
 {% set _use_icheck = sonata_admin.adminPool.getOption('use_icheck') %}
 
@@ -35,6 +36,7 @@ file that was distributed with this source code.
 
         <meta data-sonata-admin='{{ {
             config: {
+                SKIN: _skin,
                 CONFIRM_EXIT: sonata_admin.adminPool.getOption('confirm_exit'),
                 USE_SELECT2: _use_select2,
                 USE_ICHECK: _use_icheck,
@@ -113,7 +115,7 @@ file that was distributed with this source code.
     </head>
     <body
             {% block body_attributes -%}
-                class="sonata-bc skin-black fixed
+                class="sonata-bc {% block admin_lte_skin_class %}{{ _skin }}{% endblock %} fixed
                 {% if _use_select2 %}sonata-select2{% endif %}
                 {% if _use_icheck %}sonata-icheck{% endif %}
                 {% if app.request.cookies.get('sonata_sidebar_hide') -%}


### PR DESCRIPTION
## Added option to load different Admin LTE skins

Added the option `skin` to load different Admin LTE skins, making the `body` class configurable and thus allowing you to change the skin without the need to overriding the `body_attributes` block.

I am targeting this branch, because this option is currently missing.

Closes #6368.

## Changelog

```markdown
### Added
- Added option to load different Admin LTE skins
```
