### PR TITLE
Deprecate acl_user_manager without implementing AdminAclUserManagerInterface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,54 @@
 UPGRADE 3.x
 ===========
 
+### Deprecated not configuring `acl_user_manager` and using ACL security handler when `friendsofsymfony/user-bundle` is installed.
+
+If you are using `friendsofsymfony/user-bundle` and using ACL security handler, you MUST explicitly configure the `acl_user_manager`.
+
+```yaml
+sonata_admin:
+    security:
+        acl_user_manager: App\Manager\AclFOSUserManager # this service MUST implement "AdminAclUserManagerInterface"
+```
+
+### Deprecated configuring `acl_user_manager` with a service that does not implement `AdminAclUserManagerInterface`.
+
+Given this configuration:
+```yaml
+sonata_admin:
+    security:
+        acl_user_manager: 'App\Manager\AclUserManager'
+```
+
+`App\Manager\AclUserManager` MUST implement `AdminAclUserManagerInterface`, if you are using `fos_user_manager`, this could
+be an example:
+```php
+<?php
+
+namespace App\Manager;
+
+use FOS\UserBundle\Model\UserManagerInterface;
+use Sonata\AdminBundle\Util\AdminAclUserManagerInterface;
+
+final class AclUserManager implements AdminAclUserManagerInterface
+{
+    /**
+     * @var UserManagerInterface
+     */
+    private $userManager;
+
+    public function __construct(UserManagerInterface $userManager)
+    {
+        $this->userManager = $userManager;
+    }
+
+    public function findUsers(): iterable
+    {
+        return $this->userManager->findUsers();
+    }
+}
+```
+
 UPGRADE FROM 3.76 to 3.77
 =========================
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -977,6 +977,15 @@ class CRUDController implements ContainerAwareInterface
             throw $this->createNotFoundException('ACL are not enabled for this admin');
         }
 
+        if ($this->container->hasParameter('sonata.admin.security.fos_user_autoconfigured')
+            && $this->getParameter('sonata.admin.security.fos_user_autoconfigured')) {
+            @trigger_error(sprintf(
+                'Not configuring "acl_user_manager" and using ACL security handler is deprecated since'
+                .' sonata-project/admin-bundle 3.x and will not work on 4.x. You MUST specify the service name'
+                .' under "sonata_admin.security.acl_user_manager" option.'
+            ), E_USER_DEPRECATED);
+        }
+
         $request = $this->getRequest();
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
@@ -1353,6 +1362,7 @@ class CRUDController implements ContainerAwareInterface
      */
     protected function getAclUsers()
     {
+        // NEXT_MAJOR: Remove this code until the commented code and uncomment it;
         $aclUsers = [];
 
         $userManagerServiceName = $this->container->getParameter('sonata.admin.security.acl_user_manager');
@@ -1365,6 +1375,14 @@ class CRUDController implements ContainerAwareInterface
         }
 
         return \is_array($aclUsers) ? new \ArrayIterator($aclUsers) : $aclUsers;
+
+//        if (!$this->has('sonata.admin.security.acl_user_manager')) {
+//            return new \ArrayIterator([]);
+//        }
+//
+//        $aclUsers = $this->get('sonata.admin.security.acl_user_manager')->findUsers();
+//
+//        return \is_array($aclUsers) ? new \ArrayIterator($aclUsers) : $aclUsers;
     }
 
     /**

--- a/src/DependencyInjection/Compiler/CheckAclUserManagerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/CheckAclUserManagerCompilerPass.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\DependencyInjection\Compiler;
+
+use Sonata\AdminBundle\Util\AdminAclUserManagerInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @internal
+ */
+final class CheckAclUserManagerCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasParameter('sonata.admin.security.acl_user_manager')
+            || !$container->hasParameter('sonata.admin.security.fos_user_autoconfigured')) {
+            return;
+        }
+
+        $userManagerServiceName = $container->getParameter('sonata.admin.security.acl_user_manager');
+
+        if (null === $userManagerServiceName
+            || !$container->hasDefinition($userManagerServiceName)
+            || $container->getParameter('sonata.admin.security.fos_user_autoconfigured')) {
+            return;
+        }
+
+        $userManagerDefinition = $container->findDefinition($userManagerServiceName);
+
+        if (!is_a($userManagerDefinition->getClass(), AdminAclUserManagerInterface::class, true)) {
+            @trigger_error(sprintf(
+                'Configuring the service in sonata_admin.security.acl_user_manager without implementing "%s"'
+                .' is deprecated since sonata-project/admin-bundle 3.x and will throw an "%s" exception in 4.0.',
+                AdminAclUserManagerInterface::class,
+                \InvalidArgumentException::class
+            ), E_USER_DEPRECATED);
+        }
+    }
+}

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -15,6 +15,8 @@ namespace Sonata\AdminBundle\DependencyInjection;
 
 use Sonata\AdminBundle\DependencyInjection\Compiler\ModelManagerCompilerPass;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+// NEXT_MAJOR: Uncomment this line.
+//use Sonata\AdminBundle\Util\AdminAclUserManagerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -115,11 +117,20 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $container->setParameter('sonata.admin.configuration.default_icon', $config['options']['default_icon']);
         $container->setParameter('sonata.admin.configuration.breadcrumbs', $config['breadcrumbs']);
 
+        // NEXT_MAJOR: Remove this block and uncomment the one below.
         if (null === $config['security']['acl_user_manager'] && isset($bundles['FOSUserBundle'])) {
+            $container->setParameter('sonata.admin.security.fos_user_autoconfigured', true);
             $container->setParameter('sonata.admin.security.acl_user_manager', 'fos_user.user_manager');
         } else {
+            $container->setParameter('sonata.admin.security.fos_user_autoconfigured', false);
             $container->setParameter('sonata.admin.security.acl_user_manager', $config['security']['acl_user_manager']);
         }
+
+        // NEXT_MAJOR: Uncomment this code.
+        //if (null !== $config['security']['acl_user_manager']) {
+        //    $container->setAlias('sonata.admin.security.acl_user_manager', $config['security']['acl_user_manager']);
+        //    $container->setAlias(AdminAclUserManagerInterface::class, 'sonata.admin.security.acl_user_manager');
+        //}
 
         $container->setAlias('sonata.admin.security.handler', $config['security']['handler']);
 

--- a/src/Util/AdminAclUserManagerInterface.php
+++ b/src/Util/AdminAclUserManagerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Util;
+
+/**
+ * @author Mathieu Petrini <mathieupetrini@gmail.com>
+ */
+interface AdminAclUserManagerInterface
+{
+    /**
+     * Batch configure the ACLs for all objects handled by an Admin.
+     */
+    public function findUsers(): iterable;
+}

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -2662,6 +2662,30 @@ class CRUDControllerTest extends TestCase
         $this->controller->aclAction(null);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testAclTriggerDeprecationWithoutConfiguringUserManager(): void
+    {
+        $this->admin->expects($this->once())
+            ->method('isAclEnabled')
+            ->willReturn(true);
+
+        $this->admin->expects($this->once())
+            ->method('getObject')
+            ->willReturn(false);
+
+        $this->container->setParameter('sonata.admin.security.fos_user_autoconfigured', true);
+
+        $this->expectDeprecation('Not configuring "acl_user_manager" and using ACL security handler is deprecated since sonata-project/admin-bundle 3.x and will not work on 4.x. You MUST specify the service name under "sonata_admin.security.acl_user_manager" option.');
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $this->controller->aclAction(null);
+    }
+
     public function testAclActionNotFoundException(): void
     {
         $this->expectException(NotFoundHttpException::class);

--- a/tests/DependencyInjection/Compiler/CheckAclUserManagerCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/CheckAclUserManagerCompilerPassTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\AdminBundle\DependencyInjection\Compiler\CheckAclUserManagerCompilerPass;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * NEXT_MAJOR: Remove this test.
+ *
+ * @group legacy
+ */
+final class CheckAclUserManagerCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    use ExpectDeprecationTrait;
+
+    public function testTriggersADeprecationIfItAclUserManagerIsNotProperlyConfigured(): void
+    {
+        $aclUserManager = new Definition(\stdClass::class);
+        $this->setDefinition('acl_user_manager', $aclUserManager);
+        $this->setParameter('sonata.admin.security.acl_user_manager', 'acl_user_manager');
+        $this->setParameter('sonata.admin.security.fos_user_autoconfigured', false);
+
+        $this->expectDeprecation('Configuring the service in sonata_admin.security.acl_user_manager without implementing "Sonata\AdminBundle\Util\AdminAclUserManagerInterface" is deprecated since sonata-project/admin-bundle 3.x and will throw an "InvalidArgumentException" exception in 4.0.');
+
+        $this->compile();
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new CheckAclUserManagerCompilerPass());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataAdminBundle/pull/6476#issuecomment-707317147

The idea is introducing `AdminAclUserManagerInterface` which the service configured under `sonata_admin.security.acl_user_manager` must implement. If it's ok, I'll add the upgrade note.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Deprecated
- Deprecated not configuring `acl_user_manager` service explicitly when using `friendsofsymfony/user-bundle`.
- Deprecated configuring `acl_user_manager` service without implementing `AdminAclUserManagerInterface`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
- [x] Deprecate not configuring `acl_user_manager`.