### PR TITLE
[ UPGRADE-4.0.md] Note on the backward compatibility break

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -155,3 +155,6 @@ Method `SimplePager::getResults` is always returning an array
 
 ## RouteCollectionInterface
 `RouteCollection` implements `RouteCollectionInterface`.
+
+## SearchHandler
+When no Pager is found, `SearchHandler::search()` now return `null` instead of `false`.


### PR DESCRIPTION
```markdown

### Changed
- `SearchHandler::search()` now returns `null` instead of `false` when Pager is not found
