### PR TITLE
Set TemplateRegistry as a mandatory parameter for block services.

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -128,6 +128,12 @@ If you have implemented a custom admin extension, you must adapt the signature o
  * `configureBatchActions`
  * `getAccessMapping`
 
+## AdminListBlockService
+The third argument of the `AdminListBlockService::__construct` method is now mandatory.
+
+## AdminSearchBlockService
+The fourth argument of the `AdminListBlockService::__construct` method is now mandatory.
+
 ## AdminHelper
 The `AdminHelper::__construct` method changes its `Pool` param to a `PropertyAccessorInterface` one.
 

--- a/src/Block/AdminListBlockService.php
+++ b/src/Block/AdminListBlockService.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Block;
 
 use Sonata\AdminBundle\Admin\Pool;
-use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
@@ -40,12 +39,12 @@ final class AdminListBlockService extends AbstractBlockService
     public function __construct(
         Environment $twig,
         Pool $pool,
-        ?TemplateRegistryInterface $templateRegistry = null
+        TemplateRegistryInterface $templateRegistry
     ) {
         parent::__construct($twig);
 
         $this->pool = $pool;
-        $this->templateRegistry = $templateRegistry ?: new TemplateRegistry();
+        $this->templateRegistry = $templateRegistry;
     }
 
     public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response

--- a/src/Block/AdminSearchBlockService.php
+++ b/src/Block/AdminSearchBlockService.php
@@ -16,7 +16,6 @@ namespace Sonata\AdminBundle\Block;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Search\SearchHandler;
-use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
@@ -49,13 +48,13 @@ final class AdminSearchBlockService extends AbstractBlockService
         Environment $twig,
         Pool $pool,
         SearchHandler $searchHandler,
-        ?TemplateRegistryInterface $templateRegistry = null
+        TemplateRegistryInterface $templateRegistry
     ) {
         parent::__construct($twig);
 
         $this->pool = $pool;
         $this->searchHandler = $searchHandler;
-        $this->templateRegistry = $templateRegistry ?: new TemplateRegistry();
+        $this->templateRegistry = $templateRegistry;
     }
 
     public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response

--- a/tests/Block/AdminListBlockServiceTest.php
+++ b/tests/Block/AdminListBlockServiceTest.php
@@ -38,13 +38,12 @@ class AdminListBlockServiceTest extends BlockServiceTestCase
         parent::setUp();
 
         $this->pool = $this->createMock(Pool::class);
-
-        $this->templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
+        $this->templateRegistry = $this->createMock(TemplateRegistryInterface::class);
     }
 
     public function testDefaultSettings(): void
     {
-        $blockService = new AdminListBlockService($this->twig, $this->pool, $this->templateRegistry->reveal());
+        $blockService = new AdminListBlockService($this->twig, $this->pool, $this->templateRegistry);
         $blockContext = $this->getBlockContext($blockService);
 
         $this->assertSettings([

--- a/tests/Block/AdminSearchBlockServiceTest.php
+++ b/tests/Block/AdminSearchBlockServiceTest.php
@@ -53,7 +53,7 @@ class AdminSearchBlockServiceTest extends BlockServiceTestCase
 
     public function testDefaultSettings(): void
     {
-        $blockService = new AdminSearchBlockService($this->twig, $this->pool, $this->searchHandler);
+        $blockService = new AdminSearchBlockService($this->twig, $this->pool, $this->searchHandler, $this->templateRegistry);
         $blockContext = $this->getBlockContext($blockService);
 
         $this->assertSettings([
@@ -86,7 +86,7 @@ class AdminSearchBlockServiceTest extends BlockServiceTestCase
     {
         $admin = $this->createMock(AbstractAdmin::class);
 
-        $blockService = new AdminSearchBlockService($this->twig, $this->pool, $this->searchHandler);
+        $blockService = new AdminSearchBlockService($this->twig, $this->pool, $this->searchHandler, $this->templateRegistry);
         $blockContext = $this->getBlockContext($blockService);
 
         $this->searchHandler->expects(self::once())->method('search')->willReturn(false);


### PR DESCRIPTION
This code was implemented to be BC.

```markdown
### Changed
- The third argument of the `AdminListBlockService::__construct` method is now mandatory.
- The fourth argument of the `AdminListBlockService::__construct` method is now mandatory.
```