### PR TITLE
[POC] Csrf token util

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -43,7 +43,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Csrf\CsrfToken;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -162,7 +161,7 @@ class CRUDController implements ContainerAwareInterface
             'action' => 'list',
             'form' => $formView,
             'datagrid' => $datagrid,
-            'csrf_token' => $this->getCsrfToken('sonata.batch'),
+            'csrf_token' => $this->container->get('sonata.admin.helper.csrf_manager')->getCsrfToken('sonata.batch'),
             'export_formats' => $this->has('sonata.admin.admin_exporter') ?
                 $this->get('sonata.admin.admin_exporter')->getAvailableFormats($this->admin) :
                 $this->admin->getExportFormats(),
@@ -228,7 +227,7 @@ class CRUDController implements ContainerAwareInterface
 
         if (Request::METHOD_DELETE === $request->getMethod()) {
             // check the csrf token
-            $this->validateCsrfToken('sonata.delete');
+            $this->container->get('sonata.admin.helper.csrf_manager')->validateCsrfToken('sonata.delete');
 
             $objectName = $this->admin->toString($object);
 
@@ -274,7 +273,7 @@ class CRUDController implements ContainerAwareInterface
         return $this->renderWithExtraParams($template, [
             'object' => $object,
             'action' => 'delete',
-            'csrf_token' => $this->getCsrfToken('sonata.delete'),
+            'csrf_token' => $this->container->get('sonata.admin.helper.csrf_manager')->getCsrfToken('sonata.delete'),
         ]);
     }
 
@@ -424,7 +423,7 @@ class CRUDController implements ContainerAwareInterface
         }
 
         // check the csrf token
-        $this->validateCsrfToken('sonata.batch');
+        $this->container->get('sonata.admin.helper.csrf_manager')->validateCsrfToken('sonata.batch');
 
         $confirmation = $request->get('confirmation', false);
 
@@ -521,7 +520,7 @@ class CRUDController implements ContainerAwareInterface
                 'datagrid' => $datagrid,
                 'form' => $formView,
                 'data' => $data,
-                'csrf_token' => $this->getCsrfToken('sonata.batch'),
+                'csrf_token' => $this->container->get('sonata.admin.helper.csrf_manager')->getCsrfToken('sonata.batch'),
             ]);
         }
 
@@ -1475,24 +1474,15 @@ class CRUDController implements ContainerAwareInterface
     /**
      * Validate CSRF token for action without form.
      *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     *
      * @param string $intention
      *
      * @throws HttpException
      */
     protected function validateCsrfToken($intention)
     {
-        $request = $this->getRequest();
-        $token = $request->get('_sonata_csrf_token');
-
-        if ($this->container->has('security.csrf.token_manager')) {
-            $valid = $this->container->get('security.csrf.token_manager')->isTokenValid(new CsrfToken($intention, $token));
-        } else {
-            return;
-        }
-
-        if (!$valid) {
-            throw new HttpException(Response::HTTP_BAD_REQUEST, 'The csrf token is not valid, CSRF attack?');
-        }
+        return $this->container->get('sonata.admin.helper.csrf_manager')->validateCsrfToken($intention);
     }
 
     /**
@@ -1510,17 +1500,15 @@ class CRUDController implements ContainerAwareInterface
     /**
      * Get CSRF token.
      *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     *
      * @param string $intention
      *
      * @return string|false
      */
     protected function getCsrfToken($intention)
     {
-        if ($this->container->has('security.csrf.token_manager')) {
-            return $this->container->get('security.csrf.token_manager')->getToken($intention)->getValue();
-        }
-
-        return false;
+        return $this->container->get('sonata.admin.helper.csrf_manager')->getCsrfToken($intention);
     }
 
     /**

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -70,6 +70,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $loader->load('core.php');
         $loader->load('event_listener.php');
         $loader->load('form_types.php');
+        $loader->load('helper.php');
         $loader->load('menu.php');
         $loader->load('route.php');
         $loader->load('twig.php');

--- a/src/Helper/CsrfTokenManager.php
+++ b/src/Helper/CsrfTokenManager.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Helper;
+
+use Sonata\AdminBundle\Helper\CsrfTokenManagerInterface as SonataCsrfTokenManagerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+/**
+ * @author Wojciech Błoszyk <wbloszyk@gmail.com>
+ */
+final class CsrfTokenManager implements SonataCsrfTokenManagerInterface
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var CsrfTokenManagerInterface|null
+     */
+    private $csrfTokenManager;
+
+    public function __construct(RequestStack $requestStack, ?CsrfTokenManagerInterface $csrfTokenManager = null)
+    {
+        $this->requestStack = $requestStack;
+        $this->csrfTokenManager = $csrfTokenManager;
+    }
+
+    public function getCsrfToken(string $intention)
+    {
+        if (null === $this->csrfTokenManager) {
+            return false;
+        }
+
+        return $this->csrfTokenManager->getToken($intention)->getValue();
+    }
+
+    /**
+     * Validate CSRF token for action without form.
+     *
+     * @throws HttpException
+     */
+    public function validateCsrfToken(string $intention): void
+    {
+        if (null === $this->csrfTokenManager) {
+            return;
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+        $token = $request->get('_sonata_csrf_token');
+
+        $valid = $this->csrfTokenManager->isTokenValid(new CsrfToken($intention, $token));
+
+        if (!$valid) {
+            throw new HttpException(Response::HTTP_BAD_REQUEST, 'The csrf token is not valid, CSRF attack?');
+        }
+    }
+}

--- a/src/Helper/CsrfTokenManagerInterface.php
+++ b/src/Helper/CsrfTokenManagerInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Helper;
+
+/**
+ * @author Wojciech Błoszyk <wbloszyk@gmail.com>
+ */
+interface CsrfTokenManagerInterface
+{
+    public function getCsrfToken(string $intention);
+
+    public function validateCsrfToken(string $intention): void;
+}

--- a/src/Resources/config/helper.php
+++ b/src/Resources/config/helper.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Sonata\AdminBundle\Helper\CsrfTokenManager;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+
+    // Use "service" function for creating references to services when dropping support for Symfony 4.4
+    // Use "param" function for creating references to parameters when dropping support for Symfony 5.1
+
+    $csrfManager = new ReferenceConfigurator('security.csrf.token_manager');
+    $csrfManager->nullOnInvalid();
+
+    $containerConfigurator->services()
+
+        ->set('sonata.admin.helper.csrf_manager', CsrfTokenManager::class)
+            ->public()
+            ->args([
+                new ReferenceConfigurator('request_stack'),
+                $csrfManager,
+            ]);
+};

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -38,6 +38,8 @@ use Sonata\AdminBundle\Tests\Fixtures\Controller\BatchAdminController;
 use Sonata\AdminBundle\Tests\Fixtures\Controller\PreCRUDController;
 use Sonata\AdminBundle\Tests\Fixtures\Util\DummyDomainObject;
 use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
+use Sonata\AdminBundle\Util\CsrfTokenManager;
+use Sonata\AdminBundle\Util\CsrfTokenManagerInterface as SonataCsrfTokenManagerInterface;
 use Sonata\Exporter\Exporter;
 use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Exporter\Writer\JsonWriter;
@@ -145,6 +147,11 @@ class CRUDControllerTest extends TestCase
      * @var CsrfTokenManagerInterface
      */
     private $csrfProvider;
+
+    /**
+     * @var SonataCsrfTokenManagerInterface
+     */
+    private $sonataCsrfProviderUtil;
 
     /**
      * @var KernelInterface
@@ -265,6 +272,8 @@ class CRUDControllerTest extends TestCase
         $requestStack = new RequestStack();
         $requestStack->push($this->request);
 
+        $this->sonataCsrfProviderUtil = new CsrfTokenManager($requestStack, $this->csrfProvider);
+
         $this->kernel = $this->createMock(KernelInterface::class);
 
         $this->container->set('sonata.admin.pool', $this->pool);
@@ -277,6 +286,7 @@ class CRUDControllerTest extends TestCase
         $this->container->set('sonata.admin.exporter', $exporter);
         $this->container->set('sonata.admin.audit.manager', $this->auditManager);
         $this->container->set('sonata.admin.object.manipulator.acl.admin', $this->adminObjectAclManipulator);
+        $this->container->set('sonata.admin.util.csrf.manager', $this->sonataCsrfProviderUtil);
         $this->container->set('security.csrf.token_manager', $this->csrfProvider);
         $this->container->set('logger', $this->logger);
         $this->container->set('kernel', $this->kernel);
@@ -1134,7 +1144,13 @@ class CRUDControllerTest extends TestCase
 
     public function testDeleteActionNoCsrfToken(): void
     {
+        $requestStack = new RequestStack();
+        $requestStack->push($this->request);
+
+        $this->sonataCsrfProviderUtil = new CsrfTokenManager($requestStack, null);
+
         $this->container->set('security.csrf.token_manager', null);
+        $this->container->set('sonata.admin.util.csrf.manager', $this->sonataCsrfProviderUtil);
 
         $object = new \stdClass();
 
@@ -1355,7 +1371,13 @@ class CRUDControllerTest extends TestCase
      */
     public function testDeleteActionSuccessNoCsrfTokenProvider(string $expectedToStringValue, string $toStringValue): void
     {
+        $requestStack = new RequestStack();
+        $requestStack->push($this->request);
+
+        $this->sonataCsrfProviderUtil = new CsrfTokenManager($requestStack, null);
+
         $this->container->set('security.csrf.token_manager', null);
+        $this->container->set('sonata.admin.util.csrf.manager', $this->sonataCsrfProviderUtil);
 
         $object = new \stdClass();
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

Based on MVC pattern we should avoid keep "models" in "controllers" (CRUDController).





<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respect BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\AdminBundle\Helper\CsrfTokenManager` and `Sonata\AdminBundle\Helper\CsrfTokenManagerInterface` to allow easy generating and checking CSRF tokens manually
### Deprecated
- `Sonata\AdminBundle\Controller\CRUDController::validateCsrfToken()`
- `Sonata\AdminBundle\Controller\CRUDController::getCsrfToken()`
```