### PR TITLE
Deprecate ORM related functions on ProxyQueryInterface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,14 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated `Sonata\AdminBundle\Datagrid\ProxyQueryInterface::getUniqueParameterId()`
+
+This method has been deprecated without replacement.
+
+## Deprecated `Sonata\AdminBundle\Datagrid\ProxyQueryInterface::entityJoin()`
+
+This method has been deprecated without replacement.
+
 UPGRADE FROM 3.74 to 3.75
 =========================
 

--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -94,11 +94,19 @@ interface ProxyQueryInterface
     public function getMaxResults();
 
     /**
+     * NEXT_MAJOR: Remove this method from the interface.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     *
      * @return int
      */
     public function getUniqueParameterId();
 
     /**
+     * NEXT_MAJOR: Remove this method from the interface.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     *
      * @return string
      */
     public function entityJoin(array $associationMappings);

--- a/tests/App/Datagrid/ProxyQuery.php
+++ b/tests/App/Datagrid/ProxyQuery.php
@@ -74,11 +74,17 @@ final class ProxyQuery implements ProxyQueryInterface
         return 1;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getUniqueParameterId(): int
     {
         return 1;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function entityJoin(array $associationMappings): array
     {
         throw new \BadMethodCallException('Not implemented.');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Apparently [`getUniqueParameterId`](https://github.com/search?q=org%3Asonata-project+getUniqueParameterId&type=code) and [`entityJoin`](https://github.com/search?q=org%3Asonata-project+entityJoin&type=code) are only used in the ORM Bundle, in the other persistence bundles (also not maintained ones) the implementation is empty because they are not useful.

- [SonataAdminSearchBundle](https://github.com/sonata-project/SonataAdminSearchBundle/blob/d1687b05e57624c277ea46069c035bc945ed9997/src/ProxyQuery/ElasticaProxyQuery.php#L180-L188)
- [SonataDoctrinePhpcrAdminBundle](https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/blob/635efa07b866347b3b07a462d34a1c63324702e5/src/Datagrid/ProxyQuery.php#L303-L309)
- [SonataDoctrineMongoDBAdminBundle](https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3a8e9d44b6e2c67436d2fd8d23aa5dd9b41a0e0a/src/Datagrid/ProxyQuery.php#L149-L157)

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `ProxyQueryInterface::getUniqueParameterId`.
- Deprecated `ProxyQueryInterface::entityJoin`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
