### PR TITLE
[Twig] Add param & return type hints to all files in the Twig dir

### DIFF
--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -82,10 +82,7 @@ final class SonataAdminExtension extends AbstractExtension
         $this->securityChecker = $securityChecker;
     }
 
-    /**
-     * @return TwigFilter[]
-     */
-    public function getFilters(): array
+    public function getFilters()
     {
         return [
             new TwigFilter(
@@ -131,10 +128,7 @@ final class SonataAdminExtension extends AbstractExtension
         ];
     }
 
-    /**
-     * @return TwigFunction[]
-     */
-    public function getFunctions(): array
+    public function getFunctions()
     {
         return [
             new TwigFunction('canonicalize_locale_for_moment', [$this, 'getCanonicalizedLocaleForMoment'], ['needs_context' => true]),
@@ -143,9 +137,6 @@ final class SonataAdminExtension extends AbstractExtension
         ];
     }
 
-    /*
-     * @return string
-     */
     public function getName(): string
     {
         return 'sonata_admin';
@@ -155,13 +146,12 @@ final class SonataAdminExtension extends AbstractExtension
      * render a list element from the FieldDescription.
      *
      * @param object|array $listElement
-     * @param array        $params
      */
     public function renderListElement(
         Environment $environment,
         $listElement,
         FieldDescriptionInterface $fieldDescription,
-        $params = []
+        array $params = []
     ): string {
         $template = $this->getTemplate(
             $fieldDescription,
@@ -364,8 +354,6 @@ final class SonataAdminExtension extends AbstractExtension
     /*
      * Returns a canonicalized locale for "moment" NPM library,
      * or `null` if the locale's language is "en", which doesn't require localization.
-     *
-     * @return string|null
      */
     public function getCanonicalizedLocaleForMoment(array $context): ?string
     {

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -82,7 +82,10 @@ final class SonataAdminExtension extends AbstractExtension
         $this->securityChecker = $securityChecker;
     }
 
-    public function getFilters()
+    /**
+     * @return TwigFilter[]
+     */
+    public function getFilters(): array
     {
         return [
             new TwigFilter(
@@ -128,7 +131,10 @@ final class SonataAdminExtension extends AbstractExtension
         ];
     }
 
-    public function getFunctions()
+    /**
+     * @return TwigFunction[]
+     */
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('canonicalize_locale_for_moment', [$this, 'getCanonicalizedLocaleForMoment'], ['needs_context' => true]),
@@ -137,7 +143,10 @@ final class SonataAdminExtension extends AbstractExtension
         ];
     }
 
-    public function getName()
+    /*
+     * @return string
+     */
+    public function getName(): string
     {
         return 'sonata_admin';
     }
@@ -147,15 +156,13 @@ final class SonataAdminExtension extends AbstractExtension
      *
      * @param object|array $listElement
      * @param array        $params
-     *
-     * @return string
      */
     public function renderListElement(
         Environment $environment,
         $listElement,
         FieldDescriptionInterface $fieldDescription,
         $params = []
-    ) {
+    ): string {
         $template = $this->getTemplate(
             $fieldDescription,
             $this->getTemplateRegistry($fieldDescription->getAdmin()->getCode())->getTemplate('base_list_field'),
@@ -172,18 +179,11 @@ final class SonataAdminExtension extends AbstractExtension
         ]), $environment);
     }
 
-    /**
-     * render a view element.
-     *
-     * @param object $object
-     *
-     * @return string
-     */
     public function renderViewElement(
         Environment $environment,
         FieldDescriptionInterface $fieldDescription,
-        $object
-    ) {
+        object $object
+    ): string {
         $template = $this->getTemplate(
             $fieldDescription,
             '@SonataAdmin/CRUD/base_show_field.html.twig',
@@ -200,18 +200,13 @@ final class SonataAdminExtension extends AbstractExtension
 
     /**
      * render a compared view element.
-     *
-     * @param mixed $baseObject
-     * @param mixed $compareObject
-     *
-     * @return string
      */
     public function renderViewElementCompare(
         Environment $environment,
         FieldDescriptionInterface $fieldDescription,
-        $baseObject,
-        $compareObject
-    ) {
+        object $baseObject,
+        object $compareObject
+    ): string {
         $template = $this->getTemplate(
             $fieldDescription,
             '@SonataAdmin/CRUD/base_show_field.html.twig',
@@ -269,7 +264,7 @@ final class SonataAdminExtension extends AbstractExtension
             if (!method_exists($element, $method)) {
                 throw new \RuntimeException(sprintf(
                     'You must define an `associated_property` option or create a `%s::__toString` method'
-                    .' to the field option %s from service %s is ',
+                        .' to the field option %s from service %s is ',
                     \get_class($element),
                     $fieldDescription->getName(),
                     $fieldDescription->getAdmin()->getCode()
@@ -289,11 +284,9 @@ final class SonataAdminExtension extends AbstractExtension
     /**
      * Get the identifiers as a string that is safe to use in a url.
      *
-     * @param object $model
-     *
      * @return string string representation of the id that is safe to use in a url
      */
-    public function getUrlSafeIdentifier($model, ?AdminInterface $admin = null)
+    public function getUrlSafeIdentifier(object $model, ?AdminInterface $admin = null): string
     {
         if (null === $admin) {
             $class = ClassUtils::getClass($model);
@@ -310,7 +303,7 @@ final class SonataAdminExtension extends AbstractExtension
     /**
      * @param string[] $xEditableTypeMapping
      */
-    public function setXEditableTypeMapping($xEditableTypeMapping): void
+    public function setXEditableTypeMapping(array $xEditableTypeMapping): void
     {
         $this->xEditableTypeMapping = $xEditableTypeMapping;
     }
@@ -318,7 +311,7 @@ final class SonataAdminExtension extends AbstractExtension
     /**
      * @return string|bool
      */
-    public function getXEditableType($type)
+    public function getXEditableType(string $type)
     {
         return isset($this->xEditableTypeMapping[$type]) ? $this->xEditableTypeMapping[$type] : false;
     }
@@ -329,10 +322,8 @@ final class SonataAdminExtension extends AbstractExtension
      *     ['Status1' => 'Alias1', 'Status2' => 'Alias2']
      * The method will return:
      *     [['value' => 'Status1', 'text' => 'Alias1'], ['value' => 'Status2', 'text' => 'Alias2']].
-     *
-     * @return array
      */
-    public function getXEditableChoices(FieldDescriptionInterface $fieldDescription)
+    public function getXEditableChoices(FieldDescriptionInterface $fieldDescription): array
     {
         $choices = $fieldDescription->getOption('choices', []);
         $catalogue = $fieldDescription->getOption('catalogue');
@@ -357,7 +348,8 @@ final class SonataAdminExtension extends AbstractExtension
             }
         }
 
-        if (false === $fieldDescription->getOption('required', true)
+        if (
+            false === $fieldDescription->getOption('required', true)
             && false === $fieldDescription->getOption('multiple', false)
         ) {
             $xEditableChoices = array_merge([[
@@ -375,7 +367,7 @@ final class SonataAdminExtension extends AbstractExtension
      *
      * @return string|null
      */
-    public function getCanonicalizedLocaleForMoment(array $context)
+    public function getCanonicalizedLocaleForMoment(array $context): ?string
     {
         $locale = strtolower(str_replace('_', '-', $context['app']->getRequest()->getLocale()));
 
@@ -396,10 +388,8 @@ final class SonataAdminExtension extends AbstractExtension
     /**
      * Returns a canonicalized locale for "select2" NPM library,
      * or `null` if the locale's language is "en", which doesn't require localization.
-     *
-     * @return string|null
      */
-    public function getCanonicalizedLocaleForSelect2(array $context)
+    public function getCanonicalizedLocaleForSelect2(array $context): ?string
     {
         $locale = str_replace('_', '-', $context['app']->getRequest()->getLocale());
 
@@ -429,12 +419,8 @@ final class SonataAdminExtension extends AbstractExtension
 
     /**
      * @param string|array $role
-     * @param object|null  $object
-     * @param string|null  $field
-     *
-     * @return bool
      */
-    public function isGrantedAffirmative($role, $object = null, $field = null)
+    public function isGrantedAffirmative($role, ?object $object = null, ?string $field = null): bool
     {
         if (null === $this->securityChecker) {
             return false;
@@ -465,14 +451,12 @@ final class SonataAdminExtension extends AbstractExtension
      * return the value related to FieldDescription, if the associated object does no
      * exists => a temporary one is created.
      *
-     * @param object $object
-     *
      * @throws \RuntimeException
      *
      * @return mixed
      */
     private function getValueFromFieldDescription(
-        $object,
+        object $object,
         FieldDescriptionInterface $fieldDescription,
         array $params = []
     ) {
@@ -495,16 +479,12 @@ final class SonataAdminExtension extends AbstractExtension
 
     /**
      * Get template.
-     *
-     * @param string $defaultTemplate
-     *
-     * @return TemplateWrapper
      */
     private function getTemplate(
         FieldDescriptionInterface $fieldDescription,
-        $defaultTemplate,
+        string $defaultTemplate,
         Environment $environment
-    ) {
+    ): TemplateWrapper {
         $templateName = $fieldDescription->getTemplate() ?: $defaultTemplate;
 
         return $environment->load($templateName);

--- a/src/Twig/Extension/TemplateRegistryExtension.php
+++ b/src/Twig/Extension/TemplateRegistryExtension.php
@@ -47,21 +47,15 @@ final class TemplateRegistryExtension extends AbstractExtension
     }
 
     /**
-     * @param string $name
-     * @param string $adminCode
-     *
      * @throws ServiceNotFoundException
      * @throws ServiceCircularReferenceException
      */
-    public function getAdminTemplate($name, $adminCode): ?string
+    public function getAdminTemplate(string $name, string $adminCode): ?string
     {
         return $this->getTemplateRegistry($adminCode)->getTemplate($name);
     }
 
-    /**
-     * @param string $name
-     */
-    public function getGlobalTemplate($name): ?string
+    public function getGlobalTemplate(string $name): ?string
     {
         return $this->globalTemplateRegistry->getTemplate($name);
     }

--- a/src/Twig/GlobalVariables.php
+++ b/src/Twig/GlobalVariables.php
@@ -37,39 +37,19 @@ final class GlobalVariables
         $this->mosaicBackground = $mosaicBackground;
     }
 
-    /**
-     * @return Pool
-     */
-    public function getAdminPool()
+    public function getAdminPool(): Pool
     {
         return $this->adminPool;
     }
 
-    /**
-     * @param string $code
-     * @param string $action
-     * @param array  $parameters
-     * @param int    $referenceType
-     *
-     * @return string
-     */
-    public function url($code, $action, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    public function url(string $code, string $action, array $parameters = [], int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
         [$action, $code] = $this->getCodeAction($code, $action);
 
         return $this->getAdminPool()->getAdminByAdminCode($code)->generateUrl($action, $parameters, $referenceType);
     }
 
-    /**
-     * @param string $code
-     * @param string $action
-     * @param object $object
-     * @param array  $parameters
-     * @param int    $referenceType
-     *
-     * @return string
-     */
-    public function objectUrl($code, $action, $object, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    public function objectUrl(string $code, string $action, object $object, array $parameters = [], int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
         [$action, $code] = $this->getCodeAction($code, $action);
 
@@ -81,6 +61,9 @@ final class GlobalVariables
         return $this->mosaicBackground;
     }
 
+    /**
+     * @return string[]
+     */
     private function getCodeAction(string $code, string $action): array
     {
         if ($pipe = strpos($code, '|')) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

This is a follow up of #6404 to add param & return type hints.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added parameter and return type hints to all files in the Twig dir
