### PR TITLE
Prevent deprecation notice in constructor of MergeCollectionListener

### DIFF
--- a/src/Form/Type/ModelType.php
+++ b/src/Form/Type/ModelType.php
@@ -58,7 +58,7 @@ class ModelType extends AbstractType
             );
 
             $builder
-                ->addEventSubscriber(new MergeCollectionListener($options['model_manager']))
+                ->addEventSubscriber(new MergeCollectionListener())
             ;
         } else {
             $builder


### PR DESCRIPTION
## Subject

Since SonataAdminBundle 3.75 the argument to `MergeCollectionListener`s constructor is deprecated. `Sonata\AdminBundle\Form\Type\ModelType` sets this argument, causing a deprecation notice.

I am targeting this branch, because it's a backwards compatible change.

## Changelog

```markdown
### Fixed
- Deprecation notice in `MergeCollectionListener` when using the `ModelType` form type with the `model_manager` option set.
```