### PR TITLE
Access to CollectionType options in AdminType

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,8 @@
         "doctrine/doctrine-bundle": ">=3",
         "sonata-project/core-bundle": "<3.20",
         "sonata-project/doctrine-extensions": "<1.8",
+        "sonata-project/doctrine-mongodb-admin-bundle": "<3.5",
+        "sonata-project/doctrine-orm-admin-bundle": "<3.24",
         "sonata-project/media-bundle": "<3.7",
         "sonata-project/user-bundle": "<3.3"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -229,6 +229,12 @@ parameters:
             count: 1
             path: src/Command/CreateClassCacheCommand.php
 
+        -
+            # will be fixed in v4. Currently BC break
+            message: "#^Method Sonata\\\\AdminBundle\\\\Builder\\\\FormContractorInterface\\:\\:getDefaultOptions\\(\\) invoked with 3 parameters, 2 required\\.$#"
+            count: 1
+            path: src/Form/FormMapper.php
+
 # next 6 errors are due to not installed Doctrine ORM\ODM
         -
             message: "#^Class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection not found\\.$#"

--- a/src/Builder/FormContractorInterface.php
+++ b/src/Builder/FormContractorInterface.php
@@ -31,14 +31,16 @@ interface FormContractorInterface extends BuilderInterface
      *
      * @return FormBuilderInterface
      */
-    public function getFormBuilder($name, array $options = []);
+    public function getFormBuilder($name, array $formOptions = []);
 
     /**
+     * NEXT_MAJOR: Change signature to add the third parameter $formOptions.
+     *
      * Should provide Symfony form options.
      *
      * @param string|null $type
      *
      * @return array
      */
-    public function getDefaultOptions($type, FieldDescriptionInterface $fieldDescription);
+    public function getDefaultOptions($type, FieldDescriptionInterface $fieldDescription/*, array $formOptions = []*/);
 }

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -130,7 +130,10 @@ class FormMapper extends BaseGroupedMapper
             $name = $fieldDescription->getName();
 
             // Note that the builder var is actually the formContractor:
-            $options = array_replace_recursive($this->builder->getDefaultOptions($type, $fieldDescription) ?? [], $options);
+            $options = array_replace_recursive(
+                $this->builder->getDefaultOptions($type, $fieldDescription, $options),
+                $options
+            );
 
             // be compatible with mopa if not installed, avoid generating an exception for invalid option
             // force the default to false ...

--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -110,7 +110,13 @@ class AdminType extends AbstractType
                         $subject = $p->getValue($parentSubject, $parentPath.$path);
                     } catch (NoSuchIndexException $e) {
                         // no object here, we create a new one
-                        $subject = ObjectManipulator::setObject($admin->getNewInstance(), $parentSubject, $parentFieldDescription);
+                        $subject = $admin->getNewInstance();
+
+                        if ($options['by_reference']) {
+                            $subject = ObjectManipulator::addInstance($parentSubject, $subject, $parentFieldDescription);
+                        } else {
+                            $subject = ObjectManipulator::setObject($subject, $parentSubject, $parentFieldDescription);
+                        }
                     }
                 }
             }

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -57,6 +57,7 @@ class FormMapperTest extends TestCase
     protected function setUp(): void
     {
         $this->contractor = $this->createMock(FormContractorInterface::class);
+        $this->contractor->method('getDefaultOptions')->willReturn([]);
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);

--- a/tests/Form/Type/AdminTypeTest.php
+++ b/tests/Form/Type/AdminTypeTest.php
@@ -70,8 +70,8 @@ class AdminTypeTest extends TypeTestCase
         $foo = new Foo();
 
         $admin = $this->createMock(AbstractAdmin::class);
-        $admin->expects($this->atLeastOnce())->method('hasParentFieldDescription')->willReturn(true);
-        $admin->expects($this->atLeastOnce())->method('getParentFieldDescription')->willReturn($parentField);
+        $admin->expects($this->exactly(2))->method('hasParentFieldDescription')->willReturn(true);
+        $admin->expects($this->exactly(2))->method('getParentFieldDescription')->willReturn($parentField);
         $admin->expects($this->once())->method('hasAccess')->with('delete')->willReturn(false);
         $admin->expects($this->once())->method('defineFormBuilder');
         $admin->expects($this->once())->method('getModelManager')->willReturn($modelManager);
@@ -120,8 +120,8 @@ class AdminTypeTest extends TypeTestCase
         $modelManager = $this->createStub(ModelManagerInterface::class);
 
         $admin = $this->createMock(AbstractAdmin::class);
-        $admin->expects($this->atLeastOnce())->method('hasParentFieldDescription')->willReturn(true);
-        $admin->expects($this->atLeastOnce())->method('getParentFieldDescription')->willReturn($parentField);
+        $admin->expects($this->exactly(2))->method('hasParentFieldDescription')->willReturn(true);
+        $admin->expects($this->exactly(2))->method('getParentFieldDescription')->willReturn($parentField);
         $admin->expects($this->once())->method('setSubject')->with(1);
         $admin->expects($this->once())->method('defineFormBuilder');
         $admin->expects($this->once())->method('getModelManager')->willReturn($modelManager);
@@ -162,8 +162,8 @@ class AdminTypeTest extends TypeTestCase
         $modelManager = $this->createStub(ModelManagerInterface::class);
 
         $admin = $this->createMock(AbstractAdmin::class);
-        $admin->expects($this->atLeastOnce())->method('hasParentFieldDescription')->willReturn(true);
-        $admin->expects($this->atLeastOnce())->method('getParentFieldDescription')->willReturn($parentField);
+        $admin->expects($this->exactly(2))->method('hasParentFieldDescription')->willReturn(true);
+        $admin->expects($this->exactly(2))->method('getParentFieldDescription')->willReturn($parentField);
         $admin->expects($this->once())->method('defineFormBuilder');
         $admin->expects($this->once())->method('getModelManager')->willReturn($modelManager);
         $admin->expects($this->once())->method('getClass')->willReturn(Foo::class);
@@ -189,8 +189,9 @@ class AdminTypeTest extends TypeTestCase
 
     public function testArrayCollectionNotFound(): void
     {
-        $parentSubject = new \stdClass();
-        $parentSubject->foo = new ArrayCollection([]);
+        $parentSubject = new class() {
+            public $foo = [];
+        };
 
         $parentAdmin = $this->createMock(AdminInterface::class);
         $parentAdmin->expects($this->once())->method('getSubject')->willReturn($parentSubject);
@@ -203,11 +204,15 @@ class AdminTypeTest extends TypeTestCase
 
         $modelManager = $this->createStub(ModelManagerInterface::class);
 
-        $newInstance = new Foo();
+        $newInstance = new class() {
+            public function setBar()
+            {
+            }
+        };
 
         $admin = $this->createMock(AbstractAdmin::class);
-        $admin->expects($this->atLeastOnce())->method('hasParentFieldDescription')->willReturn(true);
-        $admin->expects($this->atLeastOnce())->method('getParentFieldDescription')->willReturn($parentField);
+        $admin->expects($this->exactly(2))->method('hasParentFieldDescription')->willReturn(true);
+        $admin->expects($this->exactly(2))->method('getParentFieldDescription')->willReturn($parentField);
         $admin->expects($this->once())->method('defineFormBuilder');
         $admin->expects($this->once())->method('getModelManager')->willReturn($modelManager);
         $admin->expects($this->once())->method('getClass')->willReturn(Foo::class);
@@ -226,6 +231,58 @@ class AdminTypeTest extends TypeTestCase
                 'sonata_field_description' => $field,
                 'delete' => false, // not needed
                 'property_path' => '[0]', // actual test case
+                'by_reference' => false,
+            ]);
+        } catch (NoSuchPropertyException $exception) {
+            $this->fail($exception->getMessage());
+        }
+    }
+
+    public function testArrayCollectionByReferenceNotFound(): void
+    {
+        $parentSubject = new class() {
+            public $foo = [];
+
+            public function addFoo()
+            {
+            }
+        };
+
+        $parentAdmin = $this->createMock(AdminInterface::class);
+        $parentAdmin->expects($this->once())->method('getSubject')->willReturn($parentSubject);
+        $parentAdmin->expects($this->once())->method('hasSubject')->willReturn(true);
+        $parentField = $this->createMock(FieldDescriptionInterface::class);
+        $parentField->expects($this->once())->method('setAssociationAdmin')->with($this->isInstanceOf(AdminInterface::class));
+        $parentField->expects($this->once())->method('getAdmin')->willReturn($parentAdmin);
+        $parentField->expects($this->once())->method('getParentAssociationMappings')->willReturn([]);
+        $parentField->expects($this->once())->method('getAssociationMapping')->willReturn(['fieldName' => 'foo', 'mappedBy' => 'bar']);
+
+        $modelManager = $this->createStub(ModelManagerInterface::class);
+
+        $newInstance = new \stdClass();
+
+        $admin = $this->createMock(AbstractAdmin::class);
+        $admin->expects($this->exactly(2))->method('hasParentFieldDescription')->willReturn(true);
+        $admin->expects($this->exactly(2))->method('getParentFieldDescription')->willReturn($parentField);
+        $admin->expects($this->once())->method('defineFormBuilder');
+        $admin->expects($this->once())->method('getModelManager')->willReturn($modelManager);
+        $admin->expects($this->once())->method('getClass')->willReturn(Foo::class);
+        $admin->expects($this->once())->method('setSubject')->with($newInstance);
+        $admin->expects($this->once())->method('getNewInstance')->willReturn($newInstance);
+
+        $field = $this->createMock(FieldDescriptionInterface::class);
+        $field->expects($this->once())->method('getAssociationAdmin')->willReturn($admin);
+        $field->expects($this->atLeastOnce())->method('getFieldName')->willReturn('foo');
+        $field->expects($this->once())->method('getParentAssociationMappings')->willReturn([]);
+
+        $this->builder->add('foo');
+
+        try {
+            $this->adminType->buildForm($this->builder, [
+                'sonata_field_description' => $field,
+                'delete' => false, // not needed
+                'property_path' => '[0]', // actual test case
+                'by_reference' => true,
             ]);
         } catch (NoSuchPropertyException $exception) {
             $this->fail($exception->getMessage());


### PR DESCRIPTION
This is related to https://github.com/sonata-project/SonataAdminBundle/issues/6426#issuecomment-702330648

I need to know the CollectionType value of `by_reference` in the AdminType.

The options are passed to the AdminType here:
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/src/Builder/FormContractor.php#L172-L180

So I need to change the signature of `getDefaultOptions` to allow passing the `formOptions`.

But then I have two solutions: 
- Option 1: Adding a new `symfony_form_options` option to the AdminType, then in the FormContractor I will add 
```
$options['symfony_form_options'] => $formOptions
```
And then I access to `by_reference` with `$options['symfony_form_options']['by_reference'] ?? true`.

- Option 2: Using the `by_reference` option of the AdminType, then in the FormContractor I will add 
```
if (isset($formOption['by_reference'])) {
    $options['by_reference'] => $formOptions['by_reference'];
}
```
And then I access to `by_reference` in the AdminType with `$options['by_reference']`.

WDYT @sonata-project/contributors ?

In this PR I have implemented the code for the solution 1, but passing all the options seems overkill to me and I think the solution 2 more elegant.