### PR TITLE
Prevent false deprecation error for n to m associations

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1686,8 +1686,7 @@ class CRUDController implements ContainerAwareInterface
     /**
      * Checks whether $needle is equal to $haystack or part of it.
      *
-     * @param object          $needle   Object to compare with $haystack
-     * @param object|iterable $haystack Object to compare with $needle
+     * @param object|iterable $haystack
      *
      * @return bool true when $haystack equals $needle or $haystack is iterable and contains $needle
      */

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1690,7 +1690,7 @@ class CRUDController implements ContainerAwareInterface
      *
      * @return bool true when $haystack equals $needle or $haystack is iterable and contains $needle
      */
-    private function equalsOrInList(object $needle, $haystack): bool
+    private function equalsOrContains($haystack, object $needle): bool
     {
         if ($needle === $haystack) {
             return true;

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1672,7 +1672,7 @@ class CRUDController implements ContainerAwareInterface
         $objectParent = $propertyAccessor->getValue($object, $propertyPath);
 
         // $objectParent may be an array or a Collection when the parent association is many to many.
-        $parentObjectMatches = $this->equalsOrInList($parentAdminObject, $objectParent);
+        $parentObjectMatches = $this->equalsOrContains($objectParent, $parentAdminObject);
 
         if (!$parentObjectMatches) {
             // NEXT_MAJOR: make this exception

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1668,13 +1668,44 @@ class CRUDController implements ContainerAwareInterface
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $propertyPath = new PropertyPath($this->admin->getParentAssociationMapping());
 
-        if ($parentAdmin->getObject($parentId) !== $propertyAccessor->getValue($object, $propertyPath)) {
+        $parentAdminObject = $parentAdmin->getObject($parentId);
+        $objectParent = $propertyAccessor->getValue($object, $propertyPath);
+
+        // $objectParent may be an array or a Collection when the parent association is many to many.
+        $parentObjectMatches = $this->equalsOrInList($parentAdminObject, $objectParent);
+
+        if (!$parentObjectMatches) {
             // NEXT_MAJOR: make this exception
             @trigger_error(
                 'Accessing a child that isn\'t connected to a given parent is deprecated since sonata-project/admin-bundle 3.34 and won\'t be allowed in 4.0.',
                 \E_USER_DEPRECATED
             );
         }
+    }
+
+    /**
+     * Checks whether $needle is equal to $haystack or part of it.
+     *
+     * @param object          $needle   Object to compare with $haystack
+     * @param object|iterable $haystack Object to compare with $needle
+     *
+     * @return bool true when $haystack equals $needle or $haystack is iterable and contains $needle
+     */
+    private function equalsOrInList(object $needle, $haystack): bool
+    {
+        if ($needle === $haystack) {
+            return true;
+        }
+
+        if (is_iterable($haystack)) {
+            foreach ($haystack as $haystackItem) {
+                if ($haystackItem === $needle) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -1428,6 +1428,42 @@ class CRUDControllerTest extends TestCase
         $this->assertSame(Request::METHOD_DELETE, $this->request->getMethod());
     }
 
+    public function testDeleteActionChildManyToMany(): void
+    {
+        $parent = new \stdClass();
+
+        $child = new \stdClass();
+        $child->parents = [$parent];
+
+        $parentAdmin = $this->createMock(PostAdmin::class);
+        $parentAdmin->method('getIdParameter')->willReturn('parent_id');
+
+        $childAdmin = $this->admin;
+        $childAdmin->method('getIdParameter')->willReturn('parent_id');
+
+        $parentAdmin->expects($this->once())
+            ->method('getObject')
+            ->willReturn($parent);
+
+        $childAdmin->expects($this->once())
+            ->method('getObject')
+            ->willReturn($child);
+
+        $childAdmin->expects($this->once())
+            ->method('isChild')
+            ->willReturn(true);
+
+        $childAdmin->expects($this->once())
+            ->method('getParent')
+            ->willReturn($parentAdmin);
+
+        $childAdmin->expects($this->exactly(2))
+            ->method('getParentAssociationMapping')
+            ->willReturn('parents');
+
+        $this->controller->deleteAction(1);
+    }
+
     public function testEditActionNotFoundException(): void
     {
         $this->expectException(NotFoundHttpException::class);


### PR DESCRIPTION
## Subject

`CRUDController->checkParentChildAssociation()` checks if the associated item of the child admins subject equals the parent admins subject. This doesn't work when the parent relations is many-to-many as the child property will be a Collection and not the parent item itself. In that case, the parent item must be searched in this collection.

I am targeting this branch, because its a backwards compatible fix.


## Changelog
```markdown
### Fixed
- Prevent false deprecation notice when accessing an item in a child admin that has a Many to Many relationship with the parent item.
```
