### PR TITLE
Fix \Knp\Menu\MenuItem @Label issue

### DIFF
--- a/src/Resources/views/Core/tab_menu_template.html.twig
+++ b/src/Resources/views/Core/tab_menu_template.html.twig
@@ -119,8 +119,9 @@
 {% endblock %}
 
 {% block label %}
+{# We use method accessor instead of ".label" since `item` implements `ArrayAccess` and could have a property called "label". #}
 {{-
-    item.label|trans(
+    item.getLabel()|trans(
         item.getExtra('translation_params', {}),
         item.getExtra(
             'translation_domain',

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -52,11 +52,13 @@
         {%- if is_link|default(false) -%}
             {{ icon|default|raw }}
         {%- endif -%}
+        {# We use method accessor instead of ".label" since `item` implements `ArrayAccess` and could have a property called "label". #}
+        {%- set item_label = item.getLabel() -%}
         {%- if options.allow_safe_labels and item.extra('safe_label', false) -%}
-            {{ item.label|raw }}
+            {{ item_label|raw }}
         {%- else -%}
             {%- set translation_domain = item.extra('label_catalogue', 'messages') -%}
-            {{ item.label|trans(item.extra('label_translation_parameters', {}), translation_domain) }}
+            {{ item_label|trans(item.extra('label_translation_parameters', {}), translation_domain) }}
         {%- endif -%}
     {% endapply %}
 {% endblock %}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -100,7 +100,8 @@ file that was distributed with this source code.
                             {% endif %}
 
                             {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
-                            {%- set label = menu.label -%}
+                            {# We use method accessor instead of ".label" since `menu` implements `ArrayAccess` and could have a property called "label". #}
+                            {%- set label = menu.getLabel() -%}
                             {%- if translation_domain is not same as(false) -%}
                                 {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
                             {%- endif -%}
@@ -163,7 +164,8 @@ file that was distributed with this source code.
                                                 {% if action is defined %}
                                                     {% for menu in breadcrumbs_builder.breadcrumbs(admin, action) %}
                                                         {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
-                                                        {%- set label = menu.label -%}
+                                                        {# We use method accessor instead of ".label" since `menu` implements `ArrayAccess` and could have a property called "label". #}
+                                                        {%- set label = menu.getLabel() -%}
                                                         {%- if translation_domain is not same as(false) -%}
                                                             {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
                                                         {%- endif -%}

--- a/tests/App/Admin/FooAdmin.php
+++ b/tests/App/Admin/FooAdmin.php
@@ -13,15 +13,23 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\App\Admin;
 
+use Knp\Menu\ItemInterface as MenuItemInterface;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Templating\TemplateRegistry;
+use Sonata\AdminBundle\Tests\App\Model\Foo;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 final class FooAdmin extends AbstractAdmin
 {
+    public function getNewInstance()
+    {
+        return new Foo('test_id', 'foo_name');
+    }
+
     protected function configureListFields(ListMapper $list): void
     {
         $list->add('name', TemplateRegistry::TYPE_STRING, [
@@ -37,5 +45,11 @@ final class FooAdmin extends AbstractAdmin
     protected function configureShowFields(ShowMapper $show): void
     {
         $show->add('name', TemplateRegistry::TYPE_STRING);
+    }
+
+    protected function configureTabMenu(MenuItemInterface $menu, $action, ?AdminInterface $childAdmin = null)
+    {
+        // Check conflict between `MenuItemInterface::getLabel()` method and menu item with a child with the key `label`
+        $menu->addChild('label')->addChild('label');
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is a bug fix.

Closes #6031

## Changelog

<!-- MANDATORY 
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Call \Knp\Menu\MenuItem::getLabel() method directly in twig template to avoid a possible side effect from \ArrayAccess.
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->


## Description:

\Knp\Menu\MenuItem in knplabs/knp-menu-bundle implements \ArrayAccess and defines its offsetGet method as follows:
```php
    /**
     * Implements ArrayAccess
     */
    public function offsetGet($name)
    {
        return $this->getChild($name);
    }

    public function getChild($name)
    {
        return isset($this->children[$name]) ? $this->children[$name] : null;
    }

```

It has a property `$label` with its getter: 
```php
    /**
     * Label to output, name is used by default
     *
     * @var string|null
     */
    protected $label;

    public function getLabel()
    {
        return (null !== $this->label) ? $this->label : $this->name;
    }
```
## Problem :

If a MenuItem object has a child with the key `label`, the twig expression `menu.label` will trigger the `offsetGet` method of the \ArrayAccess and return the child instead of the `$label` property of the MenuItem object.

This would result in Catchable Fatal Error: Object of class Knp\Menu\MenuItem could not be converted to string.

## Solution:

Call the getter of the `$label` property directly:
```twig
menu.getLabel()
```
