### PR TITLE
Merge 3.x into Master

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -178,7 +178,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     /**
      * The label.
      *
-     * @var string
+     * @var string|null
      */
     protected $label;
 

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -294,7 +294,16 @@ abstract class BaseGroupedMapper extends BaseMapper
     protected function getCurrentGroupName(): string
     {
         if (!$this->currentGroup) {
-            $this->with($this->admin->getLabel() ?: 'default', ['auto_created' => true]);
+            $label = $this->admin->getLabel();
+
+            if (null === $label) {
+                $this->with('default', ['auto_created' => true]);
+            } else {
+                $this->with($label, [
+                    'auto_created' => true,
+                    'translation_domain' => $this->admin->getTranslationDomain(),
+                ]);
+            }
         }
 
         return $this->currentGroup;


### PR DESCRIPTION
@sonata-project/contributors 

In master, the `AdminInterface::getLabel()` method return `?string` instead of `string`.

That's why I had to change the check 
```
if (null === $label) {
                $this->with('default', ['auto_created' => true]);
            } else {
                $this->with($label, [
                    'auto_created' => true,
                    'translation_domain' => $this->admin->getTranslationDomain(),
                ]);
            }
```
