### PR TITLE
Moved confirmExit to window.load

### DIFF
--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -791,9 +791,6 @@ jQuery(window).resize(function() {
 
 jQuery(document).ready(function() {
     jQuery('html').removeClass('no-js');
-    if (Admin.get_config('CONFIRM_EXIT')) {
-        jQuery('.sonata-ba-form form').each(function () { jQuery(this).confirmExit(); });
-    }
 
     Admin.setup_per_page_switcher(document);
     Admin.setup_collection_buttons(document);
@@ -805,4 +802,12 @@ jQuery(document).on('sonata-admin-append-form-element', function(e) {
     Admin.setup_select2(e.target);
     Admin.setup_icheck(e.target);
     Admin.setup_collection_counter(e.target);
+});
+
+jQuery(window).load(function() {
+    if (Admin.get_config('CONFIRM_EXIT')) {
+        jQuery('.sonata-ba-form form').each(function() {
+            jQuery(this).confirmExit();
+        });
+    }
 });


### PR DESCRIPTION
## Moved confirmExit to window.load

Moved `jQuery(this).confirmExit()` to `window.load` to allow custom fields that edit the DOM which causes the form to always be marked as "changed". By moving this script to the `window.load` event you can add custom scripts before `confirmExit` is initialized. 

I am targeting this branch, because it enhances an existing feature.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

```markdown
### Changed
- Moved confirmExit to window.load
```