### PR TITLE
Restore missing ellipsis in truncated words

### DIFF
--- a/src/Resources/views/CRUD/base_edit.html.twig
+++ b/src/Resources/views/CRUD/base_edit.html.twig
@@ -14,18 +14,18 @@ file that was distributed with this source code.
 {% block title %}
     {# NEXT_MAJOR: remove default filter #}
     {% if objectId|default(admin.id(object)) is not null %}
-        {{ 'title_edit'|trans({'%name%': admin.toString(object)|u.truncate(15) }, 'SonataAdminBundle') }}
+        {{ 'title_edit'|trans({'%name%': admin.toString(object)|u.truncate(15, '...') }, 'SonataAdminBundle') }}
     {% else %}
-        {{ 'title_create'|trans({}, 'SonataAdminBundle')|u.truncate(15) }}
+        {{ 'title_create'|trans({}, 'SonataAdminBundle')|u.truncate(15, '...') }}
     {% endif %}
 {% endblock %}
 
 {% block navbar_title %}
     {# NEXT_MAJOR: remove default filter #}
     {% if objectId|default(admin.id(object)) is not null %}
-        {{ 'title_edit'|trans({'%name%': admin.toString(object)|u.truncate(100) }, 'SonataAdminBundle') }}
+        {{ 'title_edit'|trans({'%name%': admin.toString(object)|u.truncate(100, '...') }, 'SonataAdminBundle') }}
     {% else %}
-        {{ 'title_create'|trans({}, 'SonataAdminBundle')|u.truncate(100) }}
+        {{ 'title_create'|trans({}, 'SonataAdminBundle')|u.truncate(100, '...') }}
     {% endif %}
 {% endblock %}
 

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -23,11 +23,11 @@ file that was distributed with this source code.
 {%- endblock -%}
 
 {% block title %}
-    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject)|u.truncate(15) }, 'SonataAdminBundle') : '' }}
+    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject)|u.truncate(15, '...') }, 'SonataAdminBundle') : '' }}
 {% endblock %}
 
 {% block navbar_title %}
-    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject)|u.truncate(100) }, 'SonataAdminBundle') : '' }}
+    {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject)|u.truncate(100, '...') }, 'SonataAdminBundle') : '' }}
 {% endblock %}
 
 {% block list_table %}

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -12,11 +12,11 @@ file that was distributed with this source code.
 {% extends base_template %}
 
 {% block title %}
-    {{ 'title_show'|trans({'%name%': admin.toString(object)|u.truncate(15) }, 'SonataAdminBundle') }}
+    {{ 'title_show'|trans({'%name%': admin.toString(object)|u.truncate(15, '...') }, 'SonataAdminBundle') }}
 {% endblock %}
 
 {% block navbar_title %}
-    {{ 'title_show'|trans({'%name%': admin.toString(object)|u.truncate(100) }, 'SonataAdminBundle') }}
+    {{ 'title_show'|trans({'%name%': admin.toString(object)|u.truncate(100, '...') }, 'SonataAdminBundle') }}
 {% endblock %}
 
 {%- block actions -%}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -177,15 +177,15 @@ file that was distributed with this source code.
                                                                         {% if menu.extra('safe_label', true) %}
                                                                             {{- label|raw -}}
                                                                         {% else %}
-                                                                            {{- label|u.truncate(100) -}}
+                                                                            {{- label|u.truncate(100, '...') -}}
                                                                         {% endif %}
                                                                     </a>
                                                                 {% else %}
-                                                                    <span>{{ label|u.truncate(100) }}</span>
+                                                                    <span>{{ label|u.truncate(100, '...') }}</span>
                                                                 {% endif %}
                                                             </li>
                                                         {% else %}
-                                                            <li class="active"><span>{{ label|u.truncate(100) }}</span></li>
+                                                            <li class="active"><span>{{ label|u.truncate(100, '...') }}</span></li>
                                                         {% endif %}
                                                     {% endfor %}
                                                 {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Restore missing ellipsis in truncated words.
<!-- Describe your Pull Request content here -->
#6132 replaces our own string "truncate" implementation with the one provided by [`symfony/string`](https://github.com/symfony/string/blob/90c2a5103f07feb19069379f3abdcdbacc7753a9/AbstractString.php#L631), but the ellipsis in the `truncate()` method has an empty string as default value there instead of the ellipsis we were using before.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to #6132.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Missing ellipsis in some truncated word.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
