### PR TITLE
Allow usage object properties to get/set instance in ObjectManipulator

### DIFF
--- a/src/Manipulator/ObjectManipulator.php
+++ b/src/Manipulator/ObjectManipulator.php
@@ -75,16 +75,24 @@ final class ObjectManipulator
         $inflector = InflectorFactory::create()->build();
         $method = sprintf('get%s', $inflector->classify($fieldName));
 
-        if (!(\is_callable([$object, $method]) && method_exists($object, $method))) {
-            /*
-             * NEXT_MAJOR: Use BadMethodCallException instead
-             */
-            throw new \RuntimeException(
-                sprintf('Method %s::%s() does not exist.', ClassUtils::getClass($object), $method)
-            );
+        if (\is_callable([$object, $method]) && method_exists($object, $method)) {
+            return $object->$method();
         }
 
-        return $object->$method();
+        if (property_exists($object, $fieldName)) {
+            $ref = new \ReflectionProperty($object, $fieldName);
+
+            if ($ref->isPublic()) {
+                return $object->$fieldName;
+            }
+        }
+
+        /*
+         * NEXT_MAJOR: Use BadMethodCallException instead
+         */
+        throw new \RuntimeException(
+            sprintf('Method %s::%s() does not exist.', ClassUtils::getClass($object), $method)
+        );
     }
 
     /**
@@ -99,18 +107,28 @@ final class ObjectManipulator
         $inflector = InflectorFactory::create()->build();
         $method = sprintf('set%s', $inflector->classify($mappedBy));
 
-        if (!(\is_callable([$instance, $method]) && method_exists($instance, $method))) {
-            /*
-             * NEXT_MAJOR: Use BadMethodCallException instead
-             */
-            throw new \RuntimeException(
-                sprintf('Method %s::%s() does not exist.', ClassUtils::getClass($instance), $method)
-            );
+        if (\is_callable([$instance, $method]) && method_exists($instance, $method)) {
+            $instance->$method($object);
+
+            return $instance;
         }
 
-        $instance->$method($object);
+        if (property_exists($instance, $mappedBy)) {
+            $ref = new \ReflectionProperty($instance, $mappedBy);
 
-        return $instance;
+            if ($ref->isPublic()) {
+                $instance->$mappedBy = $object;
+
+                return $instance;
+            }
+        }
+
+        /*
+         * NEXT_MAJOR: Use BadMethodCallException instead
+         */
+        throw new \RuntimeException(
+            sprintf('Method %s::%s() does not exist.', ClassUtils::getClass($instance), $method)
+        );
     }
 
     /**

--- a/tests/Manipulator/ObjectManipulatorTest.php
+++ b/tests/Manipulator/ObjectManipulatorTest.php
@@ -120,4 +120,38 @@ class ObjectManipulatorTest extends TestCase
 
         ObjectManipulator::setObject($instance, $object1, $fieldDescription);
     }
+
+    public function testSetObjectProperty(): void
+    {
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
+        $fieldDescription->expects($this->once())->method('getAssociationMapping')->willReturn(['mappedBy' => 'parent']);
+        $fieldDescription->expects($this->once())->method('getParentAssociationMappings')->willReturn([]);
+
+        $object = new \stdClass();
+        $instance = new \stdClass();
+        $instance->parent = null;
+
+        ObjectManipulator::setObject($instance, $object, $fieldDescription);
+
+        self::assertSame($object, $instance->parent);
+    }
+
+    public function testSetObjectPropertyWithParentAssociation(): void
+    {
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
+        $fieldDescription->expects($this->once())->method('getAssociationMapping')->willReturn(['mappedBy' => 'fooBar']);
+        $fieldDescription->expects($this->once())->method('getParentAssociationMappings')->willReturn([['fieldName' => 'parent']]);
+
+        $object2 = new \stdClass();
+
+        $instance = new \stdClass();
+        $instance->fooBar = null;
+
+        $object1 = new \stdClass();
+        $object1->parent = $object2;
+
+        ObjectManipulator::setObject($instance, $object1, $fieldDescription);
+
+        self::assertSame($object2, $instance->fooBar);
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->

Now the `ObjectManipulator` does not work correctly if you pass it a DTO without setters and getters and only with public properties.

https://github.com/sonata-project/SonataAdminBundle/pull/6171/files#r510937030

Not sure if this is related, but i got this exception after a recent update:

```
RuntimeException: Method PlaylistRelationAdminView::setPlaylist() does not exist.
#22 /vendor/sonata-project/admin-bundle/src/Manipulator/ObjectManipulator.php(106): Sonata\AdminBundle\Manipulator\ObjectManipulator::callSetter
#21 /vendor/sonata-project/admin-bundle/src/Manipulator/ObjectManipulator.php(67): Sonata\AdminBundle\Manipulator\ObjectManipulator::setObject
#20 /vendor/sonata-project/admin-bundle/src/Admin/AbstractAdmin.php(3566): Sonata\AdminBundle\Admin\AbstractAdmin::appendParentObject
#19 /vendor/sonata-project/admin-bundle/src/Admin/AbstractAdmin.php(1375): Sonata\AdminBundle\Admin\AbstractAdmin::getNewInstance
#18 /vendor/sonata-project/admin-bundle/src/Form/Type/AdminType.php(111): Sonata\AdminBundle\Form\Type\AdminType::buildForm
#17 /vendor/symfony/form/ResolvedFormType.php(128): Symfony\Component\Form\ResolvedFormType::buildForm
#16 /vendor/symfony/form/FormFactory.php(80): Symfony\Component\Form\FormFactory::createNamedBuilder
#15 /vendor/symfony/form/FormFactory.php(38): Symfony\Component\Form\FormFactory::createNamed
#14 /vendor/symfony/form/Form.php(866): Symfony\Component\Form\Form::add
#13 /vendor/sonata-project/form-extensions/src/EventListener/ResizeFormListener.php(149): Sonata\Form\EventListener\ResizeFormListener::preSubmit
#12 /vendor/symfony/event-dispatcher/EventDispatcher.php(264): Symfony\Component\EventDispatcher\EventDispatcher::doDispatch
#11 /vendor/symfony/event-dispatcher/EventDispatcher.php(239): Symfony\Component\EventDispatcher\EventDispatcher::callListeners
#10 /vendor/symfony/event-dispatcher/EventDispatcher.php(73): Symfony\Component\EventDispatcher\EventDispatcher::dispatch
#9 /vendor/symfony/event-dispatcher/ImmutableEventDispatcher.php(44): Symfony\Component\EventDispatcher\ImmutableEventDispatcher::dispatch
#8 /vendor/symfony/form/Form.php(558): Symfony\Component\Form\Form::submit
#7 /vendor/symfony/form/Form.php(579): Symfony\Component\Form\Form::submit
#6 /vendor/symfony/form/Extension/HttpFoundation/HttpFoundationRequestHandler.php(109): Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler::handleRequest
#5 /vendor/symfony/form/Form.php(493): Symfony\Component\Form\Form::handleRequest
#4 /vendor/sonata-project/admin-bundle/src/Controller/CRUDController.php(319): Sonata\AdminBundle\Controller\CRUDController::editAction
#3 /vendor/symfony/http-kernel/HttpKernel.php(158): Symfony\Component\HttpKernel\HttpKernel::handleRaw
#2 /vendor/symfony/http-kernel/HttpKernel.php(80): Symfony\Component\HttpKernel\HttpKernel::handle
#1 /vendor/symfony/http-kernel/Kernel.php(201): Symfony\Component\HttpKernel\Kernel::handle
#0 /web/app.php(53): null
```

```php
class PlaylistRelationAdminView
{
    /**
     * @ORM\Column(name="position", type="integer", nullable=false)
     *
     * @var int
     */
    public int $position = 0;

    /**
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="NONE")
     * @ORM\ManyToOne(targetEntity="PlaylistAdminView", inversedBy="relations")
     * @ORM\JoinColumn(name="playlist_id", referencedColumnName="id", nullable=false)
     */
    public ?PlaylistAdminView $playlist = null;

    /**
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="NONE")
     * @ORM\ManyToOne(targetEntity="Video", inversedBy="admin_video_relations")
     * @ORM\JoinColumn(name="video_id", referencedColumnName="id", nullable=false)
     */
    public ?Video $video = null;
}
```
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Allow usage object properties to get/set instance in ObjectManipulator
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
