### PR TITLE
Fix DI config for AdminHelper

### DIFF
--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -71,7 +71,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.admin.helper', AdminHelper::class)
             ->public()
             ->args([
-                new ReferenceConfigurator('sonata.admin.pool'),
+                new ReferenceConfigurator('property_accessor'),
             ])
 
         ->alias(AdminHelper::class, 'sonata.admin.helper')


### PR DESCRIPTION
## Subject

Fix the DI config for `Sonata\AdminBundle\Admin\AdminHelper`.

Closes #6531
