### PR TITLE
Deprecate `Validators::validateEntityName()`

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,16 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Deprecated `Sonata\AdminBundle\Command\Validators::validateEntityName()`
+
+In version 3.77, the shortcut notation for model class names (`AppBundle:User`)
+has been deprecated in favor of its FQCN (`App\Model\User`) when passing `user_model`
+option to `sonata:admin:generate-object-acl` command, so this method SHOULD not
+be called if that deprecation is addressed.
+
 ### Deprecated not configuring `acl_user_manager` and using ACL security handler when `friendsofsymfony/user-bundle` is installed.
 
 If you are using `friendsofsymfony/user-bundle` and using ACL security handler, you MUST explicitly configure the `acl_user_manager`.

--- a/src/Command/Validators.php
+++ b/src/Command/Validators.php
@@ -39,6 +39,10 @@ class Validators
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, will be removed in version 4.0.
+     *
      * @static
      *
      * @param string $shortcut
@@ -51,6 +55,12 @@ class Validators
      */
     public static function validateEntityName($shortcut)
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x'
+            .' and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $model = str_replace('/', '\\', $shortcut);
 
         if (false === $pos = strpos($model, ':')) {

--- a/tests/Command/ValidatorsTest.php
+++ b/tests/Command/ValidatorsTest.php
@@ -45,6 +45,10 @@ class ValidatorsTest extends TestCase
     }
 
     /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     *
      * @dataProvider getValidateEntityNameTests
      */
     public function testValidateEntityName(array $expected, string $value): void
@@ -52,6 +56,9 @@ class ValidatorsTest extends TestCase
         $this->assertSame($expected, Validators::validateEntityName($value));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getValidateEntityNameTests(): array
     {
         return [
@@ -62,6 +69,10 @@ class ValidatorsTest extends TestCase
     }
 
     /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     *
      * @dataProvider getValidateEntityNamesWithExceptionTests
      */
     public function testValidateEntityNameWithException(string $value): void
@@ -71,6 +82,9 @@ class ValidatorsTest extends TestCase
         Validators::validateEntityName($value);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getValidateEntityNamesWithExceptionTests(): array
     {
         return [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Deprecate `Validators::validateEntityName()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Method `Validators::validateEntityName()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
