### PR TITLE
Remove prophecy usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "symfony/css-selector": "^4.4 || ^5.1",
         "symfony/filesystem": "^4.4 || ^5.1",
         "symfony/maker-bundle": "^1.17",
-        "symfony/phpunit-bridge": "^5.1.1",
+        "symfony/phpunit-bridge": "^5.1.4",
         "symfony/yaml": "^4.4 || ^5.1",
         "vimeo/psalm": "^3.13.1"
     },

--- a/src/Form/DataTransformerResolver.php
+++ b/src/Form/DataTransformerResolver.php
@@ -108,8 +108,8 @@ final class DataTransformerResolver implements DataTransformerResolverInterface
         FieldDescriptionInterface $fieldDescription,
         string $class
     ): bool {
-        return (
-            method_exists($fieldDescription, 'getTargetModel') && $class === $fieldDescription->getTargetModel()
-        ) || $class === $fieldDescription->getTargetEntity();
+        return method_exists($fieldDescription, 'getTargetModel') ?
+            $class === $fieldDescription->getTargetModel() :
+            $class === $fieldDescription->getTargetEntity();
     }
 }

--- a/tests/Action/AppendFormFieldElementActionTest.php
+++ b/tests/Action/AppendFormFieldElementActionTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Action;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Sonata\AdminBundle\Action\AppendFormFieldElementAction;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
@@ -27,7 +26,6 @@ use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Twig\Environment;
 
 final class AppendFormFieldElementActionTest extends TestCase
@@ -53,28 +51,22 @@ final class AppendFormFieldElementActionTest extends TestCase
     private $admin;
 
     /**
-     * @var ValidatorInterface
-     */
-    private $validator;
-
-    /**
      * @var AdminHelper
      */
     private $helper;
 
     protected function setUp(): void
     {
-        $this->twig = $this->prophesize(Environment::class);
-        $this->pool = $this->prophesize(Pool::class);
-        $this->admin = $this->prophesize(AbstractAdmin::class);
-        $this->pool->getInstance(Argument::any())->willReturn($this->admin->reveal());
-        $this->admin->setRequest(Argument::type(Request::class))->shouldBeCalled();
-        $this->validator = $this->prophesize(ValidatorInterface::class);
-        $this->helper = $this->prophesize(AdminHelper::class);
+        $this->twig = $this->createStub(Environment::class);
+        $this->pool = $this->createStub(Pool::class);
+        $this->admin = $this->createMock(AbstractAdmin::class);
+        $this->pool->method('getInstance')->willReturn($this->admin);
+        $this->admin->expects($this->once())->method('setRequest');
+        $this->helper = $this->createStub(AdminHelper::class);
         $this->action = new AppendFormFieldElementAction(
-            $this->twig->reveal(),
-            $this->pool->reveal(),
-            $this->helper->reveal()
+            $this->twig,
+            $this->pool,
+            $this->helper
         );
     }
 
@@ -89,26 +81,26 @@ final class AppendFormFieldElementActionTest extends TestCase
             'context' => 'list',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST]);
 
-        $modelManager = $this->prophesize(ModelManagerInterface::class);
+        $modelManager = $this->createStub(ModelManagerInterface::class);
         $formView = new FormView();
-        $form = $this->prophesize(Form::class);
+        $form = $this->createStub(Form::class);
 
         $renderer = $this->configureFormRenderer();
 
-        $this->admin->getObject(42)->willReturn($object);
-        $this->admin->getClass()->willReturn(\get_class($object));
-        $this->admin->setSubject($object)->shouldBeCalled();
-        $this->admin->getFormTheme()->willReturn($formView);
-        $this->helper->appendFormFieldElement($this->admin->reveal(), $object, null)->willReturn([
-            $this->prophesize(FieldDescriptionInterface::class),
-            $form->reveal(),
+        $this->admin->method('getObject')->with(42)->willReturn($object);
+        $this->admin->method('getClass')->willReturn(\get_class($object));
+        $this->admin->expects($this->once())->method('setSubject')->with($object);
+        $this->admin->method('getFormTheme')->willReturn($formView);
+        $this->helper->method('appendFormFieldElement')->with($this->admin, $object, null)->willReturn([
+            $this->createStub(FieldDescriptionInterface::class),
+            $form,
         ]);
-        $this->helper->getChildFormView($formView, null)
+        $this->helper->method('getChildFormView')->with($formView, null)
             ->willReturn($formView);
-        $modelManager->find(\get_class($object), 42)->willReturn($object);
-        $form->createView()->willReturn($formView);
-        $renderer->setTheme($formView, $formView)->shouldBeCalled();
-        $renderer->searchAndRenderBlock($formView, 'widget')->willReturn('block');
+        $modelManager->method('find')->with(\get_class($object), 42)->willReturn($object);
+        $form->method('createView')->willReturn($formView);
+        $renderer->expects($this->once())->method('setTheme')->with($formView);
+        $renderer->method('searchAndRenderBlock')->with($formView, 'widget')->willReturn('block');
 
         $response = ($this->action)($request);
 
@@ -118,9 +110,9 @@ final class AppendFormFieldElementActionTest extends TestCase
 
     private function configureFormRenderer()
     {
-        $runtime = $this->prophesize(FormRenderer::class);
+        $runtime = $this->createStub(FormRenderer::class);
 
-        $this->twig->getRuntime(FormRenderer::class)->willReturn($runtime->reveal());
+        $this->twig->method('getRuntime')->with(FormRenderer::class)->willReturn($runtime);
 
         return $runtime;
     }

--- a/tests/Action/DashboardActionTest.php
+++ b/tests/Action/DashboardActionTest.php
@@ -26,6 +26,11 @@ use Twig\Environment;
 class DashboardActionTest extends TestCase
 {
     /**
+     * @var MutableTemplateRegistryInterface
+     */
+    private $templateRegistry;
+
+    /**
      * @var DashboardAction
      */
     private $action;
@@ -34,22 +39,19 @@ class DashboardActionTest extends TestCase
     {
         $container = new Container();
 
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->getTemplate('ajax')->willReturn('ajax.html');
-        $templateRegistry->getTemplate('dashboard')->willReturn('dashboard.html');
-        $templateRegistry->getTemplate('layout')->willReturn('layout.html');
+        $this->templateRegistry = $this->createStub(MutableTemplateRegistryInterface::class);
 
         $pool = new Pool($container, 'title', 'logo.png');
-        $pool->setTemplateRegistry($templateRegistry->reveal());
+        $pool->setTemplateRegistry($this->templateRegistry);
 
         $twig = $this->createMock(Environment::class);
 
-        $breadcrumbsBuilder = $this->getMockForAbstractClass(BreadcrumbsBuilderInterface::class);
+        $breadcrumbsBuilder = $this->createStub(BreadcrumbsBuilderInterface::class);
 
         $this->action = new DashboardAction(
             [],
             $breadcrumbsBuilder,
-            $templateRegistry->reveal(),
+            $this->templateRegistry,
             $pool,
             $twig
         );
@@ -59,6 +61,11 @@ class DashboardActionTest extends TestCase
     {
         $request = new Request();
 
+        $this->templateRegistry->method('getTemplate')->willReturnMap([
+            ['layout', 'layout.html'],
+            ['dashboard', 'dashboard.html'],
+        ]);
+
         $this->assertInstanceOf(Response::class, ($this->action)($request));
     }
 
@@ -66,6 +73,11 @@ class DashboardActionTest extends TestCase
     {
         $request = new Request();
         $request->headers->set('X-Requested-With', 'XMLHttpRequest');
+
+        $this->templateRegistry->method('getTemplate')->willReturnMap([
+            ['ajax', 'ajax.html'],
+            ['dashboard', 'dashboard.html'],
+        ]);
 
         $this->assertInstanceOf(Response::class, ($this->action)($request));
     }

--- a/tests/Action/GetShortObjectDescriptionActionTest.php
+++ b/tests/Action/GetShortObjectDescriptionActionTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Action;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\Pool;
@@ -50,13 +49,12 @@ final class GetShortObjectDescriptionActionTest extends TestCase
     protected function setUp(): void
     {
         $this->twig = new Environment(new ArrayLoader(['template' => 'renderedTemplate']));
-        $this->pool = $this->prophesize(Pool::class);
-        $this->admin = $this->prophesize(AbstractAdmin::class);
-        $this->pool->getInstance(Argument::any())->willReturn($this->admin->reveal());
-        $this->admin->setRequest(Argument::type(Request::class))->shouldBeCalled();
+        $this->pool = $this->createStub(Pool::class);
+        $this->admin = $this->createMock(AbstractAdmin::class);
+        $this->pool->method('getInstance')->willReturn($this->admin);
         $this->action = new GetShortObjectDescriptionAction(
             $this->twig,
-            $this->pool->reveal()
+            $this->pool
         );
     }
 
@@ -71,8 +69,8 @@ final class GetShortObjectDescriptionActionTest extends TestCase
             'uniqid' => 'asdasd123',
         ]);
 
-        $this->pool->getInstance($code)->willThrow(\InvalidArgumentException::class);
-        $this->admin->setRequest(Argument::type(Request::class))->shouldNotBeCalled();
+        $this->pool->method('getInstance')->with($code)->willThrowException(new \InvalidArgumentException());
+        $this->admin->expects($this->never())->method('setRequest');
 
         ($this->action)($request);
     }
@@ -94,8 +92,9 @@ final class GetShortObjectDescriptionActionTest extends TestCase
             'uniqid' => 'asdasd123',
         ]);
 
-        $this->admin->setUniqid('asdasd123')->shouldBeCalled();
-        $this->admin->getObject(42)->willReturn(false);
+        $this->admin->expects($this->once())->method('setRequest')->with($request);
+        $this->admin->expects($this->once())->method('setUniqid')->with('asdasd123');
+        $this->admin->method('getObject')->with(42)->willReturn(false);
 
         ($this->action)($request);
     }
@@ -114,8 +113,9 @@ final class GetShortObjectDescriptionActionTest extends TestCase
             '_format' => 'html',
         ]);
 
-        $this->admin->setUniqid('asdasd123')->shouldBeCalled();
-        $this->admin->getObject(null)->willReturn(null);
+        $this->admin->expects($this->once())->method('setRequest')->with($request);
+        $this->admin->expects($this->once())->method('setUniqid')->with('asdasd123');
+        $this->admin->method('getObject')->with(null)->willReturn(null);
 
         $this->assertInstanceOf(Response::class, ($this->action)($request));
     }
@@ -130,10 +130,11 @@ final class GetShortObjectDescriptionActionTest extends TestCase
         ]);
         $object = new \stdClass();
 
-        $this->admin->setUniqid('asdasd123')->shouldBeCalled();
-        $this->admin->getObject(42)->willReturn($object);
-        $this->admin->getTemplate('short_object_description')->willReturn('template');
-        $this->admin->toString($object)->willReturn('bar');
+        $this->admin->expects($this->once())->method('setRequest')->with($request);
+        $this->admin->expects($this->once())->method('setUniqid')->with('asdasd123');
+        $this->admin->method('getObject')->with(42)->willReturn($object);
+        $this->admin->method('getTemplate')->with('short_object_description')->willReturn('template');
+        $this->admin->method('toString')->with($object)->willReturn('bar');
 
         $response = ($this->action)($request);
 
@@ -154,10 +155,11 @@ final class GetShortObjectDescriptionActionTest extends TestCase
             '_format' => 'json',
         ]);
 
-        $this->admin->setUniqid('asdasd123')->shouldBeCalled();
-        $this->admin->getObject(null)->willReturn(null);
-        $this->admin->id(null)->willReturn('');
-        $this->admin->toString(null)->willReturn('');
+        $this->admin->expects($this->once())->method('setRequest')->with($request);
+        $this->admin->expects($this->once())->method('setUniqid')->with('asdasd123');
+        $this->admin->method('getObject')->with(null)->willReturn(null);
+        $this->admin->method('id')->with(null)->willReturn('');
+        $this->admin->method('toString')->with(null)->willReturn('');
 
         $response = ($this->action)($request);
 
@@ -175,11 +177,12 @@ final class GetShortObjectDescriptionActionTest extends TestCase
         ]);
         $object = new \stdClass();
 
-        $this->admin->setUniqid('asdasd123')->shouldBeCalled();
-        $this->admin->id($object)->willReturn(42);
-        $this->admin->getObject(42)->willReturn($object);
-        $this->admin->getTemplate('short_object_description')->willReturn('template');
-        $this->admin->toString($object)->willReturn('bar');
+        $this->admin->expects($this->once())->method('setRequest')->with($request);
+        $this->admin->expects($this->once())->method('setUniqid')->with('asdasd123');
+        $this->admin->method('id')->with($object)->willReturn(42);
+        $this->admin->method('getObject')->with(42)->willReturn($object);
+        $this->admin->method('getTemplate')->with('short_object_description')->willReturn('template');
+        $this->admin->method('toString')->with($object)->willReturn('bar');
 
         $response = ($this->action)($request);
 

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -13,9 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Action;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\Prophecy\ObjectProphecy;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Action\RetrieveAutocompleteItemsAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
@@ -50,52 +49,55 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->admin = $this->prophesize(AbstractAdmin::class);
-        $this->admin->setRequest(Argument::type(Request::class))->shouldBeCalled();
-        $this->pool = $this->prophesize(Pool::class);
-        $this->pool->getInstance(Argument::any())->willReturn($this->admin->reveal());
-        $this->action = new RetrieveAutocompleteItemsAction(
-            $this->pool->reveal()
-        );
+        $this->admin = $this->createMock(AbstractAdmin::class);
+        $this->admin->expects($this->once())->method('setRequest');
+        $this->pool = $this->createStub(Pool::class);
+        $this->pool->method('getInstance')->willReturn($this->admin);
+        $this->action = new RetrieveAutocompleteItemsAction($this->pool);
     }
 
     public function testRetrieveAutocompleteItemsActionNotGranted(): void
     {
-        $this->expectException(AccessDeniedException::class);
-
         $request = new Request([
             'admin_code' => 'foo.admin',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
-        $this->admin->hasAccess('create')->willReturn(false);
-        $this->admin->hasAccess('edit')->willReturn(false);
+        $this->admin->method('hasAccess')->willReturnMap([
+            ['create', false],
+            ['edit', true],
+        ]);
+
+        $this->expectException(AccessDeniedException::class);
 
         ($this->action)($request);
     }
 
     public function testRetrieveAutocompleteItemsActionDisabledFormelememt(): void
     {
-        $this->expectException(AccessDeniedException::class);
-        $this->expectExceptionMessage('Autocomplete list can`t be retrieved because the form element is disabled or read_only.');
-
         $object = new \stdClass();
         $request = new Request([
             'admin_code' => 'foo.admin',
             'field' => 'barField',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
-        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
+        // NEXT_MAJOR: Use `createStub` instead of using mock builder
+        $fieldDescription = $this->getMockBuilder(FieldDescriptionInterface::class)
+            ->addMethods(['getTargetModel'])
+            ->getMockForAbstractClass();
 
         $this->configureFormConfig('barField', true);
 
-        $this->admin->getNewInstance()->willReturn($object);
-        $this->admin->setSubject($object)->shouldBeCalled();
-        $this->admin->hasAccess('create')->willReturn(true);
-        $this->admin->getFormFieldDescriptions()->willReturn(null);
-        $this->admin->getFormFieldDescription('barField')->willReturn($fieldDescription->reveal());
+        $this->admin->method('getNewInstance')->willReturn($object);
+        $this->admin->expects($this->once())->method('setSubject')->with($object);
+        $this->admin->method('hasAccess')->with('create')->willReturn(true);
+        $this->admin->method('getFormFieldDescriptions')->willReturn(null);
+        $this->admin->method('getFormFieldDescription')->with('barField')->willReturn($fieldDescription);
 
-        $fieldDescription->getTargetModel()->willReturn(Foo::class);
-        $fieldDescription->getName()->willReturn('barField');
+        $fieldDescription->method('getTargetModel')->willReturn(Foo::class);
+        $fieldDescription->method('getName')->willReturn('barField');
+
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionMessage('Autocomplete list can`t be retrieved because the form element is disabled or read_only.');
 
         ($this->action)($request);
     }
@@ -109,20 +111,23 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             'q' => 'so',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
-        $targetAdmin = $this->prophesize(AbstractAdmin::class);
-        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
+        $targetAdmin = $this->createStub(AbstractAdmin::class);
+        // NEXT_MAJOR: Use `createStub` instead of using mock builder
+        $fieldDescription = $this->getMockBuilder(FieldDescriptionInterface::class)
+            ->addMethods(['getTargetModel'])
+            ->getMockForAbstractClass();
 
         $this->configureFormConfig('barField');
 
-        $this->admin->getNewInstance()->willReturn($object);
-        $this->admin->setSubject($object)->shouldBeCalled();
-        $this->admin->hasAccess('create')->willReturn(true);
-        $this->admin->getFormFieldDescription('barField')->willReturn($fieldDescription->reveal());
-        $this->admin->getFormFieldDescriptions()->willReturn(null);
-        $targetAdmin->checkAccess('list')->willReturn(null);
-        $fieldDescription->getTargetModel()->willReturn(Foo::class);
-        $fieldDescription->getName()->willReturn('barField');
-        $fieldDescription->getAssociationAdmin()->willReturn($targetAdmin->reveal());
+        $this->admin->method('getNewInstance')->willReturn($object);
+        $this->admin->expects($this->once())->method('setSubject')->with($object);
+        $this->admin->method('hasAccess')->with('create')->willReturn(true);
+        $this->admin->method('getFormFieldDescription')->with('barField')->willReturn($fieldDescription);
+        $this->admin->method('getFormFieldDescriptions')->willReturn(null);
+        $targetAdmin->method('checkAccess')->with('list')->willReturn(null);
+        $fieldDescription->method('getTargetModel')->willReturn(Foo::class);
+        $fieldDescription->method('getName')->willReturn('barField');
+        $fieldDescription->method('getAssociationAdmin')->willReturn($targetAdmin);
 
         $response = ($this->action)($request);
 
@@ -145,9 +150,13 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $filter = new FooFilter();
         $filter->initialize('foo');
 
-        $datagrid->hasFilter('foo')->willReturn(true);
-        $datagrid->getFilter('foo')->willReturn($filter);
-        $datagrid->setValue('foo', null, 'sonata')->shouldBeCalled();
+        $datagrid->method('hasFilter')->with('foo')->willReturn(true);
+        $datagrid->method('getFilter')->with('foo')->willReturn($filter);
+        $datagrid->expects($this->exactly(3))->method('setValue')->withConsecutive(
+            ['foo', null, 'sonata'],
+            ['_per_page', null, 10],
+            ['_page', null, 1]
+        );
 
         $response = ($this->action)($request);
 
@@ -170,16 +179,23 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $filter = new FooFilter();
         $filter->initialize('entity.property');
 
-        $datagrid->hasFilter('entity.property')->willReturn(true);
-        $datagrid->getFilter('entity.property')->willReturn($filter);
         $filter2 = new FooFilter();
         $filter2->initialize('entity2.property2');
 
-        $datagrid->hasFilter('entity2.property2')->willReturn(true);
-        $datagrid->getFilter('entity2.property2')->willReturn($filter2);
-
-        $datagrid->setValue('entity__property', null, 'sonata')->shouldBeCalled();
-        $datagrid->setValue('entity2__property2', null, 'sonata')->shouldBeCalled();
+        $datagrid->method('hasFilter')->willReturnMap([
+            ['entity.property', true],
+            ['entity2.property2', true],
+        ]);
+        $datagrid->method('getFilter')->willReturnMap([
+            ['entity.property', $filter],
+            ['entity2.property2', $filter2],
+        ]);
+        $datagrid->expects($this->exactly(4))->method('setValue')->withConsecutive(
+            ['entity__property', null, 'sonata'],
+            ['entity2__property2', null, 'sonata'],
+            ['_per_page', null, 10],
+            ['_page', null, 1]
+        );
 
         $response = ($this->action)($request);
 
@@ -202,9 +218,13 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $filter = new FooFilter();
         $filter->initialize('entity.property');
 
-        $datagrid->hasFilter('entity.property')->willReturn(true);
-        $datagrid->getFilter('entity.property')->willReturn($filter);
-        $datagrid->setValue('entity__property', null, 'sonata')->shouldBeCalled();
+        $datagrid->method('hasFilter')->with('entity.property')->willReturn(true);
+        $datagrid->method('getFilter')->with('entity.property')->willReturn($filter);
+        $datagrid->expects($this->exactly(3))->method('setValue')->withConsecutive(
+            ['entity__property', null, 'sonata'],
+            ['_per_page', null, 10],
+            ['_page', null, 1]
+        );
 
         $response = ($this->action)($request);
 
@@ -213,95 +233,100 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
     }
 
-    private function configureAutocompleteItemsDatagrid(): ObjectProphecy
+    private function configureAutocompleteItemsDatagrid(): MockObject
     {
         $model = new \stdClass();
 
-        $targetAdmin = $this->prophesize(AbstractAdmin::class);
-        $datagrid = $this->prophesize(DatagridInterface::class);
-        $metadata = $this->prophesize(MetadataInterface::class);
-        $pager = $this->prophesize(Pager::class);
-        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
+        $targetAdmin = $this->createStub(AbstractAdmin::class);
+        $datagrid = $this->createStub(DatagridInterface::class);
+        $metadata = $this->createStub(MetadataInterface::class);
+        $pager = $this->createStub(Pager::class);
+        // NEXT_MAJOR: Use `createStub` instead of using mock builder
+        $fieldDescription = $this->getMockBuilder(FieldDescriptionInterface::class)
+            ->addMethods(['getTargetModel'])
+            ->getMockForAbstractClass();
 
-        $this->admin->getNewInstance()->willReturn($model);
-        $this->admin->setSubject($model)->shouldBeCalled();
-        $this->admin->hasAccess('create')->willReturn(true);
-        $this->admin->getFormFieldDescription('barField')->willReturn($fieldDescription->reveal());
-        $this->admin->getFormFieldDescriptions()->willReturn(null);
-        $this->admin->id($model)->willReturn(123);
-        $targetAdmin->checkAccess('list')->shouldBeCalled();
-        $targetAdmin->setFilterPersister(null)->shouldBeCalled();
-        $targetAdmin->getDatagrid()->willReturn($datagrid->reveal());
-        $targetAdmin->getObjectMetadata($model)->willReturn($metadata->reveal());
-        $metadata->getTitle()->willReturn('FOO');
+        $this->admin->method('getNewInstance')->willReturn($model);
+        $this->admin->expects($this->once())->method('setSubject')->with($model);
+        $this->admin->method('hasAccess')->with('create')->willReturn(true);
+        $this->admin->method('getFormFieldDescription')->with('barField')->willReturn($fieldDescription);
+        $this->admin->method('getFormFieldDescriptions')->willReturn(null);
+        $this->admin->method('id')->with($model)->willReturn(123);
+        $targetAdmin->expects($this->once())->method('checkAccess')->with('list');
+        $targetAdmin->expects($this->once())->method('setFilterPersister')->with(null);
+        $targetAdmin->method('getDatagrid')->willReturn($datagrid);
+        $targetAdmin->method('getObjectMetadata')->with($model)->willReturn($metadata);
+        $metadata->method('getTitle')->willReturn('FOO');
 
-        $datagrid->setValue('_per_page', null, 10)->shouldBeCalled();
-        $datagrid->setValue('_page', null, 1)->shouldBeCalled();
-        $datagrid->buildPager()->willReturn(null);
-        $datagrid->getPager()->willReturn($pager->reveal());
-        $pager->getResults()->willReturn([$model]);
-        $pager->isLastPage()->willReturn(true);
-        $fieldDescription->getTargetModel()->willReturn(Foo::class);
-        $fieldDescription->getName()->willReturn('barField');
-        $fieldDescription->getAssociationAdmin()->willReturn($targetAdmin->reveal());
+        $datagrid->method('buildPager')->willReturn(null);
+        $datagrid->method('getPager')->willReturn($pager);
+        $pager->method('getResults')->willReturn([$model]);
+        $pager->method('isLastPage')->willReturn(true);
+        $fieldDescription->method('getTargetModel')->willReturn(Foo::class);
+        $fieldDescription->method('getName')->willReturn('barField');
+        $fieldDescription->method('getAssociationAdmin')->willReturn($targetAdmin);
 
         return $datagrid;
     }
 
     private function configureFormConfig(string $field, bool $disabled = false): void
     {
-        $form = $this->prophesize(Form::class);
-        $formType = $this->prophesize(Form::class);
-        $formConfig = $this->prophesize(FormConfigInterface::class);
+        $form = $this->createStub(Form::class);
+        $formType = $this->createStub(Form::class);
+        $formConfig = $this->createStub(FormConfigInterface::class);
 
-        $this->admin->getForm()->willReturn($form->reveal());
-        $form->get($field)->willReturn($formType->reveal());
-        $formType->getConfig()->willReturn($formConfig->reveal());
-        $formConfig->getAttribute('disabled')->willReturn($disabled);
-        $formConfig->getAttribute('property')->willReturn('foo');
-        $formConfig->getAttribute('callback')->willReturn(null);
-        $formConfig->getAttribute('minimum_input_length')->willReturn(3);
-        $formConfig->getAttribute('items_per_page')->willReturn(10);
-        $formConfig->getAttribute('req_param_name_page_number')->willReturn('_page');
-        $formConfig->getAttribute('to_string_callback')->willReturn(null);
-        $formConfig->getAttribute('target_admin_access_action')->willReturn('list');
+        $this->admin->method('getForm')->willReturn($form);
+        $form->method('get')->with($field)->willReturn($formType);
+        $formType->method('getConfig')->willReturn($formConfig);
+        $formConfig->method('getAttribute')->willReturnMap([
+            ['disabled', null, $disabled],
+            ['property', null, 'foo'],
+            ['callback', null, null],
+            ['minimum_input_length', null, 3],
+            ['items_per_page', null, 10],
+            ['req_param_name_page_number', null, '_page'],
+            ['to_string_callback', null, null],
+            ['target_admin_access_action', null, 'list'],
+        ]);
     }
 
     private function configureFormConfigComplexProperty(string $field): void
     {
-        $form = $this->prophesize(Form::class);
-        $formType = $this->prophesize(Form::class);
-        $formConfig = $this->prophesize(FormConfigInterface::class);
+        $form = $this->createStub(Form::class);
+        $formType = $this->createStub(Form::class);
+        $formConfig = $this->createStub(FormConfigInterface::class);
 
-        $this->admin->getForm()->willReturn($form->reveal());
-        $form->get($field)->willReturn($formType->reveal());
-        $formType->getConfig()->willReturn($formConfig->reveal());
-        $formConfig->getAttribute('disabled')->willReturn(false);
-        $formConfig->getAttribute('property')->willReturn('entity.property');
-        $formConfig->getAttribute('callback')->willReturn(null);
-        $formConfig->getAttribute('minimum_input_length')->willReturn(3);
-        $formConfig->getAttribute('items_per_page')->willReturn(10);
-        $formConfig->getAttribute('req_param_name_page_number')->willReturn('_page');
-        $formConfig->getAttribute('to_string_callback')->willReturn(null);
-        $formConfig->getAttribute('target_admin_access_action')->willReturn('list');
+        $this->admin->method('getForm')->willReturn($form);
+        $form->method('get')->with($field)->willReturn($formType);
+        $formType->method('getConfig')->willReturn($formConfig);
+
+        $formConfig->method('getAttribute')->willReturnMap([
+            ['disabled', null, false],
+            ['property', null, 'entity.property'],
+            ['minimum_input_length', null, 3],
+            ['items_per_page', null, 10],
+            ['req_param_name_page_number', null, '_page'],
+            ['target_admin_access_action', null, 'list'],
+        ]);
     }
 
     private function configureFormConfigComplexPropertyArray(string $field): void
     {
-        $form = $this->prophesize(Form::class);
-        $formType = $this->prophesize(Form::class);
-        $formConfig = $this->prophesize(FormConfigInterface::class);
+        $form = $this->createStub(Form::class);
+        $formType = $this->createStub(Form::class);
+        $formConfig = $this->createStub(FormConfigInterface::class);
 
-        $this->admin->getForm()->willReturn($form->reveal());
-        $form->get($field)->willReturn($formType->reveal());
-        $formType->getConfig()->willReturn($formConfig->reveal());
-        $formConfig->getAttribute('disabled')->willReturn(false);
-        $formConfig->getAttribute('property')->willReturn(['entity.property', 'entity2.property2']);
-        $formConfig->getAttribute('callback')->willReturn(null);
-        $formConfig->getAttribute('minimum_input_length')->willReturn(3);
-        $formConfig->getAttribute('items_per_page')->willReturn(10);
-        $formConfig->getAttribute('req_param_name_page_number')->willReturn('_page');
-        $formConfig->getAttribute('to_string_callback')->willReturn(null);
-        $formConfig->getAttribute('target_admin_access_action')->willReturn('list');
+        $this->admin->method('getForm')->willReturn($form);
+        $form->method('get')->with($field)->willReturn($formType);
+        $formType->method('getConfig')->willReturn($formConfig);
+
+        $formConfig->method('getAttribute')->willReturnMap([
+            ['disabled', null, false],
+            ['property', null, ['entity.property', 'entity2.property2']],
+            ['minimum_input_length', null, 3],
+            ['items_per_page', null, 10],
+            ['req_param_name_page_number', null, '_page'],
+            ['target_admin_access_action', null, 'list'],
+        ]);
     }
 }

--- a/tests/Action/RetrieveFormFieldElementActionTest.php
+++ b/tests/Action/RetrieveFormFieldElementActionTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Action;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Action\RetrieveFormFieldElementAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
@@ -58,16 +57,16 @@ final class RetrieveFormFieldElementActionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->twig = $this->prophesize(Environment::class);
-        $this->admin = $this->prophesize(AbstractAdmin::class);
-        $this->admin->setRequest(Argument::type(Request::class))->shouldBeCalled();
-        $this->pool = $this->prophesize(Pool::class);
-        $this->pool->getInstance(Argument::any())->willReturn($this->admin->reveal());
-        $this->helper = $this->prophesize(AdminHelper::class);
+        $this->twig = $this->createStub(Environment::class);
+        $this->admin = $this->createMock(AbstractAdmin::class);
+        $this->admin->expects($this->once())->method('setRequest');
+        $this->pool = $this->createStub(Pool::class);
+        $this->pool->method('getInstance')->willReturn($this->admin);
+        $this->helper = $this->createStub(AdminHelper::class);
         $this->action = new RetrieveFormFieldElementAction(
-            $this->twig->reveal(),
-            $this->pool->reveal(),
-            $this->helper->reveal()
+            $this->twig,
+            $this->pool,
+            $this->helper
         );
     }
 
@@ -82,27 +81,27 @@ final class RetrieveFormFieldElementActionTest extends TestCase
             'context' => 'list',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST]);
 
-        $modelManager = $this->prophesize(ModelManagerInterface::class);
+        $modelManager = $this->createStub(ModelManagerInterface::class);
         $formView = new FormView();
-        $form = $this->prophesize(Form::class);
-        $formBuilder = $this->prophesize(FormBuilder::class);
+        $form = $this->createStub(Form::class);
+        $formBuilder = $this->createStub(FormBuilder::class);
 
         $renderer = $this->configureFormRenderer();
 
-        $this->admin->getObject(42)->willReturn($object);
-        $this->admin->getClass()->willReturn(\get_class($object));
-        $this->admin->setSubject($object)->shouldBeCalled();
-        $this->admin->getFormTheme()->willReturn($formView);
-        $this->admin->getFormBuilder()->willReturn($formBuilder->reveal());
-        $this->helper->getChildFormView($formView, null)
+        $this->admin->method('getObject')->with(42)->willReturn($object);
+        $this->admin->method('getClass')->willReturn(\get_class($object));
+        $this->admin->expects($this->once())->method('setSubject')->with($object);
+        $this->admin->method('getFormTheme')->willReturn($formView);
+        $this->admin->method('getFormBuilder')->willReturn($formBuilder);
+        $this->helper->method('getChildFormView')->with($formView, null)
             ->willReturn($formView);
-        $modelManager->find(\get_class($object), 42)->willReturn($object);
-        $form->setData($object)->shouldBeCalled();
-        $form->handleRequest($request)->shouldBeCalled();
-        $form->createView()->willReturn($formView);
-        $formBuilder->getForm()->willReturn($form->reveal());
-        $renderer->setTheme($formView, $formView)->shouldBeCalled();
-        $renderer->searchAndRenderBlock($formView, 'widget')->willReturn('block');
+        $modelManager->method('find')->with(\get_class($object), 42)->willReturn($object);
+        $form->expects($this->once())->method('setData')->with($object);
+        $form->expects($this->once())->method('handleRequest')->with($request);
+        $form->method('createView')->willReturn($formView);
+        $formBuilder->method('getForm')->willReturn($form);
+        $renderer->expects($this->once())->method('setTheme')->with($formView, $formView);
+        $renderer->method('searchAndRenderBlock')->with($formView, 'widget')->willReturn('block');
 
         $response = ($this->action)($request);
 
@@ -112,9 +111,9 @@ final class RetrieveFormFieldElementActionTest extends TestCase
 
     private function configureFormRenderer()
     {
-        $runtime = $this->prophesize(FormRenderer::class);
+        $runtime = $this->createMock(FormRenderer::class);
 
-        $this->twig->getRuntime(FormRenderer::class)->willReturn($runtime->reveal());
+        $this->twig->method('getRuntime')->with(FormRenderer::class)->willReturn($runtime);
 
         return $runtime;
     }

--- a/tests/Action/SearchActionTest.php
+++ b/tests/Action/SearchActionTest.php
@@ -47,27 +47,27 @@ class SearchActionTest extends TestCase
 
         $this->breadcrumbsBuilder = $this->createMock(BreadcrumbsBuilderInterface::class);
         $this->searchHandler = $this->createMock(SearchHandler::class);
-        $this->twig = $this->prophesize(Environment::class);
+        $this->twig = $this->createStub(Environment::class);
 
         $this->action = new SearchAction(
             $this->pool,
             $this->searchHandler,
             $templateRegistry,
             $this->breadcrumbsBuilder,
-            $this->twig->reveal()
+            $this->twig
         );
     }
 
     public function testGlobalPage(): void
     {
         $request = new Request(['q' => 'some search']);
-        $this->twig->render('search.html.twig', [
+        $this->twig->method('render')->with('search.html.twig', [
             'base_template' => 'layout.html.twig',
             'breadcrumbs_builder' => $this->breadcrumbsBuilder,
             'admin_pool' => $this->pool,
             'query' => 'some search',
             'groups' => [],
-        ])->willReturn(new Response());
+        ])->willReturn('rendered_search');
 
         $this->assertInstanceOf(Response::class, ($this->action)($request));
     }

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Action;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Sonata\AdminBundle\Action\SetObjectFieldValueAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
@@ -78,20 +77,20 @@ final class SetObjectFieldValueActionTest extends TestCase
             'admin_template' => 'renderedTemplate',
             'field_template' => 'renderedTemplate',
         ]));
-        $this->pool = $this->prophesize(Pool::class);
-        $this->admin = $this->prophesize(AbstractAdmin::class);
-        $this->pool->getInstance(Argument::any())->willReturn($this->admin->reveal());
-        $this->admin->setRequest(Argument::type(Request::class))->shouldBeCalled();
-        $this->validator = $this->prophesize(ValidatorInterface::class);
-        $this->modelManager = $this->prophesize(ModelManagerInterface::class);
+        $this->pool = $this->createStub(Pool::class);
+        $this->admin = $this->createMock(AbstractAdmin::class);
+        $this->pool->method('getInstance')->willReturn($this->admin);
+        $this->admin->expects($this->once())->method('setRequest');
+        $this->validator = $this->createStub(ValidatorInterface::class);
+        $this->modelManager = $this->createStub(ModelManagerInterface::class);
         $this->resolver = new DataTransformerResolver();
         $this->action = new SetObjectFieldValueAction(
             $this->twig,
-            $this->pool->reveal(),
-            $this->validator->reveal(),
+            $this->pool,
+            $this->validator,
             $this->resolver
         );
-        $this->admin->getModelManager()->willReturn($this->modelManager->reveal());
+        $this->admin->method('getModelManager')->willReturn($this->modelManager);
     }
 
     public function testSetObjectFieldValueAction(): void
@@ -105,37 +104,38 @@ final class SetObjectFieldValueActionTest extends TestCase
             'context' => 'list',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
-        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
-        $pool = $this->prophesize(Pool::class);
-        $translator = $this->prophesize(TranslatorInterface::class);
+        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
+        $pool = $this->createStub(Pool::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $propertyAccessor = new PropertyAccessor();
-        $templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
-        $container = $this->prophesize(ContainerInterface::class);
+        $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
+        $container = $this->createStub(ContainerInterface::class);
 
-        $this->admin->getObject(42)->willReturn($object);
-        $this->admin->getCode()->willReturn('sonata.post.admin');
-        $this->admin->hasAccess('edit', $object)->willReturn(true);
-        $this->admin->getListFieldDescription('enabled')->willReturn($fieldDescription->reveal());
-        $this->admin->update($object)->shouldBeCalled();
+        $this->admin->method('getObject')->with(42)->willReturn($object);
+        $this->admin->method('getCode')->willReturn('sonata.post.admin');
+        $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
+        $this->admin->method('getListFieldDescription')->with('enabled')->willReturn($fieldDescription);
+        $this->admin->expects($this->once())->method('update')->with($object);
         // NEXT_MAJOR: Remove this line
-        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
-        $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
-        $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
-        $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
+        $this->admin->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
+        $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
+        $container->method('get')->with('sonata.post.admin.template_registry')->willReturn($templateRegistry);
+        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
         $this->twig->addExtension(new SonataAdminExtension(
-            $pool->reveal(),
+            $pool,
             null,
-            $translator->reveal(),
-            $container->reveal()
+            $translator,
+            $container
         ));
-        $fieldDescription->getOption('editable')->willReturn(true);
-        $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
-        $fieldDescription->getType()->willReturn('boolean');
-        $fieldDescription->getTemplate()->willReturn('field_template');
-        $fieldDescription->getValue(Argument::cetera())->willReturn('some value');
-        $fieldDescription->getOption('data_transformer')->willReturn(null);
+        $fieldDescription->method('getOption')->willReturnMap([
+            ['editable', null, true],
+        ]);
+        $fieldDescription->method('getAdmin')->willReturn($this->admin);
+        $fieldDescription->method('getType')->willReturn('boolean');
+        $fieldDescription->method('getTemplate')->willReturn('field_template');
+        $fieldDescription->method('getValue')->willReturn('some value');
 
-        $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
+        $this->validator->method('validate')->with($object)->willReturn(new ConstraintViolationList([]));
 
         $response = ($this->action)($request);
 
@@ -171,38 +171,39 @@ final class SetObjectFieldValueActionTest extends TestCase
             'context' => 'list',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
-        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
-        $pool = $this->prophesize(Pool::class);
-        $translator = $this->prophesize(TranslatorInterface::class);
+        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
+        $pool = $this->createStub(Pool::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $propertyAccessor = new PropertyAccessor();
-        $templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
-        $container = $this->prophesize(ContainerInterface::class);
+        $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
+        $container = $this->createStub(ContainerInterface::class);
 
-        $this->admin->getObject(42)->willReturn($object);
-        $this->admin->getCode()->willReturn('sonata.post.admin');
-        $this->admin->hasAccess('edit', $object)->willReturn(true);
-        $this->admin->getListFieldDescription('dateProp')->willReturn($fieldDescription->reveal());
-        $this->admin->update($object)->shouldBeCalled();
+        $this->admin->method('getObject')->with(42)->willReturn($object);
+        $this->admin->method('getCode')->willReturn('sonata.post.admin');
+        $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
+        $this->admin->method('getListFieldDescription')->with('dateProp')->willReturn($fieldDescription);
+        $this->admin->expects($this->once())->method('update')->with($object);
 
-        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
-        $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
-        $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
-        $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
+        $this->admin->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
+        $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
+        $container->method('get')->with('sonata.post.admin.template_registry')->willReturn($templateRegistry);
+        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
         $this->twig->addExtension(new SonataAdminExtension(
-            $pool->reveal(),
+            $pool,
             null,
-            $translator->reveal(),
-            $container->reveal()
+            $translator,
+            $container
         ));
-        $fieldDescription->getOption('editable')->willReturn(true);
-        $fieldDescription->getOption('timezone')->willReturn($timezone);
-        $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
-        $fieldDescription->getType()->willReturn('date');
-        $fieldDescription->getTemplate()->willReturn('field_template');
-        $fieldDescription->getValue(Argument::cetera())->willReturn('some value');
-        $fieldDescription->getOption('data_transformer')->willReturn(null);
-
-        $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
+        $fieldDescription->method('getOption')->willReturnMap([
+            ['timezone', null, $timezone],
+            ['data_transformer', null, null],
+            ['editable', null, true],
+        ]);
+        $fieldDescription->method('getAdmin')->willReturn($this->admin);
+        $fieldDescription->method('getType')->willReturn('date');
+        $fieldDescription->method('getTemplate')->willReturn('field_template');
+        $fieldDescription->method('getValue')->willReturn('some value');
+        $this->validator->method('validate')->with($object)->willReturn(new ConstraintViolationList([]));
 
         $response = ($this->action)($request);
 
@@ -229,40 +230,45 @@ final class SetObjectFieldValueActionTest extends TestCase
             'context' => 'list',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
-        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
-        $translator = $this->prophesize(TranslatorInterface::class);
+        // NEXT_MAJOR: Use `createStub` instead of using mock builder
+        $fieldDescription = $this->getMockBuilder(FieldDescriptionInterface::class)
+            ->addMethods(['getTargetModel'])
+            ->getMockForAbstractClass();
+        $translator = $this->createStub(TranslatorInterface::class);
         $propertyAccessor = new PropertyAccessor();
-        $templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
-        $container = $this->prophesize(ContainerInterface::class);
+        $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
+        $container = $this->createStub(ContainerInterface::class);
 
-        $this->admin->getObject(42)->willReturn($object);
-        $this->admin->getCode()->willReturn('sonata.post.admin');
-        $this->admin->hasAccess('edit', $object)->willReturn(true);
-        $this->admin->getListFieldDescription('bar')->willReturn($fieldDescription->reveal());
-        $this->admin->getClass()->willReturn(\get_class($object));
-        $this->admin->update($object)->shouldBeCalled();
-        $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
+        $this->admin->method('getObject')->with(42)->willReturn($object);
+        $this->admin->method('getCode')->willReturn('sonata.post.admin');
+        $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
+        $this->admin->method('getListFieldDescription')->with('bar')->willReturn($fieldDescription);
+        $this->admin->method('getClass')->willReturn(\get_class($object));
+        $this->admin->expects($this->once())->method('update')->with($object);
+        $container->method('get')->with('sonata.post.admin.template_registry')->willReturn($templateRegistry);
         // NEXT_MAJOR: Remove this line
-        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
-        $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
+        $this->admin->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
+        $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $this->twig->addExtension(new SonataAdminExtension(
-            $this->pool->reveal(),
+            $this->pool,
             null,
-            $translator->reveal(),
-            $container->reveal()
+            $translator,
+            $container
         ));
-        $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
-        $fieldDescription->getType()->willReturn('choice');
-        $fieldDescription->getOption('editable')->willReturn(true);
-        $fieldDescription->getOption('class')->willReturn(Bar::class);
-        $fieldDescription->getTargetModel()->willReturn(Bar::class);
-        $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
-        $fieldDescription->getTemplate()->willReturn('field_template');
-        $fieldDescription->getValue(Argument::cetera())->willReturn('some value');
-        $fieldDescription->getOption('data_transformer')->willReturn(null);
-        $this->modelManager->find(\get_class($associationObject), 1)->willReturn($associationObject);
+        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
+        $fieldDescription->method('getType')->willReturn('choice');
+        $fieldDescription->method('getOption')->willReturnMap([
+            ['class', null, Bar::class],
+            ['data_transformer', null, null],
+            ['editable', null, true],
+        ]);
+        $fieldDescription->method('getTargetModel')->willReturn(Bar::class);
+        $fieldDescription->method('getAdmin')->willReturn($this->admin);
+        $fieldDescription->method('getTemplate')->willReturn('field_template');
+        $fieldDescription->method('getValue')->willReturn('some value');
+        $this->modelManager->method('find')->with(\get_class($associationObject), 1)->willReturn($associationObject);
 
-        $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
+        $this->validator->method('validate')->with($object)->willReturn(new ConstraintViolationList([]));
 
         $response = ($this->action)($request);
 
@@ -283,20 +289,22 @@ final class SetObjectFieldValueActionTest extends TestCase
             'context' => 'list',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
-        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
+        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
         $propertyAccessor = new PropertyAccessor();
 
-        $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
-        $this->admin->getObject(42)->willReturn($object);
-        $this->admin->hasAccess('edit', $object)->willReturn(true);
-        $this->admin->getListFieldDescription('bar.enabled')->willReturn($fieldDescription->reveal());
-        $this->validator->validate($bar)->willReturn(new ConstraintViolationList([
+        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
+        $this->admin->method('getObject')->with(42)->willReturn($object);
+        $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
+        $this->admin->method('getListFieldDescription')->with('bar.enabled')->willReturn($fieldDescription);
+        $this->validator->method('validate')->with($bar)->willReturn(new ConstraintViolationList([
             new ConstraintViolation('error1', null, [], null, 'enabled', null),
             new ConstraintViolation('error2', null, [], null, 'enabled', null),
         ]));
-        $fieldDescription->getOption('editable')->willReturn(true);
-        $fieldDescription->getType()->willReturn('boolean');
-        $fieldDescription->getOption('data_transformer')->willReturn(null);
+        $fieldDescription->method('getOption')->willReturnMap([
+            ['data_transformer', null, null],
+            ['editable', null, true],
+        ]);
+        $fieldDescription->method('getType')->willReturn('boolean');
 
         $response = ($this->action)($request);
 
@@ -315,38 +323,40 @@ final class SetObjectFieldValueActionTest extends TestCase
             'context' => 'list',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
-        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
-        $pool = $this->prophesize(Pool::class);
-        $translator = $this->prophesize(TranslatorInterface::class);
+        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
+        $pool = $this->createStub(Pool::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $propertyAccessor = new PropertyAccessor();
-        $templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
-        $container = $this->prophesize(ContainerInterface::class);
+        $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
+        $container = $this->createStub(ContainerInterface::class);
 
-        $this->admin->getObject(42)->willReturn($object);
-        $this->admin->getCode()->willReturn('sonata.post.admin');
-        $this->admin->hasAccess('edit', $object)->willReturn(true);
-        $this->admin->getListFieldDescription('status')->willReturn($fieldDescription->reveal());
-        $this->admin->update($object)->shouldBeCalled();
+        $this->admin->method('getObject')->with(42)->willReturn($object);
+        $this->admin->method('getCode')->willReturn('sonata.post.admin');
+        $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
+        $this->admin->method('getListFieldDescription')->with('status')->willReturn($fieldDescription);
+        $this->admin->expects($this->once())->method('update')->with($object);
         // NEXT_MAJOR: Remove this line
-        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
-        $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
-        $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
-        $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
+        $this->admin->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
+        $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
+        $container->method('get')->with('sonata.post.admin.template_registry')->willReturn($templateRegistry);
+        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
         $this->twig->addExtension(new SonataAdminExtension(
-            $pool->reveal(),
+            $pool,
             null,
-            $translator->reveal(),
-            $container->reveal()
+            $translator,
+            $container
         ));
-        $fieldDescription->getOption('editable')->willReturn(true);
-        $fieldDescription->getOption('multiple')->willReturn(true);
-        $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
-        $fieldDescription->getType()->willReturn(null);
-        $fieldDescription->getTemplate()->willReturn('field_template');
-        $fieldDescription->getValue(Argument::cetera())->willReturn(['some value']);
-        $fieldDescription->getOption('data_transformer')->willReturn(null);
+        $fieldDescription->method('getOption')->willReturnMap([
+            ['data_transformer', null, null],
+            ['editable', null, true],
+            ['multiple', null, true],
+        ]);
+        $fieldDescription->method('getAdmin')->willReturn($this->admin);
+        $fieldDescription->method('getType')->willReturn(null);
+        $fieldDescription->method('getTemplate')->willReturn('field_template');
+        $fieldDescription->method('getValue')->willReturn(['some value']);
 
-        $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
+        $this->validator->method('validate')->with($object)->willReturn(new ConstraintViolationList([]));
 
         $response = ($this->action)($request);
 
@@ -371,37 +381,39 @@ final class SetObjectFieldValueActionTest extends TestCase
             return filter_var($value, FILTER_VALIDATE_BOOLEAN);
         });
 
-        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
-        $pool = $this->prophesize(Pool::class);
-        $translator = $this->prophesize(TranslatorInterface::class);
+        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
+        $pool = $this->createStub(Pool::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $propertyAccessor = new PropertyAccessor();
-        $templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
-        $container = $this->prophesize(ContainerInterface::class);
+        $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
+        $container = $this->createStub(ContainerInterface::class);
 
-        $this->admin->getObject(42)->willReturn($object);
-        $this->admin->getCode()->willReturn('sonata.post.admin');
-        $this->admin->hasAccess('edit', $object)->willReturn(true);
-        $this->admin->getListFieldDescription('enabled')->willReturn($fieldDescription->reveal());
-        $this->admin->update($object)->shouldBeCalled();
+        $this->admin->method('getObject')->with(42)->willReturn($object);
+        $this->admin->method('getCode')->willReturn('sonata.post.admin');
+        $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
+        $this->admin->method('getListFieldDescription')->with('enabled')->willReturn($fieldDescription);
+        $this->admin->expects($this->once())->method('update')->with($object);
         // NEXT_MAJOR: Remove this line
-        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
-        $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
-        $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
-        $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
+        $this->admin->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
+        $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
+        $container->method('get')->with('sonata.post.admin.template_registry')->willReturn($templateRegistry);
+        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
         $this->twig->addExtension(new SonataAdminExtension(
-            $pool->reveal(),
+            $pool,
             null,
-            $translator->reveal(),
-            $container->reveal()
+            $translator,
+            $container
         ));
-        $fieldDescription->getOption('editable')->willReturn(true);
-        $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
-        $fieldDescription->getType()->willReturn(null);
-        $fieldDescription->getTemplate()->willReturn('field_template');
-        $fieldDescription->getValue(Argument::cetera())->willReturn('some value');
-        $fieldDescription->getOption('data_transformer')->willReturn($dataTransformer);
+        $fieldDescription->method('getOption')->willReturnMap([
+            ['data_transformer', null, $dataTransformer],
+            ['editable', null, true],
+        ]);
+        $fieldDescription->method('getAdmin')->willReturn($this->admin);
+        $fieldDescription->method('getType')->willReturn(null);
+        $fieldDescription->method('getTemplate')->willReturn('field_template');
+        $fieldDescription->method('getValue')->willReturn('some value');
 
-        $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
+        $this->validator->method('validate')->with($object)->willReturn(new ConstraintViolationList([]));
 
         $response = ($this->action)($request);
 
@@ -429,37 +441,39 @@ final class SetObjectFieldValueActionTest extends TestCase
             return filter_var($value, FILTER_VALIDATE_BOOLEAN);
         });
 
-        $fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
-        $pool = $this->prophesize(Pool::class);
-        $translator = $this->prophesize(TranslatorInterface::class);
+        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
+        $pool = $this->createStub(Pool::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $propertyAccessor = new PropertyAccessor();
-        $templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
-        $container = $this->prophesize(ContainerInterface::class);
+        $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
+        $container = $this->createStub(ContainerInterface::class);
 
-        $this->admin->getObject(42)->willReturn($object);
-        $this->admin->getCode()->willReturn('sonata.post.admin');
-        $this->admin->hasAccess('edit', $object)->willReturn(true);
-        $this->admin->getListFieldDescription('enabled')->willReturn($fieldDescription->reveal());
-        $this->admin->update($object)->shouldBeCalled();
+        $this->admin->method('getObject')->with(42)->willReturn($object);
+        $this->admin->method('getCode')->willReturn('sonata.post.admin');
+        $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
+        $this->admin->method('getListFieldDescription')->with('enabled')->willReturn($fieldDescription);
+        $this->admin->expects($this->once())->method('update')->with($object);
         // NEXT_MAJOR: Remove this line
-        $this->admin->getTemplate('base_list_field')->willReturn('admin_template');
-        $templateRegistry->getTemplate('base_list_field')->willReturn('admin_template');
-        $container->get('sonata.post.admin.template_registry')->willReturn($templateRegistry->reveal());
-        $this->pool->getPropertyAccessor()->willReturn($propertyAccessor);
+        $this->admin->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
+        $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
+        $container->method('get')->with('sonata.post.admin.template_registry')->willReturn($templateRegistry);
+        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
         $this->twig->addExtension(new SonataAdminExtension(
-            $pool->reveal(),
+            $pool,
             null,
-            $translator->reveal(),
-            $container->reveal()
+            $translator,
+            $container
         ));
-        $fieldDescription->getOption('editable')->willReturn(true);
-        $fieldDescription->getAdmin()->willReturn($this->admin->reveal());
-        $fieldDescription->getType()->willReturn('boolean');
-        $fieldDescription->getTemplate()->willReturn('field_template');
-        $fieldDescription->getValue(Argument::cetera())->willReturn('some value');
-        $fieldDescription->getOption('data_transformer')->willReturn($dataTransformer);
+        $fieldDescription->method('getOption')->willReturnMap([
+            ['data_transformer', null, $dataTransformer],
+            ['editable', null, true],
+        ]);
+        $fieldDescription->method('getAdmin')->willReturn($this->admin);
+        $fieldDescription->method('getType')->willReturn('boolean');
+        $fieldDescription->method('getTemplate')->willReturn('field_template');
+        $fieldDescription->method('getValue')->willReturn('some value');
 
-        $this->validator->validate($object)->willReturn(new ConstraintViolationList([]));
+        $this->validator->method('validate')->with($object)->willReturn(new ConstraintViolationList([]));
 
         $response = ($this->action)($request);
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -851,6 +851,8 @@ class AdminTest extends TestCase
     /**
      * @group legacy
      * @expectedDeprecation Method "Sonata\AdminBundle\Admin\AbstractAdmin::addSubClass" is deprecated since sonata-project/admin-bundle 3.30 and will be removed in 4.0.
+     *
+     * @doesNotPerformAssertions
      */
     public function testAddSubClassIsDeprecated(): void
     {
@@ -2765,6 +2767,8 @@ class AdminTest extends TestCase
      * @dataProvider getDeprecatedAbstractAdminConstructorArgs
      *
      * @expectedDeprecation Passing other type than string%S as argument %d for method Sonata\AdminBundle\Admin\AbstractAdmin::__construct() is deprecated since sonata-project/admin-bundle 3.65. It will accept only string%S in version 4.0.
+     *
+     * @doesNotPerformAssertions
      */
     public function testDeprecatedAbstractAdminConstructorArgs($code, $class, $baseControllerName): void
     {

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -175,15 +175,17 @@ class AdminTest extends TestCase
             'Application\Sonata\NewsBundle\Entity\Post',
             'Sonata\NewsBundle\Controller\PostAdminController'
         );
-        $securityHandler = $this->prophesize(SecurityHandlerInterface::class);
-        $securityHandler->isGranted($admin, 'CUSTOM_ROLE', $admin)->willReturn(true);
-        $securityHandler->isGranted($admin, 'EXTRA_CUSTOM_ROLE', $admin)->willReturn(false);
-        $customExtension = $this->prophesize(AbstractAdminExtension::class);
-        $customExtension->getAccessMapping($admin)->willReturn(
+        $securityHandler = $this->createStub(SecurityHandlerInterface::class);
+        $securityHandler->method('isGranted')->willReturnMap([
+            [$admin, 'CUSTOM_ROLE', $admin, true],
+            [$admin, 'EXTRA_CUSTOM_ROLE', $admin, false],
+        ]);
+        $customExtension = $this->createStub(AbstractAdminExtension::class);
+        $customExtension->method('getAccessMapping')->with($admin)->willReturn(
             ['custom_action' => ['CUSTOM_ROLE', 'EXTRA_CUSTOM_ROLE']]
         );
-        $admin->addExtension($customExtension->reveal());
-        $admin->setSecurityHandler($securityHandler->reveal());
+        $admin->addExtension($customExtension);
+        $admin->setSecurityHandler($securityHandler);
         $this->expectException(
             AccessDeniedException::class
         );
@@ -211,15 +213,17 @@ class AdminTest extends TestCase
             'Application\Sonata\NewsBundle\Entity\Post',
             'Sonata\NewsBundle\Controller\PostAdminController'
         );
-        $securityHandler = $this->prophesize(SecurityHandlerInterface::class);
-        $securityHandler->isGranted($admin, 'CUSTOM_ROLE', $admin)->willReturn(true);
-        $securityHandler->isGranted($admin, 'EXTRA_CUSTOM_ROLE', $admin)->willReturn(false);
-        $customExtension = $this->prophesize(AbstractAdminExtension::class);
-        $customExtension->getAccessMapping($admin)->willReturn(
+        $securityHandler = $this->createStub(SecurityHandlerInterface::class);
+        $securityHandler->method('isGranted')->willReturnMap([
+            [$admin, 'CUSTOM_ROLE', $admin, true],
+            [$admin, 'EXTRA_CUSTOM_ROLE', $admin, false],
+        ]);
+        $customExtension = $this->createStub(AbstractAdminExtension::class);
+        $customExtension->method('getAccessMapping')->with($admin)->willReturn(
             ['custom_action' => ['CUSTOM_ROLE', 'EXTRA_CUSTOM_ROLE']]
         );
-        $admin->addExtension($customExtension->reveal());
-        $admin->setSecurityHandler($securityHandler->reveal());
+        $admin->addExtension($customExtension);
+        $admin->setSecurityHandler($securityHandler);
 
         $this->assertFalse($admin->hasAccess('custom_action'));
     }
@@ -231,15 +235,17 @@ class AdminTest extends TestCase
             'Application\Sonata\NewsBundle\Entity\Post',
             'Sonata\NewsBundle\Controller\PostAdminController'
         );
-        $securityHandler = $this->prophesize(SecurityHandlerInterface::class);
-        $securityHandler->isGranted($admin, 'CUSTOM_ROLE', $admin)->willReturn(true);
-        $securityHandler->isGranted($admin, 'EXTRA_CUSTOM_ROLE', $admin)->willReturn(true);
-        $customExtension = $this->prophesize(AbstractAdminExtension::class);
-        $customExtension->getAccessMapping($admin)->willReturn(
+        $securityHandler = $this->createStub(SecurityHandlerInterface::class);
+        $securityHandler->method('isGranted')->willReturnMap([
+            [$admin, 'CUSTOM_ROLE', $admin, true],
+            [$admin, 'EXTRA_CUSTOM_ROLE', $admin, true],
+        ]);
+        $customExtension = $this->createStub(AbstractAdminExtension::class);
+        $customExtension->method('getAccessMapping')->with($admin)->willReturn(
             ['custom_action' => ['CUSTOM_ROLE', 'EXTRA_CUSTOM_ROLE']]
         );
-        $admin->addExtension($customExtension->reveal());
-        $admin->setSecurityHandler($securityHandler->reveal());
+        $admin->addExtension($customExtension);
+        $admin->setSecurityHandler($securityHandler);
 
         $this->assertTrue($admin->hasAccess('custom_action'));
     }
@@ -251,14 +257,14 @@ class AdminTest extends TestCase
             'Application\Sonata\NewsBundle\Entity\Post',
             'Sonata\NewsBundle\Controller\PostAdminController'
         );
-        $securityHandler = $this->prophesize(SecurityHandlerInterface::class);
-        $securityHandler->isGranted($admin, 'EDIT_ROLE', $admin)->willReturn(true);
-        $customExtension = $this->prophesize(AbstractAdminExtension::class);
-        $customExtension->getAccessMapping($admin)->willReturn(
+        $securityHandler = $this->createStub(SecurityHandlerInterface::class);
+        $securityHandler->method('isGranted')->with($admin, 'EDIT_ROLE', $admin)->willReturn(true);
+        $customExtension = $this->createStub(AbstractAdminExtension::class);
+        $customExtension->method('getAccessMapping')->with($admin)->willReturn(
             ['edit_action' => ['EDIT_ROLE']]
         );
-        $admin->addExtension($customExtension->reveal());
-        $admin->setSecurityHandler($securityHandler->reveal());
+        $admin->addExtension($customExtension);
+        $admin->setSecurityHandler($securityHandler);
 
         $this->assertTrue($admin->hasAccess('edit_action'));
     }
@@ -1240,10 +1246,10 @@ class AdminTest extends TestCase
             'edit' => '@FooAdmin/CRUD/edit.html.twig',
         ];
 
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->getTemplates()->shouldBeCalled()->willReturn($templates);
+        $templateRegistry = $this->createMock(MutableTemplateRegistryInterface::class);
+        $templateRegistry->expects($this->once())->method('getTemplates')->willReturn($templates);
 
-        $admin->setTemplateRegistry($templateRegistry->reveal());
+        $admin->setTemplateRegistry($templateRegistry);
 
         $this->assertSame($templates, $admin->getTemplates());
     }
@@ -1252,11 +1258,13 @@ class AdminTest extends TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->getTemplate('edit')->shouldBeCalled()->willReturn('@FooAdmin/CRUD/edit.html.twig');
-        $templateRegistry->getTemplate('show')->shouldBeCalled()->willReturn('@FooAdmin/CRUD/show.html.twig');
+        $templateRegistry = $this->createMock(MutableTemplateRegistryInterface::class);
+        $templateRegistry->expects($this->exactly(2))->method('getTemplate')->willReturnMap([
+            ['edit', '@FooAdmin/CRUD/edit.html.twig'],
+            ['show', '@FooAdmin/CRUD/show.html.twig'],
+        ]);
 
-        $admin->setTemplateRegistry($templateRegistry->reveal());
+        $admin->setTemplateRegistry($templateRegistry);
 
         $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $admin->getTemplate('edit'));
         $this->assertSame('@FooAdmin/CRUD/show.html.twig', $admin->getTemplate('show'));
@@ -2109,10 +2117,10 @@ class AdminTest extends TestCase
 
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->getTemplate('button_create')->willReturn('Foo.html.twig');
+        $templateRegistry = $this->createStub(MutableTemplateRegistryInterface::class);
+        $templateRegistry->method('getTemplate')->with('button_create')->willReturn('Foo.html.twig');
 
-        $admin->setTemplateRegistry($templateRegistry->reveal());
+        $admin->setTemplateRegistry($templateRegistry);
 
         $securityHandler = $this->createMock(SecurityHandlerInterface::class);
         $securityHandler
@@ -2298,10 +2306,10 @@ class AdminTest extends TestCase
      */
     public function testDefaultDashboardActionsArePresent(string $objFqn, string $expected): void
     {
-        $pathInfo = new PathInfoBuilder($this->createMock(AuditManagerInterface::class));
+        $pathInfo = new PathInfoBuilder($this->createStub(AuditManagerInterface::class));
 
         $routeGenerator = new DefaultRouteGenerator(
-            $this->createMock(RouterInterface::class),
+            $this->createStub(RouterInterface::class),
             new RoutesCache($this->cacheTempFolder, true)
         );
 
@@ -2310,12 +2318,12 @@ class AdminTest extends TestCase
         $admin->setRouteGenerator($routeGenerator);
         $admin->initialize();
 
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->getTemplate('action_create')->willReturn('Foo.html.twig');
+        $templateRegistry = $this->createStub(MutableTemplateRegistryInterface::class);
+        $templateRegistry->method('getTemplate')->with('action_create')->willReturn('Foo.html.twig');
 
-        $admin->setTemplateRegistry($templateRegistry->reveal());
+        $admin->setTemplateRegistry($templateRegistry);
 
-        $securityHandler = $this->createMock(SecurityHandlerInterface::class);
+        $securityHandler = $this->createStub(SecurityHandlerInterface::class);
         $securityHandler
             ->method('isGranted')
             ->willReturnCallback(static function (AdminInterface $adminIn, string $attributes, $object = null) use ($admin): bool {
@@ -2445,10 +2453,10 @@ class AdminTest extends TestCase
         $admin = $this->getMockForAbstractClass(AbstractAdmin::class, [
             'admin.my_code', 'My\Class', 'MyBundle\ClassAdminController',
         ]);
-        $builder = $this->prophesize(BreadcrumbsBuilderInterface::class);
+        $builder = $this->createStub(BreadcrumbsBuilderInterface::class);
         $action = 'myaction';
-        $builder->getBreadcrumbs($admin, $action)->shouldBeCalled();
-        $admin->setBreadcrumbsBuilder($builder->reveal())->getBreadcrumbs($action);
+        $builder->expects($this->once())->method('getBreadcrumbs')->with($admin, $action);
+        $admin->setBreadcrumbsBuilder($builder)->getBreadcrumbs($action);
     }
 
     /**
@@ -2459,13 +2467,12 @@ class AdminTest extends TestCase
         $admin = $this->getMockForAbstractClass(AbstractAdmin::class, [
             'admin.my_code', 'My\Class', 'MyBundle\ClassAdminController',
         ]);
-        $builder = $this->prophesize(BreadcrumbsBuilderInterface::class);
+        $builder = $this->createStub(BreadcrumbsBuilderInterface::class);
         $action = 'myaction';
         $menu = $this->createMock(ItemInterface::class);
-        $builder->buildBreadcrumbs($admin, $action, $menu)
-            ->shouldBeCalledTimes(1)
+        $builder->expects($this->once())->method('buildBreadcrumbs')->with($admin, $action, $menu)
             ->willReturn($menu);
-        $admin->setBreadcrumbsBuilder($builder->reveal());
+        $admin->setBreadcrumbsBuilder($builder);
 
         /* check the called is proxied only once */
         $this->assertSame($menu, $admin->buildBreadcrumbs($action, $menu));

--- a/tests/Admin/BreadcrumbsBuilderTest.php
+++ b/tests/Admin/BreadcrumbsBuilderTest.php
@@ -29,6 +29,7 @@ use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\DummySubject;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * This test class contains unit and integration tests. Maybe it could be
@@ -291,130 +292,107 @@ class BreadcrumbsBuilderTest extends TestCase
 
     public function testUnitChildGetBreadCrumbs(): void
     {
-        $menu = $this->prophesize(ItemInterface::class);
-        $menu->getParent()->willReturn(null);
-
-        $dashboardMenu = $this->prophesize(ItemInterface::class);
-        $dashboardMenu->getParent()->willReturn($menu);
-
-        $adminListMenu = $this->prophesize(ItemInterface::class);
-        $adminListMenu->getParent()->willReturn($dashboardMenu);
-
-        $adminSubjectMenu = $this->prophesize(ItemInterface::class);
-        $adminSubjectMenu->getParent()->willReturn($adminListMenu);
-
-        $childMenu = $this->prophesize(ItemInterface::class);
-        $childMenu->getParent()->willReturn($adminSubjectMenu);
-
-        $leafMenu = $this->prophesize(ItemInterface::class);
-        $leafMenu->getParent()->willReturn($childMenu);
-
         $action = 'my_action';
         $breadcrumbsBuilder = new BreadcrumbsBuilder(['child_admin_route' => 'show']);
-        $admin = $this->prophesize(AbstractAdmin::class);
-        $admin->isChild()->willReturn(false);
+        $admin = $this->createMock(AbstractAdmin::class);
+        $admin->method('isChild')->willReturn(false);
 
-        $menuFactory = $this->prophesize(MenuFactory::class);
-        $menuFactory->createItem('root')->willReturn($menu);
-        $admin->getMenuFactory()->willReturn($menuFactory);
-        $labelTranslatorStrategy = $this->prophesize(
-            LabelTranslatorStrategyInterface::class
-        );
+        $admin->method('getMenuFactory')->willReturn(new MenuFactory());
+        $labelTranslatorStrategy = $this->createStub(LabelTranslatorStrategyInterface::class);
 
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeGenerator->generate('sonata_admin_dashboard')->willReturn('/dashboard');
+        $routeGenerator = $this->createStub(RouteGeneratorInterface::class);
+        $routeGenerator->method('generate')->with('sonata_admin_dashboard')->willReturn('/dashboard');
 
-        $admin->getRouteGenerator()->willReturn($routeGenerator->reveal());
-        $menu->addChild('link_breadcrumb_dashboard', [
-            'uri' => '/dashboard',
-            'extras' => [
-                'translation_domain' => 'SonataAdminBundle',
-            ],
-        ])->willReturn(
-            $dashboardMenu->reveal()
-        );
-        $labelTranslatorStrategy->getLabel(
-            'my_class_name_list',
-            'breadcrumb',
-            'link'
-        )->willReturn('My class');
-        $labelTranslatorStrategy->getLabel(
-            'my_child_class_name_list',
-            'breadcrumb',
-            'link'
-        )->willReturn('My child class');
-        $childAdmin = $this->prophesize(AbstractAdmin::class);
-        $childAdmin->isChild()->willReturn(true);
-        $childAdmin->getParent()->willReturn($admin->reveal());
-        $childAdmin->getTranslationDomain()->willReturn('ChildBundle');
-        $childAdmin->getLabelTranslatorStrategy()
-            ->shouldBeCalled()
-            ->willReturn($labelTranslatorStrategy->reveal());
-        $childAdmin->getClassnameLabel()->willReturn('my_child_class_name');
-        $childAdmin->hasRoute('list')->willReturn(true);
-        $childAdmin->hasAccess('list')->willReturn(true);
-        $childAdmin->generateUrl('list')->willReturn('/myadmin/my-object/mychildadmin/list');
-        $childAdmin->getCurrentChildAdmin()->willReturn(null);
-        $childAdmin->hasSubject()->willReturn(true);
-        $childAdmin->getSubject()->willReturn('my subject');
-        $childAdmin->toString('my subject')->willReturn('My subject');
+        $admin->method('getRouteGenerator')->willReturn($routeGenerator);
+        $labelTranslatorStrategy->method('getLabel')->willReturnMap([
+            ['my_class_name_list', 'breadcrumb', 'link', 'My class'],
+            ['my_child_class_name_list', 'breadcrumb', 'link', 'My child class'],
+        ]);
 
-        $admin->hasAccess('show', 'my subject')->willReturn(true)->shouldBeCalled();
-        $admin->hasRoute('show')->willReturn(true);
-        $admin->generateUrl('show', ['id' => 'my-object'])->willReturn('/myadmin/my-object');
+        $childAdmin = $this->createMock(AbstractAdmin::class);
+        $childAdmin->method('isChild')->willReturn(true);
+        $childAdmin->method('getParent')->willReturn($admin);
+        $childAdmin->method('getTranslationDomain')->willReturn('ChildBundle');
+        $childAdmin->expects($this->atLeastOnce())->method('getLabelTranslatorStrategy')
+            ->willReturn($labelTranslatorStrategy);
+        $childAdmin->method('getClassnameLabel')->willReturn('my_child_class_name');
+        $childAdmin->method('hasRoute')->with('list')->willReturn(true);
+        $childAdmin->method('hasAccess')->with('list')->willReturn(true);
+        $childAdmin->method('generateUrl')->with('list')->willReturn('/myadmin/my-object/mychildadmin/list');
+        $childAdmin->method('getCurrentChildAdmin')->willReturn(null);
+        $childAdmin->method('hasSubject')->willReturn(true);
+        $childAdmin->method('getSubject')->willReturn('my subject');
+        $childAdmin->method('toString')->with('my subject')->willReturn('My subject');
 
-        $admin->trans('My class', [], null)->willReturn('Ma classe');
-        $admin->hasRoute('list')->willReturn(true);
-        $admin->hasAccess('list')->willReturn(true);
-        $admin->generateUrl('list')->willReturn('/myadmin/list');
-        $admin->getCurrentChildAdmin()->willReturn($childAdmin->reveal());
-        $request = $this->prophesize(Request::class);
-        $request->get('slug')->willReturn('my-object');
+        $admin->method('hasRoute')->willReturnMap([
+            ['show', true],
+            ['list', true],
+            ['edit', true],
+        ]);
+        $admin->method('hasAccess')->willReturnMap([
+            ['show', 'my subject', true],
+            ['list', null, true],
+            ['edit', null, true],
+        ]);
+        $admin->method('generateUrl')->willReturnMap([
+            ['show', ['id' => 'my-object'], UrlGeneratorInterface::ABSOLUTE_PATH, '/myadmin/my-object'],
+            ['edit', ['id' => 'my-object'], UrlGeneratorInterface::ABSOLUTE_PATH, '/myadmin/my-object'],
+            ['list', [], UrlGeneratorInterface::ABSOLUTE_PATH, '/myadmin/list'],
+        ]);
 
-        $admin->getIdParameter()->willReturn('slug');
-        $admin->hasRoute('edit')->willReturn(true);
-        $admin->hasAccess('edit')->willReturn(true);
-        $admin->generateUrl('edit', ['id' => 'my-object'])->willReturn('/myadmin/my-object');
-        $admin->getRequest()->willReturn($request->reveal());
-        $admin->hasSubject()->willReturn(true);
-        $admin->getSubject()->willReturn('my subject');
-        $admin->toString('my subject')->willReturn('My subject');
-        $admin->getTranslationDomain()->willReturn('FooBundle');
-        $admin->getLabelTranslatorStrategy()->willReturn(
-            $labelTranslatorStrategy->reveal()
-        );
-        $admin->getClassnameLabel()->willReturn('my_class_name');
+        $admin->method('trans')->with('My class', [], null)->willReturn('Ma classe');
+        $admin->method('getCurrentChildAdmin')->willReturn($childAdmin);
+        $request = $this->createStub(Request::class);
+        $request->method('get')->with('slug')->willReturn('my-object');
 
-        $dashboardMenu->addChild('My class', [
-            'extras' => [
-                'translation_domain' => 'FooBundle',
-            ],
-            'uri' => '/myadmin/list',
-        ])->shouldBeCalled()->willReturn($adminListMenu->reveal());
+        $admin->method('getIdParameter')->willReturn('slug');
+        $admin->method('getRequest')->willReturn($request);
+        $admin->method('hasSubject')->willReturn(true);
+        $admin->method('getSubject')->willReturn('my subject');
+        $admin->method('toString')->with('my subject')->willReturn('My subject');
+        $admin->method('getTranslationDomain')->willReturn('FooBundle');
+        $admin->method('getLabelTranslatorStrategy')->willReturn($labelTranslatorStrategy);
+        $admin->method('getClassnameLabel')->willReturn('my_class_name');
 
-        $adminListMenu->addChild('My subject', [
-            'uri' => '/myadmin/my-object',
-            'extras' => [
-                'translation_domain' => false,
-            ],
-        ])->shouldBeCalled()->willReturn($adminSubjectMenu->reveal());
-
-        $adminSubjectMenu->addChild('My child class', [
-            'extras' => [
-                'translation_domain' => 'ChildBundle',
-            ],
-            'uri' => '/myadmin/my-object/mychildadmin/list',
-        ])->shouldBeCalled()->willReturn($childMenu->reveal());
-        $adminSubjectMenu->setExtra('safe_label', false)->willReturn($childMenu);
-
-        $childMenu->addChild('My subject', [
-            'extras' => [
-                'translation_domain' => false,
-            ],
-        ])->shouldBeCalled()->willReturn($leafMenu->reveal());
-
-        $breadcrumbs = $breadcrumbsBuilder->getBreadcrumbs($childAdmin->reveal(), $action);
+        $breadcrumbs = $breadcrumbsBuilder->getBreadcrumbs($childAdmin, $action);
         $this->assertCount(5, $breadcrumbs);
+        [
+            $dashboardMenu,
+            $adminListMenu,
+            $adminSubjectMenu,
+            $childMenu,
+        ] = $breadcrumbs;
+
+        self::assertSame('link_breadcrumb_dashboard', $dashboardMenu->getName());
+        self::assertSame('/dashboard', $dashboardMenu->getUri());
+        self::assertSame(
+            ['translation_domain' => 'SonataAdminBundle'],
+            $dashboardMenu->getExtras()
+        );
+
+        self::assertSame('My class', $adminListMenu->getName());
+        self::assertSame('/myadmin/list', $adminListMenu->getUri());
+        self::assertSame(
+            ['translation_domain' => 'FooBundle'],
+            $adminListMenu->getExtras()
+        );
+
+        self::assertSame('My subject', $adminSubjectMenu->getName());
+        self::assertSame('/myadmin/my-object', $adminSubjectMenu->getUri());
+        self::assertSame(
+            [
+                'translation_domain' => false,
+                'safe_label' => false,
+            ],
+            $adminSubjectMenu->getExtras()
+        );
+
+        self::assertSame('My child class', $childMenu->getName());
+        self::assertSame('/myadmin/my-object/mychildadmin/list', $childMenu->getUri());
+        self::assertSame(
+            ['translation_domain' => 'ChildBundle'],
+            $childMenu->getExtras()
+        );
     }
 
     public function actionProvider(): array
@@ -434,116 +412,91 @@ class BreadcrumbsBuilderTest extends TestCase
     {
         $breadcrumbsBuilder = new BreadcrumbsBuilder();
 
-        $menu = $this->prophesize(ItemInterface::class);
-        $menuFactory = $this->prophesize(MenuFactory::class);
-        $menuFactory->createItem('root')->willReturn($menu);
-        $admin = $this->prophesize(AbstractAdmin::class);
-        $admin->getMenuFactory()->willReturn($menuFactory);
-        $labelTranslatorStrategy = $this->prophesize(LabelTranslatorStrategyInterface::class);
+        $menu = $this->createMock(ItemInterface::class);
+        $menuFactory = $this->createStub(MenuFactory::class);
+        $menuFactory->method('createItem')->with('root')->willReturn($menu);
+        $admin = $this->createStub(AbstractAdmin::class);
+        $admin->method('getMenuFactory')->willReturn($menuFactory);
+        $labelTranslatorStrategy = $this->createStub(LabelTranslatorStrategyInterface::class);
 
-        $routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $routeGenerator->generate('sonata_admin_dashboard')->willReturn('/dashboard');
-        $admin->getRouteGenerator()->willReturn($routeGenerator->reveal());
-        $menu->addChild('link_breadcrumb_dashboard', [
-            'uri' => '/dashboard',
-            'extras' => [
-                'translation_domain' => 'SonataAdminBundle',
-            ],
-        ])->willReturn(
-            $menu->reveal()
-        );
-        $labelTranslatorStrategy->getLabel(
-            'my_class_name_list',
-            'breadcrumb',
-            'link'
-        )->willReturn('My class');
-        $labelTranslatorStrategy->getLabel(
-            'my_child_class_name_list',
-            'breadcrumb',
-            'link'
-        )->willReturn('My child class');
-        $labelTranslatorStrategy->getLabel(
-            'my_child_class_name_my_action',
-            'breadcrumb',
-            'link'
-        )->willReturn('My action');
-        if ('create' === $action) {
-            $labelTranslatorStrategy->getLabel(
-                'my_class_name_create',
-                'breadcrumb',
-                'link'
-            )->willReturn('create my object');
-            $menu->addChild('create my object', [
-                'extras' => [
-                    'translation_domain' => 'FooBundle',
-                ],
-            ])->willReturn($menu);
-        }
-        $childAdmin = $this->prophesize(AbstractAdmin::class);
-        $childAdmin->getTranslationDomain()->willReturn('ChildBundle');
-        $childAdmin->getLabelTranslatorStrategy()->willReturn($labelTranslatorStrategy->reveal());
-        $childAdmin->getClassnameLabel()->willReturn('my_child_class_name');
-        $childAdmin->hasRoute('list')->willReturn(false);
-        $childAdmin->getCurrentChildAdmin()->willReturn(null);
-        $childAdmin->hasSubject()->willReturn(false);
+        $routeGenerator = $this->createStub(RouteGeneratorInterface::class);
+        $routeGenerator->method('generate')->with('sonata_admin_dashboard')->willReturn('/dashboard');
+        $admin->method('getRouteGenerator')->willReturn($routeGenerator);
 
-        $admin->hasRoute('list')->willReturn(true);
-        $admin->hasAccess('list')->willReturn(true);
-        $admin->generateUrl('list')->willReturn('/myadmin/list');
-        $admin->getCurrentChildAdmin()->willReturn(
-            'my_action' === $action ? $childAdmin->reveal() : false
-        );
+        $menu->method('addChild')->willReturnMap([
+            ['link_breadcrumb_dashboard', [
+                'uri' => '/dashboard',
+                'extras' => ['translation_domain' => 'SonataAdminBundle'],
+            ], $menu],
+            ['create my object', [
+                'extras' => ['translation_domain' => 'FooBundle'],
+            ], $menu],
+            ['My class', [
+                'extras' => ['translation_domain' => 'FooBundle'],
+                'uri' => '/myadmin/list',
+            ], $menu],
+            ['My subject', [
+                'extras' => ['translation_domain' => false],
+            ], $menu],
+            ['My subject', [
+                'uri' => null,
+                'extras' => ['translation_domain' => false],
+            ], $menu],
+            ['My child class', [
+                'extras' => ['translation_domain' => 'ChildBundle'],
+                'uri' => null,
+            ], $menu],
+            ['My action', [
+                'extras' => ['translation_domain' => 'ChildBundle'],
+            ], $menu],
+        ]);
+
+        $menu->method('setExtra')->with('safe_label', false)->willReturn($menu);
+
+        $labelTranslatorStrategy->method('getLabel')->willReturnMap([
+            ['my_class_name_list', 'breadcrumb', 'link', 'My class'],
+            ['my_child_class_name_list', 'breadcrumb', 'link', 'My child class'],
+            ['my_child_class_name_my_action', 'breadcrumb', 'link', 'My action'],
+            ['my_class_name_create', 'breadcrumb', 'link', 'create my object'],
+        ]);
+
+        $childAdmin = $this->createStub(AbstractAdmin::class);
+        $childAdmin->method('getTranslationDomain')->willReturn('ChildBundle');
+        $childAdmin->method('getLabelTranslatorStrategy')->willReturn($labelTranslatorStrategy);
+        $childAdmin->method('getClassnameLabel')->willReturn('my_child_class_name');
+        $childAdmin->method('hasRoute')->with('list')->willReturn(false);
+        $childAdmin->method('getCurrentChildAdmin')->willReturn(null);
+        $childAdmin->method('hasSubject')->willReturn(false);
+
+        $admin->method('hasRoute')->willReturnMap([
+            ['list', true],
+            ['edit', false],
+        ]);
+        $admin->method('hasAccess')->with('list')->willReturn(true);
+        $admin->method('generateUrl')->with('list')->willReturn('/myadmin/list');
+        $admin->method('getCurrentChildAdmin')->willReturn('my_action' === $action ? $childAdmin : false);
+
         if ('list' === $action) {
-            $admin->isChild()->willReturn(true);
-            $menu->setUri(null)->shouldBeCalled();
+            $admin->method('isChild')->willReturn(true);
+            $menu->expects($this->once())->method('setUri')->with(null);
         } else {
-            $menu->setUri()->shouldNotBeCalled();
+            $menu->expects($this->never())->method('setUri');
         }
-        $request = $this->prophesize(Request::class);
-        $request->get('slug')->willReturn('my-object');
 
-        $admin->getIdParameter()->willReturn('slug');
-        $admin->hasRoute('edit')->willReturn(false);
-        $admin->getRequest()->willReturn($request->reveal());
-        $admin->hasSubject()->willReturn(true);
-        $admin->getSubject()->willReturn('my subject');
-        $admin->toString('my subject')->willReturn('My subject');
-        $admin->getTranslationDomain()->willReturn('FooBundle');
-        $admin->getLabelTranslatorStrategy()->willReturn(
-            $labelTranslatorStrategy->reveal()
+        $request = $this->createStub(Request::class);
+        $request->method('get')->with('slug')->willReturn('my-object');
+
+        $admin->method('getIdParameter')->willReturn('slug');
+        $admin->method('getRequest')->willReturn($request);
+        $admin->method('hasSubject')->willReturn(true);
+        $admin->method('getSubject')->willReturn('my subject');
+        $admin->method('toString')->with('my subject')->willReturn('My subject');
+        $admin->method('getTranslationDomain')->willReturn('FooBundle');
+        $admin->method('getLabelTranslatorStrategy')->willReturn(
+            $labelTranslatorStrategy
         );
-        $admin->getClassnameLabel()->willReturn('my_class_name');
+        $admin->method('getClassnameLabel')->willReturn('my_class_name');
 
-        $menu->addChild('My class', [
-            'uri' => '/myadmin/list',
-            'extras' => [
-                'translation_domain' => 'FooBundle',
-            ],
-        ])->willReturn($menu->reveal());
-        $menu->addChild('My subject', [
-            'extras' => [
-                'translation_domain' => false,
-            ],
-        ])->willReturn($menu);
-        $menu->addChild('My subject', [
-            'uri' => null,
-            'extras' => [
-                'translation_domain' => false,
-            ],
-        ])->willReturn($menu);
-        $menu->addChild('My child class', [
-            'extras' => [
-                'translation_domain' => 'ChildBundle',
-            ],
-            'uri' => null,
-        ])->willReturn($menu);
-        $menu->setExtra('safe_label', false)->willReturn($menu);
-        $menu->addChild('My action', [
-            'extras' => [
-                'translation_domain' => 'ChildBundle',
-            ],
-        ])->willReturn($menu);
-
-        $breadcrumbsBuilder->buildBreadcrumbs($admin->reveal(), $action);
+        $breadcrumbsBuilder->buildBreadcrumbs($admin, $action);
     }
 }

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -504,12 +504,11 @@ class PoolTest extends TestCase
      */
     public function testTemplate(): void
     {
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->getTemplate('ajax')
-            ->shouldBeCalledTimes(1)
+        $templateRegistry = $this->createMock(MutableTemplateRegistryInterface::class);
+        $templateRegistry->expects($this->once())->method('getTemplate')->with('ajax')
             ->willReturn('Foo.html.twig');
 
-        $this->pool->setTemplateRegistry($templateRegistry->reveal());
+        $this->pool->setTemplateRegistry($templateRegistry);
 
         $this->assertSame('Foo.html.twig', $this->pool->getTemplate('ajax'));
     }
@@ -524,14 +523,11 @@ class PoolTest extends TestCase
             'layout' => 'Bar.html.twig',
         ];
 
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->setTemplates($templates)
-            ->shouldBeCalledTimes(1);
-        $templateRegistry->getTemplates()
-            ->shouldBeCalledTimes(1)
-            ->willReturn($templates);
+        $templateRegistry = $this->createMock(MutableTemplateRegistryInterface::class);
+        $templateRegistry->expects($this->once())->method('setTemplates')->with($templates);
+        $templateRegistry->expects($this->once())->method('getTemplates')->willReturn($templates);
 
-        $this->pool->setTemplateRegistry($templateRegistry->reveal());
+        $this->pool->setTemplateRegistry($templateRegistry);
 
         $this->pool->setTemplates($templates);
 

--- a/tests/Block/AdminListBlockServiceTest.php
+++ b/tests/Block/AdminListBlockServiceTest.php
@@ -25,31 +25,12 @@ use Twig\Environment;
  */
 class AdminListBlockServiceTest extends BlockServiceTestCase
 {
-    /**
-     * @var Pool
-     */
-    private $pool;
-
-    /**
-     * @var TemplateRegistryInterface
-     */
-    private $templateRegistry;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->pool = $this->createMock(Pool::class);
-
-        $this->templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
-    }
-
     public function testDefaultSettings(): void
     {
         $blockService = new AdminListBlockService(
-            $this->createMock(Environment::class),
-            $this->pool,
-            $this->templateRegistry->reveal()
+            $this->createStub(Environment::class),
+            $this->createStub(Pool::class),
+            $this->createStub(TemplateRegistryInterface::class)
         );
         $blockContext = $this->getBlockContext($blockService);
 
@@ -64,9 +45,9 @@ class AdminListBlockServiceTest extends BlockServiceTestCase
     public function testOverriddenDefaultSettings(): void
     {
         $blockService = new FakeBlockService(
-            $this->createMock(Environment::class),
-            $this->pool,
-            $this->templateRegistry->reveal()
+            $this->createStub(Environment::class),
+            $this->createStub(Pool::class),
+            $this->createStub(TemplateRegistryInterface::class)
         );
         $blockContext = $this->getBlockContext($blockService);
 

--- a/tests/Block/DeprecatedAdminListBlockServiceTest.php
+++ b/tests/Block/DeprecatedAdminListBlockServiceTest.php
@@ -30,34 +30,15 @@ use Twig\Environment;
 class DeprecatedAdminListBlockServiceTest extends BlockServiceTestCase
 {
     /**
-     * @var Pool
-     */
-    private $pool;
-
-    /**
-     * @var TemplateRegistryInterface
-     */
-    private $templateRegistry;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->pool = $this->createMock(Pool::class);
-
-        $this->templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
-    }
-
-    /**
      * @expectedDeprecation Passing null as argument 2 to Sonata\AdminBundle\Block\AdminListBlockService::__construct() is deprecated since sonata-project/admin-bundle 3.76 and will throw a \TypeError in version 4.0. You must pass an instance of Sonata\AdminBundle\Admin\Pool instead.
      */
     public function testDefaultSettings(): void
     {
         $blockService = new AdminListBlockService(
-            $this->createMock(Environment::class),
+            $this->createStub(Environment::class),
             null,
-            $this->pool,
-            $this->templateRegistry->reveal()
+            $this->createStub(Pool::class),
+            $this->createStub(TemplateRegistryInterface::class)
         );
         $blockContext = $this->getBlockContext($blockService);
 
@@ -72,10 +53,10 @@ class DeprecatedAdminListBlockServiceTest extends BlockServiceTestCase
     public function testOverriddenDefaultSettings(): void
     {
         $blockService = new FakeBlockService(
-            $this->createMock(Environment::class),
+            $this->createStub(Environment::class),
             null,
-            $this->pool,
-            $this->templateRegistry->reveal()
+            $this->createStub(Pool::class),
+            $this->createStub(TemplateRegistryInterface::class)
         );
         $blockContext = $this->getBlockContext($blockService);
 

--- a/tests/Bridge/Exporter/AdminExporterTest.php
+++ b/tests/Bridge/Exporter/AdminExporterTest.php
@@ -59,7 +59,7 @@ class AdminExporterTest extends TestCase
             ->method('getClass')
             ->willReturn('MyProject\AppBundle\Model\MyClass');
         $adminExporter = new AdminExporter(new Exporter());
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '#export_myclass_\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2}.csv#',
             $adminExporter->getExportFilename($admin, 'csv')
         );

--- a/tests/Command/CreateClassCacheCommandTest.php
+++ b/tests/Command/CreateClassCacheCommandTest.php
@@ -84,7 +84,7 @@ class CreateClassCacheCommandTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()]);
 
-        $this->assertRegExp('@Writing cache file ...\s+done!@', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('@Writing cache file ...\s+done!@', $commandTester->getDisplay());
 
         $this->assertFileExists(sprintf('%s/classes.php', $this->tempDirectory));
         $this->assertFileEquals(sprintf('%s/../Fixtures/Command/classes.php', __DIR__), sprintf('%s/classes.php', $this->tempDirectory));

--- a/tests/Command/GenerateObjectAclCommandTest.php
+++ b/tests/Command/GenerateObjectAclCommandTest.php
@@ -183,6 +183,8 @@ class GenerateObjectAclCommandTest extends TestCase
      * NEXT_MAJOR: Remove this test.
      *
      * @group legacy
+     *
+     * @doesNotPerformAssertions
      */
     public function testExecuteWithDeprecatedUserModelNotation(): void
     {

--- a/tests/Command/GenerateObjectAclCommandTest.php
+++ b/tests/Command/GenerateObjectAclCommandTest.php
@@ -20,7 +20,6 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Command\GenerateObjectAclCommand;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
 use Sonata\AdminBundle\Util\ObjectAclManipulatorInterface;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\StreamOutput;
@@ -70,7 +69,7 @@ class GenerateObjectAclCommandTest extends TestCase
     {
         $pool = new Pool($this->container, '', '');
 
-        $registry = $this->createStub(RegistryInterface::class);
+        $registry = $this->createStub(ManagerRegistry::class);
         $command = new GenerateObjectAclCommand($pool, [], $registry);
 
         $application = new Application();
@@ -80,7 +79,7 @@ class GenerateObjectAclCommandTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()]);
 
-        $this->assertRegExp('/No manipulators are implemented : ignoring/', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('/No manipulators are implemented : ignoring/', $commandTester->getDisplay());
     }
 
     public function testExecuteWithEmptyManipulators(): void
@@ -97,7 +96,7 @@ class GenerateObjectAclCommandTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()]);
 
-        $this->assertRegExp('/No manipulators are implemented : ignoring/', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('/No manipulators are implemented : ignoring/', $commandTester->getDisplay());
     }
 
     public function testExecuteWithManipulatorNotFound(): void
@@ -106,17 +105,9 @@ class GenerateObjectAclCommandTest extends TestCase
         $registry = $this->createStub(ManagerRegistry::class);
         $pool = $this->createStub(Pool::class);
 
-        $admin
-            ->method('getManagerType')
-            ->willReturn('bar');
-
-        $pool
-            ->method('getAdminServiceIds')
-            ->willReturn(['acme.admin.foo']);
-
-        $pool
-            ->method('getInstance')
-            ->willReturn($admin);
+        $admin->method('getManagerType')->willReturn('bar');
+        $pool->method('getAdminServiceIds')->willReturn(['acme.admin.foo']);
+        $pool->method('getInstance')->willReturn($admin);
 
         $aclObjectManipulators = [
             'bar' => new \stdClass(),
@@ -131,7 +122,7 @@ class GenerateObjectAclCommandTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()]);
 
-        $this->assertRegExp('/Admin class is using a manager type that has no manipulator implemented : ignoring/', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('/Admin class is using a manager type that has no manipulator implemented : ignoring/', $commandTester->getDisplay());
     }
 
     public function testExecuteWithManipulatorNotObjectAclManipulatorInterface(): void
@@ -140,17 +131,9 @@ class GenerateObjectAclCommandTest extends TestCase
         $registry = $this->createStub(ManagerRegistry::class);
         $pool = $this->createStub(Pool::class);
 
-        $admin
-            ->method('getManagerType')
-            ->willReturn('bar');
-
-        $pool
-            ->method('getAdminServiceIds')
-            ->willReturn(['acme.admin.foo']);
-
-        $pool
-            ->method('getInstance')
-            ->willReturn($admin);
+        $admin->method('getManagerType')->willReturn('bar');
+        $pool->method('getAdminServiceIds')->willReturn(['acme.admin.foo']);
+        $pool->method('getInstance')->willReturn($admin);
 
         $aclObjectManipulators = [
             'sonata.admin.manipulator.acl.object.bar' => new \stdClass(),
@@ -165,7 +148,7 @@ class GenerateObjectAclCommandTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()]);
 
-        $this->assertRegExp('/The interface "ObjectAclManipulatorInterface" is not implemented for/', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('/The interface "ObjectAclManipulatorInterface" is not implemented for/', $commandTester->getDisplay());
     }
 
     public function testExecuteWithManipulator(): void
@@ -174,22 +157,12 @@ class GenerateObjectAclCommandTest extends TestCase
         $registry = $this->createStub(ManagerRegistry::class);
         $pool = $this->createStub(Pool::class);
 
-        $admin
-            ->method('getManagerType')
-            ->willReturn('bar');
-
-        $pool
-            ->method('getAdminServiceIds')
-            ->willReturn(['acme.admin.foo']);
-
-        $pool
-            ->method('getInstance')
-            ->willReturn($admin);
+        $admin->method('getManagerType')->willReturn('bar');
+        $pool->method('getAdminServiceIds')->willReturn(['acme.admin.foo']);
+        $pool->method('getInstance')->willReturn($admin);
 
         $manipulator = $this->createMock(ObjectAclManipulatorInterface::class);
-        $manipulator
-            ->expects($this->once())
-            ->method('batchConfigureAcls')
+        $manipulator->expects($this->once())->method('batchConfigureAcls')
             ->with($this->isInstanceOf(StreamOutput::class), $admin, null);
 
         $aclObjectManipulators = [

--- a/tests/Command/ListAdminCommandTest.php
+++ b/tests/Command/ListAdminCommandTest.php
@@ -55,6 +55,6 @@ class ListAdminCommandTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()]);
 
-        $this->assertRegExp('@Admin services:\s+acme.admin.foo\s+Acme\\\Entity\\\Foo\s+acme.admin.bar\s+Acme\\\Entity\\\Bar@', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('@Admin services:\s+acme.admin.foo\s+Acme\\\Entity\\\Foo\s+acme.admin.bar\s+Acme\\\Entity\\\Bar@', $commandTester->getDisplay());
     }
 }

--- a/tests/Command/SetupAclCommandTest.php
+++ b/tests/Command/SetupAclCommandTest.php
@@ -54,7 +54,7 @@ class SetupAclCommandTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()]);
 
-        $this->assertRegExp('/Starting ACL AdminBundle configuration/', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('/Starting ACL AdminBundle configuration/', $commandTester->getDisplay());
     }
 
     public function testExecuteWithException1(): void
@@ -72,7 +72,7 @@ class SetupAclCommandTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()]);
 
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '@Starting ACL AdminBundle configuration\s+Warning : The admin class cannot be initiated from the command line\s+You have requested a non-existent service "acme.admin.foo".@',
             $commandTester->getDisplay()
         );

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3849,6 +3849,8 @@ class CRUDControllerTest extends TestCase
 
     /**
      * @expectedDeprecation Method Sonata\AdminBundle\Controller\CRUDController::render has been renamed to Sonata\AdminBundle\Controller\CRUDController::renderWithExtraParams.
+     *
+     * @doesNotPerformAssertions
      */
     public function testRenderIsDeprecated(): void
     {

--- a/tests/Controller/CoreControllerTest.php
+++ b/tests/Controller/CoreControllerTest.php
@@ -34,13 +34,15 @@ class CoreControllerTest extends TestCase
     {
         $container = new Container();
 
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->getTemplate('ajax')->willReturn('ajax.html');
-        $templateRegistry->getTemplate('dashboard')->willReturn('dashboard.html');
-        $templateRegistry->getTemplate('layout')->willReturn('layout.html');
+        $templateRegistry = $this->createStub(MutableTemplateRegistryInterface::class);
+        $templateRegistry->method('getTemplate')->willReturnMap([
+            ['ajax', 'ajax.html'],
+            ['dashboard', 'dashboard.html'],
+            ['layout', 'layout.html'],
+        ]);
 
         $pool = new Pool($container, 'title', 'logo.png');
-        $pool->setTemplateRegistry($templateRegistry->reveal());
+        $pool->setTemplateRegistry($templateRegistry);
 
         $twig = $this->createMock(Environment::class);
         $request = new Request();
@@ -53,7 +55,7 @@ class CoreControllerTest extends TestCase
         $container->set(DashboardAction::class, new DashboardAction(
             [],
             $breadcrumbsBuilder,
-            $templateRegistry->reveal(),
+            $templateRegistry,
             $pool,
             $twig
         ));
@@ -72,14 +74,16 @@ class CoreControllerTest extends TestCase
     {
         $container = new Container();
 
-        $templateRegistry = $this->prophesize(MutableTemplateRegistryInterface::class);
-        $templateRegistry->getTemplate('ajax')->willReturn('ajax.html');
-        $templateRegistry->getTemplate('dashboard')->willReturn('dashboard.html');
-        $templateRegistry->getTemplate('layout')->willReturn('layout.html');
-        $breadcrumbsBuilder = $this->getMockForAbstractClass(BreadcrumbsBuilderInterface::class);
+        $templateRegistry = $this->createStub(MutableTemplateRegistryInterface::class);
+        $templateRegistry->method('getTemplate')->willReturnMap([
+            ['ajax', 'ajax.html'],
+            ['dashboard', 'dashboard.html'],
+            ['layout', 'layout.html'],
+        ]);
+        $breadcrumbsBuilder = $this->createStub(BreadcrumbsBuilderInterface::class);
 
         $pool = new Pool($container, 'title', 'logo.png');
-        $pool->setTemplateRegistry($templateRegistry->reveal());
+        $pool->setTemplateRegistry($templateRegistry);
 
         $twig = $this->createMock(Environment::class);
         $request = new Request();
@@ -91,7 +95,7 @@ class CoreControllerTest extends TestCase
         $container->set(DashboardAction::class, new DashboardAction(
             [],
             $breadcrumbsBuilder,
-            $templateRegistry->reveal(),
+            $templateRegistry,
             $pool,
             $twig
         ));

--- a/tests/Export/ExporterTest.php
+++ b/tests/Export/ExporterTest.php
@@ -57,7 +57,7 @@ class ExporterTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame($contentType, $response->headers->get('Content-Type'));
         // Quotes does not appear on some sonata versions.
-        $this->assertRegExp(sprintf('/attachment; filename="?%s"?/', $filename), $response->headers->get('Content-Disposition'));
+        $this->assertMatchesRegularExpression(sprintf('/attachment; filename="?%s"?/', $filename), $response->headers->get('Content-Disposition'));
     }
 
     public function getGetResponseTests()

--- a/tests/Filter/Persister/SessionFilterPersisterTest.php
+++ b/tests/Filter/Persister/SessionFilterPersisterTest.php
@@ -13,21 +13,21 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Filter\Persister;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Prophecy\ObjectProphecy;
 use Sonata\AdminBundle\Filter\Persister\SessionFilterPersister;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class SessionFilterPersisterTest extends TestCase
 {
     /**
-     * @var SessionInterface|ObjectProphecy
+     * @var SessionInterface|MockObject
      */
     private $session;
 
     protected function setUp(): void
     {
-        $this->session = $this->prophesize(SessionInterface::class);
+        $this->session = $this->createStub(SessionInterface::class);
     }
 
     protected function tearDown(): void
@@ -37,8 +37,8 @@ class SessionFilterPersisterTest extends TestCase
 
     public function testGetDefaultValueFromSessionIfNotDefined(): void
     {
-        $this->session->get('admin.customer.filter.parameters', [])
-            ->shouldBeCalledTimes(1)
+        $this->session->expects($this->once())->method('get')
+            ->with('admin.customer.filter.parameters', [])
             ->willReturn([]);
 
         self::assertSame([], $this->createPersister()->get('admin.customer'));
@@ -53,8 +53,8 @@ class SessionFilterPersisterTest extends TestCase
             '_sort_order' => 'ASC',
             '_per_page' => 25,
         ];
-        $this->session->get('admin.customer.filter.parameters', [])
-            ->shouldBeCalledTimes(1)
+        $this->session->expects($this->once())->method('get')
+            ->with('admin.customer.filter.parameters', [])
             ->willReturn($filters);
 
         self::assertSame($filters, $this->createPersister()->get('admin.customer'));
@@ -69,8 +69,8 @@ class SessionFilterPersisterTest extends TestCase
             '_sort_order' => 'ASC',
             '_per_page' => 25,
         ];
-        $this->session->set('admin.customer.filter.parameters', $filters)
-            ->shouldBeCalledTimes(1)
+        $this->session->expects($this->once())->method('set')
+            ->with('admin.customer.filter.parameters', $filters)
             ->willReturn(null);
 
         $this->createPersister()->set('admin.customer', $filters);
@@ -78,8 +78,8 @@ class SessionFilterPersisterTest extends TestCase
 
     public function testResetValueToSession(): void
     {
-        $this->session->remove('admin.customer.filter.parameters')
-            ->shouldBeCalledTimes(1)
+        $this->session->expects($this->once())->method('remove')
+            ->with('admin.customer.filter.parameters')
             ->willReturn(null);
 
         $this->createPersister()->reset('admin.customer');
@@ -87,6 +87,6 @@ class SessionFilterPersisterTest extends TestCase
 
     private function createPersister(): SessionFilterPersister
     {
-        return new SessionFilterPersister($this->session->reveal());
+        return new SessionFilterPersister($this->session);
     }
 }

--- a/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
+++ b/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
@@ -34,6 +34,8 @@ class ModelChoiceLoaderTest extends TestCase
      * NEXT_MAJOR: Expect exception instead.
      *
      * @group legacy
+     *
+     * @doesNotPerformAssertions
      */
     public function testConstructWithUnsupportedQuery(): void
     {

--- a/tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -21,17 +21,10 @@ use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
 
 class ModelsToArrayTransformerTest extends TestCase
 {
-    private $modelManager;
-
-    protected function setUp(): void
-    {
-        $this->modelManager = $this->prophesize(ModelManagerInterface::class)->reveal();
-    }
-
     public function testConstructor(): void
     {
         $transformer = new ModelsToArrayTransformer(
-            $this->modelManager,
+            $this->createStub(ModelManagerInterface::class),
             Foo::class
         );
 
@@ -43,13 +36,9 @@ class ModelsToArrayTransformerTest extends TestCase
      */
     public function testLegacyConstructor(): void
     {
-        $choiceListClass = ModelChoiceLoader::class;
-
-        $choiceList = $this->prophesize($choiceListClass)->reveal();
-
         $transformer = new ModelsToArrayTransformer(
-            $choiceList,
-            $this->modelManager,
+            $this->createStub(ModelChoiceLoader::class),
+            $this->createStub(ModelManagerInterface::class),
             Foo::class
         );
 

--- a/tests/Form/DataTransformerResolverTest.php
+++ b/tests/Form/DataTransformerResolverTest.php
@@ -44,8 +44,11 @@ final class DataTransformerResolverTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->fieldDescription = $this->prophesize(FieldDescriptionInterface::class);
-        $this->modelManager = $this->prophesize(ModelManagerInterface::class);
+        // NEXT_MAJOR: Use `createStub` instead of using mock builder
+        $this->fieldDescription = $this->getMockBuilder(FieldDescriptionInterface::class)
+            ->addMethods(['getTargetModel'])
+            ->getMockForAbstractClass();
+        $this->modelManager = $this->createStub(ModelManagerInterface::class);
         $this->resolver = new DataTransformerResolver();
     }
 
@@ -75,8 +78,8 @@ final class DataTransformerResolverTest extends TestCase
         }, static function ($value): bool {
             return filter_var($value, FILTER_VALIDATE_BOOLEAN);
         });
-        $this->fieldDescription->getOption('data_transformer')->willReturn($customDataTransformer);
-        $this->fieldDescription->getType()->willReturn($fieldType);
+        $this->fieldDescription->method('getOption')->with('data_transformer')->willReturn($customDataTransformer);
+        $this->fieldDescription->method('getType')->willReturn($fieldType);
 
         $dataTransformer = $this->resolve();
 
@@ -104,9 +107,11 @@ final class DataTransformerResolverTest extends TestCase
      */
     public function testResolveDateDataTransformer($timezone, \DateTimeZone $expectedTimezone): void
     {
-        $this->fieldDescription->getOption('data_transformer')->willReturn(null);
-        $this->fieldDescription->getOption('timezone')->willReturn($timezone);
-        $this->fieldDescription->getType()->willReturn('date');
+        $this->fieldDescription->method('getOption')->willReturnMap([
+            ['data_transformer', null, null],
+            ['timezone', null, $timezone],
+        ]);
+        $this->fieldDescription->method('getType')->willReturn('date');
 
         $dataTransformer = $this->resolve();
 
@@ -131,20 +136,19 @@ final class DataTransformerResolverTest extends TestCase
 
     public function testResolveChoiceWithoutClassName(): void
     {
-        $this->fieldDescription->getOption('data_transformer')->willReturn(null);
-        $this->fieldDescription->getType()->willReturn('choice');
-        $this->fieldDescription->getOption('class')->willReturn(null);
+        $this->fieldDescription->method('getType')->willReturn('choice');
 
         $this->assertNull($this->resolve());
     }
 
     public function testResolveChoiceBadClassName(): void
     {
-        $this->fieldDescription->getOption('data_transformer')->willReturn(null);
-        $this->fieldDescription->getType()->willReturn('choice');
-        $this->fieldDescription->getOption('class')->willReturn(\stdClass::class);
-        $this->fieldDescription->getTargetModel()->willReturn(\DateTime::class);
-        $this->fieldDescription->getTargetEntity()->willReturn(\DateTime::class);
+        $this->fieldDescription->method('getOption')->willReturnMap([
+            ['data_transformer', null, null],
+            ['class', null, \stdClass::class],
+        ]);
+        $this->fieldDescription->method('getType')->willReturn('choice');
+        $this->fieldDescription->method('getTargetModel')->willReturn(\DateTime::class);
 
         $this->assertNull($this->resolve());
     }
@@ -155,12 +159,13 @@ final class DataTransformerResolverTest extends TestCase
         $className = \stdClass::class;
         $object = new \stdClass();
 
-        $this->fieldDescription->getOption('data_transformer')->willReturn(null);
-        $this->fieldDescription->getType()->willReturn('choice');
-        $this->fieldDescription->getOption('class')->willReturn($className);
-        $this->fieldDescription->getTargetModel()->willReturn($className);
-
-        $this->modelManager->find($className, $newId)->willReturn($object);
+        $this->fieldDescription->method('getOption')->willReturnMap([
+            ['data_transformer', null, null],
+            ['class', null, $className],
+        ]);
+        $this->fieldDescription->method('getType')->willReturn('choice');
+        $this->fieldDescription->method('getTargetModel')->willReturn($className);
+        $this->modelManager->method('find')->with($className, $newId)->willReturn($object);
 
         $dataTransformer = $this->resolve();
 
@@ -179,8 +184,7 @@ final class DataTransformerResolverTest extends TestCase
             return filter_var($value, FILTER_VALIDATE_BOOLEAN);
         });
 
-        $this->fieldDescription->getOption('data_transformer')->willReturn(null);
-        $this->fieldDescription->getType()->willReturn($fieldType);
+        $this->fieldDescription->method('getType')->willReturn($fieldType);
 
         $this->resolver = new DataTransformerResolver([
             $fieldType => $customDataTransformer, // override predefined transformer
@@ -203,8 +207,7 @@ final class DataTransformerResolverTest extends TestCase
             return filter_var($value, FILTER_VALIDATE_BOOLEAN);
         });
 
-        $this->fieldDescription->getOption('data_transformer')->willReturn(null);
-        $this->fieldDescription->getType()->willReturn($fieldType);
+        $this->fieldDescription->method('getType')->willReturn($fieldType);
 
         $this->resolver->addCustomGlobalTransformer($fieldType, $customDataTransformer);
 
@@ -216,6 +219,6 @@ final class DataTransformerResolverTest extends TestCase
 
     private function resolve(): ?DataTransformerInterface
     {
-        return $this->resolver->resolve($this->fieldDescription->reveal(), $this->modelManager->reveal());
+        return $this->resolver->resolve($this->fieldDescription, $this->modelManager);
     }
 }

--- a/tests/Form/Type/AdminTypeTest.php
+++ b/tests/Form/Type/AdminTypeTest.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Prophecy\Argument;
-use Prophecy\Argument\Token\AnyValueToken;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
@@ -61,40 +59,43 @@ class AdminTypeTest extends TypeTestCase
 
     public function testSubmitValidData(): void
     {
-        $parentAdmin = $this->prophesize(AdminInterface::class);
-        $parentAdmin->hasSubject()->shouldBeCalled()->willReturn(false);
-        $parentField = $this->prophesize(FieldDescriptionInterface::class);
-        $parentField->setAssociationAdmin(Argument::type(AdminInterface::class))->shouldBeCalled();
-        $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
+        $parentAdmin = $this->createMock(AdminInterface::class);
+        $parentAdmin->expects($this->once())->method('hasSubject')->willReturn(false);
+        $parentField = $this->createMock(FieldDescriptionInterface::class);
+        $parentField->expects($this->once())->method('setAssociationAdmin')->with($this->isInstanceOf(AdminInterface::class));
+        $parentField->expects($this->once())->method('getAdmin')->willReturn($parentAdmin);
 
-        $modelManager = $this->prophesize(ModelManagerInterface::class);
+        $modelManager = $this->createStub(ModelManagerInterface::class);
 
         $foo = new Foo();
 
-        $admin = $this->prophesize(AbstractAdmin::class);
-        $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(true);
-        $admin->getParentFieldDescription()->shouldBeCalled()->willReturn($parentField->reveal());
-        $admin->hasAccess('delete')->shouldBeCalled()->willReturn(false);
-        $admin->defineFormBuilder(new AnyValueToken())->shouldBeCalled();
-        $admin->getModelManager()->shouldBeCalled()->willReturn($modelManager);
-        $admin->getClass()->shouldBeCalled()->willReturn(Foo::class);
-        $admin->getNewInstance()->shouldBeCalled()->willReturn($foo);
-        $admin->setSubject($foo)->shouldBeCalled();
+        $admin = $this->createMock(AbstractAdmin::class);
+        $admin->expects($this->atLeastOnce())->method('hasParentFieldDescription')->willReturn(true);
+        $admin->expects($this->atLeastOnce())->method('getParentFieldDescription')->willReturn($parentField);
+        $admin->expects($this->once())->method('hasAccess')->with('delete')->willReturn(false);
+        $admin->expects($this->once())->method('defineFormBuilder');
+        $admin->expects($this->once())->method('getModelManager')->willReturn($modelManager);
+        $admin->expects($this->once())->method('getClass')->willReturn(Foo::class);
+        $admin->expects($this->once())->method('getNewInstance')->willReturn($foo);
+        $admin->expects($this->once())->method('setSubject')->with($foo);
 
-        $field = $this->prophesize(FieldDescriptionInterface::class);
-        $field->getAssociationAdmin()->shouldBeCalled()->willReturn($admin->reveal());
-        $field->getAdmin()->shouldBeCalled();
-        $field->getName()->shouldBeCalled();
-        $field->getOption('edit', 'standard')->shouldBeCalled();
-        $field->getOption('inline', 'natural')->shouldBeCalled();
-        $field->getOption('block_name', false)->shouldBeCalled();
+        $field = $this->createMock(FieldDescriptionInterface::class);
+        $field->expects($this->once())->method('getAssociationAdmin')->willReturn($admin);
+        $field->expects($this->once())->method('getAdmin');
+        $field->expects($this->once())->method('getName');
+        $field->expects($this->exactly(3))->method('getOption')->withConsecutive(
+            ['edit', 'standard'],
+            ['inline', 'natural'],
+            ['block_name', false]
+        );
+
         $formData = [];
 
         $form = $this->factory->create(
             AdminType::class,
             null,
             [
-                'sonata_field_description' => $field->reveal(),
+                'sonata_field_description' => $field,
             ]
         );
         $form->submit($formData);
@@ -109,33 +110,33 @@ class AdminTypeTest extends TypeTestCase
         $parentSubject = new \stdClass();
         $parentSubject->foo = $foo;
 
-        $parentAdmin = $this->prophesize(AdminInterface::class);
-        $parentAdmin->getSubject()->shouldBeCalled()->willReturn($parentSubject);
-        $parentAdmin->hasSubject()->shouldBeCalled()->willReturn(true);
-        $parentField = $this->prophesize(FieldDescriptionInterface::class);
-        $parentField->setAssociationAdmin(Argument::type(AdminInterface::class))->shouldBeCalled();
-        $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
+        $parentAdmin = $this->createMock(AdminInterface::class);
+        $parentAdmin->expects($this->once())->method('getSubject')->willReturn($parentSubject);
+        $parentAdmin->expects($this->once())->method('hasSubject')->willReturn(true);
+        $parentField = $this->createMock(FieldDescriptionInterface::class);
+        $parentField->expects($this->once())->method('setAssociationAdmin')->with($this->isInstanceOf(AdminInterface::class));
+        $parentField->expects($this->once())->method('getAdmin')->willReturn($parentAdmin);
 
-        $modelManager = $this->prophesize(ModelManagerInterface::class);
+        $modelManager = $this->createStub(ModelManagerInterface::class);
 
-        $admin = $this->prophesize(AbstractAdmin::class);
-        $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(true);
-        $admin->getParentFieldDescription()->shouldBeCalled()->willReturn($parentField->reveal());
-        $admin->setSubject(1)->shouldBeCalled();
-        $admin->defineFormBuilder(new AnyValueToken())->shouldBeCalled();
-        $admin->getModelManager()->shouldBeCalled()->willReturn($modelManager);
-        $admin->getClass()->shouldBeCalled()->willReturn(Foo::class);
+        $admin = $this->createMock(AbstractAdmin::class);
+        $admin->expects($this->atLeastOnce())->method('hasParentFieldDescription')->willReturn(true);
+        $admin->expects($this->atLeastOnce())->method('getParentFieldDescription')->willReturn($parentField);
+        $admin->expects($this->once())->method('setSubject')->with(1);
+        $admin->expects($this->once())->method('defineFormBuilder');
+        $admin->expects($this->once())->method('getModelManager')->willReturn($modelManager);
+        $admin->expects($this->once())->method('getClass')->willReturn(Foo::class);
 
-        $field = $this->prophesize(FieldDescriptionInterface::class);
-        $field->getAssociationAdmin()->shouldBeCalled()->willReturn($admin->reveal());
-        $field->getFieldName()->shouldBeCalled()->willReturn('bar');
-        $field->getParentAssociationMappings()->shouldBeCalled()->willReturn([['fieldName' => 'foo']]);
+        $field = $this->createMock(FieldDescriptionInterface::class);
+        $field->expects($this->once())->method('getAssociationAdmin')->willReturn($admin);
+        $field->expects($this->once())->method('getFieldName')->willReturn('bar');
+        $field->expects($this->once())->method('getParentAssociationMappings')->willReturn([['fieldName' => 'foo']]);
 
         $this->builder->add('foo.bar');
 
         try {
             $this->adminType->buildForm($this->builder, [
-                'sonata_field_description' => $field->reveal(),
+                'sonata_field_description' => $field,
                 'delete' => false, // not needed
                 'property_path' => 'bar', // actual test case
             ]);
@@ -151,33 +152,33 @@ class AdminTypeTest extends TypeTestCase
         $parentSubject = new \stdClass();
         $parentSubject->foo = new ArrayCollection([$foo]);
 
-        $parentAdmin = $this->prophesize(AdminInterface::class);
-        $parentAdmin->getSubject()->shouldBeCalled()->willReturn($parentSubject);
-        $parentAdmin->hasSubject()->shouldBeCalled()->willReturn(true);
-        $parentField = $this->prophesize(FieldDescriptionInterface::class);
-        $parentField->setAssociationAdmin(Argument::type(AdminInterface::class))->shouldBeCalled();
-        $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
+        $parentAdmin = $this->createMock(AdminInterface::class);
+        $parentAdmin->expects($this->once())->method('getSubject')->willReturn($parentSubject);
+        $parentAdmin->expects($this->once())->method('hasSubject')->willReturn(true);
+        $parentField = $this->createMock(FieldDescriptionInterface::class);
+        $parentField->expects($this->once())->method('setAssociationAdmin')->with($this->isInstanceOf(AdminInterface::class));
+        $parentField->expects($this->once())->method('getAdmin')->willReturn($parentAdmin);
 
-        $modelManager = $this->prophesize(ModelManagerInterface::class);
+        $modelManager = $this->createStub(ModelManagerInterface::class);
 
-        $admin = $this->prophesize(AbstractAdmin::class);
-        $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(true);
-        $admin->getParentFieldDescription()->shouldBeCalled()->willReturn($parentField->reveal());
-        $admin->defineFormBuilder(new AnyValueToken())->shouldBeCalled();
-        $admin->getModelManager()->shouldBeCalled()->willReturn($modelManager);
-        $admin->getClass()->shouldBeCalled()->willReturn(Foo::class);
-        $admin->setSubject($foo)->shouldBeCalled();
+        $admin = $this->createMock(AbstractAdmin::class);
+        $admin->expects($this->atLeastOnce())->method('hasParentFieldDescription')->willReturn(true);
+        $admin->expects($this->atLeastOnce())->method('getParentFieldDescription')->willReturn($parentField);
+        $admin->expects($this->once())->method('defineFormBuilder');
+        $admin->expects($this->once())->method('getModelManager')->willReturn($modelManager);
+        $admin->expects($this->once())->method('getClass')->willReturn(Foo::class);
+        $admin->expects($this->once())->method('setSubject')->with($foo);
 
-        $field = $this->prophesize(FieldDescriptionInterface::class);
-        $field->getAssociationAdmin()->shouldBeCalled()->willReturn($admin->reveal());
-        $field->getFieldName()->shouldBeCalled()->willReturn('foo');
-        $field->getParentAssociationMappings()->shouldBeCalled()->willReturn([]);
+        $field = $this->createMock(FieldDescriptionInterface::class);
+        $field->expects($this->once())->method('getAssociationAdmin')->willReturn($admin);
+        $field->expects($this->atLeastOnce())->method('getFieldName')->willReturn('foo');
+        $field->expects($this->once())->method('getParentAssociationMappings')->willReturn([]);
 
         $this->builder->add('foo');
 
         try {
             $this->adminType->buildForm($this->builder, [
-                'sonata_field_description' => $field->reveal(),
+                'sonata_field_description' => $field,
                 'delete' => false, // not needed
                 'property_path' => '[0]', // actual test case
             ]);
@@ -191,38 +192,38 @@ class AdminTypeTest extends TypeTestCase
         $parentSubject = new \stdClass();
         $parentSubject->foo = new ArrayCollection([]);
 
-        $parentAdmin = $this->prophesize(AdminInterface::class);
-        $parentAdmin->getSubject()->shouldBeCalled()->willReturn($parentSubject);
-        $parentAdmin->hasSubject()->shouldBeCalled()->willReturn(true);
-        $parentField = $this->prophesize(FieldDescriptionInterface::class);
-        $parentField->setAssociationAdmin(Argument::type(AdminInterface::class))->shouldBeCalled();
-        $parentField->getAdmin()->shouldBeCalled()->willReturn($parentAdmin->reveal());
-        $parentField->getParentAssociationMappings()->willReturn([]);
-        $parentField->getAssociationMapping()->willReturn(['fieldName' => 'foo', 'mappedBy' => 'bar']);
+        $parentAdmin = $this->createMock(AdminInterface::class);
+        $parentAdmin->expects($this->once())->method('getSubject')->willReturn($parentSubject);
+        $parentAdmin->expects($this->once())->method('hasSubject')->willReturn(true);
+        $parentField = $this->createMock(FieldDescriptionInterface::class);
+        $parentField->expects($this->once())->method('setAssociationAdmin')->with($this->isInstanceOf(AdminInterface::class));
+        $parentField->expects($this->once())->method('getAdmin')->willReturn($parentAdmin);
+        $parentField->expects($this->once())->method('getParentAssociationMappings')->willReturn([]);
+        $parentField->expects($this->once())->method('getAssociationMapping')->willReturn(['fieldName' => 'foo', 'mappedBy' => 'bar']);
 
-        $modelManager = $this->prophesize(ModelManagerInterface::class);
+        $modelManager = $this->createStub(ModelManagerInterface::class);
 
         $newInstance = new Foo();
 
-        $admin = $this->prophesize(AbstractAdmin::class);
-        $admin->hasParentFieldDescription()->shouldBeCalled()->willReturn(true);
-        $admin->getParentFieldDescription()->shouldBeCalled()->willReturn($parentField->reveal());
-        $admin->defineFormBuilder(new AnyValueToken())->shouldBeCalled();
-        $admin->getModelManager()->shouldBeCalled()->willReturn($modelManager);
-        $admin->getClass()->shouldBeCalled()->willReturn(Foo::class);
-        $admin->setSubject($newInstance)->shouldBeCalled();
-        $admin->getNewInstance()->shouldBeCalled()->willReturn($newInstance);
+        $admin = $this->createMock(AbstractAdmin::class);
+        $admin->expects($this->atLeastOnce())->method('hasParentFieldDescription')->willReturn(true);
+        $admin->expects($this->atLeastOnce())->method('getParentFieldDescription')->willReturn($parentField);
+        $admin->expects($this->once())->method('defineFormBuilder');
+        $admin->expects($this->once())->method('getModelManager')->willReturn($modelManager);
+        $admin->expects($this->once())->method('getClass')->willReturn(Foo::class);
+        $admin->expects($this->once())->method('setSubject')->with($newInstance);
+        $admin->expects($this->once())->method('getNewInstance')->willReturn($newInstance);
 
-        $field = $this->prophesize(FieldDescriptionInterface::class);
-        $field->getAssociationAdmin()->shouldBeCalled()->willReturn($admin->reveal());
-        $field->getFieldName()->shouldBeCalled()->willReturn('foo');
-        $field->getParentAssociationMappings()->shouldBeCalled()->willReturn([]);
+        $field = $this->createMock(FieldDescriptionInterface::class);
+        $field->expects($this->once())->method('getAssociationAdmin')->willReturn($admin);
+        $field->expects($this->atLeastOnce())->method('getFieldName')->willReturn('foo');
+        $field->expects($this->once())->method('getParentAssociationMappings')->willReturn([]);
 
         $this->builder->add('foo');
 
         try {
             $this->adminType->buildForm($this->builder, [
-                'sonata_field_description' => $field->reveal(),
+                'sonata_field_description' => $field,
                 'delete' => false, // not needed
                 'property_path' => '[0]', // actual test case
             ]);
@@ -235,7 +236,7 @@ class AdminTypeTest extends TypeTestCase
     {
         $extensions = parent::getExtensions();
 
-        $guesser = $this->prophesize(FormTypeGuesserInterface::class)->reveal();
+        $guesser = $this->createStub(FormTypeGuesserInterface::class);
         $extension = new TestExtension($guesser);
 
         $extension->addTypeExtension(new FormTypeFieldExtension([], []));

--- a/tests/Form/Type/ChoiceFieldMaskTypeTest.php
+++ b/tests/Form/Type/ChoiceFieldMaskTypeTest.php
@@ -80,20 +80,18 @@ class ChoiceFieldMaskTypeTest extends TypeTestCase
     {
         $choiceFieldMaskType = new ChoiceFieldMaskType();
 
-        $view = $this->prophesize(FormView::class);
-        $form = $this->prophesize(FormInterface::class);
-        $options = [
-            'map' => [
-                'choice_1' => ['field1', 'field2'],
-                'choice_2' => ['field__3', 'field.4'],
-                'choice_3' => ['field1', 'field5'],
-            ],
-        ];
+        $view = $this->createStub(FormView::class);
 
         $choiceFieldMaskType->buildView(
-            $view->reveal(),
-            $form->reveal(),
-            $options
+            $view,
+            $this->createStub(FormInterface::class),
+            [
+                'map' => [
+                    'choice_1' => ['field1', 'field2'],
+                    'choice_2' => ['field__3', 'field.4'],
+                    'choice_3' => ['field1', 'field5'],
+                ],
+            ]
         );
 
         $expectedAllFields = [
@@ -119,30 +117,27 @@ class ChoiceFieldMaskTypeTest extends TypeTestCase
             ],
         ];
 
-        $this->assertSame(array_values($expectedAllFields), array_values($view->reveal()->vars['all_fields']), '"all_fields" is not as expected');
-        $this->assertSame($expectedMap, $view->reveal()->vars['map'], '"map" is not as expected');
+        $this->assertSame(array_values($expectedAllFields), array_values($view->vars['all_fields']), '"all_fields" is not as expected');
+        $this->assertSame($expectedMap, $view->vars['map'], '"map" is not as expected');
     }
 
     public function testBuildViewWithFaultyMapValues(): void
     {
-        $options = ['map' => [
-            'int' => 1,
-            'string' => 'string',
-            'boolean' => false,
-            'array' => ['field_1', 'field_2'],
-            'empty_array' => [],
-            'class' => new \stdClass(),
-        ]];
-
         $choiceFieldMaskType = new ChoiceFieldMaskType();
 
-        $view = $this->prophesize(FormView::class);
-        $form = $this->prophesize(FormInterface::class);
+        $view = $this->createStub(FormView::class);
 
         $choiceFieldMaskType->buildView(
-            $view->reveal(),
-            $form->reveal(),
-            $options
+            $view,
+            $this->createStub(FormInterface::class),
+            ['map' => [
+                'int' => 1,
+                'string' => 'string',
+                'boolean' => false,
+                'array' => ['field_1', 'field_2'],
+                'empty_array' => [],
+                'class' => new \stdClass(),
+            ]]
         );
 
         $expectedAllFields = ['field_1', 'field_2'];
@@ -150,8 +145,8 @@ class ChoiceFieldMaskTypeTest extends TypeTestCase
             'array' => ['field_1', 'field_2'],
         ];
 
-        $this->assertSame(array_values($expectedAllFields), array_values($view->reveal()->vars['all_fields']), '"all_fields" is not as expected');
-        $this->assertSame($expectedMap, $view->reveal()->vars['map'], '"map" is not as expected');
+        $this->assertSame(array_values($expectedAllFields), array_values($view->vars['all_fields']), '"all_fields" is not as expected');
+        $this->assertSame($expectedMap, $view->vars['map'], '"map" is not as expected');
     }
 
     private function resolveOptions(array $options): array

--- a/tests/Form/Type/ModelListTypeTest.php
+++ b/tests/Form/Type/ModelListTypeTest.php
@@ -23,7 +23,7 @@ class ModelListTypeTest extends TypeTestCase
 
     protected function setUp(): void
     {
-        $this->modelManager = $this->prophesize(ModelManagerInterface::class);
+        $this->modelManager = $this->createMock(ModelManagerInterface::class);
 
         parent::setUp();
     }
@@ -36,11 +36,11 @@ class ModelListTypeTest extends TypeTestCase
             ModelListType::class,
             null,
             [
-                'model_manager' => $this->modelManager->reveal(),
+                'model_manager' => $this->modelManager,
                 'class' => 'My\Entity',
             ]
         );
-        $this->modelManager->find('My\Entity', 42)->shouldBeCalled();
+        $this->modelManager->expects($this->once())->method('find')->with('My\Entity', 42);
         $form->submit($formData);
         $this->assertTrue($form->isSynchronized());
     }

--- a/tests/Form/Type/ModelReferenceTypeTest.php
+++ b/tests/Form/Type/ModelReferenceTypeTest.php
@@ -24,7 +24,7 @@ class ModelReferenceTypeTest extends TypeTestCase
 
     protected function setUp(): void
     {
-        $this->modelManager = $this->prophesize(ModelManagerInterface::class);
+        $this->modelManager = $this->createMock(ModelManagerInterface::class);
 
         parent::setUp();
     }
@@ -37,11 +37,11 @@ class ModelReferenceTypeTest extends TypeTestCase
             ModelReferenceType::class,
             null,
             [
-                'model_manager' => $this->modelManager->reveal(),
+                'model_manager' => $this->modelManager,
                 'class' => 'My\Entity',
             ]
         );
-        $this->modelManager->find('My\Entity', 42)->shouldBeCalled();
+        $this->modelManager->expects($this->once())->method('find')->with('My\Entity', 42);
         $form->submit($formData);
         $this->assertTrue($form->isSynchronized());
     }

--- a/tests/Functional/Translator/Extractor/AdminExtractorTest.php
+++ b/tests/Functional/Translator/Extractor/AdminExtractorTest.php
@@ -25,12 +25,12 @@ final class AdminExtractorTest extends KernelTestCase
         $tester = $this->createCommandTester();
         $tester->execute(['locale' => 'en']);
 
-        $this->assertRegExp('/group_label/', $tester->getDisplay());
-        $this->assertRegExp('/admin_label/', $tester->getDisplay());
-        $this->assertRegExp('/Name Show/', $tester->getDisplay());
-        $this->assertRegExp('/Name List/', $tester->getDisplay());
-        $this->assertRegExp('/Name Form/', $tester->getDisplay());
-        $this->assertRegExp('/Date Published/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/group_label/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/admin_label/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/Name Show/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/Name List/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/Name Form/', $tester->getDisplay());
+        $this->assertMatchesRegularExpression('/Date Published/', $tester->getDisplay());
     }
 
     protected static function getKernelClass(): string

--- a/tests/Maker/AdminMakerTest.php
+++ b/tests/Maker/AdminMakerTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Maker;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Sonata\AdminBundle\Maker\AdminMaker;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
@@ -73,11 +72,11 @@ class AdminMakerTest extends TestCase
 
     protected function setup(): void
     {
-        $managerOrmProxy = $this->prophesize(ModelManagerInterface::class);
-        $managerOrmProxy->getExportFields(Argument::exact(Foo::class))
+        $managerOrmProxy = $this->createStub(ModelManagerInterface::class);
+        $managerOrmProxy->method('getExportFields')->with(Foo::class)
             ->willReturn(['bar', 'baz']);
 
-        $this->modelManagers = ['sonata.admin.manager.orm' => $managerOrmProxy->reveal()];
+        $this->modelManagers = ['sonata.admin.manager.orm' => $managerOrmProxy];
         $this->servicesFile = sprintf('%s.yml', lcg_value());
         $this->projectDirectory = sprintf('%s/sonata-admin-bundle/', sys_get_temp_dir());
         $this->filesystem = new Filesystem();

--- a/tests/Menu/Integration/TabMenuTest.php
+++ b/tests/Menu/Integration/TabMenuTest.php
@@ -15,7 +15,6 @@ namespace Sonata\AdminBundle\Tests\Menu\Integration;
 
 use Knp\Menu\MenuFactory;
 use Knp\Menu\MenuItem;
-use Prophecy\Argument;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class TabMenuTest extends BaseMenuTest
@@ -33,17 +32,16 @@ class TabMenuTest extends BaseMenuTest
 
     public function testLabelTranslationNominalCase(): void
     {
-        $translatorProphecy = $this->prophesize(TranslatorInterface::class);
-        $translatorProphecy
-            ->trans(
+        $this->translator = $this->createStub(TranslatorInterface::class);
+        $this->translator->method('trans')
+            ->with(
                 'some-label',
                 [],
-                Argument::any(), //messages or null
+                null, //messages or null
                 null
             )
             ->willReturn('my-translation');
 
-        $this->translator = $translatorProphecy->reveal();
         $factory = new MenuFactory();
         $menu = new MenuItem('test-menu', $factory);
         $menu->addChild('some-label', ['uri' => '/whatever']);
@@ -53,17 +51,16 @@ class TabMenuTest extends BaseMenuTest
     public function testLabelTranslationWithParameters(): void
     {
         $params = ['my' => 'param'];
-        $translatorProphecy = $this->prophesize(TranslatorInterface::class);
-        $translatorProphecy
-            ->trans(
+        $this->translator = $this->createStub(TranslatorInterface::class);
+        $this->translator->method('trans')
+            ->with(
                 'some-label',
                 $params,
-                Argument::any(), // messages or null
+                null, // messages or null
                 null
             )
             ->willReturn('my-translation');
 
-        $this->translator = $translatorProphecy->reveal();
         $factory = new MenuFactory();
         $menu = new MenuItem('test-menu', $factory);
         $menu->addChild('some-label', ['uri' => '/whatever'])
@@ -74,15 +71,12 @@ class TabMenuTest extends BaseMenuTest
 
     public function testLabelTranslationDomainOverride(): void
     {
-        $translatorProphecy = $this->prophesize(TranslatorInterface::class);
-        $translatorProphecy
-            ->trans('some-label', [], 'my_local_domain', null)
-            ->willReturn('my-translation');
-        $translatorProphecy
-            ->trans('some-other-label', [], 'my_global_domain', null)
-            ->willReturn('my-other-translation');
+        $this->translator = $this->createStub(TranslatorInterface::class);
+        $this->translator->method('trans')->willReturnMap([
+            ['some-label', [], 'my_local_domain', null, 'my-translation'],
+            ['some-other-label', [], 'my_global_domain', null, 'my-other-translation'],
+        ]);
 
-        $this->translator = $translatorProphecy->reveal();
         $factory = new MenuFactory();
         $menu = new MenuItem('test-menu', $factory);
         $menu->setExtra('translation_domain', 'my_global_domain');

--- a/tests/SonataAdminBundleTest.php
+++ b/tests/SonataAdminBundleTest.php
@@ -33,9 +33,7 @@ class SonataAdminBundleTest extends TestCase
 {
     public function testBuild(): void
     {
-        $containerBuilder = $this->getMockBuilder(ContainerBuilder::class)
-            ->setMethods(['addCompilerPass'])
-            ->getMock();
+        $containerBuilder = $this->createMock(ContainerBuilder::class);
 
         $containerBuilder->expects($this->exactly(7))
             ->method('addCompilerPass')

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
@@ -155,20 +154,24 @@ class SonataAdminExtensionTest extends TestCase
 
         $this->translator = $translator;
 
-        $this->templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
-        $this->container = $this->prophesize(ContainerInterface::class);
-        $this->container->get('sonata_admin_foo_service.template_registry')->willReturn($this->templateRegistry->reveal());
+        $this->templateRegistry = $this->createStub(TemplateRegistryInterface::class);
+        $this->container = $this->createStub(ContainerInterface::class);
+        $this->container->method('get')->with('sonata_admin_foo_service.template_registry')
+            ->willReturn($this->templateRegistry);
 
-        $this->securityChecker = $this->prophesize(AuthorizationCheckerInterface::class);
-        $this->securityChecker->isGranted(['foo', 'bar'], null)->willReturn(false);
-        $this->securityChecker->isGranted(Argument::type('string'), null)->willReturn(true);
+        $this->securityChecker = $this->createStub(AuthorizationCheckerInterface::class);
+        $this->securityChecker->method('isGranted')->willReturnMap([
+            [['foo', 'bar'], null, false],
+            ['foo', null, true],
+            ['bar', null, true],
+        ]);
 
         $this->twigExtension = new SonataAdminExtension(
             $this->pool,
             $this->logger,
             $this->translator,
-            $this->container->reveal(),
-            $this->securityChecker->reveal()
+            $this->container,
+            $this->securityChecker
         );
         $this->twigExtension->setXEditableTypeMapping($this->xEditableTypeMapping);
 
@@ -318,7 +321,8 @@ class SonataAdminExtensionTest extends TestCase
             ->with('base_list_field')
             ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
-        $this->templateRegistry->getTemplate('base_list_field')->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
         $this->fieldDescription
             ->method('getValue')
@@ -400,7 +404,8 @@ class SonataAdminExtensionTest extends TestCase
             ->with('base_list_field')
             ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
-        $this->templateRegistry->getTemplate('base_list_field')->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
         $this->fieldDescription
             ->method('getTemplate')
@@ -430,7 +435,8 @@ class SonataAdminExtensionTest extends TestCase
             ->with('base_list_field')
             ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
-        $this->templateRegistry->getTemplate('base_list_field')->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
         $this->fieldDescription
             ->method('getValue')
@@ -464,7 +470,8 @@ class SonataAdminExtensionTest extends TestCase
             ->with('base_list_field')
             ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
-        $this->templateRegistry->getTemplate('base_list_field')->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
         $this->fieldDescription
             ->method('getValue')
@@ -1493,7 +1500,8 @@ EOT
             ->with('base_list_field')
             ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
-        $this->templateRegistry->getTemplate('base_list_field')->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
 
         $this->fieldDescription->expects($this->once())
             ->method('getValue')
@@ -1537,7 +1545,8 @@ EOT
             ->with('base_list_field')
             ->willReturn('@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig');
 
-        $this->templateRegistry->getTemplate('base_list_field')->willReturn('@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig');
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig');
 
         $this->fieldDescription->expects($this->once())
             ->method('getTemplate')

--- a/tests/Twig/Extension/TemplateRegistryExtensionTest.php
+++ b/tests/Twig/Extension/TemplateRegistryExtensionTest.php
@@ -50,20 +50,20 @@ class TemplateRegistryExtensionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->templateRegistry = $this->prophesize(TemplateRegistryInterface::class);
-        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->templateRegistry = $this->createStub(TemplateRegistryInterface::class);
+        $this->container = $this->createStub(ContainerInterface::class);
 
         // NEXT_MAJOR: Remove this line
-        $this->admin = $this->prophesize(AdminInterface::class);
+        $this->admin = $this->createStub(AdminInterface::class);
 
         // NEXT_MAJOR: Remove this line
-        $this->admin->getTemplate('edit')->willReturn('@SonataAdmin/CRUD/edit.html.twig');
+        $this->admin->method('getTemplate')->with('edit')->willReturn('@SonataAdmin/CRUD/edit.html.twig');
 
-        $this->templateRegistry->getTemplate('edit')->willReturn('@SonataAdmin/CRUD/edit.html.twig');
+        $this->templateRegistry->method('getTemplate')->with('edit')->willReturn('@SonataAdmin/CRUD/edit.html.twig');
 
         $this->extension = new TemplateRegistryExtension(
-            $this->templateRegistry->reveal(),
-            $this->container->reveal()
+            $this->templateRegistry,
+            $this->container
         );
     }
 
@@ -82,10 +82,11 @@ class TemplateRegistryExtensionTest extends TestCase
 
     public function testGetAdminTemplate(): void
     {
-        // NEXT_MAJOR: Remove this line
-        $this->container->get('admin.post')->willReturn($this->admin->reveal());
-
-        $this->container->get('admin.post.template_registry')->willReturn($this->templateRegistry->reveal());
+        $this->container->method('get')->willReturnMap([
+            // NEXT_MAJOR: Remove this line
+            ['admin.post', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $this->admin],
+            ['admin.post.template_registry', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $this->templateRegistry],
+        ]);
 
         $this->assertSame(
             '@SonataAdmin/CRUD/edit.html.twig',
@@ -95,10 +96,6 @@ class TemplateRegistryExtensionTest extends TestCase
 
     public function testGetAdminTemplateFailure(): void
     {
-        // NEXT_MAJOR: Remove this line
-        $this->container->get('admin.post')->willReturn(null);
-        $this->container->get('admin.post.template_registry')->willReturn(null);
-
         $this->expectException(ServiceNotFoundException::class);
 
         // NEXT_MAJOR: Remove this line and use the commented line below instead

--- a/tests/Util/ObjectAclManipulatorTest.php
+++ b/tests/Util/ObjectAclManipulatorTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Util\DummyObjectAclManipulator;
@@ -30,29 +29,29 @@ class ObjectAclManipulatorTest extends TestCase
 {
     protected function setUp(): void
     {
-        $this->output = $this->prophesize(OutputInterface::class);
-        $this->admin = $this->prophesize(AdminInterface::class);
+        $this->output = $this->createStub(OutputInterface::class);
+        $this->admin = $this->createStub(AdminInterface::class);
         $this->oids = new \ArrayIterator([
-            $this->prophesize(ObjectIdentityInterface::class)->reveal(),
-            $this->prophesize(ObjectIdentityInterface::class)->reveal(),
+            $this->createStub(ObjectIdentityInterface::class),
+            $this->createStub(ObjectIdentityInterface::class),
         ]);
         $this->securityIdentity = new UserSecurityIdentity('Michael', \stdClass::class);
     }
 
     public function testConfigureAclsIgnoresNonAclSecurityHandlers(): void
     {
-        $this->admin->getSecurityHandler()->shouldBeCalled();
-        $this->admin->getCode()->shouldBeCalled()->willReturn('test');
-        $this->output->writeln(Argument::allOf(
-            Argument::containingString('ignoring'),
-            Argument::containingString('test')
-        ))->shouldBeCalled();
+        $this->admin->expects($this->once())->method('getSecurityHandler');
+        $this->admin->expects($this->once())->method('getCode')->willReturn('test');
+        $this->output->expects($this->once())->method('writeln')->with($this->logicalAnd(
+            $this->stringContains('ignoring'),
+            $this->stringContains('test')
+        ));
         $manipulator = new DummyObjectAclManipulator();
         $this->assertSame(
             [0, 0],
             $manipulator->configureAcls(
-                $this->output->reveal(),
-                $this->admin->reveal(),
+                $this->output,
+                $this->admin,
                 $this->oids,
                 $this->securityIdentity
             )
@@ -61,35 +60,33 @@ class ObjectAclManipulatorTest extends TestCase
 
     public function testConfigureAcls(): void
     {
-        $securityHandler = $this->prophesize(AclSecurityHandlerInterface::class);
-        $acls = $this->prophesize('SplObjectStorage');
-        $acls->contains(Argument::type(ObjectIdentityInterface::class))
-            ->shouldBeCalled()
+        $securityHandler = $this->createMock(AclSecurityHandlerInterface::class);
+        $acls = $this->createMock('SplObjectStorage');
+        $acls->expects($this->atLeastOnce())->method('contains')->with($this->isInstanceOf(ObjectIdentityInterface::class))
             ->willReturn(false, true);
-        $acl = $this->prophesize(AclInterface::class)->reveal();
-        $acls->offsetGet(Argument::type(ObjectIdentityInterface::class))
-            ->shouldBeCalled()
+        $acl = $this->createStub(AclInterface::class);
+        $acls->expects($this->once())->method('offsetGet')->with($this->isInstanceOf(ObjectIdentityInterface::class))
             ->willReturn($acl);
-        $securityHandler->findObjectAcls($this->oids)->shouldBeCalled()->willReturn($acls->reveal());
-        $securityHandler->createAcl(Argument::type(ObjectIdentityInterface::class))->shouldBeCalled()->willReturn($acl);
-        $securityHandler->addObjectOwner($acl, Argument::type(UserSecurityIdentity::class))->shouldBeCalled();
-        $securityHandler->buildSecurityInformation($this->admin)->shouldBeCalled()->willReturn([]);
-        $securityHandler->addObjectClassAces($acl, [])->shouldBeCalled();
-        $securityHandler->updateAcl($acl)->shouldBeCalled()->willThrow(new \Exception('test exception'));
-        $this->output->writeln(Argument::allOf(
-            Argument::containingString('ignoring'),
-            Argument::containingString('test exception')
-        ))->shouldBeCalled();
+        $securityHandler->expects($this->once())->method('findObjectAcls')->with($this->oids)->willReturn($acls);
+        $securityHandler->expects($this->once())->method('createAcl')->with($this->isInstanceOf(ObjectIdentityInterface::class))->willReturn($acl);
+        $securityHandler->expects($this->atLeastOnce())->method('addObjectOwner')->with($acl, $this->isInstanceOf(UserSecurityIdentity::class));
+        $securityHandler->expects($this->atLeastOnce())->method('buildSecurityInformation')->with($this->admin)->willReturn([]);
+        $securityHandler->expects($this->atLeastOnce())->method('addObjectClassAces')->with($acl, []);
+        $securityHandler->expects($this->atLeastOnce())->method('updateAcl')->with($acl)->willThrowException(new \Exception('test exception'));
+        $this->output->method('writeln')->with($this->logicalAnd(
+            $this->stringContains('ignoring'),
+            $this->stringContains('test exception')
+        ));
 
-        $this->admin->getSecurityHandler()->shouldBeCalled()->willReturn($securityHandler->reveal());
+        $this->admin->expects($this->once())->method('getSecurityHandler')->willReturn($securityHandler);
 
         $manipulator = new DummyObjectAclManipulator();
 
         $this->assertSame(
             [1, 1],
             $manipulator->configureAcls(
-                $this->output->reveal(),
-                $this->admin->reveal(),
+                $this->output,
+                $this->admin,
                 $this->oids,
                 $this->securityIdentity
             )


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a changes on tests plus a patch on src

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Call to deprecated `getTargetEntity`
```


<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

This will allow us to have the php 8 build running without errors. Also it will allow to remove prophecy usage and to upgrade all builds to use phpunit 9 (Except php 7.2)
This is the first step, there are other changes needed on dev-kit and on other repositories
