### PR TITLE
Explicitly cast types in CRUDController::batchAction()

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -426,8 +426,8 @@ class CRUDController implements ContainerAwareInterface
 
         if ($data = json_decode((string) $request->get('data'), true)) {
             $action = $data['action'];
-            $idx = $data['idx'];
-            $allElements = (bool) $data['all_elements'];
+            $idx = (array) ($data['idx'] ?? []);
+            $allElements = (bool) ($data['all_elements'] ?? false);
             $forwardedRequest->request->replace(array_merge($forwardedRequest->request->all(), $data));
         } else {
             $action = $forwardedRequest->request->get('action');
@@ -437,7 +437,7 @@ class CRUDController implements ContainerAwareInterface
                 // symfony 5.1+
                 $idx = $bag->all('idx');
             } else {
-                $idx = $bag->get('idx', []);
+                $idx = (array) $bag->get('idx', []);
             }
             $allElements = $forwardedRequest->request->getBoolean('all_elements');
 
@@ -445,6 +445,7 @@ class CRUDController implements ContainerAwareInterface
             $forwardedRequest->request->set('all_elements', $allElements);
 
             $data = $forwardedRequest->request->all();
+            $data['all_elements'] = $allElements;
 
             unset($data['_sonata_csrf_token']);
         }

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3590,20 +3590,28 @@ class CRUDControllerTest extends TestCase
         $this->assertSame('list', $result->getTargetUrl());
     }
 
+    public function provideConfirmationData(): iterable
+    {
+        yield 'normal data' => [['action' => 'delete', 'idx' => ['123', '456'], 'all_elements' => false]];
+        yield 'without all elements' => [['action' => 'delete', 'idx' => ['123', '456']]];
+        yield 'all elements' => [['action' => 'delete', 'all_elements' => true]];
+        yield 'idx is null' => [['action' => 'delete', 'idx' => null, 'all_elements' => true]];
+        yield 'all_elements is null' => [['action' => 'delete', 'idx' => ['123', '456'], 'all_elements' => null]];
+    }
+
     /**
      * NEXT_MAJOR: Remove this legacy group.
      *
+     * @dataProvider provideConfirmationData
      * @group legacy
      */
-    public function testBatchActionWithConfirmation(): void
+    public function testBatchActionWithConfirmation(array $data): void
     {
         $batchActions = ['delete' => ['label' => 'Foo Bar', 'translation_domain' => 'FooBarBaz', 'ask_confirmation' => true]];
 
         $this->admin->expects($this->once())
             ->method('getBatchActions')
             ->willReturn($batchActions);
-
-        $data = ['action' => 'delete', 'idx' => ['123', '456'], 'all_elements' => false];
 
         $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('data', json_encode($data));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
This PR corrects several issues at once.

### No `data.all_elements` in tpl

> Key "all_elements" for array with keys "idx, action, won" does not exist.

Error in [`SonataAdminBundle:CRUD:batch_confirmation.html.twig`](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Resources/views/CRUD/batch_confirmation.html.twig#L35)


```twig
<div class="box-body">
    {% if data.all_elements %} {# at this line #}
        {{ 'message_batch_all_confirmation'|trans({}, 'SonataAdminBundle') }}
    {% else %}
        {% trans with {'%count%': data.idx|length} from 'SonataAdminBundle' %}message_batch_confirmation{% endtrans %}
    {% endif %}
</div>
```

The problem is due to the fact that the `all_elements` is a [checkbox](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Resources/views/CRUD/base_list.html.twig#L175) and if it is not checked, then it will not be in the HTTP request.

Form Data:

```
_sonata_csrf_token: rLjGreGh3zUGRjBSjebfU6jFjTuzbBhD0dCrs6RWn_g
idx[]: 441
idx[]: 440
idx[]: 439
idx[]: 438
idx[]: 437
action: approve
```

### Undefined index: all_elements

> Notice: Undefined index: all_elements

For the same reason, the `all_elements` will be absent in the data after confirming the action.

Form Data:

```
confirmation: ok
data: {"idx":["441","440","439","438","437"],"action":"approve"}
_sonata_csrf_token: rLjGreGh3zUGRjBSjebfU6jFjTuzbBhD0dCrs6RWn_g
```

### TypeError

If you select apply to all elements, the `ids` is missing from the data.

```
TypeError: Argument 3 passed to Sonata\AdminBundle\Admin\AbstractAdmin::preBatchAction() must be of the type array, null given, called in /www/vendor/sonata-project/admin-bundle/src/Controller/CRUDController.php on line 517
#5 /vendor/sonata-project/admin-bundle/src/Admin\AbstractAdmin.php(805): Sonata\AdminBundle\Admin\AbstractAdmin::preBatchAction
#4 /vendor/sonata-project/admin-bundle/src/Controller/CRUDController.php(517): Sonata\AdminBundle\Controller\CRUDController::batchAction
#3 /vendor/symfony/http-kernel/HttpKernel.php(158): Symfony\Component\HttpKernel\HttpKernel::handleRaw
#2 /vendor/symfony/http-kernel/HttpKernel.php(80): Symfony\Component\HttpKernel\HttpKernel::handle
#1 /vendor/symfony/http-kernel/Kernel.php(201): Symfony\Component\HttpKernel\Kernel::handle
#0 /web/index.php(53): null
```

Form Data:

```
confirmation: ok
data: {"all_elements":"on","action":"approve"}
_sonata_csrf_token: 07f1crI4LnSge9E17Q08bMZb8isUsVkZXqUS5UFsNwM
```

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Explicitly cast types in `CRUDController::batchAction()`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
