### PR TITLE
Rise requirements to php 7.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,14 +22,13 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - '7.2'
           - '7.3'
           - '7.4'
         dependencies: [highest]
         allowed_to_fail: [false]
         variant: [normal]
         include:
-          - php-version: '7.2'
+          - php-version: '7.3'
             dependencies: lowest
             allowed_to_fail: false
             variant: normal

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-json": "*",
         "doctrine/collections": "^1.6",
         "doctrine/common": "^2.7 || ^3.0",


### PR DESCRIPTION
Since php 7.2 will soon get it's end of life (see https://www.php.net/supported-versions.php). I think it will be useful to rise the requirements to php 7.3