### PR TITLE
Delegate filter query by empty value to filters

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -7,6 +7,30 @@ This interface has been deprecated without replacement.
 
 `ModelManagerInterface::getDefaultSortValues()` won't be used anymore.
 
+### Empty values in datagrid filters
+
+Empty values are passed to datagrid filters. If you have custom datagrid filters, you MUST add empty string checks to them.
+
+```php
+->add('with_open_comments', CallbackFilter::class, [
+    'callback' => static function (ProxyQueryInterface $queryBuilder, string $alias, string $field, array $value): bool {
+        if (!$value['value']) {
+            return false;
+        }
+
+        $queryBuilder
+            ->leftJoin(sprintf('%s.comments', $alias), 'c')
+            ->andWhere('c.moderation = :moderation')
+            ->setParameter('moderation', CommentModeration::APPROVED);
+
+        return true;
+    },
+    'field_type' => CheckboxType::class,
+]);
+```
+
+The `!$value['value']` check is required to avoid the filtering by `''` if you didn't used the filter.
+
 UPGRADE FROM 3.77 to 3.78
 =========================
 

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -146,50 +146,11 @@ class Datagrid implements DatagridInterface
         $this->form = $this->formBuilder->getForm();
         $this->form->submit($this->values);
 
-        $data = $this->form->getData();
+        $this->applyFilters($this->form->getData() ?? []);
+        $this->applySorting();
 
-        foreach ($this->getFilters() as $name => $filter) {
-            $this->values[$name] = $this->values[$name] ?? null;
-            $filterFormName = $filter->getFormName();
-            if (isset($this->values[$filterFormName]['value']) && '' !== $this->values[$filterFormName]['value']) {
-                $filter->apply($this->query, $data[$filterFormName]);
-            }
-        }
-
-        if (isset($this->values['_sort_by'])) {
-            if (!$this->values['_sort_by'] instanceof FieldDescriptionInterface) {
-                throw new UnexpectedTypeException($this->values['_sort_by'], FieldDescriptionInterface::class);
-            }
-
-            if ($this->values['_sort_by']->isSortable()) {
-                $this->query->setSortBy($this->values['_sort_by']->getSortParentAssociationMapping(), $this->values['_sort_by']->getSortFieldMapping());
-
-                $this->values['_sort_order'] = $this->values['_sort_order'] ?? 'ASC';
-                $this->query->setSortOrder($this->values['_sort_order']);
-            }
-        }
-
-        $maxPerPage = 25;
-        if (isset($this->values['_per_page'])) {
-            if (isset($this->values['_per_page']['value'])) {
-                $maxPerPage = $this->values['_per_page']['value'];
-            } else {
-                $maxPerPage = $this->values['_per_page'];
-            }
-        }
-        $this->pager->setMaxPerPage($maxPerPage);
-
-        $page = 1;
-        if (isset($this->values['_page'])) {
-            if (isset($this->values['_page']['value'])) {
-                $page = $this->values['_page']['value'];
-            } else {
-                $page = $this->values['_page'];
-            }
-        }
-
-        $this->pager->setPage($page);
-
+        $this->pager->setMaxPerPage($this->getMaxPerPage(25));
+        $this->pager->setPage($this->getPage(1));
         $this->pager->setQuery($this->query);
         $this->pager->init();
 
@@ -328,6 +289,68 @@ class Datagrid implements DatagridInterface
         $values['_page'] = $page;
 
         return ['filter' => $values];
+    }
+
+    private function applyFilters(array $data): void
+    {
+        foreach ($this->getFilters() as $name => $filter) {
+            $this->values[$name] = $this->values[$name] ?? null;
+            $filterFormName = $filter->getFormName();
+            if (isset($this->values[$filterFormName]['type'], $this->values[$filterFormName]['value']) &&
+                ('' !== $this->values[$filterFormName]['type'] || '' !== $this->values[$filterFormName]['value'])
+            ) {
+                $filter->apply($this->query, $data[$filterFormName]);
+            }
+        }
+    }
+
+    private function applySorting(): void
+    {
+        if (!isset($this->values['_sort_by'])) {
+            return;
+        }
+
+        if (!$this->values['_sort_by'] instanceof FieldDescriptionInterface) {
+            throw new UnexpectedTypeException($this->values['_sort_by'], FieldDescriptionInterface::class);
+        }
+
+        if (!$this->values['_sort_by']->isSortable()) {
+            return;
+        }
+
+        $this->query->setSortBy(
+            $this->values['_sort_by']->getSortParentAssociationMapping(),
+            $this->values['_sort_by']->getSortFieldMapping()
+        );
+
+        $this->values['_sort_order'] = $this->values['_sort_order'] ?? 'ASC';
+        $this->query->setSortOrder($this->values['_sort_order']);
+    }
+
+    private function getMaxPerPage(int $default): int
+    {
+        if (!isset($this->values['_per_page'])) {
+            return $default;
+        }
+
+        if (isset($this->values['_per_page']['value'])) {
+            return (int) $this->values['_per_page']['value'];
+        }
+
+        return (int) $this->values['_per_page'];
+    }
+
+    private function getPage(int $default): int
+    {
+        if (!isset($this->values['_page'])) {
+            return $default;
+        }
+
+        if (isset($this->values['_page']['value'])) {
+            return (int) $this->values['_page']['value'];
+        }
+
+        return (int) $this->values['_page'];
     }
 
     private function isFieldAlreadySorted(FieldDescriptionInterface $fieldDescription): bool


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
If the filter value is empty, but the filtering type has been changed from the default value, then this is an indication that the user wants to search by empty value.
At this level, we cannot determine whether a search can be performed on an empty value and therefore delegate it to filters.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Part of fix for #3569.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Delegate filter query by empty value to filters.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
