### PR TITLE
Fix calls to deprecated methods

### DIFF
--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+use Sonata\AdminBundle\Twig\Extension\PaginationExtension;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Sonata\AdminBundle\Twig\Extension\TemplateRegistryExtension;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -62,5 +63,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('sonata.admin.global_template_registry'),
                 new ReferenceConfigurator('service_container'),
             ])
+
+        // NEXT_MAJOR: Remove this service.
+        ->set('sonata.pagination.twig.extension', PaginationExtension::class)
+            ->tag('twig.extension')
     ;
 };

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -65,7 +65,9 @@ file that was distributed with this source code.
                                             {% set sortable = false %}
                                             {% if field_description.options.sortable is defined and field_description.options.sortable %}
                                                 {% set sortable             = true %}
-                                                {% set sort_parameters      = admin.modelmanager.sortparameters(field_description, admin.datagrid) %}
+                                                {# NEXT_MAJOR: Remove next line and uncomment the other one #}
+                                                {% set sort_parameters      = sonata_sort_parameters(field_description, admin) %}
+                                                {# {% set sort_parameters      = admin.datagrid.sortparameters(field_description) %} #}
                                                 {% set current              = admin.datagrid.values._sort_by is defined
                                                     and (admin.datagrid.values._sort_by == field_description
                                                         or admin.datagrid.values._sort_by.name == sort_parameters.filter._sort_by) %}
@@ -196,10 +198,17 @@ file that was distributed with this source code.
                                             <ul class="dropdown-menu">
                                                 {% for format in export_formats %}
                                                 <li>
-                                                    <a href="{{ admin.generateUrl('export', admin.modelmanager.paginationparameters(admin.datagrid, 0) + {'format' : format}) }}">
+                                                    {# NEXT_MAJOR: Remove completely next "<a>" element and uncomment the other one #}
+                                                    <a href="{{ admin.generateUrl('export', sonata_pagination_parameters(admin, 0) + {'format' : format}) }}">
                                                         <i class="fa fa-arrow-circle-o-down" aria-hidden="true"></i>
                                                         {{ ("export_format_" ~ format)|trans({}, 'SonataAdminBundle') }}
                                                     </a>
+                                                    {#
+                                                    <a href="{{ admin.generateUrl('export', admin.datagrid.paginationparameters(0) + {'format' : format}) }}">
+                                                        <i class="fa fa-arrow-circle-o-down" aria-hidden="true"></i>
+                                                        {{ ("export_format_" ~ format)|trans({}, 'SonataAdminBundle') }}
+                                                    </a>
+                                                    #}
                                                 </li>
                                                 {% endfor %}
                                             </ul>

--- a/src/Resources/views/Pager/base_links.html.twig
+++ b/src/Resources/views/Pager/base_links.html.twig
@@ -12,28 +12,40 @@ file that was distributed with this source code.
 <div class="text-center">
     <ul class="pagination">
         {% if admin.datagrid.pager.page > 2 %}
-            <li><a href="{{ admin.generateUrl(action, admin.modelmanager.paginationparameters(admin.datagrid, 1)) }}" title="{{ 'link_first_pager'|trans({}, 'SonataAdminBundle') }}">&laquo;</a></li>
+            {# NEXT_MAJOR: Remove next line and uncomment the other one #}
+            <li><a href="{{ admin.generateUrl(action, sonata_pagination_parameters(admin, 1)) }}" title="{{ 'link_first_pager'|trans({}, 'SonataAdminBundle') }}">&laquo;</a></li>
+            {# <li><a href="{{ admin.generateUrl(action, admin.datagrid.paginationparameters(1)) }}" title="{{ 'link_first_pager'|trans({}, 'SonataAdminBundle') }}">&laquo;</a></li> #}
         {% endif %}
 
         {% if admin.datagrid.pager.page != admin.datagrid.pager.previouspage %}
-            <li><a href="{{ admin.generateUrl(action, admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.previouspage)) }}" title="{{ 'link_previous_pager'|trans({}, 'SonataAdminBundle') }}">&lsaquo;</a></li>
+            {# NEXT_MAJOR: Remove next line and uncomment the other one #}
+            <li><a href="{{ admin.generateUrl(action, sonata_pagination_parameters(admin, admin.datagrid.pager.previouspage)) }}" title="{{ 'link_previous_pager'|trans({}, 'SonataAdminBundle') }}">&lsaquo;</a></li>
+            {# <li><a href="{{ admin.generateUrl(action, admin.datagrid.paginationparameters(admin.datagrid.pager.previouspage)) }}" title="{{ 'link_previous_pager'|trans({}, 'SonataAdminBundle') }}">&lsaquo;</a></li> #}
         {% endif %}
 
         {# Set the number of pages to display in the pager #}
         {% for page in admin.datagrid.pager.getLinks(admin_pool.getOption('pager_links')) %}
             {% if page == admin.datagrid.pager.page %}
-                <li class="active"><a href="{{ admin.generateUrl(action, admin.modelmanager.paginationparameters(admin.datagrid, page)) }}">{{ page }}</a></li>
+                {# NEXT_MAJOR: Remove next line and uncomment the other one #}
+                <li class="active"><a href="{{ admin.generateUrl(action, sonata_pagination_parameters(admin, page)) }}">{{ page }}</a></li>
+                {# <li class="active"><a href="{{ admin.generateUrl(action, admin.datagrid.paginationparameters(page)) }}">{{ page }}</a></li> #}
             {% else %}
-                <li><a href="{{ admin.generateUrl(action, admin.modelmanager.paginationparameters(admin.datagrid, page)) }}">{{ page }}</a></li>
+                {# NEXT_MAJOR: Remove next line and uncomment the other one #}
+                <li><a href="{{ admin.generateUrl(action, sonata_pagination_parameters(admin, page)) }}">{{ page }}</a></li>
+                {# <li><a href="{{ admin.generateUrl(action, admin.datagrid.paginationparameters(page)) }}">{{ page }}</a></li> #}
             {% endif %}
         {% endfor %}
 
         {% if admin.datagrid.pager.page != admin.datagrid.pager.nextpage %}
-            <li><a href="{{ admin.generateUrl(action, admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.nextpage)) }}" title="{{ 'link_next_pager'|trans({}, 'SonataAdminBundle') }}">&rsaquo;</a></li>
+            {# NEXT_MAJOR: Remove next line and uncomment the other one #}
+            <li><a href="{{ admin.generateUrl(action, sonata_pagination_parameters(admin, admin.datagrid.pager.nextpage)) }}" title="{{ 'link_next_pager'|trans({}, 'SonataAdminBundle') }}">&rsaquo;</a></li>
+            {# <li><a href="{{ admin.generateUrl(action, admin.datagrid.paginationparameters(admin.datagrid.pager.nextpage)) }}" title="{{ 'link_next_pager'|trans({}, 'SonataAdminBundle') }}">&rsaquo;</a></li> #}
         {% endif %}
 
         {% if admin.datagrid.pager.page != admin.datagrid.pager.lastpage and admin.datagrid.pager.lastpage != admin.datagrid.pager.nextpage %}
-            <li><a href="{{ admin.generateUrl(action, admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.lastpage)) }}" title="{{ 'link_last_pager'|trans({}, 'SonataAdminBundle') }}">&raquo;</a></li>
+            {# NEXT_MAJOR: Remove next line and uncomment the other one #}
+            <li><a href="{{ admin.generateUrl(action, sonata_pagination_parameters(admin, admin.datagrid.pager.lastpage)) }}" title="{{ 'link_last_pager'|trans({}, 'SonataAdminBundle') }}">&raquo;</a></li>
+            {# <li><a href="{{ admin.generateUrl(action, admin.datagrid.paginationparameters(admin.datagrid.pager.lastpage)) }}" title="{{ 'link_last_pager'|trans({}, 'SonataAdminBundle') }}">&raquo;</a></li> #}
         {% endif %}
     </ul>
 </div>

--- a/src/Twig/Extension/PaginationExtension.php
+++ b/src/Twig/Extension/PaginationExtension.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @internal
+ */
+final class PaginationExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sonata_pagination_parameters', [$this, 'getPaginationParameters']),
+            new TwigFunction('sonata_sort_parameters', [$this, 'getSortParameters']),
+        ];
+    }
+
+    public function getPaginationParameters(AdminInterface $admin, int $page): array
+    {
+        if (method_exists($admin->getDatagrid(), 'getPaginationParameters')) {
+            return $admin->getDatagrid()->getPaginationParameters($page);
+        }
+
+        return $admin->getModelManager()->getPaginationParameters($admin->getDatagrid(), $page);
+    }
+
+    public function getSortParameters(FieldDescriptionInterface $fieldDescription, AdminInterface $admin): array
+    {
+        if (method_exists($admin->getDatagrid(), 'getSortParameters')) {
+            return $admin->getDatagrid()->getSortParameters($fieldDescription);
+        }
+
+        return $admin->getModelManager()->getSortParameters($fieldDescription, $admin->getDatagrid());
+    }
+}

--- a/tests/App/Admin/FooAdmin.php
+++ b/tests/App/Admin/FooAdmin.php
@@ -24,7 +24,9 @@ final class FooAdmin extends AbstractAdmin
 {
     protected function configureListFields(ListMapper $list): void
     {
-        $list->add('name', TemplateRegistry::TYPE_STRING);
+        $list->add('name', TemplateRegistry::TYPE_STRING, [
+            'sortable' => true,
+        ]);
     }
 
     protected function configureFormFields(FormMapper $form): void

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -160,8 +160,14 @@ final class ModelManager implements ModelManagerInterface
     {
     }
 
+    // NEXT_MAJOR: Remove this method.
     public function getSortParameters(FieldDescriptionInterface $fieldDescription, DatagridInterface $datagrid)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/admin-bundle 3.66. To be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return [];
     }
 
@@ -203,8 +209,14 @@ final class ModelManager implements ModelManagerInterface
         return [];
     }
 
+    // NEXT_MAJOR: Remove this method.
     public function getPaginationParameters(DatagridInterface $datagrid, $page)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/admin-bundle 3.66. To be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return [];
     }
 

--- a/tests/Twig/Extension/PaginationExtensionTest.php
+++ b/tests/Twig/Extension/PaginationExtensionTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Twig\Extension\PaginationExtension;
+
+/**
+ * NEXT_MAJOR: Remove this class.
+ */
+final class PaginationExtensionTest extends TestCase
+{
+    public function testGetPaginationParameters(): void
+    {
+        $paginationParameters = [
+            'filter' => [
+                '_page' => 1,
+            ],
+        ];
+
+        $datagrid = $this->getMockBuilder(DatagridInterface::class)
+            ->addMethods(['getPaginationParameters'])
+            ->getMockForAbstractClass();
+        $datagrid
+            ->method('getPaginationParameters')
+            ->willReturn($paginationParameters);
+        $admin = $this->createStub(AdminInterface::class);
+        $admin
+            ->method('getDatagrid')
+            ->willReturn($datagrid);
+
+        $extension = new PaginationExtension();
+        $this->assertSame($paginationParameters, $extension->getPaginationParameters($admin, 1));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testGetPaginationParametersFromModelManager(): void
+    {
+        $paginationParameters = [
+            'filter' => [
+                '_page' => 1,
+            ],
+        ];
+
+        $datagrid = $this->createStub(DatagridInterface::class);
+        $modelManager = $this->createStub(ModelManagerInterface::class);
+        $modelManager
+            ->method('getPaginationParameters')
+            ->willReturn($paginationParameters);
+
+        $admin = $this->createStub(AdminInterface::class);
+        $admin
+            ->method('getDatagrid')
+            ->willReturn($datagrid);
+
+        $admin
+            ->method('getModelManager')
+            ->willReturn($modelManager);
+
+        $extension = new PaginationExtension();
+        $this->assertSame($paginationParameters, $extension->getPaginationParameters($admin, 1));
+    }
+
+    public function testGetSortParameters(): void
+    {
+        $sortParameters = [
+            'filter' => [
+                '_sort_order' => 'ASC',
+                '_sort_by' => 'name',
+            ],
+        ];
+
+        $datagrid = $this->getMockBuilder(DatagridInterface::class)
+            ->addMethods(['getSortParameters'])
+            ->getMockForAbstractClass();
+        $datagrid
+            ->method('getSortParameters')
+            ->willReturn($sortParameters);
+        $admin = $this->createStub(AdminInterface::class);
+        $admin
+            ->method('getDatagrid')
+            ->willReturn($datagrid);
+
+        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
+
+        $extension = new PaginationExtension();
+        $this->assertSame($sortParameters, $extension->getSortParameters($fieldDescription, $admin));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testGetSortParametersFromModelManager(): void
+    {
+        $sortParameters = [
+            'filter' => [
+                '_sort_order' => 'ASC',
+                '_sort_by' => 'name',
+            ],
+        ];
+
+        $datagrid = $this->createStub(DatagridInterface::class);
+        $modelManager = $this->createStub(ModelManagerInterface::class);
+        $modelManager
+            ->method('getSortParameters')
+            ->willReturn($sortParameters);
+
+        $admin = $this->createStub(AdminInterface::class);
+        $admin
+            ->method('getDatagrid')
+            ->willReturn($datagrid);
+
+        $admin
+            ->method('getModelManager')
+            ->willReturn($modelManager);
+
+        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
+
+        $extension = new PaginationExtension();
+        $this->assertSame($sortParameters, $extension->getSortParameters($fieldDescription, $admin));
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

These deprecations were introduced in 3.66.
This replaces calls to `ModelManagerInterface::getPaginationParameters` for `DatagridInterface::getPaginationParameters` and
`ModelManagerInterface::getSortParameters` for `DatagridInterface::getSortParameters`.

I don't know if there is a way to use a twig function just internally.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Remove calls to deprecated method `ModelInterface::getPaginationParameters()`.
- Remove calls to deprecated method `ModelInterface::getSortParameters()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
