### PR TITLE
Deprecate using shortcut notation for user_model in favor of FQCN

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,11 @@
 UPGRADE 3.x
 ===========
 
+### Deprecated using shortcut notation when specifying the `user_model` option in `sonata:admin:generate-object-acl` command.
+
+The shortcut notation (`AppBundle:User`) has been deprecated in favor of the FQCN (`App\Model\User`) when passing
+`user_model` option to `sonata:admin:generate-object-acl` command.
+
 UPGRADE FROM 3.75 to 3.76
 =========================
 

--- a/src/Resources/config/commands.php
+++ b/src/Resources/config/commands.php
@@ -48,6 +48,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('validator'),
             ])
 
+        // NEXT_MAJOR: Remove "doctrine" argument.
         ->set(GenerateObjectAclCommand::class, GenerateObjectAclCommand::class)
             ->public()
             ->tag('console.command')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataAdminBundle/pull/6407#discussion_r494063621

If we use FQCN notation for the `user_model` option in `GenerateObjectAclCommand`, there is no need for the `$registry` dependency.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate using shortcut notation for user_model in favor of FQCN in `GenerateObjectAclCommand`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do

- [x] Add an upgrade note.

