### PR TITLE
change html with a links in no_result_content

### DIFF
--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -111,19 +111,19 @@ file that was distributed with this source code.
                                 <div class="progress">
                                     <div class="progress-bar" style="width: 0%"></div>
                                 </div>
-                                <span class="progress-description">
-                                    {% if not app.request.xmlHttpRequest %}
-                                    <ul class="list-unstyled">
-                                        {% if admin.datagrid.pager.results|length > 0 %}
-                                            <a href="{{ admin.generateUrl('list') }}">
-                                                {{ 'go_to_the_first_page'|trans({}, 'SonataAdminBundle') }}
-                                            </a>
-                                        {% else %}
-                                            {% include get_admin_template('button_create', admin.code) %}
-                                        {% endif %}
+                                <div class="progress-description">
+                                    <ul class="list-inline">
+                                        {%- if admin.datagrid.pager.results|length > 0 -%}
+                                            <li>
+                                                <a href="{{ admin.generateUrl('list') }}">
+                                                    {{- 'go_to_the_first_page'|trans({}, 'SonataAdminBundle') -}}
+                                                </a>
+                                            </li>
+                                        {%- elseif not app.request.xmlHttpRequest -%}
+                                            {%- include get_admin_template('button_create', admin.code) -%}
+                                        {%- endif -%}
                                     </ul>
-                                    {% endif %}
-                                </span>
+                                </div>
                             </div><!-- /.info-box-content -->
                         </div>
                     {% endblock %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- html with a links in no_result_content
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

The `go_to_the_first_page` link appears when there are more results.
The `button_create` link only appears if it is not AJAX.

![obraz](https://user-images.githubusercontent.com/1436016/96703028-a9cefe00-1392-11eb-9667-f520a70ffe38.png)
![obraz](https://user-images.githubusercontent.com/1436016/96703044-b05d7580-1392-11eb-80ad-11e031f0ae25.png)
