### PR TITLE
Deprecate DatagridManagerInterface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,12 @@
 UPGRADE 3.x
 ===========
 
+### Deprecated `Sonata\AdminBundle\Model\DatagridManagerInterface` interface.
+
+This interface has been deprecated without replacement.
+
+`ModelManagerInterface::getDefaultSortValues()` won't be used anymore.
+
 UPGRADE FROM 3.77 to 3.78
 =========================
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -830,7 +830,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     public function getFilterParameters()
     {
         $parameters = array_merge(
-            $this->getModelManager()->getDefaultSortValues($this->getClass()),
+            $this->getModelManager()->getDefaultSortValues($this->getClass()), // NEXT_MAJOR: Remove this line.
             $this->datagridValues, // NEXT_MAJOR: Remove this line.
             $this->getDefaultSortValues(),
             $this->getDefaultFilterValues()
@@ -1713,7 +1713,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     {
         // NEXT_MAJOR: Remove this line and uncomment the following.
         return $this->maxPerPage;
-        // $sortValues = $this->getModelManager()->getDefaultSortValues($this->class);
+        // $sortValues = $this->getDefaultSortValues();
 
         // return $sortValues['_per_page'] ?? 25;
     }
@@ -2932,7 +2932,7 @@ EOT;
     {
         // NEXT_MAJOR: Remove this line and uncomment the following
         return $this->perPageOptions;
-//        $perPageOptions = $this->getModelManager()->getDefaultPerPageOptions($this->class);
+//        $perPageOptions = [10, 25, 50, 100, 250];
 //        $perPageOptions[] = $this->getMaxPerPage();
 //
 //        $perPageOptions = array_unique($perPageOptions);
@@ -3326,7 +3326,9 @@ EOT;
      */
     final protected function getDefaultSortValues(): array
     {
+        // NEXT_MAJOR: Use the next line instead.
         $defaultSortValues = [];
+        // $defaultSortValues = ['_page' => 1, '_per_page' => 25];
 
         $this->configureDefaultSortValues($defaultSortValues);
 

--- a/src/Model/DatagridManagerInterface.php
+++ b/src/Model/DatagridManagerInterface.php
@@ -16,6 +16,10 @@ namespace Sonata\AdminBundle\Model;
 /**
  * A datagrid manager is a bridge between the model classes and the admin datagrid functionality.
  *
+ * NEXT_MAJOR: Remove this interface
+ *
+ * @deprecated since sonata-project/admin-bundle 3.x
+ *
  * @method array getDefaultPerPageOptions(string $class)
  */
 interface DatagridManagerInterface
@@ -28,12 +32,4 @@ interface DatagridManagerInterface
      * @return array<string, int|string>
      */
     public function getDefaultSortValues($class);
-
-//    NEXT_MAJOR: Uncomment the following lines.
-//    /**
-//     * Return all the allowed _per_page values.
-//     *
-//     * @return array<int>
-//     */
-//    public function getDefaultPerPageOptions(string $class): array;
 }

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -20,6 +20,8 @@ use Sonata\AdminBundle\Exception\ModelManagerException;
 use Sonata\Exporter\Source\SourceIteratorInterface;
 
 /**
+ * NEXT_MAJOR: Stop to extend DatagridManagerInterface.
+ *
  * A model manager is a bridge between the model classes and the admin functionality.
  *
  * @method bool supportsQuery(object $query)

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -167,11 +167,17 @@ final class ModelManager implements ModelManagerInterface
         return [];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getDefaultSortValues($class)
     {
         return [];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getDefaultPerPageOptions(string $class): array
     {
         return [];


### PR DESCRIPTION
## Subject

Related to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1144#issuecomment-703819774

I am targeting this branch, because BC.

Imho, this does not need to be modelManager-dependant.
WDYT ?

## Changelog

```markdown
### Deprecated
- `DatagridManagerInterface` with no replacement
```
