### PR TITLE
make CRUDController Symfony 5 compatible

### DIFF
--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -405,8 +405,8 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $templateRegistryId = sprintf('%s.template_registry', $serviceId);
         $templateRegistryDefinition = $container
             ->register($templateRegistryId, TemplateRegistry::class)
-            ->addTag('sonata.admin.template_registry')
-            ->setPublic(true); // Temporary fix until we can support service locators
+            ->addTag('sonata.admin.template_registry', ['admin_code' => $serviceId])
+            ->setPublic(true);
 
         if ($container->getParameter('sonata.admin.configuration.templates') !== $definedTemplates) {
             $templateRegistryDefinition->addArgument($definedTemplates);

--- a/src/DependencyInjection/Compiler/TemplateRegistryProviderPass.php
+++ b/src/DependencyInjection/Compiler/TemplateRegistryProviderPass.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sonata\AdminBundle\DependencyInjection\Compiler;
+
+use Sonata\AdminBundle\Templating\TemplateRegistryProvider;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class TemplateRegistryProviderPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $provider = $container->register(TemplateRegistryProvider::class, TemplateRegistryProvider::class);
+
+        $registryMap = [];
+
+        foreach ($container->findTaggedServiceIds('sonata.admin.template_registry') as $serviceId => $tagAttributes) {
+            $registryMap[$tagAttributes[0]['admin_code']] = new Reference($serviceId);
+        }
+
+        $provider->addArgument(ServiceLocatorTagPass::register($container, $registryMap));
+    }
+}

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -67,6 +67,7 @@ final class SonataAdminExtension extends Extension
         $loader->load('route.php');
         $loader->load('twig.php');
         $loader->load('validator.php');
+        $loader->load('controllers.php');
 
         if (isset($bundles['MakerBundle'])) {
             $loader->load('makers.php');

--- a/src/Resources/config/controllers.php
+++ b/src/Resources/config/controllers.php
@@ -11,21 +11,18 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-use Sonata\AdminBundle\Bridge\Exporter\AdminExporter;
+use Sonata\AdminBundle\Controller\CRUDController;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
+use Symfony\Component\DependencyInjection\Reference;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     // Use "service" function for creating references to services when dropping support for Symfony 4.4
     // Use "param" function for creating references to parameters when dropping support for Symfony 5.1
     $containerConfigurator->services()
 
-        ->set('sonata.admin.admin_exporter', AdminExporter::class)
+        ->set(CRUDController::class, CRUDController::class)
             ->public()
-            ->args([
-                new ReferenceConfigurator('sonata.exporter.exporter'),
-            ])
-
-        ->alias(AdminExporter::class, 'sonata.admin.admin_exporter')
+            ->autoconfigure()
+            ->autowire()
     ;
 };

--- a/src/Resources/config/security.php
+++ b/src/Resources/config/security.php
@@ -75,5 +75,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('form.factory'),
                 '%sonata.admin.security.mask.builder.class%',
             ])
+
+        ->alias(AdminObjectAclManipulator::class, 'sonata.admin.object.manipulator.acl.admin')
     ;
 };

--- a/src/SonataAdminBundle.php
+++ b/src/SonataAdminBundle.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ModelManagerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ObjectAclManipulatorCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\Compiler\TemplateRegistryProviderPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -34,6 +35,7 @@ final class SonataAdminBundle extends Bundle
         $container->addCompilerPass(new GlobalVariablesCompilerPass());
         $container->addCompilerPass(new ModelManagerCompilerPass());
         $container->addCompilerPass(new ObjectAclManipulatorCompilerPass());
+        $container->addCompilerPass(new TemplateRegistryProviderPass());
         $container->addCompilerPass(new TwigStringExtensionCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
     }
 }

--- a/src/Templating/TemplateRegistryProvider.php
+++ b/src/Templating/TemplateRegistryProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Sonata\AdminBundle\Templating;
+
+use Psr\Container\ContainerInterface;
+
+final class TemplateRegistryProvider
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $registryLocator;
+
+    public function __construct(ContainerInterface $registryLocator)
+    {
+        $this->registryLocator = $registryLocator;
+    }
+
+    public function getTemplateRegistry(string $adminCode): ?TemplateRegistryInterface
+    {
+        if (!$this->registryLocator->has($adminCode)) {
+            return null;
+        }
+
+        return $this->registryLocator->get($adminCode);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

WIP to make the `CRUDController` Symfony 5 compatible

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it breaks BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- `CRUDController` now extends `AbstractController` and uses a ServiceLocator to be compatible with Symfony 5
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
