### PR TITLE
Avoid to pass empty array as argument 3 for implementations of `ModelManagerInterface::addIdentifiersToQuery()`

### DIFF
--- a/src/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/src/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -167,11 +167,14 @@ class ModelsToArrayTransformer implements DataTransformerInterface
             throw new UnexpectedTypeException($value, 'array');
         }
 
-        $value = array_map('strval', $value);
-
-        $query = $this->modelManager->createQuery($this->class);
-        $this->modelManager->addIdentifiersToQuery($this->class, $query, $value);
-        $result = $this->modelManager->executeQuery($query);
+        if ([] === $value) {
+            $result = $value;
+        } else {
+            $value = array_map('strval', $value);
+            $query = $this->modelManager->createQuery($this->class);
+            $this->modelManager->addIdentifiersToQuery($this->class, $query, $value);
+            $result = $this->modelManager->executeQuery($query);
+        }
 
         /** @phpstan-var ArrayCollection<array-key, T> $collection */
         $collection = TraversableToCollection::transform($result);

--- a/tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelsToArrayTransformerTest.php
@@ -90,6 +90,30 @@ class ModelsToArrayTransformerTest extends TestCase
         yield [null];
     }
 
+    public function testReverseTransformWithEmptyArray(): void
+    {
+        $modelManager = $this->createStub(ModelManagerInterface::class);
+        $modelManager
+            ->expects($this->never())
+            ->method('createQuery');
+        $modelManager
+            ->expects($this->never())
+            ->method('addIdentifiersToQuery');
+        $modelManager
+            ->expects($this->never())
+            ->method('executeQuery');
+
+        $transformer = new ModelsToArrayTransformer(
+            $modelManager,
+            Foo::class
+        );
+
+        $result = $transformer->reverseTransform([]);
+
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertCount(0, $result);
+    }
+
     public function testReverseTransformUnexpectedType(): void
     {
         $value = 'unexpected';


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Avoid to pass empty array as argument 3 for implementations of `ModelManagerInterface::addIdentifiersToQuery()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6508.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Passing an empty array as argument 3 for implementations of `ModelManagerInterface::addIdentifiersToQuery()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
