### PR TITLE
Add deprecation when injecting registry in command

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -94,12 +94,6 @@ parameters:
         -
             # will be fixed in v4. Code is marked as deprecated
             message: "#^Result of && is always false\\.$#"
-            count: 2
-            path: src/Command/GenerateObjectAclCommand.php
-
-        -
-            # will be fixed in v4. Code is marked as deprecated
-            message: "#^Instanceof between \\*NEVER\\* and Doctrine\\\\Persistence\\\\ManagerRegistry will always evaluate to false\\.$#"
             count: 1
             path: src/Command/GenerateObjectAclCommand.php
 

--- a/src/Resources/config/commands.php
+++ b/src/Resources/config/commands.php
@@ -48,15 +48,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('validator'),
             ])
 
-        // NEXT_MAJOR: Remove "doctrine" argument.
+        // NEXT_MAJOR: Remove the "setRegistry" call.
         ->set(GenerateObjectAclCommand::class, GenerateObjectAclCommand::class)
             ->public()
             ->tag('console.command')
             ->args([
                 new ReferenceConfigurator('sonata.admin.pool'),
                 [],
-                (new ReferenceConfigurator('doctrine'))->nullOnInvalid(),
             ])
+            ->call('setRegistry', [(new ReferenceConfigurator('doctrine'))->nullOnInvalid()])
 
         ->set(ListAdminCommand::class, ListAdminCommand::class)
             ->public()

--- a/tests/Command/DeprecatedGenerateObjectAclCommandTest.php
+++ b/tests/Command/DeprecatedGenerateObjectAclCommandTest.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Command;
+
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Command\GenerateObjectAclCommand;
+use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
+use Sonata\AdminBundle\Util\ObjectAclManipulatorInterface;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ *
+ * @group legacy
+ *
+ * NEXT_MAJOR: Remove this class
+ */
+final class DeprecatedGenerateObjectAclCommandTest extends TestCase
+{
+    use ExpectDeprecationTrait;
+
+    /**
+     * @var Container
+     */
+    private $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = new Container();
+    }
+
+    public function testExecuteWithDeprecatedDoctrineService(): void
+    {
+        $pool = new Pool($this->container, '', '');
+
+        $registry = $this->createStub(RegistryInterface::class);
+        $this->expectDeprecation('Passing a third argument to %s() is deprecated since sonata-project/admin-bundle 3.x.');
+        $command = new GenerateObjectAclCommand($pool, [], $registry);
+
+        $application = new Application();
+        $application->add($command);
+
+        $command = $application->find(GenerateObjectAclCommand::getDefaultName());
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertMatchesRegularExpression('/No manipulators are implemented : ignoring/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithEmptyManipulators(): void
+    {
+        $pool = new Pool($this->container, '', '');
+
+        $registry = $this->createStub(ManagerRegistry::class);
+        $this->expectDeprecation('Passing a third argument to %s() is deprecated since sonata-project/admin-bundle 3.x.');
+        $command = new GenerateObjectAclCommand($pool, [], $registry);
+
+        $application = new Application();
+        $application->add($command);
+
+        $command = $application->find(GenerateObjectAclCommand::getDefaultName());
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertMatchesRegularExpression('/No manipulators are implemented : ignoring/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithManipulatorNotFound(): void
+    {
+        $admin = $this->createStub(AbstractAdmin::class);
+        $registry = $this->createStub(ManagerRegistry::class);
+        $pool = $this->createStub(Pool::class);
+
+        $admin
+            ->method('getManagerType')
+            ->willReturn('bar');
+
+        $pool
+            ->method('getAdminServiceIds')
+            ->willReturn(['acme.admin.foo']);
+
+        $pool
+            ->method('getInstance')
+            ->willReturn($admin);
+
+        $aclObjectManipulators = [
+            'bar' => new \stdClass(),
+        ];
+
+        $this->expectDeprecation('Passing a third argument to %s() is deprecated since sonata-project/admin-bundle 3.x.');
+        $command = new GenerateObjectAclCommand($pool, $aclObjectManipulators, $registry);
+
+        $application = new Application();
+        $application->add($command);
+
+        $command = $application->find(GenerateObjectAclCommand::getDefaultName());
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertMatchesRegularExpression('/Admin class is using a manager type that has no manipulator implemented : ignoring/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithManipulatorNotObjectAclManipulatorInterface(): void
+    {
+        $admin = $this->createStub(AbstractAdmin::class);
+        $registry = $this->createStub(ManagerRegistry::class);
+        $pool = $this->createStub(Pool::class);
+
+        $admin
+            ->method('getManagerType')
+            ->willReturn('bar');
+
+        $pool
+            ->method('getAdminServiceIds')
+            ->willReturn(['acme.admin.foo']);
+
+        $pool
+            ->method('getInstance')
+            ->willReturn($admin);
+
+        $aclObjectManipulators = [
+            'sonata.admin.manipulator.acl.object.bar' => new \stdClass(),
+        ];
+
+        $this->expectDeprecation('Passing a third argument to %s() is deprecated since sonata-project/admin-bundle 3.x.');
+        $command = new GenerateObjectAclCommand($pool, $aclObjectManipulators, $registry);
+
+        $application = new Application();
+        $application->add($command);
+
+        $command = $application->find(GenerateObjectAclCommand::getDefaultName());
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertMatchesRegularExpression('/The interface "ObjectAclManipulatorInterface" is not implemented for/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithManipulator(): void
+    {
+        $admin = $this->createStub(AbstractAdmin::class);
+        $registry = $this->createStub(ManagerRegistry::class);
+        $pool = $this->createStub(Pool::class);
+
+        $admin
+            ->method('getManagerType')
+            ->willReturn('bar');
+
+        $pool
+            ->method('getAdminServiceIds')
+            ->willReturn(['acme.admin.foo']);
+
+        $pool
+            ->method('getInstance')
+            ->willReturn($admin);
+
+        $manipulator = $this->createMock(ObjectAclManipulatorInterface::class);
+        $manipulator
+            ->expects($this->once())
+            ->method('batchConfigureAcls')
+            ->with($this->isInstanceOf(StreamOutput::class), $admin, null);
+
+        $aclObjectManipulators = [
+            'sonata.admin.manipulator.acl.object.bar' => $manipulator,
+        ];
+
+        $this->expectDeprecation('Passing a third argument to %s() is deprecated since sonata-project/admin-bundle 3.x.');
+        $command = new GenerateObjectAclCommand($pool, $aclObjectManipulators, $registry);
+
+        $application = new Application();
+        $application->add($command);
+
+        $command = $application->find(GenerateObjectAclCommand::getDefaultName());
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => $command->getName()]);
+    }
+
+    public function testExecuteWithDeprecatedUserModelNotation(): void
+    {
+        $pool = new Pool($this->container, '', '');
+
+        $registry = $this->createStub(ManagerRegistry::class);
+        $this->expectDeprecation('Passing a third argument to %s() is deprecated since sonata-project/admin-bundle 3.x.');
+        $command = new GenerateObjectAclCommand($pool, [], $registry);
+
+        $application = new Application();
+        $application->add($command);
+
+        $command = $application->find(GenerateObjectAclCommand::getDefaultName());
+        $commandTester = new CommandTester($command);
+
+        $this->expectDeprecation(
+            'Passing a model shortcut name ("AppBundle:User" given) as "user_model" option is deprecated'
+            .' since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.'
+            .' Pass a fully qualified class name instead (e.g. App\Model\User).'
+        );
+        $commandTester->execute([
+            'command' => $command->getName(),
+            '--user_model' => 'AppBundle:User',
+        ]);
+    }
+
+    public function testExecuteWithDeprecatedUserModelNotationAndWithoutDoctrineService(): void
+    {
+        $pool = new Pool($this->container, '', '');
+
+        $command = new GenerateObjectAclCommand($pool, []);
+
+        $application = new Application();
+        $application->add($command);
+
+        $command = $application->find(GenerateObjectAclCommand::getDefaultName());
+        $commandTester = new CommandTester($command);
+
+        $this->expectDeprecation(
+            'Passing a model shortcut name ("AppBundle:User" given) as "user_model" option is deprecated'
+            .' since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.'
+            .' Pass a fully qualified class name instead (e.g. App\Model\User).'
+        );
+
+        $commandTester->execute([
+            'command' => $command->getName(),
+            '--user_model' => 'AppBundle:User',
+        ]);
+
+        $this->assertMatchesRegularExpression(sprintf('/The command "%s" has a dependency on a non-existent service "doctrine"./', GenerateObjectAclCommand::getDefaultName()), $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithDeprecatedUserModelNotationAndInternalSetter(): void
+    {
+        $pool = new Pool($this->container, '', '');
+
+        $registry = $this->createStub(ManagerRegistry::class);
+        $command = new GenerateObjectAclCommand($pool, []);
+        $command->setRegistry($registry);
+
+        $application = new Application();
+        $application->add($command);
+
+        $command = $application->find(GenerateObjectAclCommand::getDefaultName());
+        $commandTester = new CommandTester($command);
+
+        $this->expectDeprecation(
+            'Passing a model shortcut name ("AppBundle:User" given) as "user_model" option is deprecated'
+            .' since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.'
+            .' Pass a fully qualified class name instead (e.g. App\Model\User).'
+        );
+        $commandTester->execute([
+            'command' => $command->getName(),
+            '--user_model' => 'AppBundle:User',
+        ]);
+
+        $this->assertMatchesRegularExpression('/No manipulators are implemented : ignoring/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithUserModel(): void
+    {
+        $admin = $this->createStub(AbstractAdmin::class);
+        $registry = $this->createStub(ManagerRegistry::class);
+        $pool = $this->createStub(Pool::class);
+
+        $admin
+            ->method('getManagerType')
+            ->willReturn('bar');
+
+        $pool
+            ->method('getAdminServiceIds')
+            ->willReturn(['acme.admin.foo']);
+
+        $pool
+            ->method('getInstance')
+            ->willReturn($admin);
+
+        $manipulator = $this->createMock(ObjectAclManipulatorInterface::class);
+        $manipulator
+            ->expects($this->once())
+            ->method('batchConfigureAcls')
+            ->with(
+                $this->isInstanceOf(StreamOutput::class),
+                $admin,
+                $this->callback(static function (UserSecurityIdentity $userSecurityIdentity): bool {
+                    return Foo::class === $userSecurityIdentity->getClass();
+                })
+            );
+
+        $aclObjectManipulators = [
+            'sonata.admin.manipulator.acl.object.bar' => $manipulator,
+        ];
+
+        $this->expectDeprecation('Passing a third argument to %s() is deprecated since sonata-project/admin-bundle 3.x.');
+        $command = new GenerateObjectAclCommand($pool, $aclObjectManipulators, $registry);
+
+        $application = new Application();
+        $application->add($command);
+
+        $command = $application->find(GenerateObjectAclCommand::getDefaultName());
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'command' => $command->getName(),
+            '--user_model' => Foo::class,
+            '--object_owner' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Some deprecation and some tests updates were missing in https://github.com/sonata-project/SonataAdminBundle/pull/6413

## Changelog

<!-- MANDATORY

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate Passing a third argument to `GenerateObjectAclCommand::__construct()`
```