### PR TITLE
Add TemplateRegistryAwareInterface

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1353,7 +1353,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return $this->routeGenerator->generateMenuUrl($this, $name, $parameters, $referenceType);
     }
 
-    final public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry)
+    final public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void
     {
         $this->templateRegistry = $templateRegistry;
     }
@@ -3265,10 +3265,7 @@ EOT;
         return $this->hasAccess($action, $object);
     }
 
-    /**
-     * @return MutableTemplateRegistryInterface
-     */
-    final public function getTemplateRegistry()
+    final public function getTemplateRegistry(): ?MutableTemplateRegistryInterface
     {
         // NEXT_MAJOR: Remove the deprecation and uncomment the exception.
         if (!$this->hasTemplateRegistry()) {

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -27,7 +27,7 @@ use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Object\MetadataInterface;
 use Sonata\AdminBundle\Route\RouteGeneratorInterface;
 use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
-use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
+use Sonata\AdminBundle\Templating\TemplateRegistryAwareInterface;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Form\Validator\ErrorElement;
@@ -40,39 +40,38 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
- * @method array                            configureActionButtons(string $action, ?object $object = null)
- * @method string                           getSearchResultLink(object $object)
- * @method void                             showMosaicButton(bool $isShown)
- * @method bool                             isDefaultFilter(string $name)                                         // NEXT_MAJOR: Remove this
- * @method bool                             isCurrentRoute(string $name, ?string $adminCode)
- * @method bool                             canAccessObject(string $action, object $object)
- * @method mixed                            getPersistentParameter(string $name)
- * @method array                            getExportFields()
- * @method array                            getSubClasses()
- * @method AdminInterface                   getRoot()
- * @method string                           getRootCode()
- * @method array                            getActionButtons(string $action, ?object $object)
- * @method FieldDescriptionCollection|null  getList()
- * @method void                             setFilterPersister(?FilterPersisterInterface $filterPersister = null)
- * @method string                           getBaseRoutePattern()
- * @method string                           getBaseRouteName()
- * @method ItemInterface                    getSideMenu(string $action, ?AdminInterface $childAdmin = null)
- * @method void                             addParentAssociationMapping(string $code, string $value)
- * @method RouteGeneratorInterface          getRouteGenerator()
- * @method string                           getClassnameLabel()
- * @method AdminInterface|null              getCurrentChildAdmin()
- * @method string|null                      getParentAssociationMapping()
- * @method void                             reorderFormGroup(string $group, array $keys)
- * @method void                             defineFormBuilder(FormBuilderInterface $formBuilder)
- * @method string                           getPagerType()
- * @method MutableTemplateRegistryInterface getTemplateRegistry()
+ * @method array                           configureActionButtons(string $action, ?object $object = null)
+ * @method string                          getSearchResultLink(object $object)
+ * @method void                            showMosaicButton(bool $isShown)
+ * @method bool                            isDefaultFilter(string $name)                                         // NEXT_MAJOR: Remove this
+ * @method bool                            isCurrentRoute(string $name, ?string $adminCode)
+ * @method bool                            canAccessObject(string $action, object $object)
+ * @method mixed                           getPersistentParameter(string $name)
+ * @method array                           getExportFields()
+ * @method array                           getSubClasses()
+ * @method AdminInterface                  getRoot()
+ * @method string                          getRootCode()
+ * @method array                           getActionButtons(string $action, ?object $object)
+ * @method FieldDescriptionCollection|null getList()
+ * @method void                            setFilterPersister(?FilterPersisterInterface $filterPersister = null)
+ * @method string                          getBaseRoutePattern()
+ * @method string                          getBaseRouteName()
+ * @method ItemInterface                   getSideMenu(string $action, ?AdminInterface $childAdmin = null)
+ * @method void                            addParentAssociationMapping(string $code, string $value)
+ * @method RouteGeneratorInterface         getRouteGenerator()
+ * @method string                          getClassnameLabel()
+ * @method AdminInterface|null             getCurrentChildAdmin()
+ * @method string|null                     getParentAssociationMapping()
+ * @method void                            reorderFormGroup(string $group, array $keys)
+ * @method void                            defineFormBuilder(FormBuilderInterface $formBuilder)
+ * @method string                          getPagerType()
  *
  * @phpstan-template T of object
  * @phpstan-extends AccessRegistryInterface<T>
  * @phpstan-extends UrlGeneratorInterface<T>
  * @phpstan-extends LifecycleHookProviderInterface<T>
  */
-interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface
+interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface, TemplateRegistryAwareInterface
 {
     /**
      * @return void
@@ -593,9 +592,6 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @return string|null
      */
     public function getTemplate($name);
-
-    // NEXT_MAJOR: uncomment this method in 4.0
-    //public function getTemplateRegistry(): MutableTemplateRegistryInterface;
 
     /**
      * Set the translation domain.

--- a/src/Templating/TemplateRegistryAwareInterface.php
+++ b/src/Templating/TemplateRegistryAwareInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Templating;
+
+/**
+ * /**
+ * @author Wojciech Błoszyk <wbloszyk@gmail.com>
+ *
+ * @method MutableTemplateRegistryInterface getTemplateRegistry()
+ * @method bool                             hasTemplateRegistry()
+ * @method void                             setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry)
+ */
+interface TemplateRegistryAwareInterface
+{
+    // NEXT_MAJOR: uncomment this method in 4.0
+    //public function getTemplateRegistry(): MutableTemplateRegistryInterface;
+
+    // NEXT_MAJOR: uncomment this method in 4.0
+    //public function hasTemplateRegistry(): bool;
+
+    // NEXT_MAJOR: uncomment this method in 4.0
+    //public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void;
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
-  `Sonata\AdminBundle\Templating\TemplateRegistryAwareInterface` with `getTemplateRegistry()`, `hasTemplateRegistry()` and `setTemplateRegistry()` methods
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
