### PR TITLE
Narrow allowed types for ids passed to `find()` and `addIdentifiersToQuery()` in `ModelManagerInterface`

### DIFF
--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -82,8 +82,8 @@ interface ModelManagerInterface extends DatagridManagerInterface
     public function findOneBy($class, array $criteria = []);
 
     /**
-     * @param string $class
-     * @param mixed  $id
+     * @param string     $class
+     * @param int|string $id
      *
      * @return object|null the object with id or null if not found
      *
@@ -149,7 +149,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @param object $model
      *
-     * @return string[] list of all identifiers of this model
+     * @return array<int|string> list of all identifiers of this model
      */
     public function getIdentifierValues($model);
 
@@ -338,7 +338,8 @@ interface ModelManagerInterface extends DatagridManagerInterface
     public function getPaginationParameters(DatagridInterface $datagrid, $page);
 
     /**
-     * @param string $class
+     * @param string                 $class
+     * @param array<int, int|string> $idx
      *
      * @phpstan-param class-string $class
      */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Narrow allowed types for ids passed to `find()` and `addIdentifiersToQuery()` in `ModelManagerInterface`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to sonata-project/SonataDoctrineORMAdminBundle#1136.

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->