### PR TITLE
fix issue with translation domain

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
@@ -26,7 +26,8 @@ file that was distributed with this source code.
                         {% if nested_field.vars.translation_domain is same as(false) %}
                             {{ nested_field.vars.label }}
                         {% else %}
-                            {{ nested_field.vars.label|trans({}, nested_field.vars.translation_domain) }}
+                            {% set translationDomain = nested_field.vars.translation_domain|default(nested_field.vars['sonata_admin'].admin.translationDomain|default(null)) %}
+                            {{ nested_field.vars.label|trans({}, translationDomain) }}
                         {% endif %}
                     </th>
                 {% endif %}

--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
@@ -26,8 +26,7 @@ file that was distributed with this source code.
                         {% if nested_field.vars.translation_domain is same as(false) %}
                             {{ nested_field.vars.label }}
                         {% else %}
-                            {% set translationDomain = nested_field.vars.translation_domain|default(nested_field.vars['sonata_admin'].admin.translationDomain) %}
-                            {{ nested_field.vars.label|trans({}, translationDomain) }}
+                            {{ nested_field.vars.label|trans({}, nested_field.vars.translation_domain) }}
                         {% endif %}
                     </th>
                 {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it fixes a bug introduced in 3.77.0 (https://github.com/sonata-project/SonataAdminBundle/pull/6401).

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataAdminBundle/issues/6522

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- fixed BC break with getting the translation domain for nested fields on a one-to-many inline edit table view
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
