### PR TITLE
Add DataSourceInterface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,12 @@ UPGRADE 3.x
 UPGRADE FROM 3.77 to 3.78
 =========================
 
+### Deprecated `Sonata\AdminBundle\Model\ModelManagerInterface::getDataSourceIterator()`
+
+As replacement, you MUST inject an instance of `Sonata\AdminBundle\Exporter\DataSourceInterface` in your admin. This way, the method `DataSourceInterface::createIterator()` will be used instead.
+
+Setting a `DataSourceInterface` instance in your admin will be mandatory in version 4.0.
+
 ### Deprecated `Sonata\AdminBundle\Command\Validators::validateEntityName()`
 
 In version 3.77, the shortcut notation for model class names (`AppBundle:User`)

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -21,6 +21,7 @@ use Sonata\AdminBundle\Builder\ListBuilderInterface;
 use Sonata\AdminBundle\Builder\RouteBuilderInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Exporter\DataSourceInterface;
 use Sonata\AdminBundle\Filter\Persister\FilterPersisterInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Object\MetadataInterface;
@@ -64,6 +65,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @method void                            reorderFormGroup(string $group, array $keys)
  * @method void                            defineFormBuilder(FormBuilderInterface $formBuilder)
  * @method string                          getPagerType()
+ * @method DataSourceInterface|null        getDataSource()
  *
  * @phpstan-template T of object
  * @phpstan-extends AccessRegistryInterface<T>
@@ -172,6 +174,9 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @return ModelManagerInterface
      */
     public function getModelManager();
+
+    // NEXT_MAJOR: Uncomment the next line.
+    // public function getDataSource(): DataSourceInterface;
 
     /**
      * @return string the manager type of the admin

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -272,6 +272,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         $defaultAddServices = [
             'model_manager' => sprintf('sonata.admin.manager.%s', $managerType),
+            'data_source' => sprintf('sonata.admin.data_source.%s', $managerType),
             'form_contractor' => sprintf('sonata.admin.builder.%s_form', $managerType),
             'show_builder' => sprintf('sonata.admin.builder.%s_show', $managerType),
             'list_builder' => sprintf('sonata.admin.builder.%s_list', $managerType),
@@ -290,6 +291,11 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $definition->addMethodCall('setManagerType', [$managerType]);
 
         foreach ($defaultAddServices as $attr => $addServiceId) {
+            // NEXT_MAJOR: Remove this check
+            if ('data_source' === $attr && !$container->has($addServiceId)) {
+                continue;
+            }
+
             $method = $this->generateSetterMethodName($attr);
 
             if (isset($overwriteAdminConfiguration[$attr]) || !$definition->hasMethodCall($method)) {

--- a/src/Exporter/DataSourceInterface.php
+++ b/src/Exporter/DataSourceInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Exporter;
+
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\Exporter\Source\SourceIteratorInterface;
+
+interface DataSourceInterface
+{
+    public function createIterator(ProxyQueryInterface $query, array $field): SourceIteratorInterface;
+}

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -304,8 +304,12 @@ interface ModelManagerInterface extends DatagridManagerInterface
     public function executeQuery($query);
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param int|null $firstResult
      * @param int|null $maxResult
+     *
+     * @deprecated since sonata-admin/admin-bundle 3.x and will be removed in 4.0.
      *
      * @return SourceIteratorInterface
      */

--- a/tests/App/Exporter/DataSource.php
+++ b/tests/App/Exporter/DataSource.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Exporter;
+
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Exporter\DataSourceInterface;
+use Sonata\Exporter\Source\ArraySourceIterator;
+use Sonata\Exporter\Source\SourceIteratorInterface;
+
+class DataSource implements DataSourceInterface
+{
+    public function createIterator(ProxyQueryInterface $query, array $field): SourceIteratorInterface
+    {
+        return new ArraySourceIterator([]);
+    }
+}

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -34,6 +34,9 @@ services:
             - '@form.factory'
             - '@sonata.admin.pager.test'
 
+    sonata.admin.data_source.test:
+        class: Sonata\AdminBundle\Tests\App\Exporter\DataSource
+
     Sonata\AdminBundle\Tests\App\Admin\FooAdmin:
         arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
         tags:


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Related to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1144

## Changelog

```markdown
### Added
- Added DataSourceInterface

### Deprecate
- Deprecate not setting a DataSourceInterface to an Admin
- Deprecate `ModelManagerInterface::getDataSourceIterator()`
```