### PR TITLE
[EventListener] Add param & return type hints to a file in EventListener dir

### DIFF
--- a/src/EventListener/AssetsInstallCommandListener.php
+++ b/src/EventListener/AssetsInstallCommandListener.php
@@ -37,9 +37,19 @@ final class AssetsInstallCommandListener
     public const METHOD_ABSOLUTE_SYMLINK = 'absolute symlink';
     public const METHOD_RELATIVE_SYMLINK = 'relative symlink';
 
+    /**
+     * @var string
+     */
     protected static $defaultName = 'assets:install';
 
+    /**
+     * @var Filesystem
+     */
     private $filesystem;
+
+    /**
+     * @var string
+     */
     private $projectDir;
 
     public function __construct(Filesystem $filesystem, string $projectDir)
@@ -48,7 +58,7 @@ final class AssetsInstallCommandListener
         $this->projectDir = $projectDir;
     }
 
-    public function copySonataCoreBundleAssets(ConsoleTerminateEvent $event)
+    public function copySonataCoreBundleAssets(ConsoleTerminateEvent $event): void
     {
         $command = $event->getCommand();
         $application = $command->getApplication();
@@ -209,7 +219,7 @@ final class AssetsInstallCommandListener
      *
      * @throws IOException if link can not be created
      */
-    private function symlink(string $originDir, string $targetDir, bool $relative = false)
+    private function symlink(string $originDir, string $targetDir, bool $relative = false): void
     {
         if ($relative) {
             $this->filesystem->mkdir(\dirname($targetDir));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->

This is a follow up of #6404  to add param & return type hints.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added parameter and return type hints to `AssetsInstallCommandListener`

```
