### PR TITLE
Fix getSortBy/getSortOrder phpdoc

### DIFF
--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -44,7 +44,7 @@ interface ProxyQueryInterface
     public function setSortBy($parentAssociationMappings, $fieldMapping);
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getSortBy();
 
@@ -56,7 +56,7 @@ interface ProxyQueryInterface
     public function setSortOrder($sortOrder);
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getSortOrder();
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

This is already fixed on master.

## Changelog


<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed ProxyQueryInterface::getSortBy and ProxyQueryInterface::getSortOrder phpdoc
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
