### PR TITLE
Add scroll to filter dropdown

### DIFF
--- a/src/Resources/public/css/styles.css
+++ b/src/Resources/public/css/styles.css
@@ -53,6 +53,11 @@ body > .header .logo {
     -moz-animation-duration: .3s;
 }
 
+.dropdown-menu-scrollable {
+    overflow-y: auto;
+    max-height: 75vh;
+}
+
 /* Buttons */
 
 .btn.btn-outline {

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -258,7 +258,7 @@ file that was distributed with this source code.
                     <b class="caret"></b>
                 </a>
 
-                <ul class="dropdown-menu" role="menu">
+                <ul class="dropdown-menu dropdown-menu-scrollable" role="menu">
                     {% for filter in admin.datagrid.filters|filter(filter => filter.options['show_filter'] is not same as (false)) %}
                         {% set filterDisplayed = filter.isActive() or filter.options['show_filter'] is same as (true) %}
                         <li>


### PR DESCRIPTION
## Subject

Now, I have a filter list with a limited height and a scroll bar.
![image](https://user-images.githubusercontent.com/9052536/97009878-f3f7e100-1544-11eb-8815-fe27300370ab.png)

I am targeting this branch, because BC.
 
Closes #6528.

## Changelog

```markdown
### Added
- Added the ability to scroll the filter list dropdown
```