### PR TITLE
Add phpdoc type hints

### DIFF
--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -28,6 +28,9 @@ use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
  */
 class ShowMapper extends BaseGroupedMapper
 {
+    /**
+     * @var FieldDescriptionCollection
+     */
     protected $list;
 
     /**
@@ -47,6 +50,7 @@ class ShowMapper extends BaseGroupedMapper
     /**
      * @param FieldDescriptionInterface|string $name
      * @param string|null                      $type
+     * @param array<string, mixed>             $fieldDescriptionOptions
      *
      * @throws \LogicException
      *
@@ -81,7 +85,7 @@ class ShowMapper extends BaseGroupedMapper
         } else {
             throw new \TypeError(
                 'Unknown field name in show mapper.'
-                .' Field name should be either of FieldDescriptionInterface interface or string.'
+                    .' Field name should be either of FieldDescriptionInterface interface or string.'
             );
         }
 

--- a/src/Translator/Extractor/AdminExtractor.php
+++ b/src/Translator/Extractor/AdminExtractor.php
@@ -76,6 +76,11 @@ final class AdminExtractor implements ExtractorInterface, LabelTranslatorStrateg
         $this->breadcrumbsBuilder = $breadcrumbsBuilder;
     }
 
+    /**
+     * Extracts translation messages from files, a file or a directory to the catalogue.
+     *
+     * @param string|string[] $resource Files, a file or a directory
+     */
     public function extract($resource, MessageCatalogue $catalogue)
     {
         $this->catalogue = $catalogue;
@@ -108,6 +113,13 @@ final class AdminExtractor implements ExtractorInterface, LabelTranslatorStrateg
         }
     }
 
+    /**
+     * NEXT_MAJOR: Add string type hint when support for Symfony 4 is dropped.
+     *
+     * Sets the prefix that should be used for new found messages.
+     *
+     * @param string $prefix The prefix
+     */
     public function setPrefix($prefix): void
     {
         $this->prefix = $prefix;

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -121,6 +121,9 @@ class SonataAdminExtension extends AbstractExtension
         $this->securityChecker = $securityChecker;
     }
 
+    /**
+     * @return TwigFilter[]
+     */
     public function getFilters()
     {
         return [
@@ -167,6 +170,9 @@ class SonataAdminExtension extends AbstractExtension
         ];
     }
 
+    /**
+     * @return TwigFunction[]
+     */
     public function getFunctions()
     {
         return [

--- a/src/Twig/Extension/TemplateRegistryExtension.php
+++ b/src/Twig/Extension/TemplateRegistryExtension.php
@@ -39,6 +39,9 @@ final class TemplateRegistryExtension extends AbstractExtension
         $this->container = $container;
     }
 
+    /**
+     * @return TwigFunction[]
+     */
     public function getFunctions(): array
     {
         return [

--- a/src/Twig/GlobalVariables.php
+++ b/src/Twig/GlobalVariables.php
@@ -113,6 +113,9 @@ class GlobalVariables
         return $this->mosaicBackground;
     }
 
+    /**
+     * @return string[]
+     */
     private function getCodeAction(string $code, string $action): array
     {
         if ($pipe = strpos($code, '|')) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added phpdoc type hints to `ShowMapper`
- Added phpdoc type hints to `AdminExtractor`
- Added phpdoc type hints to `SonataAdminExtension`
- Added phpdoc type hints to `TemplateRegistryExtension`
- Added phpdoc type hints to `GlobalVariables`
