### PR TITLE
Improve error message in case of multiple admins for same entity

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1474,6 +1474,8 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         if (null !== $adminCode) {
             if (!$pool->hasAdminByAdminCode($adminCode)) {
                 return;
+                // NEXT_MAJOR: Uncomment the following exception instead.
+//                throw new \InvalidArgumentException(sprintf('No admin found for the admin_code "%s"', $adminCode));
             }
 
             $admin = $pool->getAdminByAdminCode($adminCode);
@@ -1487,6 +1489,18 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
             if (!$pool->hasAdminByClass($targetModel)) {
                 return;
+                // NEXT_MAJOR: Uncomment the following exception instead.
+//                throw new \InvalidArgumentException(sprintf(
+//                    'No admin found for the class "%s", please use the admin_code option instead',
+//                    $targetModel
+//                ));
+            }
+
+            if (!$pool->hasSingleAdminByClass($targetModel)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Too many admins found for the class "%s", please use the admin_code option instead',
+                    $targetModel
+                ));
             }
 
             $admin = $pool->getAdminByClass($targetModel);

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -222,11 +222,7 @@ class Pool
             return null;
         }
 
-        if (!\is_array($this->adminClasses[$class])) {
-            throw new \RuntimeException('Invalid format for the Pool::adminClass property');
-        }
-
-        if (\count($this->adminClasses[$class]) > 1) {
+        if (!$this->hasSingleAdminByClass($class)) {
             throw new \RuntimeException(sprintf(
                 'Unable to find a valid admin for the class: %s, there are too many registered: %s',
                 $class,
@@ -247,6 +243,18 @@ class Pool
     public function hasAdminByClass($class)
     {
         return isset($this->adminClasses[$class]);
+    }
+
+    /**
+     * @phpstan-param class-string $class
+     */
+    public function hasSingleAdminByClass(string $class): bool
+    {
+        if (!$this->hasAdminByClass($class)) {
+            return false;
+        }
+
+        return 1 === \count($this->adminClasses[$class]);
     }
 
     /**

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -142,16 +142,6 @@ class PoolTest extends TestCase
         $this->assertCount(1, $this->pool->getAdminsByGroup('adminGroup2'));
     }
 
-    public function testGetAdminForClassWithInvalidFormat(): void
-    {
-        $this->expectException(\RuntimeException::class);
-
-        $this->pool->setAdminClasses(['someclass' => 'sonata.user.admin.group1']);
-        $this->assertTrue($this->pool->hasAdminByClass('someclass'));
-
-        $this->pool->getAdminByClass('someclass');
-    }
-
     public function testGetAdminForClassWithTooManyRegisteredAdmin(): void
     {
         $this->expectException(\RuntimeException::class);
@@ -161,6 +151,7 @@ class PoolTest extends TestCase
         ]);
 
         $this->assertTrue($this->pool->hasAdminByClass('someclass'));
+        $this->assertFalse($this->pool->hasSingleAdminByClass('someclass'));
         $this->pool->getAdminByClass('someclass');
     }
 
@@ -174,6 +165,7 @@ class PoolTest extends TestCase
         ]);
 
         $this->assertTrue($this->pool->hasAdminByClass('someclass'));
+        $this->assertTrue($this->pool->hasSingleAdminByClass('someclass'));
         $this->assertInstanceOf(AdminInterface::class, $this->pool->getAdminByClass('someclass'));
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is BC

Closes #6181 

```markdown
### Added
- Added `Pool::hasSingleAdminByClass()`
```