### PR TITLE
Add ModelManagerInterface::supportsQuery

### DIFF
--- a/src/Form/ChoiceList/ModelChoiceLoader.php
+++ b/src/Form/ChoiceList/ModelChoiceLoader.php
@@ -94,8 +94,24 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
         $this->modelManager = $modelManager;
         $this->class = $class;
         $this->property = $property;
-        $this->query = $query;
         $this->choices = $choices;
+
+        if ($query) {
+            // NEXT_MAJOR: Remove the method_exists check.
+            if (method_exists($this->modelManager, 'supportsQuery')) {
+                if (!$this->modelManager->supportsQuery($query)) {
+                    // NEXT_MAJOR: Remove the deprecation and uncomment the exception.
+                    @trigger_error(
+                        'Passing a query which is not supported by the model manager is deprecated since'
+                        .' sonata-project/admin-bundle 3.x and will throw an exception in version 4.0.',
+                        E_USER_DEPRECATED
+                    );
+                    // throw new \InvalidArgumentException('The model manager does not support the query.');
+                }
+            }
+
+            $this->query = $query;
+        }
 
         $this->identifier = $this->modelManager->getIdentifierFieldNames($this->class);
 

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -21,6 +21,8 @@ use Sonata\Exporter\Source\SourceIteratorInterface;
 
 /**
  * A model manager is a bridge between the model classes and the admin functionality.
+ *
+ * @method bool supportsQuery(object $query)
  */
 interface ModelManagerInterface extends DatagridManagerInterface
 {
@@ -292,6 +294,9 @@ interface ModelManagerInterface extends DatagridManagerInterface
      * @phpstan-return T
      */
     public function modelTransform($class, $instance);
+
+    // NEXT_MAJOR: Uncomment this.
+//    public function supportsQuery(object $query): bool;
 
     /**
      * @param object $query

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -185,6 +185,11 @@ final class ModelManager implements ModelManagerInterface
         throw new \BadMethodCallException('Not implemented.');
     }
 
+    public function supportsQuery(object $query): bool
+    {
+        return true;
+    }
+
     public function executeQuery($query): void
     {
     }

--- a/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
+++ b/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
@@ -17,14 +17,36 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 class ModelChoiceLoaderTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private $modelManager;
 
     protected function setUp(): void
     {
-        $this->modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
+        $this->modelManager = $this->createMock(ModelManagerInterface::class);
+    }
+
+    /**
+     * NEXT_MAJOR: Expect exception instead.
+     *
+     * @group legacy
+     */
+    public function testConstructWithUnsupportedQuery(): void
+    {
+        // NEXT_MAJOR: Use `$this->modelManager` instead
+        $modelManager = $this
+            ->getMockBuilder(ModelManagerInterface::class)
+            ->addMethods(['supportsQuery'])
+            ->getMockForAbstractClass();
+
+        $modelManager->method('supportsQuery')->willReturn(false);
+
+        $this->expectDeprecation('Passing a query which is not supported by the model manager is deprecated since sonata-project/admin-bundle 3.x and will throw an exception in version 4.0.');
+        new ModelChoiceLoader($modelManager, \stdClass::class, null, new \stdClass());
     }
 
     public function testLoadFromEntityWithSamePropertyValues(): void


### PR DESCRIPTION
 ## Subject
 
I am targeting this branch, because BC.

Closes #6273.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `ModelManagerInterface::supportsQuery()`

### Deprecated
- Create a new instance of ModelChoiceLoader with a query unsupported by the modelManager
```