### PR TITLE
Require name to instantiate a Field description

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -90,7 +90,8 @@
         </UndefinedClass>
     </file>
     <file src="src/Admin/FieldDescriptionCollection.php">
-        <InvalidPropertyAssignmentValue occurrences="1">
+        <InvalidPropertyAssignmentValue occurrences="2">
+            <code>$this-&gt;elements</code>
             <code>array_merge(array_flip($keys), $this-&gt;elements)</code>
         </InvalidPropertyAssignmentValue>
     </file>

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -132,6 +132,23 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
      */
     private static $fieldGetters = [];
 
+    /**
+     * NEXT_MAJOR: Remove the null default value and restrict param type to `string`.
+     */
+    public function __construct(?string $name = null)
+    {
+        // NEXT_MAJOR: Remove this check and keep the else part.
+        if (null === $name) {
+            @trigger_error(sprintf(
+                'Passing no argument to %s() is deprecated since sonata-project/admin-bundle 3.x.'
+                .' In 4.0 the field description name will be required.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        } else {
+            $this->setName($name);
+        }
+    }
+
     public function setFieldName($fieldName)
     {
         $this->fieldName = $fieldName;

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -135,18 +135,20 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     /**
      * NEXT_MAJOR: Remove the null default value and restrict param type to `string`.
      */
-    public function __construct(?string $name = null)
+    public function __construct(?string $name = null, array $options = [])
     {
         // NEXT_MAJOR: Remove this check and keep the else part.
         if (null === $name) {
             @trigger_error(sprintf(
-                'Passing no argument to %s() is deprecated since sonata-project/admin-bundle 3.x.'
-                .' In 4.0 the field description name will be required.',
+                'Omitting the argument 1 for "%s()" or passing other type than "string" is deprecated'.
+                ' since sonata-project/admin-bundle 3.x. It will accept only string in version 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         } else {
             $this->setName($name);
         }
+
+        $this->setOptions($options);
     }
 
     public function setFieldName($fieldName)

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -33,7 +33,7 @@ interface FieldDescriptionInterface
     /**
      * Returns the field name.
      *
-     * @return string the field name
+     * @return string|null the field name
      */
     public function getFieldName();
 
@@ -45,9 +45,11 @@ interface FieldDescriptionInterface
     public function setName($name);
 
     /**
+     * NEXT_MAJOR: Restrict return type to string.
+     *
      * Returns the name, the name can be used as a form label or table header.
      *
-     * @return string the name
+     * @return string|null the name
      */
     public function getName();
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -146,7 +146,7 @@ class AdminTest extends TestCase
         $baseControllerName = 'Sonata\NewsBundle\Controller\PostAdminController';
 
         $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
-        $admin->setParentFieldDescription(new FieldDescription());
+        $admin->setParentFieldDescription(new FieldDescription('name'));
         $admin->setSubClasses(['foo' => 'bar']);
         $admin->setRequest(new Request(['subclass' => 'foo']));
         $admin->getClass();
@@ -1740,7 +1740,7 @@ class AdminTest extends TestCase
         $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelManager
             ->method('getNewFieldDescriptionInstance')
-            ->willReturn(new FieldDescription());
+            ->willReturn(new FieldDescription('name'));
         $modelAdmin->setModelManager($modelManager);
 
         // a Admin class to test that preValidate is called
@@ -1810,7 +1810,7 @@ class AdminTest extends TestCase
         $modelManager = $this->createStub(ModelManagerInterface::class);
         $modelManager
             ->method('getNewFieldDescriptionInstance')
-            ->willReturn(new FieldDescription());
+            ->willReturn(new FieldDescription('name'));
         $modelAdmin->setModelManager($modelManager);
 
         $event = $this->createStub(FormEvent::class);
@@ -1941,9 +1941,9 @@ class AdminTest extends TestCase
     {
         $modelAdmin = new ModelAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'Sonata\FooBundle\Controller\ModelAdminController');
 
-        $fooFieldDescription = new FieldDescription();
-        $barFieldDescription = new FieldDescription();
-        $bazFieldDescription = new FieldDescription();
+        $fooFieldDescription = new FieldDescription('foo');
+        $barFieldDescription = new FieldDescription('bar');
+        $bazFieldDescription = new FieldDescription('baz');
 
         $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelManager
@@ -2132,7 +2132,7 @@ class AdminTest extends TestCase
         $this->assertSame($comment, $commentAdmin->getSubject());
 
         $commentAdmin->setSubject(null);
-        $commentAdmin->setParentFieldDescription(new FieldDescription());
+        $commentAdmin->setParentFieldDescription(new FieldDescription('name'));
 
         $this->assertFalse($commentAdmin->hasSubject());
     }

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -26,16 +26,18 @@ class BaseFieldDescriptionTest extends TestCase
 {
     public function testSetName(): void
     {
-        $description = new FieldDescription();
-        $description->setName('foo');
-
+        $description = new FieldDescription('foo');
         $this->assertSame('foo', $description->getFieldName());
         $this->assertSame('foo', $description->getName());
+
+        $description->setName('bar');
+        $this->assertSame('foo', $description->getFieldName());
+        $this->assertSame('bar', $description->getName());
     }
 
     public function testOptions(): void
     {
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
         $description->setOption('foo', 'bar');
 
         $this->assertNull($description->getOption('bar'));
@@ -84,7 +86,7 @@ class BaseFieldDescriptionTest extends TestCase
      */
     public function testHelpOptions(): void
     {
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
 
         $description->setHelp('Please enter an integer');
         $this->assertSame('Please enter an integer', $description->getHelp());
@@ -95,7 +97,7 @@ class BaseFieldDescriptionTest extends TestCase
 
     public function testAdmin(): void
     {
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
 
         $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $description->setAdmin($admin);
@@ -116,7 +118,7 @@ class BaseFieldDescriptionTest extends TestCase
 
     public function testGetValue(): void
     {
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
         $description->setOption('code', 'getFoo');
 
         $mock = $this->getMockBuilder(\stdClass::class)
@@ -131,7 +133,7 @@ class BaseFieldDescriptionTest extends TestCase
          */
         $arg1 = 38;
         $oneParameter = [$arg1];
-        $description1 = new FieldDescription();
+        $description1 = new FieldDescription('name');
         $description1->setOption('code', 'getWithOneParameter');
         $description1->setOption('parameters', $oneParameter);
 
@@ -148,7 +150,7 @@ class BaseFieldDescriptionTest extends TestCase
          */
         $arg2 = 4;
         $twoParameters = [$arg1, $arg2];
-        $description2 = new FieldDescription();
+        $description2 = new FieldDescription('name');
         $description2->setOption('code', 'getWithTwoParameters');
         $description2->setOption('parameters', $twoParameters);
 
@@ -163,7 +165,7 @@ class BaseFieldDescriptionTest extends TestCase
          * Test with underscored attribute name
          */
         foreach (['getFake', 'isFake', 'hasFake'] as $method) {
-            $description3 = new FieldDescription();
+            $description3 = new FieldDescription('name');
             $mock3 = $this->getMockBuilder(\stdClass::class)
                 ->setMethods([$method])
                 ->getMock();
@@ -179,7 +181,7 @@ class BaseFieldDescriptionTest extends TestCase
             ->method('myMethod')
             ->willReturn('myMethodValue');
 
-        $description4 = new FieldDescription();
+        $description4 = new FieldDescription('name');
         $description4->setOption('code', 'myMethod');
 
         $this->assertSame($description4->getFieldValue($mock4, null), 'myMethodValue');
@@ -189,7 +191,7 @@ class BaseFieldDescriptionTest extends TestCase
     {
         $this->expectException(\Sonata\AdminBundle\Exception\NoValueException::class);
 
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
         $mock = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getFoo'])
             ->getMock();
@@ -202,7 +204,7 @@ class BaseFieldDescriptionTest extends TestCase
      */
     public function testGetVirtualValue(): void
     {
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
         $mock = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['getFoo'])
             ->getMock();
@@ -215,14 +217,14 @@ class BaseFieldDescriptionTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
         $description->setOption('bar', 'hello');
         $description->mergeOption('bar', ['exception']);
     }
 
     public function testGetTranslationDomain(): void
     {
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
 
         $admin = $this->createMock(AdminInterface::class);
         $description->setAdmin($admin);
@@ -259,7 +261,7 @@ class BaseFieldDescriptionTest extends TestCase
         $rm->setAccessible(true);
         $this->assertSame($quux, $rm->invokeArgs($foo, []));
 
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
 
         $this->expectException(NoValueException::class);
         $description->getFieldValue($foo, 'quux');
@@ -270,7 +272,7 @@ class BaseFieldDescriptionTest extends TestCase
         $foo = new Foo();
         $foo->setBar('Bar');
 
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
         $this->assertSame('Bar', $description->getFieldValue($foo, 'bar'));
         $foo->setBar('baR');
         $this->assertSame('baR', $description->getFieldValue($foo, 'bar'));
@@ -284,7 +286,7 @@ class BaseFieldDescriptionTest extends TestCase
         $foo->setBar(true);
         $foo->setBaz(false);
 
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
         $this->assertTrue($description->getFieldValue($foo, 'bar'));
         $this->assertFalse($description->getFieldValue($foo, 'baz'));
 
@@ -297,7 +299,7 @@ class BaseFieldDescriptionTest extends TestCase
         $foo = new Foo();
         $foo->setBaz('Baz');
 
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
 
         $description->setOption('code', 'getBaz');
         $this->assertSame('Baz', $description->getFieldValue($foo, 'inexistantMethod'));
@@ -312,7 +314,7 @@ class BaseFieldDescriptionTest extends TestCase
         $parameters = ['foo', 'bar'];
         $foo = new FooCall();
 
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
         $description->setOption('parameters', $parameters);
         $this->assertSame(['inexistantMethod', $parameters], $description->getFieldValue($foo, 'inexistantMethod'));
 
@@ -323,7 +325,7 @@ class BaseFieldDescriptionTest extends TestCase
     public function testGetFieldValueWithNullObject(): void
     {
         $foo = null;
-        $description = new FieldDescription();
+        $description = new FieldDescription('name');
         $this->assertNull($description->getFieldValue($foo, 'bar'));
     }
 }

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -41,10 +41,7 @@ final class ModelManager implements ModelManagerInterface
             $options['route']['parameters'] = [];
         }
 
-        $fieldDescription = new FieldDescription($name);
-        $fieldDescription->setOptions($options);
-
-        return $fieldDescription;
+        return new FieldDescription($name, $options);
     }
 
     public function create($object): void

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -41,8 +41,7 @@ final class ModelManager implements ModelManagerInterface
             $options['route']['parameters'] = [];
         }
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName($name);
+        $fieldDescription = new FieldDescription($name);
         $fieldDescription->setOptions($options);
 
         return $fieldDescription;

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -86,8 +86,7 @@ class DatagridMapperTest extends TestCase
         $modelManager
             ->method('getNewFieldDescriptionInstance')
             ->willReturnCallback(function (?string $class, string $name, array $options = []): BaseFieldDescription {
-                $fieldDescription = $this->getFieldDescriptionMock();
-                $fieldDescription->setName($name);
+                $fieldDescription = $this->getFieldDescriptionMock($name);
                 $fieldDescription->setOptions($options);
 
                 return $fieldDescription;
@@ -302,13 +301,9 @@ class DatagridMapperTest extends TestCase
         $this->assertTrue($this->datagridMapper->has('baz'));
     }
 
-    private function getFieldDescriptionMock(?string $name = null, ?string $label = null): BaseFieldDescription
+    private function getFieldDescriptionMock(string $name, ?string $label = null): BaseFieldDescription
     {
-        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class);
-
-        if (null !== $name) {
-            $fieldDescription->setName($name);
-        }
+        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name]);
 
         if (null !== $label) {
             $fieldDescription->setOption('label', $label);

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -133,10 +133,10 @@ class DatagridMapperTest extends TestCase
             'show_filter' => null,
             'advanced_filter' => true,
             'foo_default_option' => 'bar_default',
-            'label' => 'fooLabel',
-            'field_name' => 'fooFilterName',
             'placeholder' => 'short_object_description_placeholder',
             'link_parameters' => [],
+            'label' => 'fooLabel',
+            'field_name' => 'fooFilterName',
         ], $filter->getOptions());
     }
 
@@ -159,13 +159,13 @@ class DatagridMapperTest extends TestCase
             'show_filter' => null,
             'advanced_filter' => true,
             'foo_default_option' => 'bar_custom',
+            'placeholder' => 'short_object_description_placeholder',
+            'link_parameters' => [],
             'label' => 'fooLabel',
             'field_name' => 'fooFilterName',
             'foo_filter_option' => 'foo_filter_option_value',
             'field_options' => ['foo_field_option' => 'baz'],
             'field_type' => 'foo_field_type',
-            'placeholder' => 'short_object_description_placeholder',
-            'link_parameters' => [],
         ], $filter->getOptions());
     }
 
@@ -303,7 +303,7 @@ class DatagridMapperTest extends TestCase
 
     private function getFieldDescriptionMock(string $name, ?string $label = null): BaseFieldDescription
     {
-        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name]);
+        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name, []]);
 
         if (null !== $label) {
             $fieldDescription->setOption('label', $label);

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -69,8 +69,7 @@ class ListMapperTest extends TestCase
         $modelManager
             ->method('getNewFieldDescriptionInstance')
             ->willReturnCallback(function (?string $class, string $name, array $options = []): BaseFieldDescription {
-                $fieldDescription = $this->getFieldDescriptionMock();
-                $fieldDescription->setName($name);
+                $fieldDescription = $this->getFieldDescriptionMock($name);
                 $fieldDescription->setOptions($options);
 
                 return $fieldDescription;
@@ -412,13 +411,9 @@ class ListMapperTest extends TestCase
         );
     }
 
-    private function getFieldDescriptionMock(?string $name = null, ?string $label = null): BaseFieldDescription
+    private function getFieldDescriptionMock(string $name, ?string $label = null): BaseFieldDescription
     {
-        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class);
-
-        if (null !== $name) {
-            $fieldDescription->setName($name);
-        }
+        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name]);
 
         if (null !== $label) {
             $fieldDescription->setOption('label', $label);

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -413,7 +413,7 @@ class ListMapperTest extends TestCase
 
     private function getFieldDescriptionMock(string $name, ?string $label = null): BaseFieldDescription
     {
-        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name]);
+        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name, []]);
 
         if (null !== $label) {
             $fieldDescription->setOption('label', $label);

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -557,7 +557,7 @@ class FormMapperTest extends TestCase
         ?string $label = null,
         ?string $translationDomain = null
     ): BaseFieldDescription {
-        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name]);
+        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name, []]);
 
         if (null !== $label) {
             $fieldDescription->setOption('label', $label);

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -95,8 +95,7 @@ class FormMapperTest extends TestCase
         $this->modelManager
             ->method('getNewFieldDescriptionInstance')
             ->willReturnCallback(function (string $class, string $name, array $options = []): BaseFieldDescription {
-                $fieldDescription = $this->getFieldDescriptionMock();
-                $fieldDescription->setName($name);
+                $fieldDescription = $this->getFieldDescriptionMock($name);
                 $fieldDescription->setOptions($options);
 
                 return $fieldDescription;
@@ -554,15 +553,11 @@ class FormMapperTest extends TestCase
     }
 
     private function getFieldDescriptionMock(
-        ?string $name = null,
+        string $name,
         ?string $label = null,
         ?string $translationDomain = null
     ): BaseFieldDescription {
-        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class);
-
-        if (null !== $name) {
-            $fieldDescription->setName($name);
-        }
+        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name]);
 
         if (null !== $label) {
             $fieldDescription->setOption('label', $label);

--- a/tests/Show/ShowMapperTest.php
+++ b/tests/Show/ShowMapperTest.php
@@ -105,8 +105,7 @@ class ShowMapperTest extends TestCase
         $modelManager
             ->method('getNewFieldDescriptionInstance')
             ->willReturnCallback(function (?string $class, string $name, array $options = []) {
-                $fieldDescription = $this->getFieldDescriptionMock();
-                $fieldDescription->setName($name);
+                $fieldDescription = $this->getFieldDescriptionMock($name);
                 $fieldDescription->setOptions($options);
 
                 return $fieldDescription;
@@ -573,8 +572,7 @@ class ShowMapperTest extends TestCase
         $modelManager
             ->method('getNewFieldDescriptionInstance')
             ->willReturnCallback(function (string $class, string $name, array $options = []): FieldDescriptionInterface {
-                $fieldDescription = $this->getFieldDescriptionMock();
-                $fieldDescription->setName($name);
+                $fieldDescription = $this->getFieldDescriptionMock($name);
                 $fieldDescription->setOptions($options);
 
                 return $fieldDescription;
@@ -586,13 +584,9 @@ class ShowMapperTest extends TestCase
         $this->admin->setShowBuilder(new ShowBuilder());
     }
 
-    private function getFieldDescriptionMock(?string $name = null, ?string $label = null): BaseFieldDescription
+    private function getFieldDescriptionMock(string $name, ?string $label = null): BaseFieldDescription
     {
-        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class);
-
-        if (null !== $name) {
-            $fieldDescription->setName($name);
-        }
+        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name]);
 
         if (null !== $label) {
             $fieldDescription->setOption('label', $label);

--- a/tests/Show/ShowMapperTest.php
+++ b/tests/Show/ShowMapperTest.php
@@ -586,7 +586,7 @@ class ShowMapperTest extends TestCase
 
     private function getFieldDescriptionMock(string $name, ?string $label = null): BaseFieldDescription
     {
-        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name]);
+        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name, []]);
 
         if (null !== $label) {
             $fieldDescription->setOption('label', $label);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

BC

Related to discuss: https://github.com/sonata-project/SonataAdminBundle/pull/6501#discussion_r507513934

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Instantiate a FieldDescription without passing the name as first argument
```
