### PR TITLE
Prevent deprecation notice when AdminInterface.isCurrentChild is implemented

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2435,12 +2435,16 @@ EOT;
      */
     public function getCurrentChildAdmin()
     {
-        foreach ($this->children as $children) {
+        foreach ($this->children as $child) {
             // NEXT_MAJOR: Remove method_exists check and delete elseif case
-            if (method_exists($children, 'isCurrentChild') && $children->isCurrentChild()) {
-                return $children;
-            } elseif ($children->getCurrentChild()) {
-                return $children;
+            if (method_exists($child, 'isCurrentChild')) {
+                if ($child->isCurrentChild()) {
+                    return $child;
+                }
+            } else {
+                if ($child->getCurrentChild()) {
+                    return $child;
+                }
             }
         }
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -2678,11 +2678,6 @@ class AdminTest extends TestCase
         $this->assertSame(2, $commentVoteAdmin->getChildDepth());
     }
 
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation The Sonata\AdminBundle\Admin\AbstractAdmin::getCurrentChild() method is deprecated since version 3.65 and will be removed in 4.0. Use Sonata\AdminBundle\Admin\AbstractAdmin::isCurrentChild() instead.
-     */
     public function testGetCurrentLeafChildAdmin(): void
     {
         $postAdmin = new PostAdmin(


### PR DESCRIPTION
## Subject

Even when a child admin instance implements the `isCurrentChild()` method, `getCurrentChildAdmin()` will try to call the deprecated method `getCurrentChild()` anyway, causing this deprecation notice:

>  User Deprecated: The Sonata\AdminBundle\Admin\AbstractAdmin::getCurrentChild() method is deprecated since version 3.65 and will be removed in 4.0. Use Sonata\AdminBundle\Admin\AbstractAdmin::isCurrentChild() instead.

I changed the code such that `getCurrentChildAdmin()` only calls `getCurrentChild()` when `isCurrentChild()` is not implemented.

I am targeting this branch, because it's a backwards compatible improvement.

## Changelog

```markdown
### Fixed
- Superfluous deprecation notice in `getCurrentChild()` when calling `getCurrentChildAdmin()`.
```