### PR TITLE
Deprecate Pool::getContainer method

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+### Deprecated `Sonata\AdminBundle\Admin\Pool::getContainer()` method.
+
+This method has been deprecated without replacement.
+
 ### Deprecated using shortcut notation when specifying the `user_model` option in `sonata:admin:generate-object-acl` command.
 
 The shortcut notation (`AppBundle:User`) has been deprecated in favor of the FQCN (`App\Model\User`) when passing

--- a/docs/cookbook/recipe_image_previews.rst
+++ b/docs/cookbook/recipe_image_previews.rst
@@ -51,9 +51,9 @@ we are manipulating form fields we do this from within ``ImageAdmin::configureFo
             // use $fileFormOptions so we can add other options to the field
             $fileFormOptions = ['required' => false];
             if ($image && ($webPath = $image->getWebPath())) {
-                // get the container so the full path to the image can be set
-                $container = $this->getConfigurationPool()->getContainer();
-                $fullPath = $container->get('request_stack')->getCurrentRequest()->getBasePath().'/'.$webPath;
+                // get the request so the full path to the image can be set
+                $request = $this->getRequest();
+                $fullPath = $request->getBasePath().'/'.$webPath;
 
                 // add a 'help' option containing the preview's img tag
                 $fileFormOptions['help'] = '<img src="'.$fullPath.'" class="admin-preview"/>';

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2377,7 +2377,7 @@ EOT;
         ), E_USER_DEPRECATED);
         if (null === $this->breadcrumbsBuilder) {
             $this->breadcrumbsBuilder = new BreadcrumbsBuilder(
-                $this->getConfigurationPool()->getContainer()->getParameter('sonata.admin.configuration.breadcrumbs')
+                $this->getConfigurationPool()->getContainer('sonata_deprecation_mute')->getParameter('sonata.admin.configuration.breadcrumbs')
             );
         }
 

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -387,10 +387,21 @@ class Pool
     }
 
     /**
-     * @return ContainerInterface|null
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x.
+     *
+     * @return ContainerInterface
      */
     public function getContainer()
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         return $this->container;
     }
 

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -88,7 +88,7 @@ abstract class BaseGroupedMapper extends BaseMapper
 
         // NEXT_MAJOR: remove this code
         if ($this->admin instanceof AbstractAdmin && $pool = $this->admin->getConfigurationPool()) {
-            if ($pool->getContainer()->getParameter('sonata.admin.configuration.translate_group_label')) {
+            if ($pool->getContainer('sonata_deprecation_mute')->getParameter('sonata.admin.configuration.translate_group_label')) {
                 $defaultOptions['label'] = $this->admin->getLabelTranslatorStrategy()->getLabel($name, $this->getName(), 'group');
             }
         }

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -494,6 +494,11 @@ class PoolTest extends TestCase
         $this->assertSame(['sonata.user.admin.group1', 'sonata.user.admin.group2', 'sonata.user.admin.group3'], $this->pool->getAdminServiceIds());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetContainer(): void
     {
         $this->assertInstanceOf(ContainerInterface::class, $this->pool->getContainer());

--- a/tests/Mapper/BaseGroupedMapperTest.php
+++ b/tests/Mapper/BaseGroupedMapperTest.php
@@ -227,10 +227,11 @@ class BaseGroupedMapperTest extends TestCase
      */
     public function testLabel(bool $translated, string $name, ?string $label, string $expectedLabel): void
     {
+        // NEXT_MAJOR: Remove $container variable and the call to setParameter.
         $container = $this->baseGroupedMapper
             ->getAdmin()
             ->getConfigurationPool()
-            ->getContainer();
+            ->getContainer('sonata_deprecation_mute');
 
         $container->setParameter('sonata.admin.configuration.translate_group_label', $translated);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The [code that uses this method is already deprecated](https://github.com/sonata-project/SonataAdminBundle/search?p=1&q=getContainer). 

Deprecating this method would lead to better design, forcing the user to use dependency injection instead of getting the container from the `Pool` service.

Another further refactoring could be to inject a ServiceLocator instead of the whole container.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `Pool::getContainer()` method.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
