### PR TITLE
 [Translator] Add param & return type hints to all files in the Translator dir

### DIFF
--- a/src/Translator/BCLabelTranslatorStrategy.php
+++ b/src/Translator/BCLabelTranslatorStrategy.php
@@ -18,7 +18,7 @@ namespace Sonata\AdminBundle\Translator;
  */
 final class BCLabelTranslatorStrategy implements LabelTranslatorStrategyInterface
 {
-    public function getLabel($label, $context = '', $type = '')
+    public function getLabel(string $label, string $context = '', string $type = ''): string
     {
         if ('breadcrumb' === $context) {
             return sprintf('%s.%s_%s', $context, $type, strtolower($label));

--- a/src/Translator/Extractor/AdminExtractor.php
+++ b/src/Translator/Extractor/AdminExtractor.php
@@ -76,7 +76,12 @@ final class AdminExtractor implements ExtractorInterface, LabelTranslatorStrateg
         $this->breadcrumbsBuilder = $breadcrumbsBuilder;
     }
 
-    public function extract($resource, MessageCatalogue $catalogue)
+    /**
+     * Extracts translation messages from files, a file or a directory to the catalogue.
+     *
+     * @param string|array $resource Files, a file or a directory
+     */
+    public function extract($resource, MessageCatalogue $catalogue): void
     {
         $this->catalogue = $catalogue;
 

--- a/src/Translator/Extractor/AdminExtractor.php
+++ b/src/Translator/Extractor/AdminExtractor.php
@@ -76,12 +76,7 @@ final class AdminExtractor implements ExtractorInterface, LabelTranslatorStrateg
         $this->breadcrumbsBuilder = $breadcrumbsBuilder;
     }
 
-    /**
-     * Extracts translation messages from files, a file or a directory to the catalogue.
-     *
-     * @param string|array $resource Files, a file or a directory
-     */
-    public function extract($resource, MessageCatalogue $catalogue): void
+    public function extract($resource, MessageCatalogue $catalogue)
     {
         $this->catalogue = $catalogue;
 
@@ -113,12 +108,17 @@ final class AdminExtractor implements ExtractorInterface, LabelTranslatorStrateg
         }
     }
 
-    public function setPrefix($prefix): void
+    /**
+     * Sets the prefix that should be used for new found messages.
+     *
+     * @param string $prefix The prefix
+     */
+    public function setPrefix(string $prefix)
     {
         $this->prefix = $prefix;
     }
 
-    public function getLabel($label, $context = '', $type = ''): string
+    public function getLabel(string $label, string $context = '', string $type = ''): string
     {
         $label = $this->labelStrategy->getLabel($label, $context, $type);
 

--- a/src/Translator/Extractor/AdminExtractor.php
+++ b/src/Translator/Extractor/AdminExtractor.php
@@ -108,12 +108,7 @@ final class AdminExtractor implements ExtractorInterface, LabelTranslatorStrateg
         }
     }
 
-    /**
-     * Sets the prefix that should be used for new found messages.
-     *
-     * @param string $prefix The prefix
-     */
-    public function setPrefix(string $prefix)
+    public function setPrefix($prefix): void
     {
         $this->prefix = $prefix;
     }

--- a/src/Translator/FormLabelTranslatorStrategy.php
+++ b/src/Translator/FormLabelTranslatorStrategy.php
@@ -18,7 +18,7 @@ namespace Sonata\AdminBundle\Translator;
  */
 final class FormLabelTranslatorStrategy implements LabelTranslatorStrategyInterface
 {
-    public function getLabel($label, $context = '', $type = '')
+    public function getLabel(string $label, string $context = '', string $type = ''): string
     {
         return ucfirst(strtolower($label));
     }

--- a/src/Translator/LabelTranslatorStrategyInterface.php
+++ b/src/Translator/LabelTranslatorStrategyInterface.php
@@ -18,12 +18,5 @@ namespace Sonata\AdminBundle\Translator;
  */
 interface LabelTranslatorStrategyInterface
 {
-    /**
-     * @param string $label
-     * @param string $context
-     * @param string $type
-     *
-     * @return string
-     */
-    public function getLabel($label, $context = '', $type = '');
+    public function getLabel(string $label, string $context = '', string $type = ''): string;
 }

--- a/src/Translator/NativeLabelTranslatorStrategy.php
+++ b/src/Translator/NativeLabelTranslatorStrategy.php
@@ -18,7 +18,7 @@ namespace Sonata\AdminBundle\Translator;
  */
 final class NativeLabelTranslatorStrategy implements LabelTranslatorStrategyInterface
 {
-    public function getLabel($label, $context = '', $type = '')
+    public function getLabel(string $label, string $context = '', string $type = ''): string
     {
         $label = str_replace(['_', '.'], ' ', $label);
         $label = strtolower(preg_replace('~(?<=\\w)([A-Z])~', '_$1', $label));

--- a/src/Translator/NoopLabelTranslatorStrategy.php
+++ b/src/Translator/NoopLabelTranslatorStrategy.php
@@ -18,7 +18,7 @@ namespace Sonata\AdminBundle\Translator;
  */
 final class NoopLabelTranslatorStrategy implements LabelTranslatorStrategyInterface
 {
-    public function getLabel($label, $context = '', $type = '')
+    public function getLabel(string $label, string $context = '', string $type = ''): string
     {
         return $label;
     }

--- a/src/Translator/UnderscoreLabelTranslatorStrategy.php
+++ b/src/Translator/UnderscoreLabelTranslatorStrategy.php
@@ -18,7 +18,7 @@ namespace Sonata\AdminBundle\Translator;
  */
 final class UnderscoreLabelTranslatorStrategy implements LabelTranslatorStrategyInterface
 {
-    public function getLabel($label, $context = '', $type = '')
+    public function getLabel(string $label, string $context = '', string $type = ''): string
     {
         $label = str_replace('.', '_', $label);
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1438,10 +1438,13 @@ class AdminTest extends TestCase
                 ->willReturn($this->createMock(MemberMetadata::class));
         $modelAdmin->setValidator($validator);
 
+        $fieldDescription = new FieldDescription();
+        $fieldDescription->setName('fooName');
+
         $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelManager
             ->method('getNewFieldDescriptionInstance')
-            ->willReturn(new FieldDescription());
+            ->willReturn($fieldDescription);
         $modelAdmin->setModelManager($modelManager);
 
         // a Admin class to test that preValidate is called
@@ -1508,10 +1511,13 @@ class AdminTest extends TestCase
             ->willReturn($metadata);
         $modelAdmin->setValidator($validator);
 
+        $fieldDescription = new FieldDescription();
+        $fieldDescription->setName('fooName');
+
         $modelManager = $this->createStub(ModelManagerInterface::class);
         $modelManager
             ->method('getNewFieldDescriptionInstance')
-            ->willReturn(new FieldDescription());
+            ->willReturn($fieldDescription);
         $modelAdmin->setModelManager($modelManager);
 
         $event = $this->createStub(FormEvent::class);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

This is a follow up of #6404 to add param & return type hints.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added parameter and return type hints to all files in the Translator dir
