### PR TITLE
Deprecate FilterInterface::filter method

### DIFF
--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -25,6 +25,10 @@ interface FilterInterface
     public const CONDITION_AND = 'AND';
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0
+     *
      * Apply the filter to the QueryBuilder instance.
      *
      * @param string  $alias

--- a/tests/Fixtures/Filter/FooFilter.php
+++ b/tests/Fixtures/Filter/FooFilter.php
@@ -18,6 +18,9 @@ use Sonata\AdminBundle\Filter\Filter;
 
 class FooFilter extends Filter
 {
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value): void
     {
     }


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

This method is not used in SonataAdmin so we don't have to require this signature in our Interface.

Persistence bundle are done this way: 
```
abstract class Filter extends BaseFilter
{
    /**
     * @var bool
     */
    protected $active = false;

    public function apply($queryBuilder, $value)
    {
        $this->value = $value;
        if (\is_array($value) && \array_key_exists('value', $value)) {
            list($alias, $field) = $this->association($queryBuilder, $value);

            $this->filter($queryBuilder, $alias, $field, $value);
        }
    }
```
They just have to add 
```
abstract function filter(...)
```
With specific signature. ($alias is only useful for ORM bundle for instance)

Closes #6269.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate `FilterInterface::filter()` method
```